### PR TITLE
Add an API Token Auth Mechanism

### DIFF
--- a/config/graphql/base.py
+++ b/config/graphql/base.py
@@ -135,7 +135,7 @@ class DRFMutation(graphene.Mutation):
         try:
             logger.info("Test if context has user")
             if info.context.user:
-                logger.info("User id: ", info.context.user.id)
+                logger.info(f"User id: {info.context.user.id}")
                 # We're using the DRF Serializers to build data and edit / save objs
                 # We want to pass an ID into the creator field, not the user obj
                 kwargs["creator"] = info.context.user.id
@@ -205,13 +205,13 @@ class DRFMutation(graphene.Mutation):
                 obj_serializer = serializer(data=kwargs)
                 obj_serializer.is_valid(raise_exception=True)
                 obj = obj_serializer.save()
-                logger.info("Created obj", info.context.user)
+                # logger.info(f"Created obj for: {info.context.user}")
 
                 # If we created new obj... give user proper permissions
                 set_permissions_for_obj_to_user(
                     info.context.user, obj, [PermissionTypes.ALL]
                 )
-                logger.info("Permissioned obj")
+                # logger.info("Permissioned obj")
 
                 ok = True
                 message = "Success"

--- a/config/graphql/filters.py
+++ b/config/graphql/filters.py
@@ -1,4 +1,5 @@
 #  Copyright (C) 2022  John Scrudato
+#  License: Apache 2
 
 import django_filters
 from django.contrib.auth import get_user_model

--- a/config/graphql_api_key_auth/__init__.py
+++ b/config/graphql_api_key_auth/__init__.py
@@ -1,0 +1,14 @@
+#  Copyright (C) 2022  John Scrudato / Gordium Knot Inc. d/b/a OpenSource.Legal
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Affero General Public License as
+#  published by the Free Software Foundation, either version 3 of the
+#  License, or (at your option) any later version.
+
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Affero General Public License for more details.
+
+#  You should have received a copy of the GNU Affero General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/config/graphql_api_key_auth/backends.py
+++ b/config/graphql_api_key_auth/backends.py
@@ -1,0 +1,85 @@
+#  Copyright (C) 2022  John Scrudato / Gordium Knot Inc. d/b/a OpenSource.Legal
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Affero General Public License as
+#  published by the Free Software Foundation, either version 3 of the
+#  License, or (at your option) any later version.
+from django.conf import settings
+
+#  You should have received a copy of the GNU Affero General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+from django.contrib.auth import get_user_model
+from django.utils.translation import gettext_lazy as _
+from rest_framework import exceptions
+
+from config.graphql_api_key_auth.utils import get_authorization_header
+
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Affero General Public License for more details.
+
+
+UserModel = get_user_model()
+
+
+class Auth0ApiKeyBackend:
+
+    model = None
+
+    def get_model(self):
+
+        if self.model is not None:
+            return self.model
+
+        from rest_framework.authtoken.models import Token
+
+        return Token
+
+    """
+    A custom token model may be used, but must have the following properties.
+    * key -- The string identifying the token
+    * user -- The user to which the token belongs
+    """
+
+    def authenticate(self, request=None, **kwargs):
+
+        if request is None:
+            return None
+
+        auth = get_authorization_header(request).split()
+
+        if not auth or auth[0].lower() != settings.API_TOKEN_PREFIX.lower().encode():
+            return None
+
+        if len(auth) == 1:
+            msg = _("Invalid token header. No credentials provided.")
+            raise exceptions.AuthenticationFailed(msg)
+        elif len(auth) > 2:
+            msg = _("Invalid token header. Token string should not contain spaces.")
+            raise exceptions.AuthenticationFailed(msg)
+
+        try:
+            token = auth[1].decode()
+        except UnicodeError:
+            msg = _(
+                "Invalid token header. Token string should not contain invalid characters."
+            )
+            raise exceptions.AuthenticationFailed(msg)
+
+        return self.authenticate_credentials(token)
+
+    def authenticate_credentials(self, key):
+        model = self.get_model()
+        try:
+            token = model.objects.select_related("user").get(key=key)
+        except model.DoesNotExist:
+            raise exceptions.AuthenticationFailed(_("Invalid token."))
+
+        if not token.user.is_active:
+            raise exceptions.AuthenticationFailed(_("User inactive or deleted."))
+
+        return token.user
+
+    def authenticate_header(self, request):
+        return self.keyword

--- a/config/graphql_api_key_auth/middleware.py
+++ b/config/graphql_api_key_auth/middleware.py
@@ -1,0 +1,36 @@
+from django.contrib.auth import authenticate
+
+from config.graphql_api_key_auth.utils import get_http_authorization, get_token_argument
+
+
+def _authenticate(request):
+    is_anonymous = not hasattr(request, "user") or request.user.is_anonymous
+    return is_anonymous and get_http_authorization(request) is not None
+
+
+class ApiKeyTokenMiddleware:
+    def __init__(self):
+        self.cached_allow_any = set()
+
+    def authenticate_context(self, info, **kwargs):
+        root_path = info.path[0]
+
+        if root_path not in self.cached_allow_any:
+            return True
+        return False
+
+    def resolve(self, next, root, info, **kwargs):
+
+        context = info.context
+        token_argument = get_token_argument(context, **kwargs)
+
+        if (
+            _authenticate(context) or token_argument is not None
+        ) and self.authenticate_context(info, **kwargs):
+
+            user = authenticate(request=context, **kwargs)
+
+            if user is not None:
+                context.user = user
+
+        return next(root, info, **kwargs)

--- a/config/graphql_api_key_auth/utils.py
+++ b/config/graphql_api_key_auth/utils.py
@@ -1,0 +1,29 @@
+from django.conf import settings
+from rest_framework import HTTP_HEADER_ENCODING
+
+
+def get_authorization_header(request):
+    """
+    Return request's 'Authorization:' header, as a bytestring.
+    Hide some test client ickyness where the header can be unicode.
+    """
+    auth = request.META.get("HTTP_AUTHORIZATION", b"")
+    if isinstance(auth, str):
+        # Work around django test client oddness
+        auth = auth.encode(HTTP_HEADER_ENCODING)
+    return auth
+
+
+def get_token_argument(request, **kwargs):
+    return request.headers.get(settings.API_TOKEN_HEADER_NAME)
+
+
+def get_http_authorization(request):
+
+    auth = request.META.get("HTTP_" + settings.API_TOKEN_HEADER_NAME, "").split()
+    prefix = settings.API_TOKEN_PREFIX
+
+    if len(auth) != 2 or auth[0].lower() != prefix.lower():
+        return None
+
+    return auth[1]

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -141,6 +141,7 @@ AUTHENTICATION_BACKENDS = [
 
 # AUTH0
 USE_AUTH0 = env.bool("USE_AUTH0", False)
+USE_API_KEY_AUTH = env.bool("ALLOW_API_KEYS", True)
 
 if USE_AUTH0:
 
@@ -156,9 +157,15 @@ if USE_AUTH0:
     ]
 
 else:
-
     AUTHENTICATION_BACKENDS += [
         "graphql_jwt.backends.JSONWebTokenBackend",
+    ]
+
+if USE_API_KEY_AUTH:
+    API_TOKEN_HEADER_NAME = "AUTHORIZATION"
+    API_TOKEN_PREFIX = "KEY"
+    AUTHENTICATION_BACKENDS += [
+        "config.graphql_api_key_auth.backends.Auth0ApiKeyBackend"
     ]
 
 # https://docs.djangoproject.com/en/dev/ref/settings/#auth-user-model
@@ -427,6 +434,7 @@ GRAPHENE = {
     "MIDDLEWARE": [
         "config.graphql.permission_annotator.middleware.PermissionAnnotatingMiddleware",
         "graphql_jwt.middleware.JSONWebTokenMiddleware",
+        "config.graphql_api_key_auth.middleware.ApiKeyTokenMiddleware",
     ],
 }
 

--- a/opencontractserver/shared/resolvers.py
+++ b/opencontractserver/shared/resolvers.py
@@ -37,12 +37,12 @@ def resolve_oc_model_queryset(
         permission_model_type = apps.get_model(
             app_label, f"{model_name}userobjectpermission"
         )
-        logger.info(f"Got permission model type: {permission_model_type}")
+        # logger.info(f"Got permission model type: {permission_model_type}")
 
         must_have_permissions = permission_model_type.objects.filter(
             permission__codename=f"read_{model_name}", user_id=user.id
         )
-        logger.info(f"Must have permissions: {must_have_permissions}")
+        # logger.info(f"Must have permissions: {must_have_permissions}")
 
         queryset = django_obj_model_type.objects.filter(
             Q(creator=user)
@@ -72,7 +72,7 @@ def resolve_single_oc_model_from_id(
     django_pk = from_global_id(graphql_id)[1]
 
     if user.is_superuser:
-        print("User is a superuser... return value")
+        # print("User is a superuser... return value")
         obj = model_type.objects.get(id=django_pk)
     elif user.is_anonymous:
         obj = model_type.objects.get(id=django_pk, is_public=True)
@@ -81,7 +81,7 @@ def resolve_single_oc_model_from_id(
         permission_model_type = apps.get_model(
             app_label, f"{model_name}userobjectpermission"
         )
-        logger.info(f"Got permission model type: {permission_model_type}")
+        # logger.info(f"Got permission model type: {permission_model_type}")
 
         must_have_permissions = permission_model_type.objects.filter(
             permission__codename=f"read_{model_name}", user_id=user.id
@@ -96,11 +96,11 @@ def resolve_single_oc_model_from_id(
             & Q(id=django_pk)
         ).distinct()
 
-        logger.info(f"Obj count is {len(obj_queryset)}")
+        # logger.info(f"Obj count is {len(obj_queryset)}")
         if len(obj_queryset) == 1:
             obj = obj_queryset[0]
         else:
             obj = None
-        logger.info(f"After querying obj level permissions, returned obj is: {obj}")
+        # logger.info(f"After querying obj level permissions, returned obj is: {obj}")
 
     return obj

--- a/opencontractserver/tests/test_authentication.py
+++ b/opencontractserver/tests/test_authentication.py
@@ -1,0 +1,91 @@
+import json
+
+from django.contrib.auth import get_user_model
+from django.db import transaction
+from graphene_django.utils.testing import GraphQLTestCase
+from rest_framework.authtoken.models import Token
+
+User = get_user_model()
+
+
+class TestContext:
+    def __init__(self, user):
+        self.user = user
+
+
+class ApiTokenAuthTestCase(GraphQLTestCase):
+    GRAPHQL_URL = "http://localhost:8000/graphql/"
+    REQUEST_CORPUSES_MUTATION = """
+        {
+          corpuses {
+            edges {
+              node {
+                id
+                title
+                description
+              }
+            }
+          }
+        }
+    """
+
+    def setUp(self):
+
+        # Create test user
+        with transaction.atomic():
+            self.user = User.objects.create_user(
+                username="bob",
+                password="12345678",
+                is_usage_capped=False,  # Otherwise no importing...
+            )
+
+        # Create test API Token
+        with transaction.atomic():
+            self.token = Token.objects.create(user=self.user)
+
+    def test_token_create_corpus(self):
+
+        """
+        Test that we can import an OpenContracts export via GraphQL and get back the expected
+        responses from the endpoint.
+        """
+        response = self.query(
+            """
+            mutation(
+              $description: String!,
+              $title: String!
+            ) {
+              createCorpus(
+                description: $description,
+                title: $title
+              ) {
+                ok
+                message
+              }
+            }
+            """,
+            variables={
+                "title": "Private Corpus",
+                "description": "Randos shouldn't be peeping.",
+            },
+            headers={"HTTP_AUTHORIZATION": f"Key {self.token}"},
+        )
+        response_json = json.loads(response.content)
+        assert response_json["data"]["createCorpus"]["ok"] is True
+        assert response_json["data"]["createCorpus"]["message"] == "Success"
+
+        # Now, check without auth token for corpus... should be NONE
+        response = self.query(self.REQUEST_CORPUSES_MUTATION)
+        response_json = json.loads(response.content)
+        retrieved_corpuses = response_json["data"]["corpuses"]["edges"]
+        self.assertTrue(len(retrieved_corpuses) == 0)
+
+        # Now, check WITH auth token for corpus... should retrieve our corpus
+        response = self.query(
+            self.REQUEST_CORPUSES_MUTATION,
+            headers={"HTTP_AUTHORIZATION": f"Key {self.token}"},
+        )
+        response_json = json.loads(response.content)
+        retrieved_corpuses = response_json["data"]["corpuses"]["edges"]
+        self.assertTrue(len(retrieved_corpuses) == 1)
+        self.assertEqual(retrieved_corpuses[0]["node"]["title"], "Private Corpus")

--- a/opencontractserver/utils/permissioning_utils.py
+++ b/opencontractserver/utils/permissioning_utils.py
@@ -39,9 +39,9 @@ def set_permissions_for_obj_to_user(
     permissions (assuming they're part of the read public objects group).
     """
 
-    logger.info(
-        f"grant_permissions_for_obj_to_user - user ({user_val}) / obj ({instance})"
-    )
+    # logger.info(
+    #     f"grant_permissions_for_obj_to_user - user ({user_val}) / obj ({instance})"
+    # )
 
     # Provides some flexibility to use ids where passing object is not practical
     if isinstance(user_val, str) or isinstance(user_val, int):
@@ -50,10 +50,10 @@ def set_permissions_for_obj_to_user(
         user = user_val
 
     model_name = instance._meta.model_name
-    logger.info(f"grant_permissions_for_obj_to_user - Model name: {model_name}")
+    # logger.info(f"grant_permissions_for_obj_to_user - Model name: {model_name}")
 
     app_name = instance._meta.app_label
-    logger.info(f"grant_permissions_for_obj_to_user - App name: {app_name}")
+    # logger.info(f"grant_permissions_for_obj_to_user - App name: {app_name}")
 
     # First, get rid of old permissions ################################################################################
     with transaction.atomic():
@@ -64,9 +64,9 @@ def set_permissions_for_obj_to_user(
 
     # Now, add specified permissions ###################################################################################
     requested_permission_set = set(permissions)
-    logger.info(
-        f"grant_permissions_for_obj_to_user - Requested permissions: {requested_permission_set}"
-    )
+    # logger.info(
+    #     f"grant_permissions_for_obj_to_user - Requested permissions: {requested_permission_set}"
+    # )
 
     with transaction.atomic():
         if (
@@ -91,7 +91,7 @@ def set_permissions_for_obj_to_user(
             )
             > 0
         ):
-            logger.info("requested_permission_set - assign read permission")
+            # logger.info("requested_permission_set - assign read permission")
             assign_perm(f"{app_name}.read_{model_name}", user, instance)
 
         if (
@@ -160,9 +160,9 @@ def get_permission_id_to_name_map_for_model(
 
     model_name = instance._meta.model_name
     app_label = instance._meta.app_label
-    logger.info(
-        f"get_permission_id_to_name_map_for_model - App name: {app_label} / model name: {model_name}"
-    )
+    # logger.info(
+    #     f"get_permission_id_to_name_map_for_model - App name: {app_label} / model name: {model_name}"
+    # )
 
     model_type = ContentType.objects.get(app_label=app_label, model=model_name)
     this_model_permission_objs = list(
@@ -171,9 +171,9 @@ def get_permission_id_to_name_map_for_model(
         )
     )
     this_model_permission_id_map = reduce(combine, this_model_permission_objs, {})
-    logger.info(
-        f"get_permission_id_to_name_map_for_model - resulting map: {this_model_permission_id_map}"
-    )
+    # logger.info(
+    #     f"get_permission_id_to_name_map_for_model - resulting map: {this_model_permission_id_map}"
+    # )
     return this_model_permission_id_map
 
 
@@ -184,15 +184,15 @@ def get_users_permissions_for_obj(
 ) -> set[PermissionTypes]:
 
     model_name = instance._meta.model_name
-    logger.info(
-        f"get_users_permissions_for_obj() - Starting check for {user.username} with model type {model_name}"
-    )
+    # logger.info(
+    #     f"get_users_permissions_for_obj() - Starting check for {user.username} with model type {model_name}"
+    # )
 
-    app_label = instance._meta.app_label
-    logger.info(f"get_users_permissions_for_obj - App name: {app_label}")
+    # app_label = instance._meta.app_label
+    # logger.info(f"get_users_permissions_for_obj - App name: {app_label}")
 
     this_user_perms = getattr(instance, f"{model_name}userobjectpermission_set")
-    logger.info(f"get_users_permissions_for_obj - this_user_perms: {this_user_perms}")
+    # logger.info(f"get_users_permissions_for_obj - this_user_perms: {this_user_perms}")
     permission_id_to_name_map = get_permission_id_to_name_map_for_model(
         instance=instance
     )
@@ -239,12 +239,12 @@ def user_has_permission_for_obj(
         user = user_val
 
     model_name = instance._meta.model_name
-    logger.info(
-        f"get_users_permissions_for_obj() - Starting check for {user.username} with model type {model_name}"
-    )
+    # logger.info(
+    #     f"get_users_permissions_for_obj() - Starting check for {user.username} with model type {model_name}"
+    # )
 
-    app_label = instance._meta.app_label
-    logger.info(f"get_users_permissions_for_obj - App name: {app_label}")
+    # app_label = instance._meta.app_label
+    # logger.info(f"get_users_permissions_for_obj - App name: {app_label}")
 
     model_permissions_for_user = get_users_permissions_for_obj(
         user=user,
@@ -252,9 +252,9 @@ def user_has_permission_for_obj(
         include_group_permissions=include_group_permissions,
     )
 
-    logger.info(
-        f"user_has_permission_for_obj - user {user} has model_permissions: {model_permissions_for_user}"
-    )
+    # logger.info(
+    #     f"user_has_permission_for_obj - user {user} has model_permissions: {model_permissions_for_user}"
+    # )
 
     if permission == PermissionTypes.READ:
         return len(model_permissions_for_user.intersection({f"read_{model_name}"})) > 0


### PR DESCRIPTION
Prior to this PR, the only way to authenticate against OpenContracts is to use the JWT token, the password auth (if you've turned off auth0 authentication) or Django's session authentication. None of these are well-suited to server-side connections. It would be nice to be able to connect other backend tools and infrastructure to the platform. 

This PR lets you use Authentication Tokens linked to a particular user's account. It uses DRF's token authentication app (so DRF is a dependency, but we're using this already, so no new dependencies). It provides a Graphene Middleware and an Authentication Backend, the first base on the Graphql JWT Middleware and the latter based on DRF's token auth backend. 
