### PR TITLE
Add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,4 +10,3 @@ docs/
 .coverage
 frontend/node_modules
 opencontractserver/media
-

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+venv/
+uploadfiles/
+staticfiles/
+site/
+.git/
+.github/
+.ipython/
+.pytest_cache/
+docs/
+.coverage
+frontend/node_modules
+opencontractserver/media
+


### PR DESCRIPTION
Currently, there's no .dockerignore, so the context can expand unreasonably, particularly in dev environments.