### PR TITLE
Fix Quickstart Docs

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -50,8 +50,9 @@ This will start docker compose and add a container for the frontend to the stack
 
 __Option 2__ Use Node to Deploy Frontend
 
-If you plan to actively develop the frontend in the [/frontend](/frontend) folder, you can just point your favorite 
-typescript ID to that directory and then run 
+If you plan to actively develop the frontend in the 
+[/frontend](https://github.com/JSv4/OpenContracts/tree/main/frontend) folder, you can just point your favorite 
+typescript ID to that directory and then run:
 
 ```commandline
 yarn install

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -69,7 +69,7 @@ React app.
 
 Congrats! You have OpenContracts running. 
 
-## Step 4: Login and Start Annotating
+## **Step 4**: Login and Start Annotating
 
 If you go to `http://localhost:3000` in your browser, you'll see the login page. You can login with the default username
 and password. These are set in the environment variable file you can find in the `./.envs/.local/' directory. In that 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -7,7 +7,7 @@ do this on Windows too, assuming you have docker compose and docker installed. T
 directories will be different on Windows, but the git, docker and docker-compose commands should all be the
 same.
 
-**Step 1**: Clone this Repo
+## **Step 1**: Clone this Repo
 
 Clone the repository into a local directory of your choice. Here, we assume you are using a folder
 called source in your user's home directory:
@@ -19,7 +19,7 @@ called source in your user's home directory:
     $ git clone https://github.com/JSv4/OpenContracts.git
 ```
 
-**Step 2**: Build the Stack
+## **Step 2**: Build the Stack
 
 Change into the directory of the repository you just cloned, e.g.:
 
@@ -35,16 +35,47 @@ and no configuration is required. If you want to change the
     $ docker-compose -f local.yml build
 ```
 
-Bring up the stack:
+## **Step 3** Choose Frontend Deployment Method
 
-```
-$ docker-compose -f local.yml up
+__Option 1__ Use "Fullstack" Profile in Docker Compose
+
+If you're **not** planning to do any frontend development, the easiest way to get started with OpenContracts is to 
+just type:
+
+```commandline
+    docker-compose -f local.yml --profile fullstack up
 ```
 
-Congrats! You have OpenContracts running. If you go to `http://localhost:3000` in your browser,
-you'll see the login page. You can login with the default username and password. These are set in the
-environment variable file you can find in the `./.envs/.local/' directory. In that directory, you'll see
-a file called `.django`.
+This will start docker compose and add a container for the frontend to the stack. 
+
+__Option 2__ Use Node to Deploy Frontend
+
+If you plan to actively develop the frontend in the [/frontend](/frontend) folder, you can just point your favorite 
+typescript ID to that directory and then run 
+
+```commandline
+yarn install
+``` 
+
+and 
+
+```commandline
+yarn start
+``` 
+
+to bring up the frontend. Then you can edit the frontend code as desired and have it hot reload as you'd expect for a 
+React app.
+
+Congrats! You have OpenContracts running. 
+
+## Step 4: Login and Start Annotating
+
+If you go to `http://localhost:3000` in your browser, you'll see the login page. You can login with the default username
+and password. These are set in the environment variable file you can find in the `./.envs/.local/' directory. In that 
+directory, you'll see a file called `.django`. Backend specific configuration variables go in there. 
+
+**NOTE: The frontend is at port 3000, not 8000, so don't forget to use http://localhost:3000 for frontend access. We 
+have an open issue to add a redirect from the backend root page - http://localhost:8000/ - to http://localhost:3000**.
 
 **Caveats**
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -39,43 +39,43 @@ and no configuration is required. If you want to change the
 
 __Option 1__ Use "Fullstack" Profile in Docker Compose
 
-If you're **not** planning to do any frontend development, the easiest way to get started with OpenContracts is to 
+If you're **not** planning to do any frontend development, the easiest way to get started with OpenContracts is to
 just type:
 
 ```commandline
     docker-compose -f local.yml --profile fullstack up
 ```
 
-This will start docker compose and add a container for the frontend to the stack. 
+This will start docker compose and add a container for the frontend to the stack.
 
 __Option 2__ Use Node to Deploy Frontend
 
-If you plan to actively develop the frontend in the 
-[/frontend](https://github.com/JSv4/OpenContracts/tree/main/frontend) folder, you can just point your favorite 
+If you plan to actively develop the frontend in the
+[/frontend](https://github.com/JSv4/OpenContracts/tree/main/frontend) folder, you can just point your favorite
 typescript ID to that directory and then run:
 
 ```commandline
 yarn install
-``` 
+```
 
-and 
+and
 
 ```commandline
 yarn start
-``` 
+```
 
-to bring up the frontend. Then you can edit the frontend code as desired and have it hot reload as you'd expect for a 
+to bring up the frontend. Then you can edit the frontend code as desired and have it hot reload as you'd expect for a
 React app.
 
-Congrats! You have OpenContracts running. 
+Congrats! You have OpenContracts running.
 
 ## **Step 4**: Login and Start Annotating
 
 If you go to `http://localhost:3000` in your browser, you'll see the login page. You can login with the default username
-and password. These are set in the environment variable file you can find in the `./.envs/.local/' directory. In that 
-directory, you'll see a file called `.django`. Backend specific configuration variables go in there. 
+and password. These are set in the environment variable file you can find in the `./.envs/.local/' directory. In that
+directory, you'll see a file called `.django`. Backend specific configuration variables go in there.
 
-**NOTE: The frontend is at port 3000, not 8000, so don't forget to use http://localhost:3000 for frontend access. We 
+**NOTE: The frontend is at port 3000, not 8000, so don't forget to use http://localhost:3000 for frontend access. We
 have an open issue to add a redirect from the backend root page - http://localhost:8000/ - to http://localhost:3000**.
 
 **Caveats**

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,7 +47,9 @@ nav:
     - Philosophy: philosophy.md
     - Quick-Start: quick-start.md
     - System Requirements: requirements.md
-    - How It Works: under-the-hood.md
+    - How It Works:
+        - Application Architecture: architecture/under-the-hood.md
+        - Asynchronous Processing: architecture/asynchronous-processing.md
     - Acknowledgements: acknowledgements.md
   - Walkthrough:
       - Key-Concepts: walkthrough/key-concepts.md


### PR DESCRIPTION
As pointed out by @nihalgurjar47, the instructions to bring up the frontend locally are missing a critical step. In order to start the frontend in the compose stack you need to add `--profile fullstack` to the `up` command:

```commandline
docker-compose -f local.yml --profile fullstack up
```

Also made it clear that the proper port for the frontend is :3000, not :8000, so go to `http://localhost:3000` to use the application. 

Add this to the quickstart guide. Also fixed some out-of-date nav configurations in the mkdocs.yml file. 

Fixes #83 