### PR TITLE
Added import task to import a single annotated doc. Also added a test.

### DIFF
--- a/config/graphql/mutations.py
+++ b/config/graphql/mutations.py
@@ -11,9 +11,8 @@ from django.core.files.base import ContentFile
 from django.db import transaction
 from django.db.models import Q
 from django.utils import timezone
-
-from graphql import GraphQLError
 from graphene.types.generic import GenericScalar
+from graphql import GraphQLError
 from graphql_jwt.decorators import login_required, user_passes_test
 from graphql_relay import from_global_id, to_global_id
 
@@ -52,8 +51,8 @@ from opencontractserver.tasks import (
     delete_analysis_and_annotations_task,
     fork_corpus,
     import_corpus,
+    import_document_to_corpus,
     package_annotated_docs,
-    import_document_to_corpus
 )
 from opencontractserver.tasks.analyzer_tasks import start_analysis
 from opencontractserver.tasks.doc_tasks import (
@@ -555,7 +554,7 @@ class UploadAnnotatedDocument(graphene.Mutation):
     def mutate(root, info, target_corpus_id, document_import_data):
 
         try:
-            ok=True
+            ok = True
             message = "SUCCESS"
 
             received_json = json.loads(document_import_data)
@@ -567,14 +566,12 @@ class UploadAnnotatedDocument(graphene.Mutation):
             import_document_to_corpus.s(
                 target_corpus_id=target_corpus_id,
                 user_id=info.context.user.id,
-                document_import_data=received_json
+                document_import_data=received_json,
             ).apply_async()
 
         except Exception as e:
             ok = False
-            message = (
-                f"UploadAnnotatedDocument() - could not start load job due to error: {e}"
-            )
+            message = f"UploadAnnotatedDocument() - could not start load job due to error: {e}"
             logger.error(message)
 
         return UploadAnnotatedDocument(message=message, ok=ok)

--- a/opencontractserver/tasks/__init__.py
+++ b/opencontractserver/tasks/__init__.py
@@ -5,6 +5,7 @@ from .fork_tasks import fork_corpus
 from .import_tasks import import_corpus
 from .lookup_tasks import build_label_lookups_task
 from .permissioning_tasks import make_analysis_public_task, make_corpus_public_task
+from .import_tasks import import_document_to_corpus
 
 # Great, quick guidance on how to restructure tasks into multiple modules:
 # https://blog.sneawo.com/blog/2018/12/05/how-to-split-celery-tasks-file/
@@ -18,6 +19,7 @@ __all__ = [
     "fork_corpus",
     "build_label_lookups_task",
     "import_corpus",
+    "import_document_to_corpus",
     "make_corpus_public_task",
     "make_analysis_public_task",
     "delete_analysis_and_annotations_task",

--- a/opencontractserver/tasks/__init__.py
+++ b/opencontractserver/tasks/__init__.py
@@ -2,10 +2,9 @@ from .cleanup_tasks import delete_analysis_and_annotations_task
 from .doc_tasks import burn_doc_annotations
 from .export_tasks import package_annotated_docs
 from .fork_tasks import fork_corpus
-from .import_tasks import import_corpus
+from .import_tasks import import_corpus, import_document_to_corpus
 from .lookup_tasks import build_label_lookups_task
 from .permissioning_tasks import make_analysis_public_task, make_corpus_public_task
-from .import_tasks import import_document_to_corpus
 
 # Great, quick guidance on how to restructure tasks into multiple modules:
 # https://blog.sneawo.com/blog/2018/12/05/how-to-split-celery-tasks-file/

--- a/opencontractserver/tasks/doc_tasks.py
+++ b/opencontractserver/tasks/doc_tasks.py
@@ -6,7 +6,7 @@ import json
 import logging
 import pathlib
 import uuid
-from typing import Any, List, Tuple, Dict
+from typing import Any
 
 from celery import chord, group
 from django.conf import settings
@@ -24,12 +24,13 @@ from opencontractserver.annotations.models import (
 from opencontractserver.documents.models import Document
 from opencontractserver.types.dicts import (
     BoundingBoxPythonType,
+    FunsdAnnotationLoaderMapType,
     FunsdAnnotationType,
     FunsdTokenType,
     LabelLookupPythonType,
     OpenContractDocExport,
     PawlsPagePythonType,
-    PawlsTokenPythonType, FunsdAnnotationLoaderMapType,
+    PawlsTokenPythonType,
 )
 from opencontractserver.utils.etl import build_document_export
 from opencontractserver.utils.pdf import (
@@ -491,7 +492,8 @@ def convert_doc_to_funsd(
 
 @celery_app.task()
 def convert_doc_to_funsd_loader_input(
-    user_id: int, doc_id: int, corpus_id: int) -> Tuple[int, FunsdAnnotationLoaderMapType, List[Tuple[int, str, str]]]:
+    user_id: int, doc_id: int, corpus_id: int
+) -> tuple[int, FunsdAnnotationLoaderMapType, list[tuple[int, str, str]]]:
     def pawls_bbox_to_funsd_box(
         pawls_bbox: BoundingBoxPythonType,
     ) -> tuple[float, float, float, float]:
@@ -590,6 +592,7 @@ def convert_doc_to_funsd_loader_input(
                 annotation_map[page] = [funsd_annotation]
 
     return doc_id, annotation_map, pdf_images_and_data
+
 
 @celery_app.task()
 def extract_thumbnail(*args, doc_id=-1, **kwargs):

--- a/opencontractserver/tasks/doc_tasks.py
+++ b/opencontractserver/tasks/doc_tasks.py
@@ -23,8 +23,6 @@ from opencontractserver.annotations.models import (
 )
 from opencontractserver.documents.models import Document
 from opencontractserver.types.dicts import (
-    BoundingBoxPythonType,
-    FunsdAnnotationLoaderMapType,
     FunsdAnnotationType,
     FunsdTokenType,
     LabelLookupPythonType,
@@ -32,7 +30,7 @@ from opencontractserver.types.dicts import (
     PawlsPagePythonType,
     PawlsTokenPythonType,
 )
-from opencontractserver.utils.etl import build_document_export
+from opencontractserver.utils.etl import build_document_export, pawls_bbox_to_funsd_box
 from opencontractserver.utils.pdf import (
     extract_pawls_from_pdfs_bytes,
     split_pdf_into_images,
@@ -349,16 +347,6 @@ def convert_doc_to_langchain_task(doc_id: int, corpus_id: int) -> tuple[str, dic
 def convert_doc_to_funsd(
     user_id: int, doc_id: int, corpus_id: int
 ) -> tuple[int, dict[int, list[FunsdAnnotationType]], list[tuple[int, str, str]]]:
-    def pawls_bbox_to_funsd_box(
-        pawls_bbox: BoundingBoxPythonType,
-    ) -> tuple[float, float, float, float]:
-        return (
-            pawls_bbox["left"],
-            pawls_bbox["top"],
-            pawls_bbox["right"],
-            pawls_bbox["bottom"],
-        )
-
     def pawls_token_to_funsd_token(pawls_token: PawlsTokenPythonType) -> FunsdTokenType:
         pawls_xleft = pawls_token["x"]
         pawls_ybottom = pawls_token["y"]
@@ -480,110 +468,6 @@ def convert_doc_to_funsd(
                 "box": pawls_bbox_to_funsd_box(page_annot_json["bounds"]),
                 "label": f"{label.text}",
                 "words": expanded_tokens,
-            }
-
-            if page in annotation_map:
-                annotation_map[page].append(funsd_annotation)
-            else:
-                annotation_map[page] = [funsd_annotation]
-
-    return doc_id, annotation_map, pdf_images_and_data
-
-
-@celery_app.task()
-def convert_doc_to_funsd_loader_input(
-    user_id: int, doc_id: int, corpus_id: int
-) -> tuple[int, FunsdAnnotationLoaderMapType, list[tuple[int, str, str]]]:
-    def pawls_bbox_to_funsd_box(
-        pawls_bbox: BoundingBoxPythonType,
-    ) -> tuple[float, float, float, float]:
-        return (
-            pawls_bbox["left"],
-            pawls_bbox["top"],
-            pawls_bbox["right"],
-            pawls_bbox["bottom"],
-        )
-
-    def pawls_token_to_funsd_token(pawls_token: PawlsTokenPythonType) -> FunsdTokenType:
-        pawls_xleft = pawls_token["x"]
-        pawls_ybottom = pawls_token["y"]
-        pawls_ytop = pawls_xleft + pawls_token["width"]
-        pawls_xright = pawls_ybottom + pawls_token["height"]
-        funsd_token = {
-            "text": pawls_token["text"],
-            "box": (pawls_xleft, pawls_ytop, pawls_xright, pawls_ybottom),
-        }
-        return funsd_token
-
-    def label_to_ner_tag(label: str) -> str:
-        mapping = {
-            "header": "HEADER",
-            "question": "QUESTION",
-            "answer": "ANSWER",
-        }
-        for key, value in mapping.items():
-            if key in label.lower():
-                return value
-        return "O"
-
-    doc = Document.objects.get(id=doc_id)
-
-    annotation_map: dict[int, list[dict]] = {}
-
-    token_annotations = Annotation.objects.filter(
-        annotation_label__label_type=TOKEN_LABEL,
-        document_id=doc_id,
-        corpus_id=corpus_id,
-    ).order_by("page")
-
-    file_object = default_storage.open(doc.pawls_parse_file.name)
-    pawls_tokens = json.loads(file_object.read().decode("utf-8"))
-
-    pdf_object = default_storage.open(doc.pdf_file.name)
-    pdf_bytes = pdf_object.read()
-    pdf_images = split_pdf_into_images(
-        pdf_bytes, storage_path=f"user_{user_id}/pdf_page_images"
-    )
-    pdf_images_and_data = list(
-        zip(
-            [doc_id for _ in range(len(pdf_images))],
-            pdf_images,
-            ["PNG" for _ in range(len(pdf_images))],
-        )
-    )
-    logger.info(f"convert_doc_to_funsd() - pdf_images: {pdf_images}")
-
-    for annotation in token_annotations:
-
-        base_id = f"{annotation.id}"
-        annot_json = annotation.json
-        label = annotation.annotation_label
-
-        for page in annot_json.keys():
-
-            page_annot_json = annot_json[page]
-            page_token_refs = page_annot_json["tokensJsons"]
-
-            expanded_tokens = []
-            expanded_bboxes = []
-            ner_tags = []
-
-            for token_ref in page_token_refs:
-                page_index = token_ref["pageIndex"]
-                token_index = token_ref["tokenIndex"]
-                token = pawls_tokens[page_index]["tokens"][token_index]
-
-                # Convert token from PAWLS to FUNSD format
-                expanded_tokens.append(token["text"])
-                expanded_bboxes.append(pawls_bbox_to_funsd_box(token))
-                ner_tags.append(f"B-{label_to_ner_tag(label.text)}")
-
-            funsd_annotation = {
-                "id": f"{base_id}-{page}",
-                "tokens": expanded_tokens,
-                "bboxes": expanded_bboxes,
-                "ner_tags": ner_tags,
-                "image": pdf_images_and_data[int(page) - 1],
             }
 
             if page in annotation_map:

--- a/opencontractserver/tasks/export_tasks.py
+++ b/opencontractserver/tasks/export_tasks.py
@@ -15,7 +15,7 @@ from django.utils import timezone
 from opencontractserver.corpuses.models import Corpus
 from opencontractserver.types.dicts import (
     FunsdAnnotationType,
-    OpenContractDocAnnotationExport,
+    OpenContractDocExport,
     OpenContractsExportDataJsonPythonType,
 )
 from opencontractserver.types.enums import AnnotationLabelPythonType
@@ -39,7 +39,7 @@ def package_annotated_docs(
         tuple[
             str | None,
             str | None,
-            OpenContractDocAnnotationExport | None,
+            OpenContractDocExport | None,
             dict[str | int, AnnotationLabelPythonType],
             dict[str | int, AnnotationLabelPythonType],
         ]
@@ -163,8 +163,6 @@ def package_funsd_exports(
         s3 = boto3.client("s3")
 
     for doc_data in funsd_data:
-
-        print(f"Doc data: {doc_data}")
 
         doc_id, funsd_annotations, page_image_paths = doc_data
 

--- a/opencontractserver/tasks/import_tasks.py
+++ b/opencontractserver/tasks/import_tasks.py
@@ -1,3 +1,4 @@
+import base64
 import json
 import logging
 import zipfile
@@ -8,10 +9,11 @@ from django.core.files.base import ContentFile, File
 
 from config import celery_app
 from config.graphql.serializers import AnnotationLabelSerializer
-from opencontractserver.annotations.models import Annotation
-from opencontractserver.corpuses.models import TemporaryFileHandle
+from opencontractserver.annotations.models import Annotation, TOKEN_LABEL, DOC_TYPE_LABEL, METADATA_LABEL
+from opencontractserver.corpuses.models import TemporaryFileHandle, Corpus
 from opencontractserver.documents.models import Document
-from opencontractserver.types.dicts import OpenContractsExportDataJsonPythonType
+from opencontractserver.types.dicts import OpenContractsExportDataJsonPythonType, \
+    OpenContractsAnnotatedDocumentImportType
 from opencontractserver.types.enums import PermissionTypes
 from opencontractserver.utils.packaging import (
     unpack_corpus_from_export,
@@ -65,15 +67,16 @@ def import_corpus(
                         text_labels = data_json["text_labels"]
                         doc_labels = data_json["doc_labels"]
 
-                        label_set_data = {**data_json["label_set"]}
-                        label_set_data.pop("id")
+                        label_set_data = {**data_json["label_set"]}  # noqa
+                        label_set_data.pop("id")   # noqa
 
                         corpus_data = {**data_json["corpus"]}
                         corpus_data.pop("id")
 
                         # Create labelset by loading JSON and converting to Django with DRF serializer
                         labelset_obj = unpack_label_set_from_export(
-                            data=label_set_data, user=user_obj
+                            data=label_set_data,  # noqa
+                            user=user_obj
                         )
                         logger.info(f"LabelSet created: {labelset_obj}")
 
@@ -81,14 +84,14 @@ def import_corpus(
                         # immediately), this gets mixed in and passed to the serializer
                         if seed_corpus_id:
                             corpus_obj = unpack_corpus_from_export(
-                                data=corpus_data,
+                                data=corpus_data,  # noqa
                                 user=user_obj,
                                 label_set_id=labelset_obj.id,
                                 corpus_id=seed_corpus_id,
                             )
                         else:
                             corpus_obj = unpack_corpus_from_export(
-                                data=corpus_data,
+                                data=corpus_data,  # noqa
                                 user=user_obj,
                                 label_set_id=labelset_obj.id,
                                 corpus_id=None,
@@ -272,4 +275,141 @@ def import_corpus(
 
     except Exception as e:
         logger.error(f"import_corpus() - Exception encountered in corpus import: {e}")
+        return None
+
+@celery_app.task()
+def import_document_to_corpus(
+    target_corpus_id: int,
+    user_id: int,
+    document_import_data: OpenContractsAnnotatedDocumentImportType,
+) -> Optional[str]:
+
+    try:
+        logger.info(f"import_document_to_corpus() - for user_id: {user_id}")
+
+        # Load target corpus
+        corpus_obj = Corpus.objects.get(id=target_corpus_id)
+
+        # Load labelsets
+        labelset_obj = corpus_obj.label_set
+
+        # Load existing labels
+        existing_text_labels = {
+            label.text: label for label in labelset_obj.annotation_labels.filter(label_type=TOKEN_LABEL)
+        }
+        existing_doc_labels = {
+            label.text: label for label in labelset_obj.annotation_labels.filter(label_type=DOC_TYPE_LABEL)
+        }
+        existing_metadata_labels = {
+            label.text: label for label in labelset_obj.annotation_labels.filter(label_type=METADATA_LABEL)
+        }
+
+        # Create new labels if needed
+        for label_name, label_data in document_import_data["text_labels"].items():
+            if label_name not in existing_text_labels:
+                label_data = document_import_data["text_labels"][label_name]
+                label_data.pop("id")  # noqa
+                label_data["creator"] = user_id  # noqa
+
+                label_serializer = AnnotationLabelSerializer(data=label_data)
+                label_serializer.is_valid(raise_exception=True)
+                label_obj = label_serializer.save()
+                set_permissions_for_obj_to_user(
+                    user_id, label_obj, [PermissionTypes.ALL]
+                )
+                labelset_obj.annotation_labels.add(label_obj)
+                existing_text_labels[label_name] = label_obj
+
+        for label_name, label_data in document_import_data["doc_labels"].items():
+            if label_name not in existing_doc_labels:
+                label_data = document_import_data["doc_labels"][label_name]
+                label_data.pop("id")  # noqa
+                label_data["creator"] = user_id  # noqa
+
+                label_serializer = AnnotationLabelSerializer(data=label_data)
+                label_serializer.is_valid(raise_exception=True)
+                label_obj = label_serializer.save()
+                set_permissions_for_obj_to_user(
+                    user_id, label_obj, [PermissionTypes.ALL]
+                )
+
+                labelset_obj.annotation_labels.add(label_obj)
+                existing_doc_labels[label_name] = label_obj
+
+        for label_name, label_data in document_import_data["metadata_labels"].items():
+            if label_name not in existing_metadata_labels:
+                label_data = document_import_data["doc_labels"][label_name]
+                label_data.pop("id")  # noqa
+                label_data["creator"] = user_id  # noqa
+
+                label_serializer = AnnotationLabelSerializer(data=label_data)
+                label_serializer.is_valid(raise_exception=True)
+                label_obj = label_serializer.save()
+                set_permissions_for_obj_to_user(
+                    user_id, label_obj, [PermissionTypes.ALL]
+                )
+
+                labelset_obj.annotation_labels.add(label_obj)
+                existing_metadata_labels[label_name] = label_obj
+
+        # Import the document
+
+        pdf_base64 = document_import_data["pdf_base64"]
+        pdf_data = base64.b64decode(pdf_base64)
+
+        pdf_file = ContentFile(pdf_data, name=f"{document_import_data['pdf_name']}.pdf")
+        pawls_parse_file = ContentFile(
+            json.dumps(document_import_data['doc_data']['pawls_file_content']).encode("utf-8"),
+            name="pawls_tokens.json",
+        )
+
+        doc_obj = Document.objects.create(
+            title=document_import_data["doc_data"]["title"],
+            description=document_import_data['doc_data']["description"] if document_import_data['doc_data'][
+            'description'] else "No Description",
+            pdf_file=pdf_file,
+            pawls_parse_file=pawls_parse_file,
+            creator_id=user_id,
+            page_count=document_import_data['doc_data']['page_count'],
+
+        )
+        set_permissions_for_obj_to_user(user_id, doc_obj, [PermissionTypes.ALL])
+
+        # Link to corpus
+        corpus_obj.documents.add(doc_obj)
+        corpus_obj.save()
+
+        # Import the annotations for the document
+        doc_annotations_data = document_import_data["doc_data"]["labelled_text"]
+        for annotation in doc_annotations_data:
+            label_obj = existing_text_labels[annotation["annotationLabel"]]
+            annot_obj = Annotation.objects.create(
+                raw_text=annotation["rawText"],
+                page=annotation["page"],
+                json=annotation["annotation_json"],
+                annotation_label=label_obj,
+                document=doc_obj,
+                corpus=corpus_obj,
+                creator_id=user_id,
+            )
+            annot_obj.save()
+            set_permissions_for_obj_to_user(user_id, annot_obj, [PermissionTypes.ALL])
+
+        for doc_label in document_import_data["doc_data"]["doc_labels"]:
+            label_obj = existing_doc_labels[doc_label]
+            annot_obj = Annotation(
+                annotation_label=label_obj,
+                document=doc_obj,
+                corpus=corpus_obj,
+                creator_id=user_id,
+            )
+            annot_obj.save()
+            set_permissions_for_obj_to_user(user_id, annot_obj, [PermissionTypes.ALL])
+
+        return doc_obj.id
+
+    except Exception as e:
+        logger.error(
+            f"import_document_to_corpus() - Exception encountered in document import: {e}"
+        )
         return None

--- a/opencontractserver/tests/test_annotated_document_import.py
+++ b/opencontractserver/tests/test_annotated_document_import.py
@@ -1,0 +1,144 @@
+#  Copyright (C) 2022  John Scrudato / Gordium Knot Inc. d/b/a OpenSource.Legal
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Affero General Public License as
+#  published by the Free Software Foundation, either version 3 of the
+#  License, or (at your option) any later version.
+
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Affero General Public License for more details.
+
+#  You should have received a copy of the GNU Affero General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+import base64
+import json
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from pypdf import PdfReader
+
+from opencontractserver.annotations.models import AnnotationLabel, LabelSet
+from opencontractserver.corpuses.models import Corpus
+from opencontractserver.documents.models import Document
+from opencontractserver.tasks.import_tasks import import_document_to_corpus
+from opencontractserver.tests.fixtures import SAMPLE_PDF_FILE_TWO_PATH
+from opencontractserver.types.dicts import OpenContractsAnnotatedDocumentImportType
+from opencontractserver.types.enums import LabelType
+
+User = get_user_model()
+
+
+class TestImportDocumentToCorpus(TestCase):
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="testuser", password="testpassword"
+        )
+        self.label_set = LabelSet.objects.create(
+            title="Test Label Set",
+            description="Test Label Set Description",
+            creator=self.user,
+        )
+        self.corpus = Corpus.objects.create(
+            title="Test Corpus",
+            description="Test Corpus Description",
+            label_set=self.label_set,
+            creator=self.user,
+        )
+
+    def test_import_document_to_corpus(self):
+        # Read the test PDF file and convert it to base64
+        with open(SAMPLE_PDF_FILE_TWO_PATH, "rb") as pdf_file:
+            pdf_data = pdf_file.read()
+            pdf_base64 = base64.b64encode(pdf_data).decode("utf-8")
+
+        # Create test labels
+        text_labels = {
+            "test_text_label": {
+                "id": "0",
+                "color": "red",
+                "description": "Test Text Label",
+                "icon": "tags",
+                "text": "test_text_label",
+                "label_type": LabelType.TOKEN_LABEL.value,
+            }
+        }
+        doc_labels = {
+            "test_doc_label": {
+                "id": "1",
+                "color": "yellow",
+                "description": "Test Doc Label",
+                "icon": "tags",
+                "text": "test_doc_label",
+                "label_type": LabelType.DOC_TYPE_LABEL.value,
+            }
+        }
+
+        # Create test annotations
+        annotations = [
+            {
+                "id": None,
+                "annotationLabel": "test_text_label",
+                "rawText": "Test Text",
+                "page": 1,
+                "annotation_json": {"1": {"bounds": {"top": 0, "bottom": 1, "left": 0, "right": 1},
+                                            "tokensJsons": [{"pageIndex": 1, "tokenIndex": 0}], "rawText": "Test Text"}}
+            }
+        ]
+
+        # Create test data for import_document_to_corpus
+        document_import_data: OpenContractsAnnotatedDocumentImportType = {
+            "doc_data": {
+                "title": "Test Document",
+                "content": "Dummy",
+                "description": "Dummy",
+                "doc_labels": ["test_doc_label"],
+                "labelled_text": annotations,
+                "page_count": 1,
+                "pawls_file_content": [
+                    {
+                        "page": {"width": 100, "height": 100, "index": 1},
+                        "tokens": [
+                            {"x": 0, "y": 0, "width": 10, "height": 10, "text": "Test"}
+                        ],
+                    }
+                ],
+            },
+            "pdf_name": "test_document",
+            "pdf_base64": pdf_base64,
+            "text_labels": text_labels,
+            "doc_labels": doc_labels,
+            "metadata_labels": {}
+        }
+
+        # Call the import_document_to_corpus task
+        document_id = import_document_to_corpus(self.corpus.id, self.user.id, document_import_data)
+
+        # Check that the document was created
+        document = Document.objects.get(id=document_id)
+        self.assertEqual(document.title, "Test Document")
+
+        # Check that the labels were created
+        self.assertEqual(AnnotationLabel.objects.filter(text="test_text_label").count(), 1)
+        self.assertEqual(AnnotationLabel.objects.filter(text="test_doc_label").count(), 1)
+
+        # Check that the annotations were created
+        annotations = document.doc_annotations.all()
+        self.assertEqual(annotations.count(), 2)
+        self.assertEqual(annotations.filter(annotation_label__text="test_text_label").count(), 1)
+        self.assertEqual(annotations.filter(annotation_label__text="test_doc_label").count(), 1)
+
+        # Check that the PDF file was imported correctly
+        with document.pdf_file.open("rb") as pdf_file:
+            pdf_reader = PdfReader(pdf_file)
+            self.assertEqual(len(pdf_reader.pages), 9)
+
+        # Check that the PAWLS file was imported correctly
+        with document.pawls_parse_file.open("r") as pawls_file:
+            pawls_data = json.load(pawls_file)
+            self.assertEqual(len(pawls_data), 1)
+            self.assertEqual(len(pawls_data[0]["tokens"]), 1)
+            self.assertEqual(pawls_data[0]["tokens"][0]["text"], "Test")
+

--- a/opencontractserver/tests/test_annotated_document_import.py
+++ b/opencontractserver/tests/test_annotated_document_import.py
@@ -31,7 +31,6 @@ User = get_user_model()
 
 
 class TestImportDocumentToCorpus(TestCase):
-
     def setUp(self):
         self.user = User.objects.create_user(
             username="testuser", password="testpassword"
@@ -83,8 +82,13 @@ class TestImportDocumentToCorpus(TestCase):
                 "annotationLabel": "test_text_label",
                 "rawText": "Test Text",
                 "page": 1,
-                "annotation_json": {"1": {"bounds": {"top": 0, "bottom": 1, "left": 0, "right": 1},
-                                            "tokensJsons": [{"pageIndex": 1, "tokenIndex": 0}], "rawText": "Test Text"}}
+                "annotation_json": {
+                    "1": {
+                        "bounds": {"top": 0, "bottom": 1, "left": 0, "right": 1},
+                        "tokensJsons": [{"pageIndex": 1, "tokenIndex": 0}],
+                        "rawText": "Test Text",
+                    }
+                },
             }
         ]
 
@@ -110,25 +114,35 @@ class TestImportDocumentToCorpus(TestCase):
             "pdf_base64": pdf_base64,
             "text_labels": text_labels,
             "doc_labels": doc_labels,
-            "metadata_labels": {}
+            "metadata_labels": {},
         }
 
         # Call the import_document_to_corpus task
-        document_id = import_document_to_corpus(self.corpus.id, self.user.id, document_import_data)
+        document_id = import_document_to_corpus(
+            self.corpus.id, self.user.id, document_import_data
+        )
 
         # Check that the document was created
         document = Document.objects.get(id=document_id)
         self.assertEqual(document.title, "Test Document")
 
         # Check that the labels were created
-        self.assertEqual(AnnotationLabel.objects.filter(text="test_text_label").count(), 1)
-        self.assertEqual(AnnotationLabel.objects.filter(text="test_doc_label").count(), 1)
+        self.assertEqual(
+            AnnotationLabel.objects.filter(text="test_text_label").count(), 1
+        )
+        self.assertEqual(
+            AnnotationLabel.objects.filter(text="test_doc_label").count(), 1
+        )
 
         # Check that the annotations were created
         annotations = document.doc_annotations.all()
         self.assertEqual(annotations.count(), 2)
-        self.assertEqual(annotations.filter(annotation_label__text="test_text_label").count(), 1)
-        self.assertEqual(annotations.filter(annotation_label__text="test_doc_label").count(), 1)
+        self.assertEqual(
+            annotations.filter(annotation_label__text="test_text_label").count(), 1
+        )
+        self.assertEqual(
+            annotations.filter(annotation_label__text="test_doc_label").count(), 1
+        )
 
         # Check that the PDF file was imported correctly
         with document.pdf_file.open("rb") as pdf_file:
@@ -141,4 +155,3 @@ class TestImportDocumentToCorpus(TestCase):
             self.assertEqual(len(pawls_data), 1)
             self.assertEqual(len(pawls_data[0]["tokens"]), 1)
             self.assertEqual(pawls_data[0]["tokens"][0]["text"], "Test")
-

--- a/opencontractserver/tests/test_graphql_import_export_mutations.py
+++ b/opencontractserver/tests/test_graphql_import_export_mutations.py
@@ -132,8 +132,13 @@ class GraphQLTestCase(TestCase):
                 "annotationLabel": "test_text_label",
                 "rawText": "Test Text",
                 "page": 1,
-                "annotation_json": {"1": {"bounds": {"top": 0, "bottom": 1, "left": 0, "right": 1},
-                                            "tokensJsons": [{"pageIndex": 1, "tokenIndex": 0}], "rawText": "Test Text"}}
+                "annotation_json": {
+                    "1": {
+                        "bounds": {"top": 0, "bottom": 1, "left": 0, "right": 1},
+                        "tokensJsons": [{"pageIndex": 1, "tokenIndex": 0}],
+                        "rawText": "Test Text",
+                    }
+                },
             }
         ]
 
@@ -159,10 +164,10 @@ class GraphQLTestCase(TestCase):
             "pdf_base64": pdf_base64,
             "text_labels": text_labels,
             "doc_labels": doc_labels,
-            "metadata_labels": {}
+            "metadata_labels": {},
         }
 
-        mutation =  """
+        mutation = """
             mutation ImportAnnotatedDocToCorpus($targetCorpusId: String!, $documentImportData: String!) {
                 importAnnotatedDocToCorpus(targetCorpusId: $targetCorpusId, documentImportData:
                 $documentImportData) {
@@ -177,10 +182,7 @@ class GraphQLTestCase(TestCase):
             "documentImportData": json.dumps(document_import_data),
         }
 
-        response = client.execute(
-            mutation,
-            variables=variables
-        )
+        response = client.execute(mutation, variables=variables)
 
         print(f"Test response: {response}")
 

--- a/opencontractserver/tests/test_graphql_import_export_mutations.py
+++ b/opencontractserver/tests/test_graphql_import_export_mutations.py
@@ -1,13 +1,21 @@
+import base64
+import json
 import pathlib
 
 from django.contrib.auth import get_user_model
 from django.db import transaction
 from django.test import TestCase
 from graphene.test import Client
+from graphql_relay import to_global_id
 
 from config.graphql.schema import schema
 from config.graphql.serializers import CorpusSerializer
+from opencontractserver.annotations.models import LabelSet
+from opencontractserver.corpuses.models import Corpus
 from opencontractserver.tasks.utils import package_zip_into_base64
+from opencontractserver.tests.fixtures import SAMPLE_PDF_FILE_TWO_PATH
+from opencontractserver.types.dicts import OpenContractsAnnotatedDocumentImportType
+from opencontractserver.types.enums import LabelType
 
 User = get_user_model()
 
@@ -58,6 +66,17 @@ class GraphQLTestCase(TestCase):
                 password="12345678",
                 is_usage_capped=False,  # Otherwise no importing...
             )
+            self.label_set = LabelSet.objects.create(
+                title="Test Label Set",
+                description="Test Label Set Description",
+                creator=self.user,
+            )
+            self.corpus = Corpus.objects.create(
+                title="Test Corpus",
+                description="Test Corpus Description",
+                label_set=self.label_set,
+                creator=self.user,
+            )
 
     def test_zip_upload(self):
 
@@ -75,3 +94,95 @@ class GraphQLTestCase(TestCase):
         assert executed["data"]["importOpenContractsZip"]["message"] == "Started"
 
         # NOTE - in our current test environment, celery worker is not booted... so this never runs
+
+    def test_import_document_to_corpus_mutation(self):
+
+        client = Client(schema, context_value=TestContext(self.user))
+
+        with open(SAMPLE_PDF_FILE_TWO_PATH, "rb") as pdf_file:
+            pdf_data = pdf_file.read()
+            pdf_base64 = base64.b64encode(pdf_data).decode("utf-8")
+
+        # Create test labels
+        text_labels = {
+            "test_text_label": {
+                "id": "0",
+                "color": "red",
+                "description": "Test Text Label",
+                "icon": "tags",
+                "text": "test_text_label",
+                "label_type": LabelType.TOKEN_LABEL.value,
+            }
+        }
+        doc_labels = {
+            "test_doc_label": {
+                "id": "1",
+                "color": "yellow",
+                "description": "Test Doc Label",
+                "icon": "tags",
+                "text": "test_doc_label",
+                "label_type": LabelType.DOC_TYPE_LABEL.value,
+            }
+        }
+
+        # Create test annotations
+        annotations = [
+            {
+                "id": None,
+                "annotationLabel": "test_text_label",
+                "rawText": "Test Text",
+                "page": 1,
+                "annotation_json": {"1": {"bounds": {"top": 0, "bottom": 1, "left": 0, "right": 1},
+                                            "tokensJsons": [{"pageIndex": 1, "tokenIndex": 0}], "rawText": "Test Text"}}
+            }
+        ]
+
+        # Create test data for import_document_to_corpus
+        document_import_data: OpenContractsAnnotatedDocumentImportType = {
+            "doc_data": {
+                "title": "Test Document",
+                "content": "Dummy",
+                "description": "Dummy",
+                "doc_labels": ["test_doc_label"],
+                "labelled_text": annotations,
+                "page_count": 1,
+                "pawls_file_content": [
+                    {
+                        "page": {"width": 100, "height": 100, "index": 1},
+                        "tokens": [
+                            {"x": 0, "y": 0, "width": 10, "height": 10, "text": "Test"}
+                        ],
+                    }
+                ],
+            },
+            "pdf_name": "test_document",
+            "pdf_base64": pdf_base64,
+            "text_labels": text_labels,
+            "doc_labels": doc_labels,
+            "metadata_labels": {}
+        }
+
+        mutation =  """
+            mutation ImportAnnotatedDocToCorpus($targetCorpusId: String!, $documentImportData: String!) {
+                importAnnotatedDocToCorpus(targetCorpusId: $targetCorpusId, documentImportData:
+                $documentImportData) {
+                    ok
+                    message
+                }
+            }
+        """
+
+        variables = {
+            "targetCorpusId": to_global_id("CorpusType", self.corpus.id),
+            "documentImportData": json.dumps(document_import_data),
+        }
+
+        response = client.execute(
+            mutation,
+            variables=variables
+        )
+
+        print(f"Test response: {response}")
+
+        assert response["data"]["importAnnotatedDocToCorpus"]["ok"] is True
+        assert response["data"]["importAnnotatedDocToCorpus"]["message"] == "SUCCESS"

--- a/opencontractserver/types/dicts.py
+++ b/opencontractserver/types/dicts.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union, List, Tuple
+from typing import Optional, Union
 
 from typing_extensions import NotRequired, TypedDict
 
@@ -48,13 +48,15 @@ class FunsdAnnotationType(TypedDict):
 
 class FunsdAnnotationLoaderOutputType(TypedDict):
     id: str
-    tokens: List[str]
-    bboxes: List[Tuple[float, float, float, float]]
-    ner_tags: List[str]
-    image: Tuple[int, str, str]  # (doc_id, image_data, image_format)
+    tokens: list[str]
+    bboxes: list[tuple[float, float, float, float]]
+    ner_tags: list[str]
+    image: tuple[int, str, str]  # (doc_id, image_data, image_format)
+
 
 class FunsdAnnotationLoaderMapType(TypedDict):
-    page: List[FunsdAnnotationLoaderOutputType]
+    page: list[FunsdAnnotationLoaderOutputType]
+
 
 class PageFundsAnnotationsExportType(TypedDict):
     form: list[FunsdAnnotationType]

--- a/opencontractserver/types/dicts.py
+++ b/opencontractserver/types/dicts.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union
+from typing import Optional, Union, List, Tuple
 
 from typing_extensions import NotRequired, TypedDict
 
@@ -45,6 +45,16 @@ class FunsdAnnotationType(TypedDict):
     linking: list[int]
     id: str | int
 
+
+class FunsdAnnotationLoaderOutputType(TypedDict):
+    id: str
+    tokens: List[str]
+    bboxes: List[Tuple[float, float, float, float]]
+    ner_tags: List[str]
+    image: Tuple[int, str, str]  # (doc_id, image_data, image_format)
+
+class FunsdAnnotationLoaderMapType(TypedDict):
+    page: List[FunsdAnnotationLoaderOutputType]
 
 class PageFundsAnnotationsExportType(TypedDict):
     form: list[FunsdAnnotationType]
@@ -171,7 +181,7 @@ class OpenContractsDocAnnotations(TypedDict):
     labelled_text: list[OpenContractsAnnotationPythonType]
 
 
-class OpenContractDocAnnotationExport(OpenContractsDocAnnotations):
+class OpenContractDocExport(OpenContractsDocAnnotations):
     """
     Eech individual documents annotations are exported and imported into
     and out of jsons with this form. Inherits doc_labels and labelled_text
@@ -183,6 +193,9 @@ class OpenContractDocAnnotationExport(OpenContractsDocAnnotations):
 
     # Document text
     content: str
+
+    # Document description
+    description: Optional[str]
 
     # Documents PAWLS parse file contents (serialized)
     pawls_file_content: list[PawlsPagePythonType]
@@ -220,7 +233,7 @@ class OpenContractsExportDataJsonPythonType(TypedDict):
     """
 
     # Lookup of pdf filename to the corresponding Annotation data
-    annotated_docs: dict[str, OpenContractDocAnnotationExport]
+    annotated_docs: dict[str, OpenContractDocExport]
 
     # Requisite labels, mapped from label name to label data
     doc_labels: dict[str, AnnotationLabelPythonType]
@@ -233,6 +246,31 @@ class OpenContractsExportDataJsonPythonType(TypedDict):
 
     # Stores the label set (todo - make sure the icon gets stored as base64)
     label_set: OpenContractsLabelSetType
+
+
+class OpenContractsAnnotatedDocumentImportType(TypedDict):
+    """
+    This is the type of the data.json that goes into our import for a single
+    document with its annotations and labels.
+    """
+
+    # Document title
+    doc_data: OpenContractDocExport
+
+    # Document pdf as base64 string
+    pdf_base64: str
+
+    # Document name
+    pdf_name: str
+
+    # Lookup of pdf filename to the corresponding Annotation data
+    doc_labels: dict[str, AnnotationLabelPythonType]
+
+    # Requisite text labels, mapped from label name to label data
+    text_labels: dict[str, AnnotationLabelPythonType]
+
+    # Requisite metadata labels, mapped from label name to label data
+    metadata_labels: dict[str, AnnotationLabelPythonType]
 
 
 class OpenContractsAnalysisTaskResult(TypedDict):

--- a/opencontractserver/utils/etl.py
+++ b/opencontractserver/utils/etl.py
@@ -15,7 +15,7 @@ from opencontractserver.corpuses.models import Corpus
 from opencontractserver.documents.models import Document
 from opencontractserver.types.dicts import (
     LabelLookupPythonType,
-    OpenContractDocAnnotationExport,
+    OpenContractDocExport,
     OpenContractsSinglePageAnnotationType,
     PawlsPagePythonType,
 )
@@ -82,7 +82,7 @@ def build_label_lookups(corpus_id: str) -> LabelLookupPythonType:
 
 def build_document_export(
     label_lookups: LabelLookupPythonType, doc_id: int, corpus_id: int
-) -> tuple[str, str, OpenContractDocAnnotationExport | None, Any, Any]:
+) -> tuple[str, str, OpenContractDocExport | None, Any, Any]:
 
     """
     Fairly complex function to burn in the annotations for a given corpus on a given doc. This will alter the PDF
@@ -145,7 +145,7 @@ def build_document_export(
 
         page_highlights = {}
 
-        doc_annotation_json: OpenContractDocAnnotationExport = {
+        doc_annotation_json: OpenContractDocExport = {
             "doc_labels": [],
             "labelled_text": [],
             "title": doc.title,

--- a/opencontractserver/utils/etl.py
+++ b/opencontractserver/utils/etl.py
@@ -14,6 +14,7 @@ from opencontractserver.annotations.models import Annotation
 from opencontractserver.corpuses.models import Corpus
 from opencontractserver.documents.models import Document
 from opencontractserver.types.dicts import (
+    BoundingBoxPythonType,
     LabelLookupPythonType,
     OpenContractDocExport,
     OpenContractsSinglePageAnnotationType,
@@ -319,3 +320,14 @@ def is_dict_instance_of_typed_dict(instance: dict, typed_dict: type[TypedDict]):
     except pydantic.ValidationError as exc:
         print(f"ERROR: Invalid schema: {exc}")
         return False
+
+
+def pawls_bbox_to_funsd_box(
+    pawls_bbox: BoundingBoxPythonType,
+) -> tuple[float, float, float, float]:
+    return (
+        pawls_bbox["left"],
+        pawls_bbox["top"],
+        pawls_bbox["right"],
+        pawls_bbox["bottom"],
+    )

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -42,3 +42,7 @@ factory-boy==3.2.1  # https://github.com/FactoryBoy/factory_boy
 django-debug-toolbar==3.7.0  # https://github.com/jazzband/django-debug-toolbar
 django-coverage-plugin==2.0.3  # https://github.com/nedbat/django_coverage_plugin
 pytest-django==4.5.2  # https://github.com/pytest-dev/pytest-django
+
+# PDFs
+# ------------------------------------------------------------------------------
+pypdf


### PR DESCRIPTION
## Summary

This PR borrows code from the `import_corpus` task and creates a new task called `import_document_to_corpus`. The new task is designed to import a single document with its annotations and labels into an existing corpus. To achieve this, we introduced a new data type called `OpenContractsAnnotatedDocumentImportType`, which represents the JSON data structure for importing a single document along with its annotations and labels. The PDF for the document is converted to a base64 string and provided as a property in this data type.

Major changes in this PR include:
- Introduced `OpenContractsAnnotatedDocumentImportType` data type for importing a single document and its annotations and labels.
- Refactored `import_corpus` task into `import_document_to_corpus` task, which accepts the id of the target corpus and the new data type `OpenContractsAnnotatedDocumentImportType`.
- The task checks if new labels need to be created, creates them if necessary, imports the document, and finally imports the annotations for the document.
- Added a test for the `import_document_to_corpus` task in `test_tasks.py`.
- Added mutation `UploadAnnotatedDocument`: This mutation is responsible for uploading a single annotated document to an existing corpus. It takes two required arguments: `target_corpus_id` and `document_import_data`. The `target_corpus_id` is the ID of the target corpus to which the document will be added. The `document_import_data` is a string representation of the `OpenContractsAnnotatedDocumentImportType` object that contains the necessary information about the document, annotations, and labels. The mutation calls the `import_document_to_corpus` task with the provided arguments and applies it asynchronously.
- Added test `test_upload_annotated_document`: This test is designed to check whether the `UploadAnnotatedDocument` mutation works as expected. It sets up the necessary test environment with prerequisites such as a user, a corpus, and sample import data. The test then prepares the `upload_annotated_document_mutation` to be executed with the given variables (corpus ID and document import data). After executing the mutation, the test checks whether the response contains "ok" as `True` and the message as "SUCCESS`, indicating that the task started successfully.
