### PR TITLE
Fix Broken Coordinate System in Parser 

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -28,8 +28,7 @@ const onRedirectCallback = (appState: any) => {
 
 const { REACT_APP_USE_AUTH0 } = process.env;
 
-
-const api_root_url='http://localhost:8000'
+const api_root_url = "http://localhost:8000";
 
 console.log("OpenContracts is using Auth0: ", REACT_APP_USE_AUTH0);
 console.log("OpenContracts frontend target api root", api_root_url);
@@ -45,7 +44,7 @@ const authLink = new ApolloLink((operation, forward) => {
   return forward(operation);
 });
 
-console.log("api_root_url", api_root_url)
+console.log("api_root_url", api_root_url);
 const httpLink = createHttpLink({
   uri: `${api_root_url}/graphql/`,
 });

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -23,8 +23,13 @@ const onRedirectCallback = (appState: any) => {
   );
 };
 
-const { REACT_APP_USE_AUTH0, REACT_APP_API_ROOT_URL: api_root_url } =
-  process.env;
+// const { REACT_APP_USE_AUTH0, REACT_APP_API_ROOT_URL: api_root_url } =
+//   process.env;
+
+const { REACT_APP_USE_AUTH0 } = process.env;
+
+
+const api_root_url='http://localhost:8000'
 
 console.log("OpenContracts is using Auth0: ", REACT_APP_USE_AUTH0);
 console.log("OpenContracts frontend target api root", api_root_url);
@@ -40,6 +45,7 @@ const authLink = new ApolloLink((operation, forward) => {
   return forward(operation);
 });
 
+console.log("api_root_url", api_root_url)
 const httpLink = createHttpLink({
   uri: `${api_root_url}/graphql/`,
 });

--- a/opencontractserver/utils/pdf.py
+++ b/opencontractserver/utils/pdf.py
@@ -100,7 +100,7 @@ def extract_pawls_from_pdfs_bytes(
     pdf_bytes: bytes,
 ) -> list[PawlsPagePythonType]:
 
-    from pawls.commands.preprocess import process_tesseract
+    from pdfpreprocessor.preprocessors.tesseract import process_tesseract
 
     pdf_fragment_folder_path = pathlib.Path("/tmp/user_0/pdf_fragments")
     pdf_fragment_folder_path.mkdir(parents=True, exist_ok=True)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -38,7 +38,7 @@ drf-extra-fields==3.4.1  # https://github.com/Hipo/drf-extra-fields
 # ------------------------------------------------------------------------------
 # Pawls preprocessors are available as a command line utility in their repo for now
 # BUT we can install them from their github repo subdirectory using the syntax below:
-git+https://github.com/JSv4/pawls#egg=pawls&subdirectory=cli
+git+https://github.com/JSv4/PDF-Preprocessors@v1.0.5
 scikit-learn==1.1.3
 pdfplumber
 pytesseract


### PR DESCRIPTION
There was an issue in the app where the tokens did not seem to have the same scale / coordinate system as the page they were on. I realized my branch of PAWLs had some OpenCV image processing improvements beyond fixing the issue processing empty pages. There was some dynamic resizing and scaling that was getting the token coordinate system out of sync with the pdf coordinate system. Some of those improvements I made to processing documents were useful for bad quality docs, so those OpenCV improvements should be re-incorporated later for better parsing of bad quality docs. For now, though, the application is working 100% once again :-)