### PR TITLE
Upgrade Django App Dependencies to work with Django LTS

### DIFF
--- a/compose/local/django/Dockerfile
+++ b/compose/local/django/Dockerfile
@@ -36,6 +36,8 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 # Requirements are installed here to ensure they will be cached.
 COPY ./requirements .
 
+RUN pip install --upgrade pip
+
 # Create Python Dependency and Sub-Dependency Wheels.
 RUN pip wheel --wheel-dir /usr/src/app/wheels  \
   -r ${BUILD_ENVIRONMENT}.txt
@@ -73,6 +75,8 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 # All absolute dir copies ignore workdir instruction. All relative dir copies are wrt to the workdir instruction
 # copy python dependency wheels from python-build-stage
 COPY --from=python-build-stage /usr/src/app/wheels  /wheels/
+
+RUN pip install --upgrade pip
 
 # Install CPU-less requirements
 RUN pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu

--- a/config/wsgi.py
+++ b/config/wsgi.py
@@ -33,6 +33,7 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.production")
 # file. This includes Django's development server, if the WSGI_APPLICATION
 # setting points here.
 application = get_wsgi_application()
+
 # Apply WSGI middleware here.
 # from helloworld.wsgi import HelloWorldApplication
 # application = HelloWorldApplication(application)

--- a/opencontractserver/tests/test_corpus_query.py
+++ b/opencontractserver/tests/test_corpus_query.py
@@ -66,7 +66,9 @@ class QueryTasksTestCase(TestCase):
         )
 
     @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
-    @vcr.use_cassette("fixtures/vcr_cassettes/run_query.yaml", filter_headers=['authorization'])
+    @vcr.use_cassette(
+        "fixtures/vcr_cassettes/run_query.yaml", filter_headers=["authorization"]
+    )
     def test_run_query(self):
 
         print(self.query)

--- a/opencontractserver/tests/test_corpus_query.py
+++ b/opencontractserver/tests/test_corpus_query.py
@@ -66,7 +66,7 @@ class QueryTasksTestCase(TestCase):
         )
 
     @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
-    @vcr.use_cassette("fixtures/vcr_cassettes/run_query.yaml")
+    @vcr.use_cassette("fixtures/vcr_cassettes/run_query.yaml", filter_headers=['authorization'])
     def test_run_query(self):
 
         print(self.query)

--- a/opencontractserver/tests/test_extract_tasks.py
+++ b/opencontractserver/tests/test_extract_tasks.py
@@ -140,7 +140,10 @@ class ExtractsTaskTestCase(TestCase):
         self.extract.save()
 
     @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
-    @vcr.use_cassette("fixtures/vcr_cassettes/test_run_extract_task.yaml", filter_headers=['authorization'])
+    @vcr.use_cassette(
+        "fixtures/vcr_cassettes/test_run_extract_task.yaml",
+        filter_headers=["authorization"],
+    )
     def test_run_extract_task(self):
         print(f"{self.extract.documents.all()}")
 

--- a/opencontractserver/tests/test_extract_tasks.py
+++ b/opencontractserver/tests/test_extract_tasks.py
@@ -140,7 +140,7 @@ class ExtractsTaskTestCase(TestCase):
         self.extract.save()
 
     @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
-    @vcr.use_cassette("fixtures/vcr_cassettes/test_run_extract_task.yaml")
+    @vcr.use_cassette("fixtures/vcr_cassettes/test_run_extract_task.yaml", filter_headers=['authorization'])
     def test_run_extract_task(self):
         print(f"{self.extract.documents.all()}")
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -63,7 +63,7 @@ marvin==2.3.4
 
 # Data Processing Tools
 # -------------------------------------------------------------------------------
-opencv-python==4.7.0.68 # https://github.com/opencv/opencv-python
+opencv-python==4.10.0.84 # https://github.com/opencv/opencv-python
 filetype==1.2.0  # https://github.com/h2non/filetype.py
 
 # Permissioning

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -24,7 +24,7 @@ crispy-bootstrap5==0.7  # https://github.com/django-crispy-forms/crispy-bootstra
 django-redis==5.2.0  # https://github.com/jazzband/django-redis
 django-filter==22.1  # https://github.com/carltongibson/django-filter
 django-storages[boto3]==1.13.1  # https://github.com/jschneier/django-storages
-django-extensions==3.2.0  # https://github.com/django-extensions/django-extensions
+django-extensions==3.2.3  # https://github.com/django-extensions/django-extensions
 whitenoise
 django-tree-queries
 pgvector  # For vector embeddings

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -14,7 +14,7 @@ pytest-cov==4.0.0  # https://github.com/pytest-dev/pytest-cov
 pytest-sugar==0.9.5  # https://github.com/Frozenball/pytest-sugar
 djangorestframework-stubs==1.8.0  # https://github.com/typeddjango/djangorestframework-stubs
 responses==0.22.0  # https://github.com/getsentry/responses
-vcrpy==6.0.1  # https://vcrpy.readthedocs.io/en/latest/
+vcrpy==5.1.0  # https://vcrpy.readthedocs.io/en/latest/
 
 # Profiling
 # ------------------------------------------------------------------------------

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -8,7 +8,7 @@ watchgod==0.8.2  # https://github.com/samuelcolvin/watchgod
 # Testing
 # ------------------------------------------------------------------------------
 mypy==0.991  # https://github.com/python/mypy
-django-stubs==1.13.0  # https://github.com/typeddjango/django-stubs
+django-stubs==4.2.7  # https://github.com/typeddjango/django-stubs
 pytest==8.2.2  # https://github.com/pytest-dev/pytest
 pytest-cov==4.0.0  # https://github.com/pytest-dev/pytest-cov
 pytest-sugar==0.9.5  # https://github.com/Frozenball/pytest-sugar

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -14,7 +14,7 @@ pytest-cov==4.0.0  # https://github.com/pytest-dev/pytest-cov
 pytest-sugar==0.9.5  # https://github.com/Frozenball/pytest-sugar
 djangorestframework-stubs==1.8.0  # https://github.com/typeddjango/djangorestframework-stubs
 responses==0.22.0  # https://github.com/getsentry/responses
-vcrpy==5.1.0  # https://vcrpy.readthedocs.io/en/latest/
+git+https://github.com/kevin1024/vcrpy.git@35650b141b5689eed84eac05c23b48412c76dd52 # VCR.py 6.0.* has deprecated setuptools which broke recently.
 
 # Profiling
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Django-stubs and django extensions both have management commands that don't work with post Django 4.1 syntax. This was not caught by the tests so v2.0 branch fails on startup. I've upgraded the dependency versions to work with Django 4.2

**There is another issue here... for some reason, upgrading to Django 4.2 creates an issue with opencv and/or vcr.py. At the moment, I can fix one or the other but not both.** Extract thumbnail fails when the upgrades mentioned above are applied and opencv throws some kind of numpy version error. If you upgrade opencv to latest, it works fine, but then vcr.py throws a super cryptic error about a setuptools issue. If you do not install vcr.py (which is only needed for tests), then the application (plus thumbnail extraction) appears to work. It's a bit of a quandary, though, as dropping vcr.py really drops test coverage and is not really a "fix". I'm opening an issue in the vcr.py repo and the issue may be due to how they're using pyproject.toml and setuptools.  

Given the choices here, I'm going to merge this without a resolution for the opencv/vcr,py problem so the v2.post1 release works and tests continue to function, but thumbnails are broken. I don't love that, but I consider a minor cosmetic function to be the least important of possible issues here (1. boot failure, 2. huge drop in test coverage, 3. missing thumbnail).