### PR TITLE
Pre 3.0.0 Alpha Cleanup

### DIFF
--- a/compose/local/django/celery/worker/start
+++ b/compose/local/django/celery/worker/start
@@ -4,4 +4,4 @@ set -o errexit
 set -o nounset
 
 
-watchgod celery.__main__.main --args -A config.celery_app worker -l INFO --concurrency=1
+watchfiles celery.__main__.main --args -A config.celery_app worker -l INFO --concurrency=1

--- a/compose/local/django/celery/worker/start
+++ b/compose/local/django/celery/worker/start
@@ -4,4 +4,4 @@ set -o errexit
 set -o nounset
 
 
-watchfiles celery.__main__.main --args -A config.celery_app worker -l INFO --concurrency=1
+watchfiles --target-type command "celery -A config.celery_app worker -l INFO --concurrency=1"

--- a/compose/local/django/start
+++ b/compose/local/django/start
@@ -6,4 +6,4 @@ set -o nounset
 
 
 python manage.py migrate
-python manage.py runserver_plus 0.0.0.0:8000
+python manage.py runserver 0.0.0.0:8000

--- a/config/graphql/graphene_types.py
+++ b/config/graphql/graphene_types.py
@@ -303,6 +303,24 @@ class LabelSetType(AnnotatePermissionsForReadMixin, DjangoObjectType):
         AnnotationLabelType, filterset_class=LabelFilter
     )
 
+    # Count fields for different label types
+    doc_label_count = graphene.Int(description="Count of document-level type labels")
+    span_label_count = graphene.Int(description="Count of span-based labels")
+    token_label_count = graphene.Int(description="Count of token-level labels")
+    metadata_label_count = graphene.Int(description="Count of metadata labels")
+
+    def resolve_doc_label_count(self, info):
+        return self.annotation_labels.filter(label_type="DOC_TYPE_LABEL").count()
+
+    def resolve_span_label_count(self, info):
+        return self.annotation_labels.filter(label_type="SPAN_LABEL").count()
+
+    def resolve_token_label_count(self, info):
+        return self.annotation_labels.filter(label_type="TOKEN_LABEL").count()
+
+    def resolve_metadata_label_count(self, info):
+        return self.annotation_labels.filter(label_type="METADATA_LABEL").count()
+
     # To get ALL labels for a given labelset
     all_annotation_labels = graphene.Field(graphene.List(AnnotationLabelType))
 

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -523,7 +523,7 @@ SENTENCE_TRANSFORMER_MODELS_PATH = env.str(
 
 # Preferred parsers for each MIME type
 PREFERRED_PARSERS = {
-    "application/pdf": "opencontractserver.pipeline.parsers.nlm_ingest_parser.NLMIngestParser",
+    "application/pdf": "opencontractserver.pipeline.parsers.docling_parser.DoclingParser",
     "text/plain": "opencontractserver.pipeline.parsers.oc_text_parser.TxtParser",
     "application/txt": "opencontractserver.pipeline.parsers.oc_text_parser.TxtParser",
     "application/vnd.openxmlformats-officedocument.wordprocessingml.document": "opencontractserver.pipeline.parsers.docling_parser.DoclingParser",  # noqa

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -3,8 +3,8 @@ from .base import env
 
 # GENERAL
 # ------------------------------------------------------------------------------
-# https://docs.djangoproject.com/en/dev/ref/settings/#debug
-DEBUG = True
+USE_SILK = False
+
 # https://docs.djangoproject.com/en/dev/ref/settings/#secret-key
 SECRET_KEY = env(
     "DJANGO_SECRET_KEY",
@@ -39,7 +39,7 @@ if env("USE_DOCKER") == "yes":
 # django-extensions
 # ------------------------------------------------------------------------------
 # https://django-extensions.readthedocs.io/en/latest/installation_instructions.html#configuration
-INSTALLED_APPS += ["django_extensions", "silk"]  # noqa F405
+INSTALLED_APPS += ["django_extensions"]  # noqa F405
 
 # Celery
 # ------------------------------------------------------------------------------
@@ -63,8 +63,11 @@ CSRF_COOKIE_HTTPONLY = False
 
 # Your stuff...
 # ------------------------------------------------------------------------------
-MIDDLEWARE += [
-    "django_cprofile_middleware.middleware.ProfilerMiddleware",
-    "silk.middleware.SilkyMiddleware",
-]
-SILKY_PYTHON_PROFILER = True
+if DEBUG and USE_SILK:
+    MIDDLEWARE += [
+        "django_cprofile_middleware.middleware.ProfilerMiddleware",
+        "silk.middleware.SilkyMiddleware",
+    ]
+    SILKY_PYTHON_PROFILER = True
+
+DEBUG = True

--- a/config/urls.py
+++ b/config/urls.py
@@ -26,7 +26,11 @@ urlpatterns = [
         []
         if not settings.DEBUG
         else [
-            *([] if not settings.USE_SILK else [path("silk/", include("silk.urls", namespace="silk"))]),
+            *(
+                []
+                if not settings.USE_SILK
+                else [path("silk/", include("silk.urls", namespace="silk"))]
+            ),
             path(
                 "400/",
                 default_views.bad_request,

--- a/config/urls.py
+++ b/config/urls.py
@@ -26,7 +26,7 @@ urlpatterns = [
         []
         if not settings.DEBUG
         else [
-            path("silk/", include("silk.urls", namespace="silk")),
+            *([] if not settings.USE_SILK else [path("silk/", include("silk.urls", namespace="silk"))]),
             path(
                 "400/",
                 default_views.bad_request,

--- a/frontend/src/components/analyses/AnalysisItem.tsx
+++ b/frontend/src/components/analyses/AnalysisItem.tsx
@@ -25,7 +25,6 @@ import { getPermissions } from "../../utils/transform";
 import { selectedAnalyses, selectedAnalysesIds } from "../../graphql/cache";
 import useWindowDimensions from "../hooks/WindowDimensionHook";
 import { MOBILE_VIEW_BREAKPOINT } from "../../assets/configurations/constants";
-import { useSelectedCorpus } from "../annotator/context/DocumentAtom";
 
 interface AnalysisItemProps {
   analysis: AnalysisType;

--- a/frontend/src/components/analyses/AnalysisSelectorForCorpus.tsx
+++ b/frontend/src/components/analyses/AnalysisSelectorForCorpus.tsx
@@ -18,8 +18,8 @@ import {
   useAnalysisManager,
   useAnalysisSelection,
 } from "../annotator/hooks/AnalysisHooks";
-import { useSelectedCorpus } from "../annotator/context/DocumentAtom";
 import { useAdditionalUIStates } from "../annotator/context/UISettingsAtom";
+import { useCorpusState } from "../annotator/context/CorpusAtom";
 
 interface HorizontalSelectorForCorpusProps {
   read_only: boolean;
@@ -31,7 +31,7 @@ export const ExtractAndAnalysisHorizontalSelector: React.FC<
   HorizontalSelectorForCorpusProps
 > = ({ read_only, analyses, extracts }) => {
   const { width } = useWindowDimensions();
-  const { selectedCorpus } = useSelectedCorpus();
+  const { selectedCorpus } = useCorpusState();
   const { selectedAnalysis, selectedExtract } = useAnalysisSelection();
   const { topbarVisible, setTopbarVisible } = useAdditionalUIStates();
 

--- a/frontend/src/components/annotator/DocumentAnnotator.tsx
+++ b/frontend/src/components/annotator/DocumentAnnotator.tsx
@@ -232,9 +232,59 @@ export const DocumentAnnotator = ({
       hasData: !!humanAnnotationsAndRelationshipsData,
       displayOnlyTheseAnnotations,
       isLoading: humanDataLoading,
+      data: humanAnnotationsAndRelationshipsData,
+      corpus: humanAnnotationsAndRelationshipsData?.corpus,
+      labelSet: humanAnnotationsAndRelationshipsData?.corpus?.labelSet,
+      allLabels:
+        humanAnnotationsAndRelationshipsData?.corpus?.labelSet
+          ?.allAnnotationLabels,
     });
 
     if (humanAnnotationsAndRelationshipsData && !displayOnlyTheseAnnotations) {
+      // First, ensure we have the labelSet data
+      if (
+        humanAnnotationsAndRelationshipsData.corpus?.labelSet
+          ?.allAnnotationLabels
+      ) {
+        console.log("Processing labelSet from GraphQL response:", {
+          labelSet: humanAnnotationsAndRelationshipsData.corpus.labelSet,
+          allLabels:
+            humanAnnotationsAndRelationshipsData.corpus.labelSet
+              .allAnnotationLabels,
+        });
+
+        // Set the labels first
+        const allLabels =
+          humanAnnotationsAndRelationshipsData.corpus.labelSet
+            .allAnnotationLabels;
+        const filteredTokenLabels = allLabels.filter(
+          (label) => label.labelType === LabelType.TokenLabel
+        );
+        const filteredSpanLabels = allLabels.filter(
+          (label) => label.labelType === LabelType.SpanLabel
+        );
+        const filteredRelationLabels = allLabels.filter(
+          (label) => label.labelType === LabelType.RelationshipLabel
+        );
+        const filteredDocTypeLabels = allLabels.filter(
+          (label) => label.labelType === LabelType.DocTypeLabel
+        );
+
+        console.log("Setting filtered labels from GraphQL response:", {
+          spanLabels: filteredSpanLabels,
+          tokenLabels: filteredTokenLabels,
+          relationLabels: filteredRelationLabels,
+          docTypeLabels: filteredDocTypeLabels,
+        });
+
+        setSpanLabels(filteredSpanLabels);
+        setHumanSpanLabels(filteredSpanLabels);
+        setHumanTokenLabels(filteredTokenLabels);
+        setRelationLabels(filteredRelationLabels);
+        setDocTypeLabels(filteredDocTypeLabels);
+      }
+
+      // Then process the annotations
       processAnnotationsData(humanAnnotationsAndRelationshipsData);
     }
   }, [humanAnnotationsAndRelationshipsData, displayOnlyTheseAnnotations]);
@@ -269,6 +319,7 @@ export const DocumentAnnotator = ({
         documentId: opened_document?.id,
         corpusId: opened_corpus?.id,
         analysisId: selected_analysis?.id || "__none__",
+        labelSet: opened_corpus?.labelSet,
       });
       if (opened_document) {
         if (opened_corpus?.labelSet && !displayOnlyTheseAnnotations) {
@@ -457,7 +508,6 @@ export const DocumentAnnotator = ({
 
       // Update label atoms
       if (data.corpus?.labelSet) {
-        console.log("React to label set", data.corpus.labelSet);
         const allLabels = data.corpus.labelSet.allAnnotationLabels ?? [];
         const filteredTokenLabels = allLabels.filter(
           (label) => label.labelType === LabelType.TokenLabel
@@ -471,11 +521,6 @@ export const DocumentAnnotator = ({
         const filteredDocTypeLabels = allLabels.filter(
           (label) => label.labelType === LabelType.DocTypeLabel
         );
-
-        console.log("Setting filtered labels:", {
-          spanLabels: filteredSpanLabels,
-          tokenLabels: filteredTokenLabels,
-        });
 
         setSpanLabels(filteredSpanLabels);
         setHumanSpanLabels(filteredSpanLabels);
@@ -756,29 +801,12 @@ export const DocumentAnnotator = ({
     }
   }, [open]);
 
-  // Add a separate effect to handle label initialization
+  // Remove the label initialization from the open/opened_corpus useEffect since we'll handle it in the query response
   useEffect(() => {
     if (open && opened_corpus?.labelSet) {
-      console.log("Initializing labels from corpus", opened_corpus.labelSet);
-      const allLabels = opened_corpus.labelSet.allAnnotationLabels ?? [];
-      const filteredTokenLabels = allLabels.filter(
-        (label) => label.labelType === LabelType.TokenLabel
+      console.log(
+        "Skipping label initialization in open effect - will be handled by query response"
       );
-      const filteredSpanLabels = allLabels.filter(
-        (label) => label.labelType === LabelType.SpanLabel
-      );
-      const filteredRelationLabels = allLabels.filter(
-        (label) => label.labelType === LabelType.RelationshipLabel
-      );
-      const filteredDocTypeLabels = allLabels.filter(
-        (label) => label.labelType === LabelType.DocTypeLabel
-      );
-
-      setSpanLabels(filteredSpanLabels);
-      setHumanSpanLabels(filteredSpanLabels);
-      setHumanTokenLabels(filteredTokenLabels);
-      setRelationLabels(filteredRelationLabels);
-      setDocTypeLabels(filteredDocTypeLabels);
     }
   }, [open, opened_corpus?.labelSet]);
 

--- a/frontend/src/components/annotator/DocumentAnnotator.tsx
+++ b/frontend/src/components/annotator/DocumentAnnotator.tsx
@@ -17,6 +17,8 @@ import {
   PermissionTypes,
 } from "../types";
 import {
+  convertToDocTypeAnnotation,
+  convertToDocTypeAnnotations,
   convertToServerAnnotation,
   convertToServerAnnotations,
   getPermissions,
@@ -433,13 +435,19 @@ export const DocumentAnnotator = ({
           convertToServerAnnotation(annotation)
         ) ?? [];
 
+      const processedDocTypeAnnotations = convertToDocTypeAnnotations(
+        data.document.allAnnotations?.filter(
+          (ann) => ann.annotationLabel.labelType === LabelType.DocTypeLabel
+        ) ?? []
+      );
+
       // Update pdfAnnotations atom
       setPdfAnnotations(
         (prev) =>
           new PdfAnnotations(
             processedAnnotations,
             prev.relations,
-            prev.docTypes,
+            processedDocTypeAnnotations,
             true
           )
       );

--- a/frontend/src/components/annotator/DocumentAnnotator.tsx
+++ b/frontend/src/components/annotator/DocumentAnnotator.tsx
@@ -248,6 +248,8 @@ export const DocumentAnnotator = ({
     }
   }, [opened_document]);
 
+  const [loadTrigger, setLoadTrigger] = useState(0);
+
   // Handle opening of the annotator
   useEffect(() => {
     console.log("DocumentAnnotator open effect triggered with:", {
@@ -256,6 +258,7 @@ export const DocumentAnnotator = ({
       opened_corpus,
       displayOnlyTheseAnnotations,
       selected_analysis,
+      loadTrigger,
     });
 
     const loadAnnotations = () => {
@@ -380,7 +383,13 @@ export const DocumentAnnotator = ({
         displayOnlyTheseAnnotations,
       });
     }
-  }, [open, opened_document, opened_corpus, displayOnlyTheseAnnotations]);
+  }, [
+    open,
+    opened_document,
+    opened_corpus,
+    displayOnlyTheseAnnotations,
+    loadTrigger,
+  ]);
 
   // Use the initialAnnotationsAtom to store initial annotations
   const { setInitialAnnotations } = useInitialAnnotations();
@@ -741,6 +750,7 @@ export const DocumentAnnotator = ({
         matches: [],
         selectedIndex: 0,
       });
+      setLoadTrigger((prev) => prev + 1);
     }
   }, [open]);
 

--- a/frontend/src/components/annotator/DocumentAnnotator.tsx
+++ b/frontend/src/components/annotator/DocumentAnnotator.tsx
@@ -463,6 +463,11 @@ export const DocumentAnnotator = ({
           (label) => label.labelType === LabelType.DocTypeLabel
         );
 
+        console.log("Setting filtered labels:", {
+          spanLabels: filteredSpanLabels,
+          tokenLabels: filteredTokenLabels,
+        });
+
         setSpanLabels(filteredSpanLabels);
         setHumanSpanLabels(filteredSpanLabels);
         setHumanTokenLabels(filteredTokenLabels);

--- a/frontend/src/components/annotator/DocumentAnnotator.tsx
+++ b/frontend/src/components/annotator/DocumentAnnotator.tsx
@@ -370,6 +370,11 @@ export const DocumentAnnotator = ({
           convertToServerAnnotation(annotation)
         ) ?? [];
 
+      const structuralAnnotations =
+        data.document.allStructuralAnnotations?.map((annotation) =>
+          convertToServerAnnotation(annotation)
+        ) ?? [];
+
       const processedDocTypeAnnotations = convertToDocTypeAnnotations(
         data.document.allAnnotations?.filter(
           (ann) => ann.annotationLabel.labelType === LabelType.DocTypeLabel
@@ -380,7 +385,7 @@ export const DocumentAnnotator = ({
       setPdfAnnotations(
         (prev) =>
           new PdfAnnotations(
-            processedAnnotations,
+            [...processedAnnotations, ...structuralAnnotations],
             prev.relations,
             processedDocTypeAnnotations,
             true
@@ -684,7 +689,7 @@ export const DocumentAnnotator = ({
   useEffect(() => {
     if (!open) {
       // Reset only annotation-specific state
-      setPdfAnnotations(new PdfAnnotations([], [], []));
+      setPdfAnnotations(new PdfAnnotations([], [], [], false));
       setStructuralAnnotations([]);
       setDocTypeAnnotations([]);
       setAnnotationObjs([]);

--- a/frontend/src/components/annotator/DocumentAnnotator.tsx
+++ b/frontend/src/components/annotator/DocumentAnnotator.tsx
@@ -302,25 +302,7 @@ export const DocumentAnnotator = ({
 
   // Handle opening of the annotator
   useEffect(() => {
-    console.log("DocumentAnnotator open effect triggered with:", {
-      open,
-      opened_document,
-      opened_corpus,
-      displayOnlyTheseAnnotations,
-      selected_analysis,
-      loadTrigger,
-    });
-
     const loadAnnotations = () => {
-      console.log("loadAnnotations called with:", {
-        opened_corpus,
-        hasLabelSet: opened_corpus?.labelSet ? true : false,
-        displayOnlyTheseAnnotations,
-        documentId: opened_document?.id,
-        corpusId: opened_corpus?.id,
-        analysisId: selected_analysis?.id || "__none__",
-        labelSet: opened_corpus?.labelSet,
-      });
       if (opened_document) {
         if (opened_corpus?.labelSet && !displayOnlyTheseAnnotations) {
           console.log("Calling getDocumentAnnotationsAndRelationships");
@@ -346,7 +328,6 @@ export const DocumentAnnotator = ({
           // Return a Promise that resolves to an object similar to the Apollo QueryResult
           return Promise.resolve({ data: mockData });
         }
-        console.log("No conditions met for loading annotations");
         return Promise.resolve(null);
       }
     };
@@ -358,7 +339,7 @@ export const DocumentAnnotator = ({
         opened_document.fileType === "application/pdf" &&
         opened_document.pdfFile
       ) {
-        console.log("React to PDF doc load request");
+        console.debug("React to PDF doc load request");
         const loadingTask: PDFDocumentLoadingTask = pdfjsLib.getDocument(
           opened_document.pdfFile
         );
@@ -409,7 +390,7 @@ export const DocumentAnnotator = ({
             viewStateVar(ViewState.ERROR);
           });
       } else if (opened_document.fileType === "application/txt") {
-        console.log("React to TXT document");
+        console.debug("React to TXT document");
 
         Promise.all([
           getDocumentRawText(opened_document.txtExtractFile || ""),
@@ -424,15 +405,8 @@ export const DocumentAnnotator = ({
             viewStateVar(ViewState.ERROR);
           });
       } else {
-        console.log("Unexpected filetype: ", opened_document.fileType);
+        console.error("Unexpected filetype: ", opened_document.fileType);
       }
-    } else {
-      console.log("3) Skip document load for vars", {
-        open,
-        opened_document,
-        opened_corpus,
-        displayOnlyTheseAnnotations,
-      });
     }
   }, [
     open,
@@ -535,7 +509,6 @@ export const DocumentAnnotator = ({
   useEffect(() => {
     if (opened_document && opened_document.fileType === "application/pdf") {
       if (pdfDoc && pageTextMaps && Object.keys(pages).length > 0) {
-        console.log("React to PDF document loading properly", pdfDoc);
         viewStateVar(ViewState.LOADED);
       }
     }
@@ -650,7 +623,7 @@ export const DocumentAnnotator = ({
 
   // When annotations are provided to display only, update annotation states
   useEffect(() => {
-    console.log(
+    console.debug(
       "React to displayOnlyTheseAnnotations",
       displayOnlyTheseAnnotations
     );
@@ -776,8 +749,6 @@ export const DocumentAnnotator = ({
 
   useEffect(() => {
     if (!open) {
-      console.log("React to close");
-
       // Reset only annotation-specific state
       setPdfAnnotations(new PdfAnnotations([], [], []));
       setStructuralAnnotations([]);
@@ -800,15 +771,6 @@ export const DocumentAnnotator = ({
       setLoadTrigger((prev) => prev + 1);
     }
   }, [open]);
-
-  // Remove the label initialization from the open/opened_corpus useEffect since we'll handle it in the query response
-  useEffect(() => {
-    if (open && opened_corpus?.labelSet) {
-      console.log(
-        "Skipping label initialization in open effect - will be handled by query response"
-      );
-    }
-  }, [open, opened_corpus?.labelSet]);
 
   // Return early if no document is provided
   if (!opened_document) {

--- a/frontend/src/components/annotator/DocumentAnnotator.tsx
+++ b/frontend/src/components/annotator/DocumentAnnotator.tsx
@@ -733,7 +733,7 @@ export const DocumentAnnotator = ({
     if (!open) {
       console.log("React to close");
 
-      // Reset annotations when the annotator closes
+      // Reset only annotation-specific state
       setPdfAnnotations(new PdfAnnotations([], [], []));
       setStructuralAnnotations([]);
       setDocTypeAnnotations([]);
@@ -750,9 +750,37 @@ export const DocumentAnnotator = ({
         matches: [],
         selectedIndex: 0,
       });
+
+      // Increment load trigger to force reload of annotations
       setLoadTrigger((prev) => prev + 1);
     }
   }, [open]);
+
+  // Add a separate effect to handle label initialization
+  useEffect(() => {
+    if (open && opened_corpus?.labelSet) {
+      console.log("Initializing labels from corpus", opened_corpus.labelSet);
+      const allLabels = opened_corpus.labelSet.allAnnotationLabels ?? [];
+      const filteredTokenLabels = allLabels.filter(
+        (label) => label.labelType === LabelType.TokenLabel
+      );
+      const filteredSpanLabels = allLabels.filter(
+        (label) => label.labelType === LabelType.SpanLabel
+      );
+      const filteredRelationLabels = allLabels.filter(
+        (label) => label.labelType === LabelType.RelationshipLabel
+      );
+      const filteredDocTypeLabels = allLabels.filter(
+        (label) => label.labelType === LabelType.DocTypeLabel
+      );
+
+      setSpanLabels(filteredSpanLabels);
+      setHumanSpanLabels(filteredSpanLabels);
+      setHumanTokenLabels(filteredTokenLabels);
+      setRelationLabels(filteredRelationLabels);
+      setDocTypeLabels(filteredDocTypeLabels);
+    }
+  }, [open, opened_corpus?.labelSet]);
 
   // Return early if no document is provided
   if (!opened_document) {

--- a/frontend/src/components/annotator/components/modals/EditLabelModal.tsx
+++ b/frontend/src/components/annotator/components/modals/EditLabelModal.tsx
@@ -22,7 +22,7 @@ export const EditLabelModal = ({
   visible,
   onHide,
 }: EditLabelModalProps) => {
-  const { spanLabels, setSpanLabels } = useCorpusState();
+  const { setCorpus, humanSpanLabels: spanLabels } = useCorpusState();
 
   const [selectedLabel, setSelectedLabel] = useState(
     annotation.annotationLabel
@@ -43,9 +43,11 @@ export const EditLabelModal = ({
         const index = Number.parseInt(e.key) - 1;
         if (index < spanLabels.length) {
           // Note: You'll need to implement updateAnnotation functionality separately
-          setSpanLabels(
-            spanLabels.map((label, i) => (i === index ? selectedLabel : label))
-          );
+          setCorpus({
+            humanSpanLabels: spanLabels.map((label, i) =>
+              i === index ? selectedLabel : label
+            ),
+          });
           onHide();
         }
       }
@@ -97,11 +99,11 @@ export const EditLabelModal = ({
             event.preventDefault();
             event.stopPropagation();
 
-            setSpanLabels(
-              spanLabels.map((label, i) =>
+            setCorpus({
+              humanSpanLabels: spanLabels.map((label, i) =>
                 i === spanLabels.indexOf(selectedLabel) ? selectedLabel : label
-              )
-            );
+              ),
+            });
 
             onHide();
           }}

--- a/frontend/src/components/annotator/context/CorpusAtom.tsx
+++ b/frontend/src/components/annotator/context/CorpusAtom.tsx
@@ -1,174 +1,86 @@
 import { atom, useAtom } from "jotai";
-import { useEffect, useMemo } from "react";
+import { useMemo } from "react";
 import { CorpusType, AnnotationLabelType } from "../../../types/graphql-api";
-import { getPermissions } from "../../../utils/transform";
 import { PermissionTypes } from "../../types";
 
-// Atoms for core corpus data
-export const selectedCorpusAtom = atom<CorpusType | null | undefined>(null);
-
-// Atoms for permissions
-export const permissionsAtom = atom<PermissionTypes[]>([]);
-
-// Atoms for label sets
-export const spanLabelsAtom = atom<AnnotationLabelType[]>([]);
-export const humanSpanLabelsAtom = atom<AnnotationLabelType[]>([]);
-export const relationLabelsAtom = atom<AnnotationLabelType[]>([]);
-export const docTypeLabelsAtom = atom<AnnotationLabelType[]>([]);
-export const humanTokenLabelsAtom = atom<AnnotationLabelType[]>([]);
-
-// Atoms for corpus features
-export const allowCommentsAtom = atom<boolean>(true);
-
-// Atom for loading state
-export const isLoadingAtom = atom<boolean>(false);
-
-// Custom hook to initialize corpus-related atoms
-export function useInitializeCorpusAtoms(params: {
+/**
+ * Represents the entire corpus state stored in a single atom.
+ */
+interface CorpusState {
   selectedCorpus: CorpusType | null | undefined;
+  permissions: PermissionTypes[];
   spanLabels: AnnotationLabelType[];
   humanSpanLabels: AnnotationLabelType[];
-  humanTokenLabels: AnnotationLabelType[];
   relationLabels: AnnotationLabelType[];
   docTypeLabels: AnnotationLabelType[];
+  humanTokenLabels: AnnotationLabelType[];
+  allowComments: boolean;
   isLoading: boolean;
-}) {
-  const {
-    selectedCorpus,
-    spanLabels,
-    humanSpanLabels,
-    humanTokenLabels,
-    relationLabels,
-    docTypeLabels,
-    isLoading,
-  } = params;
-
-  const [, setSelectedCorpus] = useAtom(selectedCorpusAtom);
-  const [, setPermissions] = useAtom(permissionsAtom);
-  const [, setSpanLabelsAtom] = useAtom(spanLabelsAtom);
-  const [, setHumanSpanLabelsAtom] = useAtom(humanSpanLabelsAtom);
-  const [, setRelationLabelsAtom] = useAtom(relationLabelsAtom);
-  const [, setDocTypeLabelsAtom] = useAtom(docTypeLabelsAtom);
-  const [, setAllowComments] = useAtom(allowCommentsAtom);
-  const [, setIsLoadingAtom] = useAtom(isLoadingAtom);
-  const [, setHumanTokenLabelsAtom] = useAtom(humanTokenLabelsAtom);
-
-  useEffect(() => {
-    // Update corpus and permissions
-    setSelectedCorpus(selectedCorpus);
-    const rawPermissions = selectedCorpus?.myPermissions ?? ["READ"];
-    setPermissions(getPermissions(rawPermissions));
-    setAllowComments(selectedCorpus?.allowComments ?? true);
-
-    // Update label sets
-    setSpanLabelsAtom(spanLabels);
-    setHumanSpanLabelsAtom(humanSpanLabels);
-    setRelationLabelsAtom(relationLabels);
-    setDocTypeLabelsAtom(docTypeLabels);
-    setHumanTokenLabelsAtom(humanTokenLabels);
-
-    // Update loading state
-    setIsLoadingAtom(isLoading);
-  }, [
-    selectedCorpus,
-    spanLabels,
-    humanSpanLabels,
-    humanTokenLabels,
-    relationLabels,
-    docTypeLabels,
-    isLoading,
-  ]);
 }
 
-// Comprehensive hook for corpus state
+export const corpusStateAtom = atom<CorpusState>({
+  selectedCorpus: null,
+  permissions: [],
+  spanLabels: [],
+  humanSpanLabels: [],
+  relationLabels: [],
+  docTypeLabels: [],
+  humanTokenLabels: [],
+  allowComments: true,
+  isLoading: false,
+});
+
+/**
+ * A hook that returns the entire corpus state, plus methods to perform
+ * batch updates and derived permission checks.
+ */
 export function useCorpusState() {
-  const [selectedCorpus, setSelectedCorpus] = useAtom(selectedCorpusAtom);
-  const [permissions, setPermissions] = useAtom(permissionsAtom);
-  const [spanLabels, setSpanLabels] = useAtom(spanLabelsAtom);
-  const [humanSpanLabels, setHumanSpanLabels] = useAtom(humanSpanLabelsAtom);
-  const [relationLabels, setRelationLabels] = useAtom(relationLabelsAtom);
-  const [docTypeLabels, setDocTypeLabels] = useAtom(docTypeLabelsAtom);
-  const [humanTokenLabels, setHumanTokenLabels] = useAtom(humanTokenLabelsAtom);
-  const [allowComments, setAllowComments] = useAtom(allowCommentsAtom);
-  const [isLoading, setIsLoading] = useAtom(isLoadingAtom);
+  const [corpusState, setCorpusState] = useAtom(corpusStateAtom);
 
-  // Initialize labels from corpus if available and labels are empty
-  useEffect(() => {
-    if (
-      selectedCorpus?.labelSet?.allAnnotationLabels &&
-      humanSpanLabels.length === 0 &&
-      humanTokenLabels.length === 0
-    ) {
-      const allLabels = selectedCorpus.labelSet.allAnnotationLabels;
-      const filteredTokenLabels = allLabels.filter(
-        (label) => label.labelType === "TOKEN_LABEL"
-      );
-      const filteredSpanLabels = allLabels.filter(
-        (label) => label.labelType === "SPAN_LABEL"
-      );
-      setHumanSpanLabels(filteredSpanLabels);
-      setHumanTokenLabels(filteredTokenLabels);
-    }
-  }, [
-    selectedCorpus?.labelSet?.allAnnotationLabels,
-    humanSpanLabels.length,
-    humanTokenLabels.length,
-  ]);
+  /**
+   * Batch-update the corpus state to avoid multiple, separate set calls.
+   *
+   * @param partial partial object to merge into the CorpusState
+   */
+  function setCorpus(partial: Partial<CorpusState>) {
+    setCorpusState((prev) => ({ ...prev, ...partial }));
+  }
 
-  // Permission checks
-  const canUpdateCorpus = permissions.includes(PermissionTypes.CAN_UPDATE);
-  const canDeleteCorpus = permissions.includes(PermissionTypes.CAN_REMOVE);
-  const canManageCorpus = permissions.includes(PermissionTypes.CAN_PERMISSION);
-  const hasCorpusPermission = (permission: PermissionTypes) =>
-    permissions.includes(permission);
+  // Compute permission checks as derived state
+  const canUpdateCorpus = corpusState.permissions.includes(
+    PermissionTypes.CAN_UPDATE
+  );
+  const canDeleteCorpus = corpusState.permissions.includes(
+    PermissionTypes.CAN_REMOVE
+  );
+  const canManageCorpus = corpusState.permissions.includes(
+    PermissionTypes.CAN_PERMISSION
+  );
 
+  /**
+   * Helper to check for a given permission type in the corpus permissions.
+   *
+   * @param permission a specific PermissionTypes value to be checked
+   */
+  function hasCorpusPermission(permission: PermissionTypes): boolean {
+    return corpusState.permissions.includes(permission);
+  }
+
+  // Memoize for performance, so consumers don't re-render unnecessarily
   return useMemo(
     () => ({
-      // Corpus
-      selectedCorpus,
-      setSelectedCorpus,
+      // State
+      ...corpusState,
 
-      // Permissions
-      permissions,
-      setPermissions,
+      // Batch set
+      setCorpus,
+
+      // Derived permission checks
       canUpdateCorpus,
       canDeleteCorpus,
       canManageCorpus,
       hasCorpusPermission,
-
-      // Labels
-      spanLabels,
-      setSpanLabels,
-      humanSpanLabels,
-      setHumanSpanLabels,
-      relationLabels,
-      setRelationLabels,
-      docTypeLabels,
-      setDocTypeLabels,
-      humanTokenLabels,
-      setHumanTokenLabels,
-
-      // Features
-      allowComments,
-      setAllowComments,
-
-      // Loading state
-      isLoading,
-      setIsLoading,
     }),
-    [
-      selectedCorpus,
-      permissions,
-      spanLabels,
-      humanSpanLabels,
-      relationLabels,
-      docTypeLabels,
-      humanTokenLabels,
-      allowComments,
-      isLoading,
-      canUpdateCorpus,
-      canDeleteCorpus,
-      canManageCorpus,
-    ]
+    [corpusState, canUpdateCorpus, canDeleteCorpus, canManageCorpus]
   );
 }

--- a/frontend/src/components/annotator/context/CorpusAtom.tsx
+++ b/frontend/src/components/annotator/context/CorpusAtom.tsx
@@ -92,9 +92,13 @@ export function useCorpusState() {
   const [allowComments, setAllowComments] = useAtom(allowCommentsAtom);
   const [isLoading, setIsLoading] = useAtom(isLoadingAtom);
 
-  // Initialize labels from corpus if available
+  // Initialize labels from corpus if available and labels are empty
   useEffect(() => {
-    if (selectedCorpus?.labelSet?.allAnnotationLabels) {
+    if (
+      selectedCorpus?.labelSet?.allAnnotationLabels &&
+      humanSpanLabels.length === 0 &&
+      humanTokenLabels.length === 0
+    ) {
       const allLabels = selectedCorpus.labelSet.allAnnotationLabels;
       const filteredTokenLabels = allLabels.filter(
         (label) => label.labelType === "TOKEN_LABEL"
@@ -105,7 +109,11 @@ export function useCorpusState() {
       setHumanSpanLabels(filteredSpanLabels);
       setHumanTokenLabels(filteredTokenLabels);
     }
-  }, [selectedCorpus?.labelSet?.allAnnotationLabels]);
+  }, [
+    selectedCorpus?.labelSet?.allAnnotationLabels,
+    humanSpanLabels.length,
+    humanTokenLabels.length,
+  ]);
 
   // Permission checks
   const canUpdateCorpus = permissions.includes(PermissionTypes.CAN_UPDATE);

--- a/frontend/src/components/annotator/context/CorpusAtom.tsx
+++ b/frontend/src/components/annotator/context/CorpusAtom.tsx
@@ -92,6 +92,21 @@ export function useCorpusState() {
   const [allowComments, setAllowComments] = useAtom(allowCommentsAtom);
   const [isLoading, setIsLoading] = useAtom(isLoadingAtom);
 
+  // Initialize labels from corpus if available
+  useEffect(() => {
+    if (selectedCorpus?.labelSet?.allAnnotationLabels) {
+      const allLabels = selectedCorpus.labelSet.allAnnotationLabels;
+      const filteredTokenLabels = allLabels.filter(
+        (label) => label.labelType === "TOKEN_LABEL"
+      );
+      const filteredSpanLabels = allLabels.filter(
+        (label) => label.labelType === "SPAN_LABEL"
+      );
+      setHumanSpanLabels(filteredSpanLabels);
+      setHumanTokenLabels(filteredTokenLabels);
+    }
+  }, [selectedCorpus?.labelSet?.allAnnotationLabels]);
+
   // Permission checks
   const canUpdateCorpus = permissions.includes(PermissionTypes.CAN_UPDATE);
   const canDeleteCorpus = permissions.includes(PermissionTypes.CAN_REMOVE);

--- a/frontend/src/components/annotator/context/DocumentAtom.tsx
+++ b/frontend/src/components/annotator/context/DocumentAtom.tsx
@@ -12,12 +12,12 @@ import {
 import { CorpusType, DocumentType } from "../../../types/graphql-api";
 import { getPermissions } from "../../../utils/transform";
 import { RefObject, useEffect, useMemo } from "react";
+import { useCorpusState } from "./CorpusAtom";
 
 /**
  * Core document data atoms.
  */
 export const selectedDocumentAtom = atom<DocumentType | null>(null);
-export const selectedCorpusAtom = atom<CorpusType | null | undefined>(null);
 export const fileTypeAtom = atom<string>("");
 export const docTextAtom = atom<string>("");
 
@@ -122,7 +122,7 @@ export function useInitializeDocumentAtoms(params: {
   } = params;
 
   const setSelectedDocument = useSetAtom(selectedDocumentAtom);
-  const setSelectedCorpus = useSetAtom(selectedCorpusAtom);
+  const { setCorpus } = useCorpusState();
   const setFileType = useSetAtom(fileTypeAtom);
   const setDocText = useSetAtom(docTextAtom);
   const setPdfDoc = useSetAtom(pdfDocAtom);
@@ -136,7 +136,7 @@ export function useInitializeDocumentAtoms(params: {
 
   useEffect(() => {
     setSelectedDocument(selectedDocument);
-    setSelectedCorpus(selectedCorpus);
+    setCorpus({ selectedCorpus });
     setFileType(selectedDocument.fileType || "");
     setDocText(docText);
     setPdfDoc(pdfDoc);
@@ -158,7 +158,7 @@ export function useInitializeDocumentAtoms(params: {
     isLoading,
     viewState,
     setSelectedDocument,
-    setSelectedCorpus,
+    setCorpus,
     setFileType,
     setDocText,
     setPdfDoc,
@@ -181,14 +181,6 @@ export function useSelectedDocument() {
   return useMemo(
     () => ({ selectedDocument, setSelectedDocument }),
     [selectedDocument, setSelectedDocument]
-  );
-}
-
-export function useSelectedCorpus() {
-  const [selectedCorpus, setSelectedCorpus] = useAtom(selectedCorpusAtom);
-  return useMemo(
-    () => ({ selectedCorpus, setSelectedCorpus }),
-    [selectedCorpus, setSelectedCorpus]
   );
 }
 

--- a/frontend/src/components/annotator/context/UISettingsAtom.tsx
+++ b/frontend/src/components/annotator/context/UISettingsAtom.tsx
@@ -45,6 +45,7 @@ export const modalOpenAtom = atom<boolean>(false);
 export const readOnlyAtom = atom<boolean>(false);
 export const loadingMessageAtom = atom<string>("");
 export const shiftDownAtom = atom<boolean>(false);
+export const isCreatingAnnotationAtom = atom<boolean>(false);
 
 /**
  * Query State Atoms

--- a/frontend/src/components/annotator/display/components/ActionBar.tsx
+++ b/frontend/src/components/annotator/display/components/ActionBar.tsx
@@ -39,8 +39,7 @@ const StyledSearchInput = styled(Form.Input)`
 
   input {
     border: none !important;
-    padding-left: 40px !important;
-    padding-right: 40px !important;
+    padding-left: 2.67142857em !important;
   }
 
   i.icon {
@@ -48,14 +47,8 @@ const StyledSearchInput = styled(Form.Input)`
     display: flex !important;
     align-items: center;
     justify-content: center;
-  }
-
-  i.icon:first-child {
+    cursor: pointer;
     left: 10px !important;
-  }
-
-  i.icon:last-child {
-    right: 10px !important;
   }
 `;
 
@@ -212,27 +205,12 @@ export const PDFActionBar: React.FC<PDFActionBarProps> = ({
         />
         <StyledSearchInput
           icon={
-            localSearchText ? (
-              <div
-                style={{
-                  display: "flex",
-                  flexDirection: "column",
-                  justifyContent: "center",
-                }}
-              >
-                <Icon as={X} link onClick={clearSearch} />
-              </div>
-            ) : (
-              <div
-                style={{
-                  display: "flex",
-                  flexDirection: "column",
-                  justifyContent: "center",
-                }}
-              >
-                <Icon as={Search} />
-              </div>
-            )
+            <Icon
+              name={localSearchText ? "cancel" : "search"}
+              link={!!localSearchText}
+              onClick={() => (localSearchText ? clearSearch() : undefined)}
+              style={{ color: localSearchText ? "#db2828" : "#2185d0" }}
+            />
           }
           iconPosition="left"
           placeholder="Search document..."

--- a/frontend/src/components/annotator/display/components/SelectionBoundary.tsx
+++ b/frontend/src/components/annotator/display/components/SelectionBoundary.tsx
@@ -7,6 +7,8 @@ import {
 } from "../../../../utils/transform";
 import { pulseGreen, pulseMaroon } from "../effects";
 import { useAnnotationRefs } from "../../hooks/useAnnotationRefs";
+import { useAtomValue } from "jotai";
+import { isCreatingAnnotationAtom } from "../../context/UISettingsAtom";
 
 interface SelectionBoundaryProps {
   id: string;
@@ -86,6 +88,7 @@ export const SelectionBoundary: React.FC<SelectionBoundaryProps> = ({
 }) => {
   const { registerRef, unregisterRef } = useAnnotationRefs();
   const boundaryRef = useRef<HTMLSpanElement | null>(null);
+  const isCreatingAnnotation = useAtomValue(isCreatingAnnotationAtom);
 
   useEffect(() => {
     if (id) {
@@ -115,6 +118,7 @@ export const SelectionBoundary: React.FC<SelectionBoundaryProps> = ({
   const backgroundColor = `rgba(${rgbColor.r}, ${rgbColor.g}, ${rgbColor.b}, ${opacity})`;
 
   const handleClick = (e: React.MouseEvent) => {
+    if (isCreatingAnnotation) return;
     if (e.shiftKey && onClick) {
       e.stopPropagation();
       onClick();
@@ -122,6 +126,7 @@ export const SelectionBoundary: React.FC<SelectionBoundaryProps> = ({
   };
 
   const handleMouseDown = (e: React.MouseEvent) => {
+    if (isCreatingAnnotation) return;
     if (e.shiftKey && onClick) {
       e.stopPropagation();
     }
@@ -133,8 +138,16 @@ export const SelectionBoundary: React.FC<SelectionBoundaryProps> = ({
       ref={boundaryRef}
       onClick={handleClick}
       onMouseDown={handleMouseDown}
-      onMouseEnter={onHover && !hidden ? () => onHover(true) : undefined}
-      onMouseLeave={onHover && !hidden ? () => onHover(false) : undefined}
+      onMouseEnter={
+        onHover && !hidden && !isCreatingAnnotation
+          ? () => onHover(true)
+          : undefined
+      }
+      onMouseLeave={
+        onHover && !hidden && !isCreatingAnnotation
+          ? () => onHover(false)
+          : undefined
+      }
       $width={width}
       $height={height}
       $rotateX={rotateX}
@@ -147,6 +160,7 @@ export const SelectionBoundary: React.FC<SelectionBoundaryProps> = ({
       $bounds={bounds}
       $approved={approved}
       $rejected={rejected}
+      style={{ pointerEvents: isCreatingAnnotation ? "none" : "auto" }}
     >
       {children || null}
     </BoundarySpan>

--- a/frontend/src/components/annotator/display/viewer/DocumentViewer.tsx
+++ b/frontend/src/components/annotator/display/viewer/DocumentViewer.tsx
@@ -41,10 +41,7 @@ import { useUISettings } from "../../hooks/useUISettings";
 import { useCreateRelationship } from "../../hooks/AnnotationHooks";
 import { useAnnotationRefs } from "../../hooks/useAnnotationRefs";
 import TxtAnnotatorWrapper from "../../components/wrappers/TxtAnnotatorWrapper";
-import {
-  useSelectedCorpus,
-  useSelectedDocument,
-} from "../../context/DocumentAtom";
+import { useSelectedDocument } from "../../context/DocumentAtom";
 
 export const PDFViewContainer = styled.div`
   width: "100%",

--- a/frontend/src/components/annotator/hooks/AnalysisHooks.tsx
+++ b/frontend/src/components/annotator/hooks/AnalysisHooks.tsx
@@ -48,10 +48,7 @@ import {
   ServerTokenAnnotation,
   ServerSpanAnnotation,
 } from "../types/annotations";
-import {
-  selectedDocumentAtom,
-  selectedCorpusAtom,
-} from "../context/DocumentAtom";
+import { selectedDocumentAtom } from "../context/DocumentAtom";
 
 /**
  * Custom hook to manage analysis and extract data using Jotai atoms.
@@ -60,7 +57,7 @@ import {
 export const useAnalysisManager = () => {
   // Get document and corpus from atoms instead of props
   const selectedDocument = useAtomValue(selectedDocumentAtom);
-  const selectedCorpus = useAtomValue(selectedCorpusAtom);
+  const { selectedCorpus } = useCorpusState();
 
   // Use atoms for state management
   const [analysisRows, setAnalysisRows] = useAtom(analysisRowsAtom);
@@ -82,12 +79,8 @@ export const useAnalysisManager = () => {
     showSelectedAnnotationOnlyAtom
   );
 
-  const {
-    addMultipleAnnotations,
-    replaceDocTypeAnnotations,
-    replaceAnnotations,
-  } = usePdfAnnotations();
-  const { setSpanLabels, setDocTypeLabels } = useCorpusState();
+  const { replaceDocTypeAnnotations, replaceAnnotations } = usePdfAnnotations();
+  const { setCorpus } = useCorpusState();
 
   const { setQueryLoadingStates } = useQueryLoadingStates();
   const { setQueryErrors } = useQueryErrors();
@@ -273,7 +266,7 @@ export const useAnalysisManager = () => {
         processedSpanAnnotations.map((a) => a.annotationLabel),
         "id"
       );
-      setSpanLabels(uniqueSpanLabels);
+      setCorpus({ spanLabels: uniqueSpanLabels });
 
       // Process doc type annotations
       const rawDocAnnotations =
@@ -293,7 +286,7 @@ export const useAnalysisManager = () => {
         processedDocAnnotations.map((a) => a.annotationLabel),
         "id"
       );
-      setDocTypeLabels(uniqueDocLabels);
+      setCorpus({ docTypeLabels: uniqueDocLabels });
     }
   }, [annotationsLoading, annotationsError, annotationsData]);
 

--- a/frontend/src/components/annotator/hooks/AnnotationHooks.tsx
+++ b/frontend/src/components/annotator/hooks/AnnotationHooks.tsx
@@ -48,14 +48,12 @@ import {
   docTypeAnnotationsAtom,
   initialAnnotationsAtom,
 } from "../context/AnnotationAtoms";
-import {
-  selectedDocumentAtom,
-  selectedCorpusAtom,
-} from "../context/DocumentAtom";
+import { selectedDocumentAtom } from "../context/DocumentAtom";
 import { LabelType } from "../types/enums";
 import { getPermissions } from "../../../utils/transform";
 import { SpanAnnotationJson } from "../../types";
 import { AnnotationLabelType } from "../../../types/graphql-api";
+import { useCorpusState } from "../context/CorpusAtom";
 
 /**
  * Hook to manage PdfAnnotations state.
@@ -228,7 +226,7 @@ export function useInitialAnnotations() {
 export function useCreateAnnotation() {
   const { addMultipleAnnotations } = usePdfAnnotations();
   const selectedDocument = useAtomValue(selectedDocumentAtom);
-  const selectedCorpus = useAtomValue(selectedCorpusAtom);
+  const { selectedCorpus } = useCorpusState();
 
   const [createAnnotation] = useMutation<
     NewAnnotationOutputType,
@@ -389,7 +387,7 @@ export function useUpdateAnnotation() {
 export function useDeleteAnnotation() {
   const { pdfAnnotations, setPdfAnnotations } = usePdfAnnotations();
   const selectedDocument = useAtomValue(selectedDocumentAtom);
-  const selectedCorpus = useAtomValue(selectedCorpusAtom);
+  const { selectedCorpus } = useCorpusState();
 
   const [deleteAnnotationMutation] = useMutation<
     RemoveAnnotationOutputType,
@@ -663,7 +661,7 @@ export function useRejectAnnotation() {
 export function useAddDocTypeAnnotation() {
   const { addDocTypeAnnotations } = usePdfAnnotations();
   const selectedDocument = useAtomValue(selectedDocumentAtom);
-  const selectedCorpus = useAtomValue(selectedCorpusAtom);
+  const { selectedCorpus } = useCorpusState();
 
   const [addDocTypeAnnotationMutation] = useMutation<
     NewDocTypeAnnotationOutputType,
@@ -720,7 +718,7 @@ export function useAddDocTypeAnnotation() {
 export function useCreateRelationship() {
   const { replaceRelations } = usePdfAnnotations();
   const selectedDocument = useAtomValue(selectedDocumentAtom);
-  const selectedCorpus = useAtomValue(selectedCorpusAtom);
+  const { selectedCorpus } = useCorpusState();
 
   const [createRelationshipMutation] = useMutation<
     NewRelationshipOutputType,
@@ -822,7 +820,7 @@ export function useRemoveRelationship() {
 export function useUpdateRelations() {
   const { replaceRelations } = usePdfAnnotations();
   const selectedDocument = useAtomValue(selectedDocumentAtom);
-  const selectedCorpus = useAtomValue(selectedCorpusAtom);
+  const { selectedCorpus } = useCorpusState();
 
   const [updateRelationsMutation] = useMutation<
     UpdateRelationOutputType,
@@ -874,7 +872,7 @@ export function useUpdateRelations() {
  */
 export function useRemoveAnnotationFromRelationship() {
   const { pdfAnnotations, setPdfAnnotations } = usePdfAnnotations();
-  const selectedCorpus = useAtomValue(selectedCorpusAtom);
+  const { selectedCorpus } = useCorpusState();
   const selectedDocument = useAtomValue(selectedDocumentAtom);
 
   const [deleteRelationMutation] = useMutation<

--- a/frontend/src/components/annotator/hooks/useAnnotationSelection.tsx
+++ b/frontend/src/components/annotator/hooks/useAnnotationSelection.tsx
@@ -40,7 +40,14 @@ export function useAnnotationSelection({
   // Event handlers
   const handleAnnotationSelect = useCallback(
     (annotationId: string) => {
-      setSelectedAnnotations([annotationId]);
+      setSelectedAnnotations((prev) => {
+        // If the annotation is already selected, deselect it
+        if (prev.includes(annotationId)) {
+          return [];
+        }
+        // Otherwise, select it
+        return [annotationId];
+      });
     },
     [setSelectedAnnotations]
   );

--- a/frontend/src/components/annotator/hooks/useTextSearch.tsx
+++ b/frontend/src/components/annotator/hooks/useTextSearch.tsx
@@ -32,22 +32,11 @@ export const useTextSearch = () => {
     updateCountRef.current += 1;
     const updateId = updateCountRef.current;
 
-    console.log(`useTextSearch effect #${updateId} triggered`, {
-      searchText,
-      previousSearch: previousSearchTextRef.current,
-      stack: new Error().stack,
-    });
-
     // Clear search results if search text is empty
     if (!searchText) {
       if (previousSearchTextRef.current !== searchText) {
-        console.log(
-          `[${updateId}] Clearing search results due to empty search`
-        );
         setTextSearchState({ matches: [], selectedIndex: 0 });
         previousSearchTextRef.current = searchText;
-      } else {
-        console.log(`[${updateId}] Skipping duplicate empty search clear`);
       }
       return;
     }
@@ -58,17 +47,11 @@ export const useTextSearch = () => {
 
     // Guard clause for required dependencies
     if (!selectedDocument || !pageTokenTextMaps || !pages) {
-      console.log(`[${updateId}] TextSearch: Missing dependencies`, {
-        hasDocument: !!selectedDocument,
-        hasTokenMaps: !!pageTokenTextMaps,
-        pagesCount: pages ? Object.keys(pages).length : 0,
-      });
       return;
     }
 
     // Skip if the search text hasn't actually changed
     if (previousSearchTextRef.current === searchText && !documentChanged) {
-      console.log(`[${updateId}] Skipping search - no changes`);
       return;
     }
 
@@ -77,7 +60,6 @@ export const useTextSearch = () => {
     previousSelectedDocumentRef.current = selectedDocument;
 
     // Proceed with search logic
-    console.log(`[${updateId}] Starting search for:`, searchText);
     const searchHits: (TextSearchTokenResult | TextSearchSpanResult)[] = [];
 
     // Now TypeScript knows these values are defined for the rest of the function
@@ -166,17 +148,9 @@ export const useTextSearch = () => {
         const bounds: Record<number, BoundingBox> = {};
         for (const [key, value] of Object.entries(grouped_tokens)) {
           const pageIndex = parseInt(key);
-          console.log(`TextSearch: Processing page ${pageIndex}`, {
-            hasPage: !!pages[pageIndex],
-            tokenCount: value.length,
-          });
 
           if (pages[pageIndex] !== undefined) {
             const page_bounds = pages[pageIndex].getBoundsForTokens(value);
-            console.log(`TextSearch: Bounds for page ${pageIndex}`, {
-              hasBounds: !!page_bounds,
-              bounds: page_bounds,
-            });
             if (page_bounds) {
               bounds[pageIndex] = page_bounds;
             }
@@ -199,7 +173,6 @@ export const useTextSearch = () => {
       }
     }
 
-    console.log(`[${updateId}] Setting search results`, searchHits);
     setTextSearchState({ matches: searchHits, selectedIndex: 0 });
   }, [
     searchText,

--- a/frontend/src/components/annotator/labels/doc_types/DocTypeLabelDisplay.tsx
+++ b/frontend/src/components/annotator/labels/doc_types/DocTypeLabelDisplay.tsx
@@ -33,6 +33,11 @@ import { selectedAnalysis, selectedExtract } from "../../../../graphql/cache";
 const StyledPopup = styled(Popup)`
   &.ui.popup {
     z-index: 100000 !important;
+    padding: 0 !important;
+    border: none !important;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12) !important;
+    border-radius: 12px !important;
+    overflow: hidden !important;
   }
 `;
 
@@ -152,7 +157,7 @@ export const DocTypeLabelDisplay = () => {
                     onOpen={() => setOpen(true)}
                     on="click"
                     position="top right"
-                    style={{ padding: "0px", zIndex: "2100 !important" }}
+                    style={{ padding: "0px" }}
                     trigger={
                       <Button
                         style={{
@@ -160,12 +165,26 @@ export const DocTypeLabelDisplay = () => {
                           height: "2.25vw",
                           minWidth: "40px",
                           minHeight: "40px",
+                          padding: 0,
+                          display: "flex",
+                          alignItems: "center",
+                          justifyContent: "center",
+                          background: "transparent",
+                          border: "none",
+                          boxShadow: "none",
                         }}
-                        floated="right"
-                        icon="plus"
+                        className="add-doc-type-button"
+                        icon={
+                          <Icon
+                            name="plus"
+                            style={{
+                              margin: 0,
+                              fontSize: "1.2em",
+                              color: "white",
+                            }}
+                          />
+                        }
                         circular
-                        positive
-                        color="green"
                       />
                     }
                   >
@@ -263,7 +282,11 @@ export const DocTypeLabelDisplay = () => {
                 <Icon
                   link
                   name={expanded ? "compress" : "expand"}
-                  color={expanded ? "orange" : "blue"}
+                  style={{
+                    transition: "all 0.2s ease",
+                    transform: expanded ? "rotate(180deg)" : "rotate(0deg)",
+                    color: expanded ? "#00b09b" : "#495057",
+                  }}
                   onClick={() => setExpanded(!expanded)}
                 />
               </div>

--- a/frontend/src/components/annotator/labels/doc_types/DocTypeLabelDisplay.tsx
+++ b/frontend/src/components/annotator/labels/doc_types/DocTypeLabelDisplay.tsx
@@ -128,147 +128,143 @@ export const DocTypeLabelDisplay = () => {
   }
 
   return (
-    <>
-      <DocTypeWidgetContainer
-        id="DocTypeWidget_Container"
-        onMouseEnter={() => setHover(true)}
-        onMouseLeave={() => setHover(false)}
-        width={width}
-      >
-        {!read_only ? (
-          <div className="DocTypeWidget_ButtonFlexContainer">
-            <div
-              id="DocTypeWidget_ButtonContainer"
-              className={
-                hovered ? "hovered_plus_button" : "not_hovered_plus_button"
-              }
-            >
-              <div
-                style={{
-                  display: "flex",
-                  flexDirection: "row",
-                  justifyContent: "center",
-                }}
-              >
-                <div>
-                  <StyledPopup
-                    open={open}
-                    onClose={() => setOpen(false)}
-                    onOpen={() => setOpen(true)}
-                    on="click"
-                    position="top right"
-                    style={{ padding: "0px" }}
-                    trigger={
-                      <Button
-                        style={{
-                          width: "2.25vw",
-                          height: "2.25vw",
-                          minWidth: "40px",
-                          minHeight: "40px",
-                          padding: 0,
-                          display: "flex",
-                          alignItems: "center",
-                          justifyContent: "center",
-                          background: "transparent",
-                          border: "none",
-                          boxShadow: "none",
-                        }}
-                        className="add-doc-type-button"
-                        icon={
-                          <Icon
-                            name="plus"
-                            style={{
-                              margin: 0,
-                              fontSize: "1.2em",
-                              color: "white",
-                            }}
-                          />
-                        }
-                        circular
-                      />
-                    }
-                  >
-                    <DocTypePopup
-                      labels={filtered_doc_label_choices}
-                      onAdd={onAdd}
-                    />
-                  </StyledPopup>
-                </div>
-              </div>
-            </div>
-          </div>
-        ) : (
-          <></>
-        )}
-        <div
-          id="DocTypeWidget_ContentFlexContainer"
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            justifyContent: "flex-start",
-          }}
-        >
-          <Segment
-            secondary
-            inverted
-            className="DocTypeWidget_HeaderSegment"
-            attached="top"
-          >
-            <Divider horizontal style={{ margin: "0px" }}>
-              <Header as="h5">
-                ({annotation_elements.length}) Doc Type
-                {annotation_elements.length > 1 ? "(s)" : ""}
-              </Header>
-            </Divider>
-          </Segment>
-          <Segment
-            inverted
-            secondary
-            className={`${
-              expanded ? " expanded_labels" : " collapsed_labels"
-            } ${
-              hovered
-                ? " DocTypeWidget_BodySegment_hovered"
-                : " DocTypeWidget_BodySegment"
-            }`}
-            attached="bottom"
+    <DocTypeWidgetContainer
+      id="DocTypeWidget_Container"
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+      width={width}
+      className="DocTypeWidget_Container"
+    >
+      {!read_only ? (
+        <div className="DocTypeWidget_ButtonFlexContainer">
+          <div
+            id="DocTypeWidget_ButtonContainer"
+            className={
+              hovered ? "hovered_plus_button" : "not_hovered_plus_button"
+            }
           >
             <div
               style={{
                 display: "flex",
-                flexDirection: "column",
+                flexDirection: "row",
                 justifyContent: "center",
-                flex: 1,
               }}
             >
-              <CardGroupScrollContainer>
-                <div
-                  style={{
-                    width: "100%",
-                    display: "flex",
-                    flexDirection: "column",
-                    justifyContent: "flex-start",
-                  }}
+              <div>
+                <StyledPopup
+                  open={open}
+                  onClose={() => setOpen(false)}
+                  onOpen={() => setOpen(true)}
+                  on="click"
+                  position="top right"
+                  style={{ padding: "0px" }}
+                  trigger={
+                    <Button
+                      style={{
+                        width: "2.25vw",
+                        height: "2.25vw",
+                        minWidth: "40px",
+                        minHeight: "40px",
+                        padding: 0,
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        background: "transparent",
+                        border: "none",
+                        boxShadow: "none",
+                      }}
+                      className="add-doc-type-button"
+                      icon={
+                        <Icon
+                          name="plus"
+                          style={{
+                            margin: 0,
+                            fontSize: "1.2em",
+                            color: "white",
+                          }}
+                        />
+                      }
+                      circular
+                    />
+                  }
                 >
-                  {annotation_elements}
-                </div>
-              </CardGroupScrollContainer>
+                  <DocTypePopup
+                    labels={filtered_doc_label_choices}
+                    onAdd={onAdd}
+                  />
+                </StyledPopup>
+              </div>
             </div>
-          </Segment>
+          </div>
         </div>
-        <div
-          style={{
-            flex: 1,
-            display: "flex",
-            flexDirection: "column",
-            justifyContent: "flex-end",
-          }}
+      ) : null}
+      <div
+        id="DocTypeWidget_ContentFlexContainer"
+        className="DocTypeWidget_ContentFlexContainer"
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "flex-start",
+        }}
+      >
+        <Segment
+          secondary
+          inverted
+          className="DocTypeWidget_HeaderSegment"
+          attached="top"
+        >
+          <Divider horizontal>
+            <Header as="h5">
+              ({annotation_elements.length}) Doc Type
+              {annotation_elements.length > 1 ? "(s)" : ""}
+            </Header>
+          </Divider>
+        </Segment>
+        <Segment
+          inverted
+          secondary
+          className={`${expanded ? " expanded_labels" : " collapsed_labels"} ${
+            hovered
+              ? " DocTypeWidget_BodySegment_hovered"
+              : " DocTypeWidget_BodySegment"
+          }`}
+          attached="bottom"
         >
           <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              justifyContent: "center",
+              flex: 1,
+            }}
+          >
+            <CardGroupScrollContainer>
+              <div
+                style={{
+                  width: "100%",
+                  display: "flex",
+                  flexDirection: "column",
+                  justifyContent: "flex-start",
+                }}
+              >
+                {annotation_elements}
+              </div>
+            </CardGroupScrollContainer>
+          </div>
+        </Segment>
+      </div>
+      <div
+        style={{
+          flex: 1,
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "flex-end",
+        }}
+      >
+        {annotation_elements.length > 1 && (
+          <div
             className={
-              hovered && annotation_elements.length > 1
-                ? "hovered_expand_button"
-                : "not_hovered_expand_button"
+              hovered ? "hovered_expand_button" : "not_hovered_expand_button"
             }
           >
             <div
@@ -292,25 +288,28 @@ export const DocTypeLabelDisplay = () => {
               </div>
             </div>
           </div>
-        </div>
-      </DocTypeWidgetContainer>
-    </>
+        )}
+      </div>
+    </DocTypeWidgetContainer>
   );
 };
 
-// Need to investigate why right value of 0 is required to get this to look like matching
-// left posiiton on the span label container... not a huge priority atm
-const DocTypeWidgetContainer = styled.div<HideableHasWidth>(
-  () => `
-    position: fixed;
-    z-index: 1002;
-    top: 8vh;
-    right: 0px;
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-  `
-);
+const DocTypeWidgetContainer = styled.div<HideableHasWidth>`
+  position: fixed;
+  z-index: 1002;
+  top: 8vh;
+  right: 16px;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  transform: translateZ(0);
+  -webkit-font-smoothing: antialiased;
+  pointer-events: none;
+
+  & > * {
+    pointer-events: auto;
+  }
+`;
 
 const CardGroupScrollContainer = styled.div`
   display: flex;
@@ -320,4 +319,22 @@ const CardGroupScrollContainer = styled.div`
   overflow-y: auto;
   overflow-x: hidden;
   height: 100% !important;
+  padding: 4px;
+
+  &::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background-color: rgba(155, 155, 155, 0.5);
+    border-radius: 20px;
+    border: transparent;
+  }
+
+  scrollbar-width: thin;
+  scrollbar-color: rgba(155, 155, 155, 0.5) transparent;
 `;

--- a/frontend/src/components/annotator/labels/doc_types/DocTypeLabelDisplay.tsx
+++ b/frontend/src/components/annotator/labels/doc_types/DocTypeLabelDisplay.tsx
@@ -30,6 +30,12 @@ import { useCorpusState } from "../../context/CorpusAtom";
 import { useReactiveVar } from "@apollo/client";
 import { selectedAnalysis, selectedExtract } from "../../../../graphql/cache";
 
+const StyledPopup = styled(Popup)`
+  &.ui.popup {
+    z-index: 100000 !important;
+  }
+`;
+
 export const DocTypeLabelDisplay = () => {
   const { width } = useWindowDimensions();
 
@@ -140,13 +146,13 @@ export const DocTypeLabelDisplay = () => {
                 }}
               >
                 <div>
-                  <Popup
+                  <StyledPopup
                     open={open}
                     onClose={() => setOpen(false)}
                     onOpen={() => setOpen(true)}
                     on="click"
                     position="top right"
-                    offset={[-30, -10]}
+                    style={{ padding: "0px", zIndex: "2100 !important" }}
                     trigger={
                       <Button
                         style={{
@@ -167,7 +173,7 @@ export const DocTypeLabelDisplay = () => {
                       labels={filtered_doc_label_choices}
                       onAdd={onAdd}
                     />
-                  </Popup>
+                  </StyledPopup>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/annotator/labels/doc_types/DocTypeLabelDisplayStyles.css
+++ b/frontend/src/components/annotator/labels/doc_types/DocTypeLabelDisplayStyles.css
@@ -1,11 +1,11 @@
 .hovered_plus_button {
   opacity: 1;
-  transition: opacity 0.5s;
-  border-radius: 2vw 0px 0px 2vw;
-  border: 1px solid rgba(34, 36, 38, 0.15);
-  background: #4c4f52
-    linear-gradient(rgba(255, 255, 255, 0.2) 0%, rgba(255, 255, 255, 0.2) 100%);
-  color: rgba(255, 255, 255, 0.8);
+  transition: all 0.3s ease;
+  border-radius: 12px 0 0 12px;
+  border: none;
+  background: linear-gradient(135deg, #00b09b, #96c93d);
+  box-shadow: 0 4px 15px rgba(0, 176, 155, 0.2);
+  color: white;
   width: 3vw;
   height: 3vw;
   min-width: 50px;
@@ -13,16 +13,17 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
+  transform: translateX(0);
 }
 
 .not_hovered_plus_button {
   opacity: 0;
-  transition: opacity 0.5s;
-  border-radius: 2vw 0px 0px 2vw;
-  border: 1px solid rgba(34, 36, 38, 0.15);
-  background: #4c4f52
-    linear-gradient(rgba(255, 255, 255, 0.2) 0%, rgba(255, 255, 255, 0.2) 100%);
-  color: rgba(255, 255, 255, 0.8);
+  transition: all 0.3s ease;
+  border-radius: 12px 0 0 12px;
+  border: none;
+  background: linear-gradient(135deg, #00b09b, #96c93d);
+  box-shadow: 0 4px 15px rgba(0, 176, 155, 0.2);
+  color: white;
   width: 3vw;
   height: 3vw;
   min-width: 50px;
@@ -30,14 +31,16 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
+  transform: translateX(-100%);
 }
 
 .not_hovered_expand_button {
   opacity: 0;
-  transition: opacity 0.5s;
-  border-radius: 0px 1vw 1vw 0px;
-  border: 1px solid rgba(34, 36, 38, 0.15);
-  background: rgb(208, 208, 208);
+  transition: all 0.3s ease;
+  border-radius: 0 12px 12px 0;
+  border: none;
+  background: linear-gradient(135deg, #f6f8fa, #e9ecef);
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.05);
   width: 1.5vw;
   height: 3vw;
   min-height: 50px;
@@ -46,14 +49,16 @@
   flex-direction: column;
   justify-content: center;
   margin-right: 0.5rem;
+  transform: translateX(100%);
 }
 
 .hovered_expand_button {
   opacity: 1;
-  transition: opacity 0.5s;
-  border-radius: 0px 1vw 1vw 0px;
-  border: 1px solid rgba(34, 36, 38, 0.15);
-  background: rgb(208, 208, 208);
+  transition: all 0.3s ease;
+  border-radius: 0 12px 12px 0;
+  border: none;
+  background: linear-gradient(135deg, #f6f8fa, #e9ecef);
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.05);
   width: 1.5vw;
   height: 3vw;
   min-height: 50px;
@@ -62,18 +67,37 @@
   flex-direction: column;
   justify-content: center;
   margin-right: 0.5rem;
+  transform: translateX(0);
 }
 
 .collapsed_labels {
-  transition: height 0.5s;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   height: 3vw;
   min-height: 50px;
+  overflow: hidden;
 }
 
 .expanded_labels {
   height: 20vh;
   min-height: 200px;
-  transition: height 0.5s;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  overflow: auto;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(155, 155, 155, 0.5) transparent;
+}
+
+.expanded_labels::-webkit-scrollbar {
+  width: 6px;
+}
+
+.expanded_labels::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.expanded_labels::-webkit-scrollbar-thumb {
+  background-color: rgba(155, 155, 155, 0.5);
+  border-radius: 20px;
+  border: transparent;
 }
 
 .DocTypeWidget_ButtonFlexContainer {
@@ -86,37 +110,47 @@
 .DocTypeWidget_BodySegment {
   width: 150px !important;
   min-height: 50px;
-  transition: border-radius 0.5s;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   display: flex;
   flex-direction: row;
   justify-content: center;
-  border-radius: 0px 0px 0.5vw 0.5vw !important;
-  border: 1px solid rgba(34, 36, 38, 0.15);
-  background: rgb(208, 208, 208);
-  padding: 8px;
+  border-radius: 0 0 12px 12px !important;
+  border: none;
+  background: white;
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.05);
+  padding: 12px;
 }
 
 .DocTypeWidget_BodySegment_hovered {
   width: 150px !important;
   min-height: 50px;
-  transition: border-radius 0.5s;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   display: flex;
   flex-direction: row;
   justify-content: center;
-  border-radius: 0px 0px 0px 0px !important;
-  border: 1px solid rgba(34, 36, 38, 0.15);
-  background: rgb(208, 208, 208);
+  border-radius: 0 !important;
+  border: none;
+  background: white;
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.05);
+  padding: 12px;
 }
 
 .DocTypeWidget_HeaderSegment {
   width: 150px !important;
   margin-bottom: 0px;
-  padding: 0.5vw;
-  padding-bottom: 0.25vw;
+  padding: 12px;
   text-align: center;
-  border-radius: 0.5vw 0.5vw 0px 0px;
-  border: 1px solid rgba(34, 36, 38, 0.15);
-  background: rgb(208, 208, 208);
+  border-radius: 12px 12px 0 0;
+  border: none;
+  background: linear-gradient(135deg, #f8f9fa, #e9ecef);
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.05);
+}
+
+.DocTypeWidget_HeaderSegment h5 {
+  margin: 0;
+  color: #495057;
+  font-weight: 600;
+  font-size: 0.9rem;
 }
 
 @media (max-width: 400px) {
@@ -173,4 +207,20 @@
   .collapsed_labels {
     width: 200px !important;
   }
+}
+
+.add-doc-type-button.ui.circular.button {
+  background: linear-gradient(135deg, #00b09b, #96c93d) !important;
+  transition: all 0.2s ease !important;
+  box-shadow: 0 4px 15px rgba(0, 176, 155, 0.2) !important;
+}
+
+.add-doc-type-button.ui.circular.button:hover {
+  transform: translateY(-1px) !important;
+  box-shadow: 0 6px 20px rgba(0, 176, 155, 0.3) !important;
+}
+
+.add-doc-type-button.ui.circular.button:active {
+  transform: translateY(1px) !important;
+  box-shadow: 0 2px 10px rgba(0, 176, 155, 0.2) !important;
 }

--- a/frontend/src/components/annotator/labels/doc_types/DocTypeLabelDisplayStyles.css
+++ b/frontend/src/components/annotator/labels/doc_types/DocTypeLabelDisplayStyles.css
@@ -48,7 +48,7 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
-  margin-right: 0.5rem;
+  margin-right: 1rem;
   transform: translateX(100%);
 }
 
@@ -66,7 +66,7 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
-  margin-right: 0.5rem;
+  margin-right: 1rem;
   transform: translateX(0);
 }
 
@@ -104,7 +104,8 @@
   flex: 1;
   display: flex;
   flex-direction: column;
-  justify-content: flex-end;
+  justify-content: flex-start;
+  margin-top: 10px;
 }
 
 .DocTypeWidget_BodySegment {
@@ -119,6 +120,7 @@
   background: white;
   box-shadow: 0 4px 15px rgba(0, 0, 0, 0.05);
   padding: 12px;
+  margin: 0 !important;
 }
 
 .DocTypeWidget_BodySegment_hovered {
@@ -133,12 +135,13 @@
   background: white;
   box-shadow: 0 4px 15px rgba(0, 0, 0, 0.05);
   padding: 12px;
+  margin: 0 !important;
 }
 
 .DocTypeWidget_HeaderSegment {
   width: 150px !important;
-  margin-bottom: 0px;
-  padding: 12px;
+  margin: 0 !important;
+  padding: 10px !important;
   text-align: center;
   border-radius: 12px 12px 0 0;
   border: none;
@@ -146,11 +149,34 @@
   box-shadow: 0 4px 15px rgba(0, 0, 0, 0.05);
 }
 
+.DocTypeWidget_HeaderSegment .ui.horizontal.divider {
+  margin: 0;
+  opacity: 0.8;
+}
+
 .DocTypeWidget_HeaderSegment h5 {
   margin: 0;
   color: #495057;
   font-weight: 600;
   font-size: 0.9rem;
+}
+
+.DocTypeWidget_Container {
+  background: transparent;
+  border-radius: 12px;
+  overflow: visible;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  margin-right: 16px;
+}
+
+.DocTypeWidget_Container:hover {
+  box-shadow: none;
+}
+
+.DocTypeWidget_ContentFlexContainer {
+  background: transparent;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  margin-top: 10px;
 }
 
 @media (max-width: 400px) {

--- a/frontend/src/components/annotator/labels/doc_types/DocTypeLabels.css
+++ b/frontend/src/components/annotator/labels/doc_types/DocTypeLabels.css
@@ -1,5 +1,6 @@
 .DocTypeLabelHeader {
   font-size: 1rem;
+  color: #495057;
 }
 
 .DocTypeLabelCard {
@@ -13,12 +14,20 @@
   min-width: 100px;
   min-height: 34px !important;
   height: 3vh !important;
-  margin: 0.25vw;
-  margin-top: 1rem !important;
-  margin-bottom: 1rem !important;
+  margin: 0.5rem 0.25rem !important;
   user-select: none;
   -ms-user-select: none;
   -moz-user-select: none;
+  background: white !important;
+  border: none !important;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05) !important;
+  border-radius: 8px !important;
+  transition: all 0.2s ease !important;
+}
+
+.DocTypeLabelCard:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1) !important;
 }
 
 .DocTypeLabelContent {
@@ -26,19 +35,20 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
+  padding: 8px !important;
 }
 
 @media (max-width: 400px) {
   .DocTypeLabelHeader {
-    font-size: 0.65rem !important;
+    font-size: 0.75rem !important;
     padding-left: 5px !important;
   }
   .DocTypeLabelContent {
-    padding: 0px !important;
+    padding: 6px !important;
   }
   .DocTypeLabelCard {
-    padding: 5px !important;
-    margin: 2px !important;
+    padding: 4px !important;
+    margin: 4px !important;
     margin-left: auto !important;
     margin-right: auto !important;
     width: 95% !important;
@@ -50,19 +60,19 @@
 
 @media (min-width: 401px) {
   .DocTypeLabelHeader {
-    font-size: 0.75rem !important;
+    font-size: 0.8rem !important;
     padding-left: 5px !important;
   }
   .DocTypeLabelIcon {
-    font-size: 1.1rem !important;
+    font-size: 1.2rem !important;
   }
   .DocTypeLabelContent {
-    padding: 0px !important;
+    padding: 8px !important;
   }
   .DocTypeLabelCard {
     min-height: 34px !important;
-    padding: 5px !important;
-    margin: 5px !important;
+    padding: 6px !important;
+    margin: 6px !important;
     margin-left: auto !important;
     margin-right: auto !important;
     width: 95% !important;
@@ -71,19 +81,18 @@
 
 @media (min-width: 768px) {
   .DocTypeLabelHeader {
-    font-size: 0.9rem;
-    padding-left: 10px !important;
+    font-size: 0.9rem !important;
+    padding-left: 8px !important;
   }
   .DocTypeLabelIcon {
-    font-size: 1.4rem !important;
+    font-size: 1.3rem !important;
   }
   .DocTypeLabelContent {
-    padding: 3px !important;
+    padding: 10px !important;
   }
   .DocTypeLabelCard {
-    padding: 10px !important;
-    margin-left: auto !important;
-    margin-right: auto !important;
+    padding: 8px !important;
+    margin: 8px auto !important;
     width: 98% !important;
   }
 }

--- a/frontend/src/components/annotator/labels/doc_types/DocTypePopup.tsx
+++ b/frontend/src/components/annotator/labels/doc_types/DocTypePopup.tsx
@@ -49,6 +49,7 @@ export const DocTypePopup = ({ labels, onAdd }: DocTypePopupProps) => {
 
   return (
     <div
+      id="doc-type-popup"
       style={{
         display: "flex",
         flexDirection: "column",

--- a/frontend/src/components/annotator/labels/doc_types/DocTypePopup.tsx
+++ b/frontend/src/components/annotator/labels/doc_types/DocTypePopup.tsx
@@ -1,12 +1,137 @@
 import React, { useState } from "react";
-import { Segment, Button, Comment, Input } from "semantic-ui-react";
-import {
-  EmptyLabelListItem,
-  LabelListItem,
-} from "../../sidebar/LabelListItems";
+import { Button, Input, Icon } from "semantic-ui-react";
+import styled from "styled-components";
 import Fuse from "fuse.js";
-import _ from "lodash";
 import { AnnotationLabelType } from "../../../../types/graphql-api";
+
+const PopupContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  background: white;
+  border-radius: 12px;
+  overflow: hidden;
+  width: 320px;
+`;
+
+const SearchContainer = styled.div`
+  padding: 16px;
+  background: linear-gradient(135deg, #f8f9fa, #e9ecef);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+`;
+
+const StyledInput = styled(Input)`
+  &.ui.input {
+    width: 100%;
+
+    input {
+      border-radius: 8px !important;
+      border: 1px solid rgba(0, 0, 0, 0.1) !important;
+      padding: 8px 16px !important;
+      transition: all 0.2s ease !important;
+
+      &:focus {
+        border-color: #00b09b !important;
+        box-shadow: 0 0 0 2px rgba(0, 176, 155, 0.2) !important;
+      }
+    }
+  }
+`;
+
+const LabelsContainer = styled.div`
+  max-height: 400px;
+  overflow-y: auto;
+  padding: 8px;
+
+  &::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background-color: rgba(155, 155, 155, 0.5);
+    border-radius: 20px;
+    border: transparent;
+  }
+`;
+
+const LabelCard = styled.div<{ selected: boolean }>`
+  padding: 12px;
+  margin: 8px 4px;
+  background: ${(props) =>
+    props.selected ? "linear-gradient(135deg, #00b09b15, #96c93d15)" : "white"};
+  border: 1px solid
+    ${(props) => (props.selected ? "#00b09b" : "rgba(0,0,0,0.05)")};
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+
+  &:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+    border-color: ${(props) => (props.selected ? "#00b09b" : "#00b09b50")};
+  }
+
+  &:active {
+    transform: translateY(0px);
+  }
+`;
+
+const LabelHeader = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 4px;
+`;
+
+const LabelTitle = styled.div`
+  font-weight: 600;
+  color: #2d3436;
+  font-size: 0.95rem;
+`;
+
+const LabelDescription = styled.div`
+  color: #636e72;
+  font-size: 0.85rem;
+  line-height: 1.4;
+`;
+
+const FooterContainer = styled.div`
+  padding: 16px;
+  background: linear-gradient(135deg, #f8f9fa, #e9ecef);
+  border-top: 1px solid rgba(0, 0, 0, 0.05);
+  display: flex;
+  justify-content: flex-end;
+`;
+
+const AddButton = styled(Button)`
+  &.ui.button {
+    background: linear-gradient(135deg, #00b09b, #96c93d) !important;
+    color: white !important;
+    border: none !important;
+    padding: 10px 20px !important;
+    border-radius: 8px !important;
+    font-weight: 500 !important;
+    transition: all 0.2s ease !important;
+
+    &:hover:not(:disabled) {
+      transform: translateY(-1px);
+      box-shadow: 0 4px 12px rgba(0, 176, 155, 0.2) !important;
+    }
+
+    &:active:not(:disabled) {
+      transform: translateY(0px);
+    }
+
+    &:disabled {
+      opacity: 0.7 !important;
+      background: #e9ecef !important;
+      color: #636e72 !important;
+    }
+  }
+`;
 
 interface DocTypePopupProps {
   labels: AnnotationLabelType[];
@@ -19,7 +144,7 @@ export const DocTypePopup = ({ labels, onAdd }: DocTypePopupProps) => {
 
   const labelFuse = new Fuse(labels, {
     threshold: 0.4,
-    keys: ["label", "description"],
+    keys: ["text", "description"],
   });
 
   const filteredLabels =
@@ -27,65 +152,67 @@ export const DocTypePopup = ({ labels, onAdd }: DocTypePopupProps) => {
       ? labels
       : labelFuse.search(searchString).map((item) => item.item);
 
-  const items =
-    filteredLabels.length > 0 ? (
-      filteredLabels.map((label) => (
-        <LabelListItem
-          key={label.id}
-          label={label}
-          selected={Boolean(selectedLabel && selectedLabel.id === label.id)}
-          onSelect={selectLabel}
-        />
-      ))
-    ) : (
-      <EmptyLabelListItem />
-    );
-
-  function handleChange(e: {
-    target: { value: React.SetStateAction<string> };
-  }) {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setSearchString(e.target.value);
-  }
+  };
 
   return (
-    <div
-      id="doc-type-popup"
-      style={{
-        display: "flex",
-        flexDirection: "column",
-        justifyContent: "flex-start",
-      }}
-    >
-      <Segment style={{ width: "100%", margin: "0px" }}>
-        <Input
-          style={{ width: "100%" }}
-          placeholder="Search..."
-          name="searchString"
-          icon="search"
+    <PopupContainer>
+      <SearchContainer>
+        <StyledInput
+          placeholder="Search labels..."
           value={searchString}
           onChange={handleChange}
+          icon={<Icon name="search" color="grey" />}
         />
-      </Segment>
-      <Segment>
-        <Comment.Group
-          style={{
-            height: "30vh",
-            overflowY: "scroll",
-          }}
-        >
-          {items}
-        </Comment.Group>
-      </Segment>
-      <div>
-        <Button
+      </SearchContainer>
+
+      <LabelsContainer>
+        {filteredLabels.length > 0 ? (
+          filteredLabels.map((label) => (
+            <LabelCard
+              key={label.id}
+              selected={Boolean(selectedLabel && selectedLabel.id === label.id)}
+              onClick={() => selectLabel(label)}
+            >
+              <LabelHeader>
+                <LabelTitle>{label.text}</LabelTitle>
+                <Icon
+                  name={label.icon || "tag"}
+                  style={{
+                    color: label.color || "#00b09b",
+                    fontSize: "1.1em",
+                    opacity: 0.8,
+                  }}
+                />
+              </LabelHeader>
+              {label.description && (
+                <LabelDescription>{label.description}</LabelDescription>
+              )}
+            </LabelCard>
+          ))
+        ) : (
+          <LabelCard selected={false}>
+            <LabelHeader>
+              <LabelTitle>No Matching Labels</LabelTitle>
+              <Icon name="search minus" color="grey" />
+            </LabelHeader>
+            <LabelDescription>
+              No labels match your search criteria. Try adjusting your search
+              terms.
+            </LabelDescription>
+          </LabelCard>
+        )}
+      </LabelsContainer>
+
+      <FooterContainer>
+        <AddButton
           disabled={!selectedLabel}
-          floated="right"
-          positive
-          onClick={selectedLabel ? () => onAdd(selectedLabel) : () => {}}
+          onClick={selectedLabel ? () => onAdd(selectedLabel) : undefined}
         >
           Add Label
-        </Button>
-      </div>
-    </div>
+        </AddButton>
+      </FooterContainer>
+    </PopupContainer>
   );
 };

--- a/frontend/src/components/annotator/labels/label_selector/LabelSelector.tsx
+++ b/frontend/src/components/annotator/labels/label_selector/LabelSelector.tsx
@@ -24,6 +24,13 @@ export const LabelSelector: React.FC<LabelSelectorProps> = ({
 
   const { humanSpanLabels, humanTokenLabels } = useCorpusState();
 
+  // Add debug logging
+  console.log("LabelSelector state:", {
+    humanSpanLabels,
+    humanTokenLabels,
+    activeSpanLabel,
+  });
+
   const titleCharCount = width >= 1024 ? 64 : width >= 800 ? 36 : 24;
 
   const filteredLabelChoices = useMemo(() => {

--- a/frontend/src/components/annotator/labels/label_selector/LabelSelector.tsx
+++ b/frontend/src/components/annotator/labels/label_selector/LabelSelector.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from "react";
+import React, { useState, useMemo, useEffect } from "react";
 import styled from "styled-components";
 import { Icon, Popup } from "semantic-ui-react";
 import { AnnotationLabelType } from "../../../../types/graphql-api";
@@ -24,21 +24,25 @@ export const LabelSelector: React.FC<LabelSelectorProps> = ({
 
   const { humanSpanLabels, humanTokenLabels } = useCorpusState();
 
-  // Add debug logging
-  console.log("LabelSelector state:", {
-    humanSpanLabels,
-    humanTokenLabels,
-    activeSpanLabel,
-  });
+  // Add detailed debug logging
+
+  useEffect(() => {
+    console.log("LabelSelector labels changed:", {
+      humanSpanLabels,
+      humanTokenLabels,
+    });
+  }, [humanSpanLabels, humanTokenLabels]);
 
   const titleCharCount = width >= 1024 ? 64 : width >= 800 ? 36 : 24;
 
   const filteredLabelChoices = useMemo(() => {
-    return activeSpanLabel
+    const choices = activeSpanLabel
       ? [...humanSpanLabels, ...humanTokenLabels].filter(
           (obj) => obj.id !== activeSpanLabel.id
         )
       : [...humanSpanLabels, ...humanTokenLabels];
+
+    return choices;
   }, [humanSpanLabels, humanTokenLabels, activeSpanLabel]);
 
   const onSelect = (label: AnnotationLabelType): void => {

--- a/frontend/src/components/annotator/renderers/pdf/PDFPage.tsx
+++ b/frontend/src/components/annotator/renderers/pdf/PDFPage.tsx
@@ -11,7 +11,6 @@ import {
 } from "../../hooks/AnnotationHooks";
 import {
   scrollContainerRefAtom,
-  useSelectedCorpus,
   usePages,
   useTextSearchState,
 } from "../../context/DocumentAtom";
@@ -25,6 +24,7 @@ import { useAnnotationRefs } from "../../hooks/useAnnotationRefs";
 import SelectionLayer from "./SelectionLayer";
 import { PDFPageInfo } from "../../types/pdf";
 import _ from "lodash";
+import { useCorpusState } from "../../context/CorpusAtom";
 
 /**
  * PDFPage Component
@@ -64,7 +64,7 @@ export const PDFPage = ({ pageInfo, read_only, onError }: PageProps) => {
 
   const { textSearchMatches: searchResults, selectedTextSearchMatchIndex } =
     useTextSearchState();
-  const { selectedCorpus } = useSelectedCorpus();
+  const { selectedCorpus } = useCorpusState();
 
   const annotationControls = useAnnotationControls();
   const { spanLabelsToView, activeSpanLabel } = annotationControls;

--- a/frontend/src/components/annotator/renderers/pdf/SelectionLayer.tsx
+++ b/frontend/src/components/annotator/renderers/pdf/SelectionLayer.tsx
@@ -12,6 +12,7 @@ import { ServerTokenAnnotation } from "../../types/annotations";
 import { SelectionBoundary } from "../../display/components/SelectionBoundary";
 import { SelectionTokenGroup } from "../../display/components/SelectionTokenGroup";
 import { useCorpusState } from "../../context/CorpusAtom";
+import { useAnnotationSelection } from "../../hooks/useAnnotationSelection";
 
 interface SelectionLayerProps {
   pageInfo: PDFPageInfo;
@@ -30,6 +31,7 @@ const SelectionLayer = ({
 }: SelectionLayerProps) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const { permissions: corpus_permissions } = useCorpusState();
+  const { setSelectedAnnotations } = useAnnotationSelection();
   const [localPageSelection, setLocalPageSelection] = useState<
     { pageNumber: number; bounds: BoundingBox } | undefined
   >();
@@ -136,6 +138,7 @@ const SelectionLayer = ({
         corpus_permissions.includes(PermissionTypes.CAN_UPDATE)
       ) {
         if (!localPageSelection && event.buttons === 1) {
+          setSelectedAnnotations([]); // Clear any selected annotations
           const { left: containerAbsLeftOffset, top: containerAbsTopOffset } =
             containerRef.current.getBoundingClientRect();
           const left = event.pageX - containerAbsLeftOffset;
@@ -163,6 +166,7 @@ const SelectionLayer = ({
       localPageSelection,
       pageNumber,
       pageInfo,
+      setSelectedAnnotations,
     ]
   );
 

--- a/frontend/src/components/annotator/renderers/pdf/SelectionLayer.tsx
+++ b/frontend/src/components/annotator/renderers/pdf/SelectionLayer.tsx
@@ -13,6 +13,8 @@ import { SelectionBoundary } from "../../display/components/SelectionBoundary";
 import { SelectionTokenGroup } from "../../display/components/SelectionTokenGroup";
 import { useCorpusState } from "../../context/CorpusAtom";
 import { useAnnotationSelection } from "../../hooks/useAnnotationSelection";
+import { useAtom } from "jotai";
+import { isCreatingAnnotationAtom } from "../../context/UISettingsAtom";
 
 interface SelectionLayerProps {
   pageInfo: PDFPageInfo;
@@ -32,6 +34,7 @@ const SelectionLayer = ({
   const containerRef = useRef<HTMLDivElement>(null);
   const { permissions: corpus_permissions } = useCorpusState();
   const { setSelectedAnnotations } = useAnnotationSelection();
+  const [, setIsCreatingAnnotation] = useAtom(isCreatingAnnotationAtom);
   const [localPageSelection, setLocalPageSelection] = useState<
     { pageNumber: number; bounds: BoundingBox } | undefined
   >();
@@ -110,6 +113,7 @@ const SelectionLayer = ({
             [pageNum]: [...(prev[pageNum] || []), localPageSelection.bounds],
           };
           setLocalPageSelection(undefined);
+          setIsCreatingAnnotation(false); // Reset creating annotation state
 
           if (!event.shiftKey) {
             console.log("onMouseUp - handleCreateMultiPageAnnotation");
@@ -122,7 +126,13 @@ const SelectionLayer = ({
         console.log("onMouseUp - localPageSelection", localPageSelection);
       }
     },
-    [localPageSelection, pageNumber, handleCreateMultiPageAnnotation, pageInfo]
+    [
+      localPageSelection,
+      pageNumber,
+      handleCreateMultiPageAnnotation,
+      pageInfo,
+      setIsCreatingAnnotation,
+    ]
   );
 
   /**
@@ -139,6 +149,7 @@ const SelectionLayer = ({
       ) {
         if (!localPageSelection && event.buttons === 1) {
           setSelectedAnnotations([]); // Clear any selected annotations
+          setIsCreatingAnnotation(true); // Set creating annotation state
           const { left: containerAbsLeftOffset, top: containerAbsTopOffset } =
             containerRef.current.getBoundingClientRect();
           const left = event.pageX - containerAbsLeftOffset;
@@ -167,6 +178,7 @@ const SelectionLayer = ({
       pageNumber,
       pageInfo,
       setSelectedAnnotations,
+      setIsCreatingAnnotation,
     ]
   );
 

--- a/frontend/src/components/annotator/search_widget/SearchSidebarWidget.tsx
+++ b/frontend/src/components/annotator/search_widget/SearchSidebarWidget.tsx
@@ -150,14 +150,14 @@ export const SearchSidebarWidget: React.FC = () => {
             icon={
               <Icon
                 name={searchText ? "cancel" : "search"}
-                link
-                onClick={searchText ? setSearchText("") : undefined}
+                link={!!searchText}
+                onClick={() => (searchText ? setSearchText("") : undefined)}
                 style={{ color: searchText ? "#db2828" : "#2185d0" }}
               />
             }
             placeholder="Search document..."
             onChange={(e) => setSearchText(e.target.value)}
-            value={searchText}
+            value={searchText || ""}
             style={{ boxShadow: "0 2px 4px rgba(0,0,0,0.1)" }}
           />
         </Form>

--- a/frontend/src/components/annotator/sidebar/AnnotatorSidebar.tsx
+++ b/frontend/src/components/annotator/sidebar/AnnotatorSidebar.tsx
@@ -49,7 +49,7 @@ import {
 } from "../hooks/AnnotationHooks";
 import { ViewSettingsPopup } from "../../widgets/popups/ViewSettingsPopup";
 import { LabelDisplayBehavior } from "../../../types/graphql-api";
-import { useSelectedCorpus, useTextSearchState } from "../context/DocumentAtom";
+import { useTextSearchState } from "../context/DocumentAtom";
 import { useCorpusState } from "../context/CorpusAtom";
 
 interface TabPanelProps {
@@ -322,7 +322,7 @@ export const AnnotatorSidebar = ({
     setSelectedRelations,
   } = useAnnotationSelection();
   const { isSidebarVisible, setSidebarVisible } = useUISettings();
-  const { selectedCorpus: selected_corpus } = useSelectedCorpus();
+  const { selectedCorpus: selected_corpus } = useCorpusState();
   const {
     selectedAnalysis: selected_analysis,
     selectedExtract: selected_extract,

--- a/frontend/src/components/corpuses/CorpusItem.tsx
+++ b/frontend/src/components/corpuses/CorpusItem.tsx
@@ -416,9 +416,7 @@ export const CorpusItem: React.FC<CorpusItemProps> = ({
                   <span>
                     Text Labels:{" "}
                     <span className="count">
-                      {labelSet.allAnnotationLabels?.filter(
-                        (l) => l?.labelType === LabelType.TokenLabel
-                      ).length || 0}
+                      {labelSet.tokenLabelCount || 0}
                     </span>
                   </span>
                 </StatItem>
@@ -426,11 +424,7 @@ export const CorpusItem: React.FC<CorpusItemProps> = ({
                   <FileText />
                   <span>
                     Doc Types:{" "}
-                    <span className="count">
-                      {labelSet.allAnnotationLabels?.filter(
-                        (l) => l?.labelType === LabelType.DocTypeLabel
-                      ).length || 0}
-                    </span>
+                    <span className="count">{labelSet.docLabelCount || 0}</span>
                   </span>
                 </StatItem>
                 <StatItem>
@@ -438,9 +432,7 @@ export const CorpusItem: React.FC<CorpusItemProps> = ({
                   <span>
                     Relations:{" "}
                     <span className="count">
-                      {labelSet.allAnnotationLabels?.filter(
-                        (l) => l?.labelType === LabelType.RelationshipLabel
-                      ).length || 0}
+                      {labelSet.spanLabelCount || 0}
                     </span>
                   </span>
                 </StatItem>
@@ -449,9 +441,7 @@ export const CorpusItem: React.FC<CorpusItemProps> = ({
                   <span>
                     Metadata:{" "}
                     <span className="count">
-                      {labelSet.allAnnotationLabels?.filter(
-                        (l) => l?.labelType === LabelType.MetadataLabel
-                      ).length || 0}
+                      {labelSet.metadataLabelCount || 0}
                     </span>
                   </span>
                 </StatItem>

--- a/frontend/src/components/layout/CardLayout.tsx
+++ b/frontend/src/components/layout/CardLayout.tsx
@@ -35,6 +35,7 @@ const ScrollableSegment = styled(StyledSegment)`
     scrollbar-width: thin;
     scrollbar-color: #888 #f1f1f1;
     color: red;
+    border-radius: 12px !important;
 
     &::-webkit-scrollbar {
       width: 8px;
@@ -42,6 +43,7 @@ const ScrollableSegment = styled(StyledSegment)`
 
     &::-webkit-scrollbar-track {
       background: #f1f1f1;
+      border-radius: 4px;
     }
 
     &::-webkit-scrollbar-thumb {

--- a/frontend/src/components/layout/CardLayout.tsx
+++ b/frontend/src/components/layout/CardLayout.tsx
@@ -16,6 +16,38 @@ const StyledSegment = styled(Segment)`
     border: none;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
     margin-bottom: 1rem;
+    border-radius: 12px !important;
+    background: #ffffff !important;
+    transition: all 0.2s ease;
+
+    &:hover {
+      background: #ffffff !important;
+      box-shadow: 0 4px 8px rgba(0, 0, 0, 0.08);
+    }
+
+    /* Style for breadcrumb links */
+    .breadcrumb {
+      a {
+        color: var(--text-primary, #1a2433);
+        opacity: 0.85;
+        transition: all 0.2s ease;
+
+        &:hover {
+          opacity: 1;
+          transform: translateY(-1px);
+        }
+      }
+
+      .active {
+        color: var(--text-primary, #1a2433);
+        font-weight: 500;
+      }
+
+      .divider {
+        opacity: 0.5;
+        margin: 0 0.5em;
+      }
+    }
   }
 `;
 
@@ -36,6 +68,11 @@ const ScrollableSegment = styled(StyledSegment)`
     scrollbar-color: #888 #f1f1f1;
     color: red;
     border-radius: 12px !important;
+    background: #ffffff !important;
+
+    &:hover {
+      background: #ffffff !important;
+    }
 
     &::-webkit-scrollbar {
       width: 8px;

--- a/frontend/src/components/layout/CardLayout.tsx
+++ b/frontend/src/components/layout/CardLayout.tsx
@@ -19,6 +19,11 @@ const StyledSegment = styled(Segment)`
   }
 `;
 
+const SearchBarWrapper = styled.div`
+  width: 100%;
+  margin-bottom: 1rem;
+`;
+
 const ScrollableSegment = styled(StyledSegment)`
   &.ui.segment {
     flex: 1;
@@ -68,9 +73,7 @@ export const CardLayout: React.FC<CardLayoutProps> = ({
       style={{ maxHeight: "90vh", ...style }}
     >
       {Modals}
-      <StyledSegment attached="top" secondary className="SearchBar">
-        {SearchBar}
-      </StyledSegment>
+      <SearchBarWrapper>{SearchBar}</SearchBarWrapper>
       {BreadCrumbs && (
         <StyledSegment attached secondary>
           {BreadCrumbs}

--- a/frontend/src/components/widgets/popups/ViewSettingsPopup.tsx
+++ b/frontend/src/components/widgets/popups/ViewSettingsPopup.tsx
@@ -83,14 +83,7 @@ export const ViewSettingsPopup: React.FC<ViewSettingsPopupProps> = ({
               checked={localShowSelected}
             />
           </Grid.Column>
-          <Grid.Column textAlign="center" verticalAlign="middle">
-            <Header size="tiny">Show Layout Blocks</Header>
-            <Checkbox
-              toggle
-              onChange={handleShowStructuralChange}
-              checked={localShowStructural}
-            />
-          </Grid.Column>
+
           <Grid.Column textAlign="center" verticalAlign="middle">
             <Header size="tiny">Show Bounding Boxes</Header>
             <Checkbox

--- a/frontend/src/graphql/queries.ts
+++ b/frontend/src/graphql/queries.ts
@@ -468,6 +468,10 @@ export const GET_CORPUSES = gql`
             id
             title
             description
+            docLabelCount
+            spanLabelCount
+            tokenLabelCount
+            metadataLabelCount
           }
         }
       }

--- a/frontend/src/graphql/queries.ts
+++ b/frontend/src/graphql/queries.ts
@@ -1665,6 +1665,9 @@ export const GET_DOCUMENT_ANNOTATIONS_AND_RELATIONSHIPS = gql`
       allStructuralAnnotations {
         id
         page
+        parent {
+          id
+        }
         annotationLabel {
           id
           text

--- a/frontend/src/types/graphql-api.ts
+++ b/frontend/src/types/graphql-api.ts
@@ -112,6 +112,7 @@ export type AnnotationLabelTypeEdge = {
 export type ServerAnnotationType = Node & {
   __typename?: "AnnotationType";
   id: Scalars["ID"];
+  parent?: Maybe<ServerAnnotationType>;
   page: Scalars["Int"];
   annotationType?: LabelType;
   userFeedback?: FeedbackTypeConnection;

--- a/frontend/src/types/graphql-api.ts
+++ b/frontend/src/types/graphql-api.ts
@@ -367,6 +367,10 @@ export type LabelSetType = Node & {
   icon?: Scalars["String"];
   annotationLabels?: AnnotationLabelTypeConnection;
   allAnnotationLabels?: AnnotationLabelType[];
+  docLabelCount?: Scalars["Int"];
+  spanLabelCount?: Scalars["Int"];
+  tokenLabelCount?: Scalars["Int"];
+  metadataLabelCount?: Scalars["Int"];
   creator?: UserType;
   created?: Scalars["DateTime"];
   modified?: Scalars["DateTime"];

--- a/frontend/src/utils/transform.ts
+++ b/frontend/src/utils/transform.ts
@@ -101,6 +101,14 @@ export function convertToDocTypeAnnotation(
   );
 }
 
+export function convertToDocTypeAnnotations(
+  annotations: ServerAnnotationType[]
+): DocTypeAnnotation[] {
+  return annotations
+    .filter((ann) => ann.annotationLabel.labelType === LabelType.DocTypeLabel)
+    .map((ann) => convertToDocTypeAnnotation(ann));
+}
+
 export function convertToServerAnnotation(
   annotation: ServerAnnotationType,
   allowComments?: boolean

--- a/frontend/src/views/Corpuses.tsx
+++ b/frontend/src/views/Corpuses.tsx
@@ -411,11 +411,14 @@ export const Corpuses = () => {
   // TODO - Improve typing.
   const handleUpdateCorpus = (corpus_obj: any) => {
     console.log("handleUpdateCorpus", corpus_obj);
-    let variables = {
-      variables: corpus_obj,
+
+    // Extract just the labelSet ID if it exists
+    const variables = {
+      ...corpus_obj,
+      labelSet: corpus_obj.labelSet?.id || null,
     };
-    // console.log("handleUpdateCorpus variables", variables);
-    tryMutateCorpus(variables);
+
+    tryMutateCorpus({ variables });
   };
 
   // TODO - Improve typing.

--- a/opencontractserver/pipeline/parsers/docling_parser.py
+++ b/opencontractserver/pipeline/parsers/docling_parser.py
@@ -541,9 +541,7 @@ class DoclingParser(BaseParser):
 
                         w = x1 - x0
                         h = y1 - y0
-                        y = (
-                            height - y1
-                        )  # Flip y-coordinate to match the coordinate system
+                        y = y0  # Use y0 directly without flipping
 
                         token: PawlsTokenPythonType = {
                             "x": x0,
@@ -577,8 +575,8 @@ class DoclingParser(BaseParser):
                     # Create PawlsPagePythonType
                     pawls_page: PawlsPagePythonType = {
                         "page": {
-                            "width": width,
-                            "height": height,
+                            "width": width * scale_x,
+                            "height": height * scale_y,
                             "index": page_num,
                         },
                         "tokens": tokens,
@@ -643,7 +641,7 @@ class DoclingParser(BaseParser):
                         w *= scale_x
                         h *= scale_y
 
-                        y = height - y - h  # Flip y-coordinate
+                        y = y  # Use y directly without flipping
 
                         token: PawlsTokenPythonType = {
                             "x": x,

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -1,12 +1,13 @@
 -r base.txt
 
-Werkzeug==3.0.3 # https://github.com/pallets/werkzeug
+psycopg[c]==3.2.3  # https://github.com/psycopg/psycopg
+watchfiles==1.0.3  # https://github.com/samuelcolvin/watchfiles
+Werkzeug[watchdog]==3.1.3 # https://github.com/pallets/werkzeug
 ipdb==0.13.13  # https://github.com/gotcha/ipdb
-psycopg2==2.9.9  # https://github.com/psycopg/psycopg2
-watchgod==0.8.2  # https://github.com/samuelcolvin/watchgod
 
 # Testing
 # ------------------------------------------------------------------------------
+
 mypy==1.11.2  # https://github.com/python/mypy
 django-stubs==4.2.7  # https://github.com/typeddjango/django-stubs
 pytest==8.3.3  # https://github.com/pytest-dev/pytest
@@ -39,8 +40,8 @@ pre-commit==3.7.1  # https://github.com/pre-commit/pre-commit
 # Django
 # ------------------------------------------------------------------------------
 factory-boy==3.3.1  # https://github.com/FactoryBoy/factory_boy
-
 django-debug-toolbar==4.4.6  # https://github.com/jazzband/django-debug-toolbar
+django-extensions==3.2.3  # https://github.com/django-extensions/django-extensions
 django-coverage-plugin==3.1.0  # https://github.com/nedbat/django_coverage_plugin
 pytest-django==4.9.0  # https://github.com/pytest-dev/pytest-django
 


### PR DESCRIPTION
Fixed some issues:

- [X] `runserver_plus` failing post modular parser pipeline 
- [X] celery worker watchdog syntax replaced with watchfiles
- [X] Fixed annotation and doc type label state handling and styling
- [X] Fix y coordinate inversion on docling parser
- [X] Fix search handling in annotator
- [X] Fix responsiveness of annotation selection layer so we can easily drag over existing annotations
- [X] Improve edit modal styling (e.g. edit corpus details)
- [X] Improve edit labelset modal styling (layout is off but overall look is OK)
- [X] Improve labelset popup on corpus card positioning (looks awful)
- [X] Fix card layout so we're not adding extract card around search bar
- [X] Ensure structural annotations are loading (they are, but, for a number of reasons, we are NOT going to allow all of them to render. It is a nightmare on performance to have hundreds of annotations potentially rendered at once. 