### PR TITLE
Fix non-PDF document export functionality (#449)

### DIFF
--- a/opencontractserver/tests/test_non_pdf_export.py
+++ b/opencontractserver/tests/test_non_pdf_export.py
@@ -1,0 +1,253 @@
+import io
+import pathlib
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.core.files.base import ContentFile
+from django.test import TestCase
+
+from opencontractserver.annotations.models import Annotation, AnnotationLabel
+from opencontractserver.corpuses.models import Corpus
+from opencontractserver.documents.models import Document
+from opencontractserver.types.enums import PermissionTypes
+from opencontractserver.utils.etl import build_document_export, build_label_lookups
+from opencontractserver.utils.permissioning import set_permissions_for_obj_to_user
+
+User = get_user_model()
+
+pytestmark = pytest.mark.django_db
+
+
+class NonPDFExportTestCase(TestCase):
+    """Test that non-PDF documents can be exported without errors"""
+
+    fixtures_path = pathlib.Path(__file__).parent / "fixtures"
+
+    def setUp(self):
+        self.user = User.objects.create_user(username="testuser", password="testpass123")
+
+        # Create a corpus
+        self.corpus = Corpus.objects.create(
+            title="Test Corpus",
+            creator=self.user,
+            backend_lock=False
+        )
+        set_permissions_for_obj_to_user(
+            self.user, self.corpus, [PermissionTypes.ALL]
+        )
+
+        # Create annotation labels
+        self.text_label = AnnotationLabel.objects.create(
+            text="TestLabel",
+            label_type="TOKEN_LABEL",
+            color="#FF0000",
+            description="Test label",
+            creator=self.user
+        )
+
+        self.doc_label = AnnotationLabel.objects.create(
+            text="DocTypeLabel",
+            label_type="DOC_TYPE_LABEL",
+            color="#00FF00",
+            description="Doc type label",
+            creator=self.user
+        )
+
+    def create_document(self, file_type="application/pdf", has_pdf_file=True):
+        """Helper to create a document with specified file type"""
+        doc = Document.objects.create(
+            title="Test Document",
+            description="Test description",
+            creator=self.user,
+            file_type=file_type,
+            page_count=1
+        )
+
+        if has_pdf_file:
+            # Create a simple file (not a real PDF for non-PDF types)
+            content = b"Test content"
+            doc.pdf_file.save(
+                f"test_doc_{doc.id}.txt",
+                ContentFile(content)
+            )
+
+        # Create a simple text extract file
+        doc.txt_extract_file.save(
+            f"test_extract_{doc.id}.txt",
+            ContentFile(b"Extracted text content")
+        )
+
+        # Create a simple pawls file with minimal structure
+        pawls_content = b'[{"page": {"index": 1, "width": 612, "height": 792}, "tokens": []}]'
+        doc.pawls_parse_file.save(
+            f"test_pawls_{doc.id}.json",
+            ContentFile(pawls_content)
+        )
+
+        doc.save()
+        return doc
+
+    def add_annotation_to_doc(self, doc, label, annotation_json=None):
+        """Helper to add an annotation to a document"""
+        if annotation_json is None:
+            annotation_json = {
+                "1": {
+                    "bounds": {
+                        "left": 10,
+                        "top": 20,
+                        "right": 100,
+                        "bottom": 40
+                    }
+                }
+            }
+
+        return Annotation.objects.create(
+            document=doc,
+            corpus=self.corpus,
+            annotation_label=label,
+            raw_text="Test annotation text",
+            page=1,
+            json=annotation_json,
+            creator=self.user
+        )
+
+    def test_pdf_export_still_works(self):
+        """Test that PDF export still works as before (backward compatibility)"""
+        print("\n# TEST PDF EXPORT BACKWARD COMPATIBILITY ##")
+
+        # Create a PDF document
+        pdf_doc = self.create_document(file_type="application/pdf")
+        self.corpus.documents.add(pdf_doc)
+
+        # Add annotation
+        self.add_annotation_to_doc(pdf_doc, self.text_label)
+
+        # Build label lookups
+        label_lookups = build_label_lookups(corpus_id=self.corpus.id)
+
+        # Export the document
+        doc_name, base64_pdf, doc_json, text_labels, doc_labels = build_document_export(
+            label_lookups=label_lookups,
+            doc_id=pdf_doc.id,
+            corpus_id=self.corpus.id
+        )
+
+        print(f"PDF export - doc_name: {doc_name}")
+        print(f"PDF export - has base64_pdf: {bool(base64_pdf)}")
+        print(f"PDF export - has doc_json: {bool(doc_json)}")
+
+        # For PDFs, we should get the PDF bytes (though they might fail if not a real PDF)
+        # The important thing is that it doesn't crash
+        assert doc_name is not None
+        assert doc_json is not None
+        assert doc_json["title"] == "Test Document"
+        print("\t\tSUCCESS - PDF export works")
+
+    def test_non_pdf_text_export(self):
+        """Test that non-PDF text documents can be exported"""
+        print("\n# TEST NON-PDF TEXT DOCUMENT EXPORT ##")
+
+        # Create a text document
+        text_doc = self.create_document(file_type="text/plain")
+        self.corpus.documents.add(text_doc)
+
+        # Add annotations
+        self.add_annotation_to_doc(text_doc, self.text_label)
+        doc_annot = Annotation.objects.create(
+            document=text_doc,
+            corpus=self.corpus,
+            annotation_label=self.doc_label,
+            raw_text="",
+            creator=self.user
+        )
+
+        # Build label lookups
+        label_lookups = build_label_lookups(corpus_id=self.corpus.id)
+
+        # Export the document
+        doc_name, base64_pdf, doc_json, text_labels, doc_labels = build_document_export(
+            label_lookups=label_lookups,
+            doc_id=text_doc.id,
+            corpus_id=self.corpus.id
+        )
+
+        print(f"Text export - doc_name: {doc_name}")
+        print(f"Text export - base64_pdf: '{base64_pdf}' (should be empty)")
+        print(f"Text export - has doc_json: {bool(doc_json)}")
+
+        # For non-PDFs, we should get empty PDF bytes but valid JSON
+        assert doc_name is not None
+        assert base64_pdf == "", "Non-PDF should have empty base64_pdf string"
+        assert doc_json is not None
+        assert doc_json["title"] == "Test Document"
+        assert doc_json["content"] == "Extracted text content"
+        assert len(doc_json["labelled_text"]) == 1
+        assert len(doc_json["doc_labels"]) == 1
+        print("\t\tSUCCESS - Non-PDF text export works correctly")
+
+    def test_non_pdf_docx_export(self):
+        """Test that DOCX documents can be exported"""
+        print("\n# TEST DOCX DOCUMENT EXPORT ##")
+
+        # Create a DOCX document
+        docx_doc = self.create_document(
+            file_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        )
+        self.corpus.documents.add(docx_doc)
+
+        # Add annotation
+        self.add_annotation_to_doc(docx_doc, self.text_label)
+
+        # Build label lookups
+        label_lookups = build_label_lookups(corpus_id=self.corpus.id)
+
+        # Export the document
+        doc_name, base64_pdf, doc_json, text_labels, doc_labels = build_document_export(
+            label_lookups=label_lookups,
+            doc_id=docx_doc.id,
+            corpus_id=self.corpus.id
+        )
+
+        print(f"DOCX export - doc_name: {doc_name}")
+        print(f"DOCX export - base64_pdf: '{base64_pdf}' (should be empty)")
+        print(f"DOCX export - has doc_json: {bool(doc_json)}")
+
+        # For non-PDFs, we should get empty PDF bytes but valid JSON
+        assert doc_name is not None
+        assert base64_pdf == "", "Non-PDF should have empty base64_pdf string"
+        assert doc_json is not None
+        assert doc_json["title"] == "Test Document"
+        assert len(doc_json["labelled_text"]) == 1
+        print("\t\tSUCCESS - DOCX export works correctly")
+
+    def test_non_pdf_without_pdf_file(self):
+        """Test that documents without pdf_file can be exported"""
+        print("\n# TEST DOCUMENT WITHOUT PDF FILE ##")
+
+        # Create a document without a pdf_file
+        doc = self.create_document(file_type="text/plain", has_pdf_file=False)
+        self.corpus.documents.add(doc)
+
+        # Add annotation
+        self.add_annotation_to_doc(doc, self.text_label)
+
+        # Build label lookups
+        label_lookups = build_label_lookups(corpus_id=self.corpus.id)
+
+        # Export the document
+        doc_name, base64_pdf, doc_json, text_labels, doc_labels = build_document_export(
+            label_lookups=label_lookups,
+            doc_id=doc.id,
+            corpus_id=self.corpus.id
+        )
+
+        print(f"No PDF file export - doc_name: {doc_name}")
+        print(f"No PDF file export - base64_pdf: '{base64_pdf}' (should be empty)")
+        print(f"No PDF file export - has doc_json: {bool(doc_json)}")
+
+        # Should still work with empty PDF bytes
+        assert doc_name == "document"
+        assert base64_pdf == ""
+        assert doc_json is not None
+        assert len(doc_json["labelled_text"]) == 1
+        print("\t\tSUCCESS - Export without PDF file works correctly")

--- a/opencontractserver/tests/test_non_pdf_export.py
+++ b/opencontractserver/tests/test_non_pdf_export.py
@@ -1,4 +1,3 @@
-import io
 import pathlib
 
 import pytest
@@ -24,17 +23,15 @@ class NonPDFExportTestCase(TestCase):
     fixtures_path = pathlib.Path(__file__).parent / "fixtures"
 
     def setUp(self):
-        self.user = User.objects.create_user(username="testuser", password="testpass123")
+        self.user = User.objects.create_user(
+            username="testuser", password="testpass123"
+        )
 
         # Create a corpus
         self.corpus = Corpus.objects.create(
-            title="Test Corpus",
-            creator=self.user,
-            backend_lock=False
+            title="Test Corpus", creator=self.user, backend_lock=False
         )
-        set_permissions_for_obj_to_user(
-            self.user, self.corpus, [PermissionTypes.ALL]
-        )
+        set_permissions_for_obj_to_user(self.user, self.corpus, [PermissionTypes.ALL])
 
         # Create annotation labels
         self.text_label = AnnotationLabel.objects.create(
@@ -42,7 +39,7 @@ class NonPDFExportTestCase(TestCase):
             label_type="TOKEN_LABEL",
             color="#FF0000",
             description="Test label",
-            creator=self.user
+            creator=self.user,
         )
 
         self.doc_label = AnnotationLabel.objects.create(
@@ -50,7 +47,7 @@ class NonPDFExportTestCase(TestCase):
             label_type="DOC_TYPE_LABEL",
             color="#00FF00",
             description="Doc type label",
-            creator=self.user
+            creator=self.user,
         )
 
     def create_document(self, file_type="application/pdf", has_pdf_file=True):
@@ -60,28 +57,25 @@ class NonPDFExportTestCase(TestCase):
             description="Test description",
             creator=self.user,
             file_type=file_type,
-            page_count=1
+            page_count=1,
         )
 
         if has_pdf_file:
             # Create a simple file (not a real PDF for non-PDF types)
             content = b"Test content"
-            doc.pdf_file.save(
-                f"test_doc_{doc.id}.txt",
-                ContentFile(content)
-            )
+            doc.pdf_file.save(f"test_doc_{doc.id}.txt", ContentFile(content))
 
         # Create a simple text extract file
         doc.txt_extract_file.save(
-            f"test_extract_{doc.id}.txt",
-            ContentFile(b"Extracted text content")
+            f"test_extract_{doc.id}.txt", ContentFile(b"Extracted text content")
         )
 
         # Create a simple pawls file with minimal structure
-        pawls_content = b'[{"page": {"index": 1, "width": 612, "height": 792}, "tokens": []}]'
+        pawls_content = (
+            b'[{"page": {"index": 1, "width": 612, "height": 792}, "tokens": []}]'
+        )
         doc.pawls_parse_file.save(
-            f"test_pawls_{doc.id}.json",
-            ContentFile(pawls_content)
+            f"test_pawls_{doc.id}.json", ContentFile(pawls_content)
         )
 
         doc.save()
@@ -91,14 +85,7 @@ class NonPDFExportTestCase(TestCase):
         """Helper to add an annotation to a document"""
         if annotation_json is None:
             annotation_json = {
-                "1": {
-                    "bounds": {
-                        "left": 10,
-                        "top": 20,
-                        "right": 100,
-                        "bottom": 40
-                    }
-                }
+                "1": {"bounds": {"left": 10, "top": 20, "right": 100, "bottom": 40}}
             }
 
         return Annotation.objects.create(
@@ -108,7 +95,7 @@ class NonPDFExportTestCase(TestCase):
             raw_text="Test annotation text",
             page=1,
             json=annotation_json,
-            creator=self.user
+            creator=self.user,
         )
 
     def test_pdf_export_still_works(self):
@@ -127,9 +114,7 @@ class NonPDFExportTestCase(TestCase):
 
         # Export the document
         doc_name, base64_pdf, doc_json, text_labels, doc_labels = build_document_export(
-            label_lookups=label_lookups,
-            doc_id=pdf_doc.id,
-            corpus_id=self.corpus.id
+            label_lookups=label_lookups, doc_id=pdf_doc.id, corpus_id=self.corpus.id
         )
 
         print(f"PDF export - doc_name: {doc_name}")
@@ -153,12 +138,12 @@ class NonPDFExportTestCase(TestCase):
 
         # Add annotations
         self.add_annotation_to_doc(text_doc, self.text_label)
-        doc_annot = Annotation.objects.create(
+        Annotation.objects.create(
             document=text_doc,
             corpus=self.corpus,
             annotation_label=self.doc_label,
             raw_text="",
-            creator=self.user
+            creator=self.user,
         )
 
         # Build label lookups
@@ -166,9 +151,7 @@ class NonPDFExportTestCase(TestCase):
 
         # Export the document
         doc_name, base64_pdf, doc_json, text_labels, doc_labels = build_document_export(
-            label_lookups=label_lookups,
-            doc_id=text_doc.id,
-            corpus_id=self.corpus.id
+            label_lookups=label_lookups, doc_id=text_doc.id, corpus_id=self.corpus.id
         )
 
         print(f"Text export - doc_name: {doc_name}")
@@ -203,9 +186,7 @@ class NonPDFExportTestCase(TestCase):
 
         # Export the document
         doc_name, base64_pdf, doc_json, text_labels, doc_labels = build_document_export(
-            label_lookups=label_lookups,
-            doc_id=docx_doc.id,
-            corpus_id=self.corpus.id
+            label_lookups=label_lookups, doc_id=docx_doc.id, corpus_id=self.corpus.id
         )
 
         print(f"DOCX export - doc_name: {doc_name}")
@@ -236,9 +217,7 @@ class NonPDFExportTestCase(TestCase):
 
         # Export the document
         doc_name, base64_pdf, doc_json, text_labels, doc_labels = build_document_export(
-            label_lookups=label_lookups,
-            doc_id=doc.id,
-            corpus_id=self.corpus.id
+            label_lookups=label_lookups, doc_id=doc.id, corpus_id=self.corpus.id
         )
 
         print(f"No PDF file export - doc_name: {doc_name}")

--- a/opencontractserver/utils/etl.py
+++ b/opencontractserver/utils/etl.py
@@ -163,7 +163,9 @@ def build_document_export(
         doc_labels = label_lookups["doc_labels"]
 
         doc = Document.objects.get(pk=doc_id)
-        doc_name: str = os.path.basename(doc.pdf_file.name) if doc.pdf_file else "document"
+        doc_name: str = (
+            os.path.basename(doc.pdf_file.name) if doc.pdf_file else "document"
+        )
 
         corpus = Corpus.objects.get(pk=corpus_id)
 
@@ -181,9 +183,7 @@ def build_document_export(
         pawls_tokens: list[PawlsPagePythonType] = []
         try:
             with default_storage.open(doc.pawls_parse_file.name) as pawls_file:
-                pawls_tokens = json.loads(
-                    pawls_file.read().decode("utf-8")
-                )
+                pawls_tokens = json.loads(pawls_file.read().decode("utf-8"))
         except Exception as e:
             logger.warning(f"Could not export pawls tokens for doc {doc_id}: {e}")
 
@@ -307,6 +307,7 @@ def build_document_export(
             logger.info(f"Processing as PDF document: {doc_id}")
 
             from PyPDF2 import PdfReader, PdfWriter
+
             from opencontractserver.utils.files import (
                 add_highlight_to_new_page,
                 createHighlight,
@@ -344,10 +345,13 @@ def build_document_export(
                                     round(x_scale * rect["left"]),
                                     round(float(page_height) - y_scale * rect["top"]),
                                     round(x_scale * rect["right"]),
-                                    round(float(page_height) - y_scale * rect["bottom"]),
+                                    round(
+                                        float(page_height) - y_scale * rect["bottom"]
+                                    ),
                                     {"author": "Label:", "contents": label["text"]},
                                     color=tuple(
-                                        int(label["color"].lstrip("#")[i : i + 2], 16) / 256
+                                        int(label["color"].lstrip("#")[i : i + 2], 16)
+                                        / 256
                                         for i in (0, 2, 4)
                                     ),
                                 )
@@ -365,7 +369,9 @@ def build_document_export(
                 logger.error(f"Stack trace: {traceback.format_exc()}")
                 # Continue with empty PDF bytes for non-PDF or failed PDF processing
         else:
-            logger.info(f"Skipping PDF processing for non-PDF document: {doc_id} (file_type: {doc.file_type})")
+            logger.info(
+                f"Skipping PDF processing for non-PDF document: {doc_id} (file_type: {doc.file_type})"
+            )
 
         return (
             doc_name,


### PR DESCRIPTION
## Summary
- Fixes #449: Ensures non-PDF documents can be exported without errors
- Modified `build_document_export()` to check `file_type` before PDF processing
- Non-PDF documents now skip PDF processing but still return annotation data
- Added comprehensive test suite for various document types

## Changes
- Modified `opencontractserver/utils/etl.py` to conditionally process PDFs
- Added `test_non_pdf_export.py` with tests for PDF, text, DOCX, and documents without pdf_file
- All tests pass successfully

## Test Plan
- [x] Test PDF export (backward compatibility)
- [x] Test non-PDF text document export
- [x] Test DOCX document export
- [x] Test document without pdf_file
- [x] All 4 test cases pass