### PR TITLE
Add Page Imaging Tool for Agents (#403)

### DIFF
--- a/opencontractserver/llms/tools/tool_factory.py
+++ b/opencontractserver/llms/tools/tool_factory.py
@@ -264,6 +264,7 @@ def _extract_parameter_descriptions_from_docstring(func: Callable) -> dict[str, 
 def create_document_tools() -> list[CoreTool]:
     """Create standard document-related tools."""
     from opencontractserver.llms.tools.core_tools import (
+        aget_page_image,
         asearch_exact_text_as_sources,
         get_md_summary_token_length,
         get_note_content_token_length,
@@ -299,5 +300,12 @@ def create_document_tools() -> list[CoreTool]:
         CoreTool.from_function(
             get_partial_note_content,
             description="Get a substring of a note's content by start/end indices.",
+        ),
+        CoreTool.from_function(
+            aget_page_image,
+            description=(
+                "Get a visual image of a specific page from a PDF document. "
+                "Useful for inspecting diagrams, tables, images, and other visual content that may not be captured in text."
+            ),
         ),
     ]

--- a/opencontractserver/llms/tools/tool_factory.py
+++ b/opencontractserver/llms/tools/tool_factory.py
@@ -305,7 +305,8 @@ def create_document_tools() -> list[CoreTool]:
             aget_page_image,
             description=(
                 "Get a visual image of a specific page from a PDF document. "
-                "Useful for inspecting diagrams, tables, images, and other visual content that may not be captured in text."
+                "Useful for inspecting diagrams, tables, images, and other "
+                "visual content that may not be captured in text."
             ),
         ),
     ]

--- a/opencontractserver/tests/test_core_tool_factory.py
+++ b/opencontractserver/tests/test_core_tool_factory.py
@@ -163,6 +163,7 @@ class TestCreateDocumentTools(SimpleTestCase):
             "get_notes_for_document_corpus",
             "get_note_content_token_length",
             "get_partial_note_content",
+            "aget_page_image",
         }
         self.assertEqual({tool.name for tool in tools}, expected_names)
         # Ensure all returned objects are CoreTool instances

--- a/opencontractserver/tests/test_page_imaging_tool.py
+++ b/opencontractserver/tests/test_page_imaging_tool.py
@@ -23,7 +23,9 @@ class PageImagingToolTestCase(TestCase):
     fixtures_path = pathlib.Path(__file__).parent / "fixtures"
 
     def setUp(self):
-        self.user = User.objects.create_user(username="testuser", password="testpass123")
+        self.user = User.objects.create_user(
+            username="testuser", password="testpass123"
+        )
 
     def create_pdf_document(self, pdf_filename="TestDocument.pdf"):
         """Helper to create a document with a real PDF file from fixtures"""
@@ -32,17 +34,14 @@ class PageImagingToolTestCase(TestCase):
             description="Test document for page imaging",
             creator=self.user,
             file_type="application/pdf",
-            page_count=2  # Assuming test PDF has 2 pages
+            page_count=2,  # Assuming test PDF has 2 pages
         )
 
         # Load a real PDF from fixtures
         pdf_path = self.fixtures_path / pdf_filename
         if pdf_path.exists():
             with open(pdf_path, "rb") as pdf_file:
-                doc.pdf_file.save(
-                    pdf_filename,
-                    ContentFile(pdf_file.read())
-                )
+                doc.pdf_file.save(pdf_filename, ContentFile(pdf_file.read()))
         else:
             # Create a minimal valid PDF if fixture doesn't exist
             # This is a minimal PDF with 1 blank page
@@ -55,10 +54,7 @@ class PageImagingToolTestCase(TestCase):
                 b"0000000058 00000 n\n0000000115 00000 n\ntrailer\n"
                 b"<</Size 4/Root 1 0 R>>\nstartxref\n206\n%%EOF"
             )
-            doc.pdf_file.save(
-                "minimal.pdf",
-                ContentFile(minimal_pdf)
-            )
+            doc.pdf_file.save("minimal.pdf", ContentFile(minimal_pdf))
             doc.page_count = 1
 
         doc.save()
@@ -72,14 +68,11 @@ class PageImagingToolTestCase(TestCase):
             description="Non-PDF document",
             creator=self.user,
             file_type="text/plain",
-            page_count=1
+            page_count=1,
         )
 
         content = b"Test content"
-        doc.pdf_file.save(
-            f"test_doc.txt",
-            ContentFile(content)
-        )
+        doc.pdf_file.save("test_doc.txt", ContentFile(content))
 
         doc.save()
         return doc
@@ -95,7 +88,7 @@ class PageImagingToolTestCase(TestCase):
             document_id=pdf_doc.id,
             page_number=1,
             image_format="jpeg",
-            dpi=72  # Low DPI for faster tests
+            dpi=72,  # Low DPI for faster tests
         )
 
         print(f"Got base64 image, length: {len(base64_image)}")
@@ -110,6 +103,7 @@ class PageImagingToolTestCase(TestCase):
 
         # Verify it's a valid JPEG
         import io
+
         image = Image.open(io.BytesIO(image_bytes))
         assert image.format == "JPEG"
         print(f"Image dimensions: {image.size}")
@@ -124,15 +118,13 @@ class PageImagingToolTestCase(TestCase):
 
         # Get the first page as PNG
         base64_image = get_page_image(
-            document_id=pdf_doc.id,
-            page_number=1,
-            image_format="png",
-            dpi=72
+            document_id=pdf_doc.id, page_number=1, image_format="png", dpi=72
         )
 
         # Verify it's a valid PNG
         image_bytes = base64.b64decode(base64_image)
         import io
+
         image = Image.open(io.BytesIO(image_bytes))
         assert image.format == "PNG"
 
@@ -145,18 +137,10 @@ class PageImagingToolTestCase(TestCase):
         pdf_doc = self.create_pdf_document()
 
         # Test with low DPI
-        low_dpi_image = get_page_image(
-            document_id=pdf_doc.id,
-            page_number=1,
-            dpi=50
-        )
+        low_dpi_image = get_page_image(document_id=pdf_doc.id, page_number=1, dpi=50)
 
         # Test with higher DPI
-        high_dpi_image = get_page_image(
-            document_id=pdf_doc.id,
-            page_number=1,
-            dpi=150
-        )
+        high_dpi_image = get_page_image(document_id=pdf_doc.id, page_number=1, dpi=150)
 
         # Higher DPI should generally produce larger images
         print(f"Low DPI image size: {len(low_dpi_image)}")
@@ -172,10 +156,7 @@ class PageImagingToolTestCase(TestCase):
         print("\n# TEST GET PAGE IMAGE INVALID DOCUMENT ##")
 
         with pytest.raises(ValueError, match="does not exist"):
-            get_page_image(
-                document_id=99999,
-                page_number=1
-            )
+            get_page_image(document_id=99999, page_number=1)
 
         print("\t\tSUCCESS - Raises error for non-existent document")
 
@@ -186,10 +167,7 @@ class PageImagingToolTestCase(TestCase):
         text_doc = self.create_non_pdf_document()
 
         with pytest.raises(ValueError, match="is not a PDF"):
-            get_page_image(
-                document_id=text_doc.id,
-                page_number=1
-            )
+            get_page_image(document_id=text_doc.id, page_number=1)
 
         print("\t\tSUCCESS - Raises error for non-PDF document")
 
@@ -201,17 +179,11 @@ class PageImagingToolTestCase(TestCase):
 
         # Test page number less than 1
         with pytest.raises(ValueError, match="Page numbers start at 1"):
-            get_page_image(
-                document_id=pdf_doc.id,
-                page_number=0
-            )
+            get_page_image(document_id=pdf_doc.id, page_number=0)
 
         # Test page number greater than page count
         with pytest.raises(ValueError, match="exceeds document page count"):
-            get_page_image(
-                document_id=pdf_doc.id,
-                page_number=999
-            )
+            get_page_image(document_id=pdf_doc.id, page_number=999)
 
         print("\t\tSUCCESS - Raises error for invalid page numbers")
 
@@ -225,7 +197,7 @@ class PageImagingToolTestCase(TestCase):
             get_page_image(
                 document_id=pdf_doc.id,
                 page_number=1,
-                image_format="bmp"  # Unsupported format
+                image_format="bmp",  # Unsupported format
             )
 
         print("\t\tSUCCESS - Raises error for unsupported format")
@@ -238,13 +210,10 @@ class PageImagingToolTestCase(TestCase):
             title="Document Without PDF",
             creator=self.user,
             file_type="application/pdf",
-            page_count=1
+            page_count=1,
         )
 
         with pytest.raises(ValueError, match="has no PDF file attached"):
-            get_page_image(
-                document_id=doc.id,
-                page_number=1
-            )
+            get_page_image(document_id=doc.id, page_number=1)
 
         print("\t\tSUCCESS - Raises error for documents without PDF file")

--- a/opencontractserver/tests/test_page_imaging_tool.py
+++ b/opencontractserver/tests/test_page_imaging_tool.py
@@ -1,0 +1,250 @@
+import base64
+import pathlib
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.core.files.base import ContentFile
+from django.test import TestCase
+from PIL import Image
+
+from opencontractserver.documents.models import Document
+from opencontractserver.llms.tools.core_tools import get_page_image
+from opencontractserver.types.enums import PermissionTypes
+from opencontractserver.utils.permissioning import set_permissions_for_obj_to_user
+
+User = get_user_model()
+
+pytestmark = pytest.mark.django_db
+
+
+class PageImagingToolTestCase(TestCase):
+    """Test that the page imaging tool correctly renders PDF pages as images"""
+
+    fixtures_path = pathlib.Path(__file__).parent / "fixtures"
+
+    def setUp(self):
+        self.user = User.objects.create_user(username="testuser", password="testpass123")
+
+    def create_pdf_document(self, pdf_filename="TestDocument.pdf"):
+        """Helper to create a document with a real PDF file from fixtures"""
+        doc = Document.objects.create(
+            title="Test PDF Document",
+            description="Test document for page imaging",
+            creator=self.user,
+            file_type="application/pdf",
+            page_count=2  # Assuming test PDF has 2 pages
+        )
+
+        # Load a real PDF from fixtures
+        pdf_path = self.fixtures_path / pdf_filename
+        if pdf_path.exists():
+            with open(pdf_path, "rb") as pdf_file:
+                doc.pdf_file.save(
+                    pdf_filename,
+                    ContentFile(pdf_file.read())
+                )
+        else:
+            # Create a minimal valid PDF if fixture doesn't exist
+            # This is a minimal PDF with 1 blank page
+            minimal_pdf = (
+                b"%PDF-1.4\n"
+                b"1 0 obj <</Type/Catalog/Pages 2 0 R>>endobj\n"
+                b"2 0 obj <</Type/Pages/Kids[3 0 R]/Count 1>>endobj\n"
+                b"3 0 obj <</Type/Page/Parent 2 0 R/MediaBox[0 0 612 792]/Resources<<>>>>endobj\n"
+                b"xref\n0 4\n0000000000 65535 f\n0000000009 00000 n\n"
+                b"0000000058 00000 n\n0000000115 00000 n\ntrailer\n"
+                b"<</Size 4/Root 1 0 R>>\nstartxref\n206\n%%EOF"
+            )
+            doc.pdf_file.save(
+                "minimal.pdf",
+                ContentFile(minimal_pdf)
+            )
+            doc.page_count = 1
+
+        doc.save()
+        set_permissions_for_obj_to_user(self.user, doc, [PermissionTypes.ALL])
+        return doc
+
+    def create_non_pdf_document(self):
+        """Helper to create a non-PDF document"""
+        doc = Document.objects.create(
+            title="Test Text Document",
+            description="Non-PDF document",
+            creator=self.user,
+            file_type="text/plain",
+            page_count=1
+        )
+
+        content = b"Test content"
+        doc.pdf_file.save(
+            f"test_doc.txt",
+            ContentFile(content)
+        )
+
+        doc.save()
+        return doc
+
+    def test_get_page_image_success(self):
+        """Test successfully getting a page image from a PDF"""
+        print("\n# TEST GET PAGE IMAGE SUCCESS ##")
+
+        pdf_doc = self.create_pdf_document()
+
+        # Get the first page as an image
+        base64_image = get_page_image(
+            document_id=pdf_doc.id,
+            page_number=1,
+            image_format="jpeg",
+            dpi=72  # Low DPI for faster tests
+        )
+
+        print(f"Got base64 image, length: {len(base64_image)}")
+
+        # Verify it's valid base64
+        assert isinstance(base64_image, str)
+        assert len(base64_image) > 0
+
+        # Verify we can decode it back to an image
+        image_bytes = base64.b64decode(base64_image)
+        assert len(image_bytes) > 0
+
+        # Verify it's a valid JPEG
+        import io
+        image = Image.open(io.BytesIO(image_bytes))
+        assert image.format == "JPEG"
+        print(f"Image dimensions: {image.size}")
+
+        print("\t\tSUCCESS - Page image rendered correctly")
+
+    def test_get_page_image_png_format(self):
+        """Test getting a page image in PNG format"""
+        print("\n# TEST GET PAGE IMAGE PNG FORMAT ##")
+
+        pdf_doc = self.create_pdf_document()
+
+        # Get the first page as PNG
+        base64_image = get_page_image(
+            document_id=pdf_doc.id,
+            page_number=1,
+            image_format="png",
+            dpi=72
+        )
+
+        # Verify it's a valid PNG
+        image_bytes = base64.b64decode(base64_image)
+        import io
+        image = Image.open(io.BytesIO(image_bytes))
+        assert image.format == "PNG"
+
+        print("\t\tSUCCESS - PNG format works correctly")
+
+    def test_get_page_image_different_dpi(self):
+        """Test that different DPI values work"""
+        print("\n# TEST GET PAGE IMAGE DIFFERENT DPI ##")
+
+        pdf_doc = self.create_pdf_document()
+
+        # Test with low DPI
+        low_dpi_image = get_page_image(
+            document_id=pdf_doc.id,
+            page_number=1,
+            dpi=50
+        )
+
+        # Test with higher DPI
+        high_dpi_image = get_page_image(
+            document_id=pdf_doc.id,
+            page_number=1,
+            dpi=150
+        )
+
+        # Higher DPI should generally produce larger images
+        print(f"Low DPI image size: {len(low_dpi_image)}")
+        print(f"High DPI image size: {len(high_dpi_image)}")
+
+        assert len(low_dpi_image) > 0
+        assert len(high_dpi_image) > 0
+
+        print("\t\tSUCCESS - Different DPI values work")
+
+    def test_get_page_image_invalid_document(self):
+        """Test error handling for non-existent document"""
+        print("\n# TEST GET PAGE IMAGE INVALID DOCUMENT ##")
+
+        with pytest.raises(ValueError, match="does not exist"):
+            get_page_image(
+                document_id=99999,
+                page_number=1
+            )
+
+        print("\t\tSUCCESS - Raises error for non-existent document")
+
+    def test_get_page_image_non_pdf_document(self):
+        """Test error handling for non-PDF documents"""
+        print("\n# TEST GET PAGE IMAGE NON-PDF DOCUMENT ##")
+
+        text_doc = self.create_non_pdf_document()
+
+        with pytest.raises(ValueError, match="is not a PDF"):
+            get_page_image(
+                document_id=text_doc.id,
+                page_number=1
+            )
+
+        print("\t\tSUCCESS - Raises error for non-PDF document")
+
+    def test_get_page_image_invalid_page_number(self):
+        """Test error handling for invalid page numbers"""
+        print("\n# TEST GET PAGE IMAGE INVALID PAGE NUMBER ##")
+
+        pdf_doc = self.create_pdf_document()
+
+        # Test page number less than 1
+        with pytest.raises(ValueError, match="Page numbers start at 1"):
+            get_page_image(
+                document_id=pdf_doc.id,
+                page_number=0
+            )
+
+        # Test page number greater than page count
+        with pytest.raises(ValueError, match="exceeds document page count"):
+            get_page_image(
+                document_id=pdf_doc.id,
+                page_number=999
+            )
+
+        print("\t\tSUCCESS - Raises error for invalid page numbers")
+
+    def test_get_page_image_invalid_format(self):
+        """Test error handling for unsupported image formats"""
+        print("\n# TEST GET PAGE IMAGE INVALID FORMAT ##")
+
+        pdf_doc = self.create_pdf_document()
+
+        with pytest.raises(ValueError, match="Unsupported image format"):
+            get_page_image(
+                document_id=pdf_doc.id,
+                page_number=1,
+                image_format="bmp"  # Unsupported format
+            )
+
+        print("\t\tSUCCESS - Raises error for unsupported format")
+
+    def test_get_page_image_no_pdf_file(self):
+        """Test error handling for documents without PDF files"""
+        print("\n# TEST GET PAGE IMAGE NO PDF FILE ##")
+
+        doc = Document.objects.create(
+            title="Document Without PDF",
+            creator=self.user,
+            file_type="application/pdf",
+            page_count=1
+        )
+
+        with pytest.raises(ValueError, match="has no PDF file attached"):
+            get_page_image(
+                document_id=doc.id,
+                page_number=1
+            )
+
+        print("\t\tSUCCESS - Raises error for documents without PDF file")


### PR DESCRIPTION
## Summary
- Fixes #403: Adds page imaging tool for agents to visually inspect PDF pages
- Enables agents to handle diagrams, tables, images, and visual content
- Returns base64-encoded images of PDF pages

## Changes
- Added `get_page_image()` and `aget_page_image()` to core_tools.py
- Registered new tool in `create_document_tools()` function
- Supports JPEG and PNG formats with configurable DPI (default 150)
- Comprehensive error handling and validation
- Added test suite with 8 comprehensive test cases

## Features
- Render specific PDF pages as images
- Configurable image format (JPEG/PNG)
- Configurable resolution (DPI)
- Validates document existence, PDF file type, and page numbers
- Returns base64-encoded images for easy transmission

## Test Plan
- [x] Test successful page rendering (JPEG format)
- [x] Test PNG format support
- [x] Test different DPI values
- [x] Test error handling for invalid documents
- [x] Test error handling for non-PDF documents
- [x] Test error handling for invalid page numbers
- [x] Test error handling for unsupported formats
- [x] Test error handling for documents without PDF files
- [x] All 8 test cases pass