### PR TITLE
Enable CI workflows for version branches

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -12,11 +12,11 @@ defaults:
 
 on:
   pull_request:
-    branches: [ "master", "main" ]
+    branches: [ "master", "main", "v*" ]
     paths-ignore: [ "docs/**" ]
 
   push:
-    branches: [ "master", "main" ]
+    branches: [ "master", "main", "v*" ]
     paths-ignore: [ "docs/**" ]
 
 concurrency:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - main
+      - v*
   pull_request:
     paths:
       - 'frontend/**'

--- a/.github/workflows/production-stack.yml
+++ b/.github/workflows/production-stack.yml
@@ -11,14 +11,14 @@ defaults:
 
 on:
   pull_request:
-    branches: [ "master", "main" ]
+    branches: [ "master", "main", "v*" ]
     paths:
       - "compose/production/**"
       - "production.yml"
       - ".github/workflows/production-stack.yml"
 
   push:
-    branches: [ "master", "main" ]
+    branches: [ "master", "main", "v*" ]
     paths:
       - "compose/production/**"
       - "production.yml"


### PR DESCRIPTION
## Summary

Updates GitHub Actions workflows to run on PRs targeting version branches (v*) in addition to main/master. This enables CI checks for PRs targeting development branches like v3.0.0.b3.

**Note:** This PR won't have CI checks itself (since the base branch doesn't have the updated workflows yet), but once merged, all future PRs to v3.0.0.b3 will automatically run CI checks.

## Changes

- **backend.yml**: Add `v*` pattern to pull_request and push branch triggers
- **frontend.yml**: Add `v*` pattern to push branch triggers  
- **production-stack.yml**: Add `v*` pattern to pull_request and push branch triggers

## Impact

After merging this PR:
- ✅ PRs targeting v3.0.0.b3 (like #583) will run backend tests
- ✅ PRs targeting v3.0.0.b3 will run frontend tests (when frontend files change)
- ✅ PRs targeting v3.0.0.b3 will run production stack tests (when relevant files change)
- ✅ Any future version branches (v3.0.1, v4.0.0, etc.) will also get CI checks

## Testing

This change is low-risk:
- Only adds additional branch patterns to existing workflows
- Doesn't modify any test logic or workflow steps
- Uses standard glob pattern `v*` for version branches