### PR TITLE
Issue #557: GraphQL mutations for moderation actions

### DIFF
--- a/config/graphql/moderation_mutations.py
+++ b/config/graphql/moderation_mutations.py
@@ -1,0 +1,511 @@
+"""
+GraphQL mutations for moderation actions.
+
+This module provides mutations for moderating threads and messages:
+- LockThreadMutation: Lock conversation to prevent new messages
+- UnlockThreadMutation: Unlock conversation
+- PinThreadMutation: Pin conversation to top
+- UnpinThreadMutation: Unpin conversation
+- AddModeratorMutation: Add moderator to corpus
+- RemoveModeratorMutation: Remove moderator from corpus
+- UpdateModeratorPermissionsMutation: Update moderator permissions
+"""
+
+import logging
+
+import graphene
+from graphql_jwt.decorators import login_required
+from graphql_relay import from_global_id
+
+from config.graphql.graphene_types import ConversationType
+from config.graphql.ratelimits import graphql_ratelimit
+from opencontractserver.conversations.models import Conversation, CorpusModerator
+from opencontractserver.corpuses.models import Corpus
+
+logger = logging.getLogger(__name__)
+
+
+class LockThreadMutation(graphene.Mutation):
+    """
+    Lock a conversation/thread to prevent new messages.
+    Only corpus owners or moderators with lock_threads permission can lock threads.
+    """
+
+    class Arguments:
+        conversation_id = graphene.String(
+            required=True, description="ID of the conversation to lock"
+        )
+        reason = graphene.String(
+            required=False, description="Optional reason for locking"
+        )
+
+    ok = graphene.Boolean()
+    message = graphene.String()
+    obj = graphene.Field(ConversationType)
+
+    @login_required
+    @graphql_ratelimit(rate="20/m")
+    def mutate(root, info, conversation_id, reason=""):
+        ok = False
+        obj = None
+        message_text = ""
+
+        try:
+            user = info.context.user
+
+            # Get conversation
+            try:
+                conversation_pk = from_global_id(conversation_id)[1]
+                conversation = Conversation.objects.get(pk=conversation_pk)
+            except Conversation.DoesNotExist:
+                return LockThreadMutation(
+                    ok=False, message="Conversation not found", obj=None
+                )
+
+            # Check if user can moderate
+            if not conversation.can_moderate(user):
+                return LockThreadMutation(
+                    ok=False,
+                    message="You do not have permission to lock this conversation",
+                    obj=None,
+                )
+
+            # Lock the conversation
+            conversation.lock(user, reason)
+
+            ok = True
+            obj = conversation
+            message_text = "Conversation locked successfully"
+
+        except PermissionError as e:
+            message_text = str(e)
+        except Exception as e:
+            logger.error(f"Error locking conversation: {e}", exc_info=True)
+            message_text = f"Failed to lock conversation: {str(e)}"
+
+        return LockThreadMutation(ok=ok, message=message_text, obj=obj)
+
+
+class UnlockThreadMutation(graphene.Mutation):
+    """
+    Unlock a conversation/thread to allow new messages.
+    Only corpus owners or moderators with lock_threads permission can unlock threads.
+    """
+
+    class Arguments:
+        conversation_id = graphene.String(
+            required=True, description="ID of the conversation to unlock"
+        )
+        reason = graphene.String(
+            required=False, description="Optional reason for unlocking"
+        )
+
+    ok = graphene.Boolean()
+    message = graphene.String()
+    obj = graphene.Field(ConversationType)
+
+    @login_required
+    @graphql_ratelimit(rate="20/m")
+    def mutate(root, info, conversation_id, reason=""):
+        ok = False
+        obj = None
+        message_text = ""
+
+        try:
+            user = info.context.user
+
+            # Get conversation
+            try:
+                conversation_pk = from_global_id(conversation_id)[1]
+                conversation = Conversation.objects.get(pk=conversation_pk)
+            except Conversation.DoesNotExist:
+                return UnlockThreadMutation(
+                    ok=False, message="Conversation not found", obj=None
+                )
+
+            # Check if user can moderate
+            if not conversation.can_moderate(user):
+                return UnlockThreadMutation(
+                    ok=False,
+                    message="You do not have permission to unlock this conversation",
+                    obj=None,
+                )
+
+            # Unlock the conversation
+            conversation.unlock(user, reason)
+
+            ok = True
+            obj = conversation
+            message_text = "Conversation unlocked successfully"
+
+        except PermissionError as e:
+            message_text = str(e)
+        except Exception as e:
+            logger.error(f"Error unlocking conversation: {e}", exc_info=True)
+            message_text = f"Failed to unlock conversation: {str(e)}"
+
+        return UnlockThreadMutation(ok=ok, message=message_text, obj=obj)
+
+
+class PinThreadMutation(graphene.Mutation):
+    """
+    Pin a conversation/thread to the top of the list.
+    Only corpus owners or moderators with pin_threads permission can pin threads.
+    """
+
+    class Arguments:
+        conversation_id = graphene.String(
+            required=True, description="ID of the conversation to pin"
+        )
+        reason = graphene.String(
+            required=False, description="Optional reason for pinning"
+        )
+
+    ok = graphene.Boolean()
+    message = graphene.String()
+    obj = graphene.Field(ConversationType)
+
+    @login_required
+    @graphql_ratelimit(rate="20/m")
+    def mutate(root, info, conversation_id, reason=""):
+        ok = False
+        obj = None
+        message_text = ""
+
+        try:
+            user = info.context.user
+
+            # Get conversation
+            try:
+                conversation_pk = from_global_id(conversation_id)[1]
+                conversation = Conversation.objects.get(pk=conversation_pk)
+            except Conversation.DoesNotExist:
+                return PinThreadMutation(
+                    ok=False, message="Conversation not found", obj=None
+                )
+
+            # Check if user can moderate
+            if not conversation.can_moderate(user):
+                return PinThreadMutation(
+                    ok=False,
+                    message="You do not have permission to pin this conversation",
+                    obj=None,
+                )
+
+            # Pin the conversation
+            conversation.pin(user, reason)
+
+            ok = True
+            obj = conversation
+            message_text = "Conversation pinned successfully"
+
+        except PermissionError as e:
+            message_text = str(e)
+        except Exception as e:
+            logger.error(f"Error pinning conversation: {e}", exc_info=True)
+            message_text = f"Failed to pin conversation: {str(e)}"
+
+        return PinThreadMutation(ok=ok, message=message_text, obj=obj)
+
+
+class UnpinThreadMutation(graphene.Mutation):
+    """
+    Unpin a conversation/thread from the top of the list.
+    Only corpus owners or moderators with pin_threads permission can unpin threads.
+    """
+
+    class Arguments:
+        conversation_id = graphene.String(
+            required=True, description="ID of the conversation to unpin"
+        )
+        reason = graphene.String(
+            required=False, description="Optional reason for unpinning"
+        )
+
+    ok = graphene.Boolean()
+    message = graphene.String()
+    obj = graphene.Field(ConversationType)
+
+    @login_required
+    @graphql_ratelimit(rate="20/m")
+    def mutate(root, info, conversation_id, reason=""):
+        ok = False
+        obj = None
+        message_text = ""
+
+        try:
+            user = info.context.user
+
+            # Get conversation
+            try:
+                conversation_pk = from_global_id(conversation_id)[1]
+                conversation = Conversation.objects.get(pk=conversation_pk)
+            except Conversation.DoesNotExist:
+                return UnpinThreadMutation(
+                    ok=False, message="Conversation not found", obj=None
+                )
+
+            # Check if user can moderate
+            if not conversation.can_moderate(user):
+                return UnpinThreadMutation(
+                    ok=False,
+                    message="You do not have permission to unpin this conversation",
+                    obj=None,
+                )
+
+            # Unpin the conversation
+            conversation.unpin(user, reason)
+
+            ok = True
+            obj = conversation
+            message_text = "Conversation unpinned successfully"
+
+        except PermissionError as e:
+            message_text = str(e)
+        except Exception as e:
+            logger.error(f"Error unpinning conversation: {e}", exc_info=True)
+            message_text = f"Failed to unpin conversation: {str(e)}"
+
+        return UnpinThreadMutation(ok=ok, message=message_text, obj=obj)
+
+
+class AddModeratorMutation(graphene.Mutation):
+    """
+    Add a moderator to a corpus with specific permissions.
+    Only corpus owners can add moderators.
+    """
+
+    class Arguments:
+        corpus_id = graphene.String(required=True, description="ID of the corpus")
+        user_id = graphene.String(
+            required=True, description="ID of the user to add as moderator"
+        )
+        permissions = graphene.List(
+            graphene.String,
+            required=True,
+            description="List of permissions: lock_threads, pin_threads, delete_messages, delete_threads",
+        )
+
+    ok = graphene.Boolean()
+    message = graphene.String()
+
+    @login_required
+    @graphql_ratelimit(rate="20/m")
+    def mutate(root, info, corpus_id, user_id, permissions):
+        ok = False
+        message_text = ""
+
+        try:
+            user = info.context.user
+
+            # Get corpus
+            try:
+                corpus_pk = from_global_id(corpus_id)[1]
+                corpus = Corpus.objects.get(pk=corpus_pk)
+            except Corpus.DoesNotExist:
+                return AddModeratorMutation(ok=False, message="Corpus not found")
+
+            # Only corpus owner can add moderators
+            if corpus.creator != user:
+                return AddModeratorMutation(
+                    ok=False,
+                    message="Only corpus owners can add moderators",
+                )
+
+            # Get target user
+            try:
+                from django.contrib.auth import get_user_model
+
+                User = get_user_model()
+                target_user_pk = from_global_id(user_id)[1]
+                target_user = User.objects.get(pk=target_user_pk)
+            except User.DoesNotExist:
+                return AddModeratorMutation(ok=False, message="User not found")
+
+            # Validate permissions
+            valid_permissions = [
+                "lock_threads",
+                "pin_threads",
+                "delete_messages",
+                "delete_threads",
+            ]
+            for perm in permissions:
+                if perm not in valid_permissions:
+                    return AddModeratorMutation(
+                        ok=False,
+                        message=f"Invalid permission: {perm}. Valid options: {', '.join(valid_permissions)}",
+                    )
+
+            # Create or update moderator
+            moderator, created = CorpusModerator.objects.update_or_create(
+                corpus=corpus,
+                user=target_user,
+                defaults={
+                    "permissions": {perm: True for perm in permissions},
+                    "added_by": user,
+                    "creator": user,
+                },
+            )
+
+            ok = True
+            message_text = f"Moderator {'added' if created else 'updated'} successfully"
+
+        except Exception as e:
+            logger.error(f"Error adding moderator: {e}", exc_info=True)
+            message_text = f"Failed to add moderator: {str(e)}"
+
+        return AddModeratorMutation(ok=ok, message=message_text)
+
+
+class RemoveModeratorMutation(graphene.Mutation):
+    """
+    Remove a moderator from a corpus.
+    Only corpus owners can remove moderators.
+    """
+
+    class Arguments:
+        corpus_id = graphene.String(required=True, description="ID of the corpus")
+        user_id = graphene.String(
+            required=True, description="ID of the user to remove as moderator"
+        )
+
+    ok = graphene.Boolean()
+    message = graphene.String()
+
+    @login_required
+    @graphql_ratelimit(rate="20/m")
+    def mutate(root, info, corpus_id, user_id):
+        ok = False
+        message_text = ""
+
+        try:
+            user = info.context.user
+
+            # Get corpus
+            try:
+                corpus_pk = from_global_id(corpus_id)[1]
+                corpus = Corpus.objects.get(pk=corpus_pk)
+            except Corpus.DoesNotExist:
+                return RemoveModeratorMutation(ok=False, message="Corpus not found")
+
+            # Only corpus owner can remove moderators
+            if corpus.creator != user:
+                return RemoveModeratorMutation(
+                    ok=False,
+                    message="Only corpus owners can remove moderators",
+                )
+
+            # Get target user
+            try:
+                from django.contrib.auth import get_user_model
+
+                User = get_user_model()
+                target_user_pk = from_global_id(user_id)[1]
+                target_user = User.objects.get(pk=target_user_pk)
+            except User.DoesNotExist:
+                return RemoveModeratorMutation(ok=False, message="User not found")
+
+            # Remove moderator
+            try:
+                moderator = CorpusModerator.objects.get(corpus=corpus, user=target_user)
+                moderator.delete()
+                ok = True
+                message_text = "Moderator removed successfully"
+            except CorpusModerator.DoesNotExist:
+                message_text = "User is not a moderator of this corpus"
+                ok = True  # Not an error, just already not a moderator
+
+        except Exception as e:
+            logger.error(f"Error removing moderator: {e}", exc_info=True)
+            message_text = f"Failed to remove moderator: {str(e)}"
+
+        return RemoveModeratorMutation(ok=ok, message=message_text)
+
+
+class UpdateModeratorPermissionsMutation(graphene.Mutation):
+    """
+    Update a moderator's permissions for a corpus.
+    Only corpus owners can update moderator permissions.
+    """
+
+    class Arguments:
+        corpus_id = graphene.String(required=True, description="ID of the corpus")
+        user_id = graphene.String(required=True, description="ID of the moderator user")
+        permissions = graphene.List(
+            graphene.String,
+            required=True,
+            description="List of permissions: lock_threads, pin_threads, delete_messages, delete_threads",
+        )
+
+    ok = graphene.Boolean()
+    message = graphene.String()
+
+    @login_required
+    @graphql_ratelimit(rate="20/m")
+    def mutate(root, info, corpus_id, user_id, permissions):
+        ok = False
+        message_text = ""
+
+        try:
+            user = info.context.user
+
+            # Get corpus
+            try:
+                corpus_pk = from_global_id(corpus_id)[1]
+                corpus = Corpus.objects.get(pk=corpus_pk)
+            except Corpus.DoesNotExist:
+                return UpdateModeratorPermissionsMutation(
+                    ok=False, message="Corpus not found"
+                )
+
+            # Only corpus owner can update moderator permissions
+            if corpus.creator != user:
+                return UpdateModeratorPermissionsMutation(
+                    ok=False,
+                    message="Only corpus owners can update moderator permissions",
+                )
+
+            # Get target user
+            try:
+                from django.contrib.auth import get_user_model
+
+                User = get_user_model()
+                target_user_pk = from_global_id(user_id)[1]
+                target_user = User.objects.get(pk=target_user_pk)
+            except User.DoesNotExist:
+                return UpdateModeratorPermissionsMutation(
+                    ok=False, message="User not found"
+                )
+
+            # Validate permissions
+            valid_permissions = [
+                "lock_threads",
+                "pin_threads",
+                "delete_messages",
+                "delete_threads",
+            ]
+            for perm in permissions:
+                if perm not in valid_permissions:
+                    return UpdateModeratorPermissionsMutation(
+                        ok=False,
+                        message=f"Invalid permission: {perm}. Valid options: {', '.join(valid_permissions)}",
+                    )
+
+            # Update moderator permissions
+            try:
+                moderator = CorpusModerator.objects.get(corpus=corpus, user=target_user)
+                moderator.permissions = {perm: True for perm in permissions}
+                moderator.save(update_fields=["permissions"])
+                ok = True
+                message_text = "Moderator permissions updated successfully"
+            except CorpusModerator.DoesNotExist:
+                return UpdateModeratorPermissionsMutation(
+                    ok=False,
+                    message="User is not a moderator of this corpus",
+                )
+
+        except Exception as e:
+            logger.error(f"Error updating moderator permissions: {e}", exc_info=True)
+            message_text = f"Failed to update moderator permissions: {str(e)}"
+
+        return UpdateModeratorPermissionsMutation(ok=ok, message=message_text)

--- a/config/graphql/mutations.py
+++ b/config/graphql/mutations.py
@@ -40,6 +40,17 @@ from config.graphql.graphene_types import (
     UserFeedbackType,
     UserType,
 )
+
+# Import moderation mutations
+from config.graphql.moderation_mutations import (
+    AddModeratorMutation,
+    LockThreadMutation,
+    PinThreadMutation,
+    RemoveModeratorMutation,
+    UnlockThreadMutation,
+    UnpinThreadMutation,
+    UpdateModeratorPermissionsMutation,
+)
 from config.graphql.ratelimits import (
     RateLimits,
     get_user_tier_rate,
@@ -3816,3 +3827,12 @@ class Mutation(graphene.ObjectType):
     update_metadata_column = UpdateMetadataColumn.Field()
     set_metadata_value = SetMetadataValue.Field()
     delete_metadata_value = DeleteMetadataValue.Field()
+
+    # MODERATION MUTATIONS #######################################################
+    lock_thread = LockThreadMutation.Field()
+    unlock_thread = UnlockThreadMutation.Field()
+    pin_thread = PinThreadMutation.Field()
+    unpin_thread = UnpinThreadMutation.Field()
+    add_moderator = AddModeratorMutation.Field()
+    remove_moderator = RemoveModeratorMutation.Field()
+    update_moderator_permissions = UpdateModeratorPermissionsMutation.Field()


### PR DESCRIPTION
## Summary

Implements Issue #557: Create GraphQL mutations for moderation actions with rate limiting.

This PR adds comprehensive moderation functionality for discussion threads, allowing corpus owners and designated moderators to manage content.

**Related Issues:** Closes #557, contributes to #581 (Epic: Discussion Collaboration System), depends on #586 (Moderation System backend)

## Changes

### New Mutations (`config/graphql/moderation_mutations.py`)

**Thread Moderation:**
1. **`LockThreadMutation`**: Lock conversations to prevent new messages
2. **`UnlockThreadMutation`**: Unlock conversations to allow new messages
3. **`PinThreadMutation`**: Pin conversations to top of list
4. **`UnpinThreadMutation`**: Unpin conversations

**Moderator Management:**
5. **`AddModeratorMutation`**: Add moderators to corpus with permissions
6. **`RemoveModeratorMutation`**: Remove moderators from corpus
7. **`UpdateModeratorPermissionsMutation`**: Update moderator permissions

All mutations have 20 requests/minute rate limit.

### Mutations Registration (`config/graphql/mutations.py`)
- `lock_thread`, `unlock_thread`
- `pin_thread`, `unpin_thread`
- `add_moderator`, `remove_moderator`, `update_moderator_permissions`

## Features

### Thread Moderation
- **Lock/Unlock**: Prevent or allow new messages in conversations
- **Pin/Unpin**: Highlight important threads at top of list
- **Permission checks**: Only owners/moderators can moderate
- **Audit trail**: All actions logged via ModerationAction model

### Moderator Management
- **Add moderators**: Corpus owners can designate moderators
- **Granular permissions**: 
  - `lock_threads`: Can lock/unlock threads
  - `pin_threads`: Can pin/unpin threads
  - `delete_messages`: Can soft-delete messages
  - `delete_threads`: Can soft-delete threads
- **Update permissions**: Modify moderator access levels
- **Remove moderators**: Revoke moderation privileges

### Permission System
- **Corpus owner**: Full moderation access
- **Designated moderators**: Granular permissions
- **Non-corpus conversations**: Only creator can moderate
- **Validation**: Permission checks on all operations

### Rate Limiting
- 20 requests/minute for all moderation actions
- Prevents abuse while allowing active moderation
- Consistent across all moderation mutations

## Integration with Backend

This PR builds on PR #586 (Moderation System backend) which provides:
- CorpusModerator model with permission tracking
- ModerationAction audit trail
- Conversation lock/unlock/pin/unpin methods
- Permission validation logic

## Success Criteria (from #557)

- [x] All 7 mutations implemented
- [x] Rate limiting applied (20/m MODERATE_ACTION)
- [x] Permission checks in place
- [x] Corpus owner always has permissions
- [x] Granular moderator permission checks
- [x] Works with moderation action audit trail

## Backward Compatibility

✅ No breaking changes - only additions
✅ Extends existing conversation/corpus infrastructure
✅ Works with existing permission system

## Next Steps

After this PR is merged:
- [ ] Issue #553: Celery task for async reputation updates (optional optimization)
- [ ] Issue #572: Frontend UI implementation (moderation controls, moderator management)
- [ ] Testing of full moderation workflow end-to-end

## Screenshots

N/A - This is a GraphQL API change. No UI modifications.