### PR TITLE
Notification Center UI

### DIFF
--- a/docs/commenting_system/IMPLEMENTATION_GUIDE.md
+++ b/docs/commenting_system/IMPLEMENTATION_GUIDE.md
@@ -1,13 +1,33 @@
 # Frontend Implementation Guide: Commenting & Discussion System
 
 ## Table of Contents
+
+### Foundation (Issues #573-577 - Completed)
 1. [Architecture Overview](#architecture-overview)
 2. [State Management Strategy](#state-management-strategy)
-3. [Component Specifications](#component-specifications)
+3. [Component Specifications](#component-specifications) - Components for #573-577
 4. [Data Flow Patterns](#data-flow-patterns)
 5. [Testing Strategy](#testing-strategy)
-6. [Implementation Checklist](#implementation-checklist)
-7. [Code Examples & Patterns](#code-examples--patterns)
+
+### Implementation History
+6. [Implementation Checklist](#implementation-checklist) - Completed issues #573-577
+7. [Pending Issues: Roadmap to Full Integration](#pending-issues-roadmap-to-full-integration) - Issues #578-580, #621-623
+8. [Branch Dependency Tree](#branch-dependency-tree)
+
+### Integration Work (Issues #621-623)
+9. [Integration with Existing Views](#integration-with-existing-views) - Detailed specs for #621-623
+   - [Routing Architecture](#routing-architecture)
+   - [Corpus View Integration](#corpus-view-integration) - Issue #621
+   - [DocumentKnowledgeBase Integration](#documentknowledgebase-integration) - Issue #622
+   - [Global Discussions View](#global-discussions-view) - Issue #623
+   - [@ Mentions Feature](#-mentions-feature) - Issue #623
+   - [Conversation Type Flexibility](#conversation-type-flexibility)
+   - [Implementation Checklist](#implementation-checklist-1) - Phases mapped to issues
+
+### Reference Material
+10. [Code Examples & Patterns](#code-examples--patterns)
+11. [Performance Considerations](#performance-considerations)
+12. [Accessibility Requirements](#accessibility-requirements)
 
 ---
 
@@ -83,16 +103,18 @@
 
 ## State Management Strategy
 
+> **Note**: These atoms were created in **Issue #573** and are used across all integration work. For URL-driven state (like thread selection), see [Integration with Existing Views → Routing Architecture](#routing-architecture) which adds Apollo reactive vars in issues #621-623.
+
 ### Jotai Atoms Architecture
 
-**File**: `frontend/src/atoms/threadAtoms.ts`
+**File**: `frontend/src/atoms/threadAtoms.ts` (Created in Issue #573)
 
 ```typescript
 import { atom } from "jotai";
 import { ConversationType, ChatMessageType } from "../types/graphql-api";
 
 // ============================================================================
-// THREAD LIST STATE
+// THREAD LIST STATE (Issue #573)
 // ============================================================================
 
 export type ThreadSortOption = "newest" | "active" | "upvoted" | "pinned";
@@ -114,7 +136,7 @@ export const threadFiltersAtom = atom<ThreadFilterOptions>({
 });
 
 // ============================================================================
-// THREAD DETAIL STATE
+// THREAD DETAIL STATE (Issue #573)
 // ============================================================================
 
 // Currently viewing thread
@@ -127,13 +149,13 @@ export const selectedMessageIdAtom = atom<string | null>(null);
 export const expandedMessageIdsAtom = atom<Set<string>>(new Set());
 
 // ============================================================================
-// UI STATE
+// UI STATE (Issues #573-574)
 // ============================================================================
 
-// Show/hide thread creation modal
+// Show/hide thread creation modal (Issue #574)
 export const showCreateThreadModalAtom = atom<boolean>(false);
 
-// Show/hide reply form for specific message
+// Show/hide reply form for specific message (Issue #574)
 export const replyingToMessageIdAtom = atom<string | null>(null);
 
 // Editing message (for edit functionality in future)
@@ -242,6 +264,10 @@ export function useThreadPreferences() {
 
 ## Component Specifications
 
+> **Note**: This section describes components created in completed issues **#573-577** (Thread List, Message Composer, Voting, Moderation, Notifications). These are the **foundation components** that are reused in the integration work.
+>
+> For **new components** needed for integration with Corpuses, Documents, and Global views (issues #621-623), see the [Integration with Existing Views](#integration-with-existing-views) section.
+
 ### Component Tree Structure
 
 ```
@@ -287,11 +313,52 @@ Shared Components:
 └── RelativeTime.tsx (time formatting)
 ```
 
+### Component-to-Issue Mapping
+
+The components above were created across multiple issues. Here's the mapping:
+
+**Issue #573 - Thread List and Detail Views:**
+- `ThreadList.tsx`, `ThreadListItem.tsx`, `ThreadBadge.tsx`
+- `ThreadDetail.tsx`, `MessageItem.tsx`, `MessageTree.tsx`
+- `RelativeTime.tsx`, `utils.ts`, `threadAtoms.ts`
+
+**Issue #574 - Message Composer and Reply UI:**
+- `MessageComposer.tsx` (TipTap rich text editor)
+- `CreateThreadForm.tsx` (thread creation modal)
+- `ReplyForm.tsx` (inline reply component)
+- GraphQL mutations: CREATE_THREAD, CREATE_THREAD_MESSAGE, REPLY_TO_MESSAGE
+
+**Issue #575 - Voting UI and Reputation Display:**
+- `VoteButtons.tsx` (upvote/downvote with optimistic updates)
+- `ReputationBadge.tsx`, `ReputationDisplay.tsx`, `UserProfileReputation.tsx`
+- GraphQL mutations: UPVOTE_MESSAGE, DOWNVOTE_MESSAGE, REMOVE_VOTE
+
+**Issue #576 - Moderation UI and Controls:**
+- `ModerationControls.tsx` (pin/lock/delete/restore actions)
+- `ModeratorBadge.tsx` (visual moderator indicator)
+- GraphQL mutations: PIN_THREAD, UNPIN_THREAD, LOCK_THREAD, UNLOCK_THREAD, DELETE_THREAD, RESTORE_THREAD
+
+**Issue #577 - Notification Center UI:**
+- `NotificationBell.tsx` (header bell icon with badge)
+- `NotificationDropdown.tsx` (quick access dropdown)
+- `NotificationItem.tsx` (individual notification display)
+- `NotificationCenter.tsx` (full-page notification center)
+- GraphQL queries: GET_NOTIFICATIONS, GET_UNREAD_NOTIFICATION_COUNT
+- GraphQL mutations: MARK_NOTIFICATION_READ, MARK_ALL_NOTIFICATIONS_READ, DELETE_NOTIFICATION
+
+**Issues #621-623 - Integration Components (To Be Created):**
+- `CorpusDiscussionsView.tsx` (Issue #621)
+- `DocumentDiscussionsContent.tsx` (Issue #622)
+- `GlobalDiscussions.tsx`, `MentionList.tsx`, `MessageContent.tsx` with mentions (Issue #623)
+
 ### Detailed Component Specs
 
-#### 1. ThreadList.tsx
+#### 1. ThreadList.tsx (Issue #573)
 
 **Purpose**: Container component that fetches and displays list of threads
+
+**Created in**: Issue #573 - Thread List and Detail Views
+**Reused in**: Issues #621, #622, #623 - All integration views
 
 **Props**:
 ```typescript
@@ -369,9 +436,12 @@ const ThreadGrid = styled.div`
 
 ---
 
-#### 2. ThreadListItem.tsx
+#### 2. ThreadListItem.tsx (Issue #573)
 
 **Purpose**: Individual thread card in list view
+
+**Created in**: Issue #573 - Thread List and Detail Views
+**Reused in**: Issues #621, #622, #623 - All integration views
 
 **Props**:
 ```typescript
@@ -465,9 +535,12 @@ const BadgeRow = styled.div`
 
 ---
 
-#### 3. ThreadDetail.tsx
+#### 3. ThreadDetail.tsx (Issue #573)
 
 **Purpose**: Full thread view with all messages
+
+**Created in**: Issue #573 - Thread List and Detail Views
+**Reused in**: Issues #621, #622, #623 - All integration views
 
 **Props**:
 ```typescript
@@ -608,9 +681,12 @@ const MessageListContainer = styled.div`
 
 ---
 
-#### 4. MessageItem.tsx
+#### 4. MessageItem.tsx (Issue #573)
 
 **Purpose**: Individual message with threading support
+
+**Created in**: Issue #573 - Thread List and Detail Views
+**Enhanced in**: Issue #574 (Reply UI), #575 (Voting), #576 (Moderation)
 
 **Props**:
 ```typescript
@@ -725,9 +801,11 @@ const MessageFooter = styled.div`
 
 ---
 
-#### 5. MessageTree.tsx
+#### 5. MessageTree.tsx (Issue #573)
 
 **Purpose**: Recursive component for rendering message hierarchy
+
+**Created in**: Issue #573 - Thread List and Detail Views
 
 **Props**:
 ```typescript
@@ -991,6 +1069,8 @@ const { data, refetch } = useQuery(GET_CONVERSATIONS, {
 ---
 
 ## Testing Strategy
+
+> **Note**: Testing patterns established in **Issues #573-577** (foundation components) should be followed for **Issues #621-623** (integration views). All new components need comprehensive Playwright component tests following these patterns.
 
 ### Test File Structure
 
@@ -1372,6 +1452,24 @@ yarn run test:ct --ui frontend/tests/threads/ThreadList.test.tsx
 
 ---
 
+## Pending Issues: Roadmap to Full Integration
+
+The remaining issues (#578-580, #621-623) complete the discussion system by adding supporting features and full integration into existing views. Issues **#621-623 now link to detailed specifications** in the [Integration with Existing Views](#integration-with-existing-views) section.
+
+**Key Update**: Issues #621-623 have been enhanced with:
+- Comprehensive routing architecture following `docs/frontend/routing_system.md`
+- Detailed component specifications with code examples
+- @ mentions feature for cross-referencing corpuses and documents
+- Implementation checklists mapped to specific phases
+
+**Progression Summary**:
+1. **#578-580**: Supporting features (badges, analytics, search)
+2. **#621**: Corpus integration with full-page thread routing
+3. **#622**: Document integration with sidebar discussions
+4. **#623**: Global discussions view + @ mentions
+
+---
+
 ### ⏳ Issue #578: Badge Display and Management UI
 
 **Status**: ⏳ Pending (after #577)
@@ -1396,7 +1494,22 @@ yarn run test:ct --ui frontend/tests/threads/ThreadList.test.tsx
 ### ⏳ Issue #621: Forum-like Corpus Discussion View
 
 **Status**: ⏳ Pending (after #580)
-**Estimated**: 2 days
+**Estimated**: 3 days (updated to include routing)
+**Specification**: See [Integration with Existing Views → Corpus View Integration](#corpus-view-integration)
+
+**Scope**:
+- Implement routing infrastructure (Phase 1 of Implementation Checklist)
+- Add Discussions tab to Corpuses sidebar
+- Create `CorpusDiscussionsView.tsx` component
+- Implement full-page thread navigation via `/c/:user/:corpus/discussions/:threadId`
+- Wire up CreateThreadButton in corpus context
+- Complete Phase 2 tasks from Implementation Checklist
+
+**Related Sections**:
+- [Component Specifications](#component-specifications) - Reuse ThreadList, ThreadDetail, CreateThreadForm
+- [Testing Strategy](#testing-strategy) - Test patterns for component tests
+- [Performance Considerations](#performance-considerations) - Virtual scrolling, memoization patterns
+- [Accessibility Requirements](#accessibility-requirements) - Keyboard nav, ARIA labels
 
 ---
 
@@ -1404,13 +1517,49 @@ yarn run test:ct --ui frontend/tests/threads/ThreadList.test.tsx
 
 **Status**: ⏳ Pending (after #621)
 **Estimated**: 3 days
+**Specification**: See [Integration with Existing Views → DocumentKnowledgeBase Integration](#documentknowledgebase-integration)
+
+**Scope**:
+- Add Discussions tab to DocumentKnowledgeBase sidebar
+- Create `DocumentDiscussionsContent.tsx` component
+- Implement auto-open sidebar on `?thread=` query param
+- Add thread count badge to sidebar tab
+- Wire up CreateThreadButton in document context
+- Complete Phase 3 tasks from Implementation Checklist
+
+**Related Sections**:
+- [Component Specifications](#component-specifications) - Reuse ThreadList, ThreadDetail, CreateThreadForm
+- [State Management Strategy](#state-management-strategy) - Sidebar state management patterns
+- [Testing Strategy](#testing-strategy) - Test patterns for sidebar integration
+- [Performance Considerations](#performance-considerations) - Lazy loading, debounced updates
+- [Accessibility Requirements](#accessibility-requirements) - Focus management for sidebar
 
 ---
 
 ### ⏳ Issue #623: Global Discussions Forum View
 
 **Status**: ⏳ Pending (after #622)
-**Estimated**: 3 days
+**Estimated**: 4 days (updated to include @ mentions)
+**Specification**: See [Integration with Existing Views → Global Discussions View](#global-discussions-view) and [@ Mentions Feature](#-mentions-feature)
+
+**Scope**:
+- Create `GlobalDiscussionsRoute.tsx` and `GlobalDiscussions.tsx`
+- Implement tabbed sections (All/Corpus/Document/General)
+- Add search/filter functionality
+- Implement FAB for creating threads
+- Add rich visual design with animations
+- **NEW**: Implement @ mentions feature for cross-referencing corpuses and documents
+- Complete Phase 4 and Phase 5 tasks from Implementation Checklist
+
+**Note**: This issue now includes the @ mentions feature, which adds significant value for cross-referencing resources within discussions.
+
+**Related Sections**:
+- [Component Specifications](#component-specifications) - Reuse ThreadList, ThreadDetail, MessageComposer
+- [State Management Strategy](#state-management-strategy) - Global state and filter atoms
+- [Testing Strategy](#testing-strategy) - Test patterns for full-page views and @ mentions
+- [Code Examples & Patterns](#code-examples--patterns) - Animation patterns, optimistic updates
+- [Performance Considerations](#performance-considerations) - Virtual scrolling for large lists
+- [Accessibility Requirements](#accessibility-requirements) - Tabbed navigation, mention autocomplete
 
 ---
 
@@ -1418,16 +1567,22 @@ yarn run test:ct --ui frontend/tests/threads/ThreadList.test.tsx
 
 ```
 v3.0.0.b3 (base)
-└─ feature/thread-list-detail-573 ✅
-   └─ feature/message-composer-574 ✅
-      └─ feature/voting-ui-575 ✅
-         └─ feature/moderation-ui-576 ✅
-            └─ feature/notification-center-577 ✅ (current)
-               └─ feature/badge-display-578 (next)
-                  └─ ... (subsequent issues)
+└─ feature/thread-list-detail-573 ✅ (committed)
+   └─ feature/message-composer-574 ✅ (committed)
+      └─ feature/voting-ui-575 ✅ (committed)
+         └─ feature/moderation-ui-576 ✅ (committed)
+            └─ feature/notification-center-577 ✅ (committed)
+               └─ feature/badge-display-578 ⏳ (4 days - next)
+                  └─ feature/analytics-dashboard-579 ⏳ (4 days)
+                     └─ feature/thread-search-580 ⏳ (4 days)
+                        └─ feature/corpus-discussions-621 ⏳ (3 days - includes routing)
+                           └─ feature/document-discussions-622 ⏳ (3 days)
+                              └─ feature/global-discussions-623 ⏳ (4 days - includes @ mentions)
 ```
 
 **IMPORTANT**: Each branch builds on the previous issue's branch to maintain a clean dependency chain.
+
+**Total Remaining Effort**: ~22 days across 6 issues (#578-580, #621-623)
 
 ---
 
@@ -1551,22 +1706,9 @@ const ThreadCard = styled.div`
 
 ---
 
-## Next Steps After #573
-
-Once #573 is complete and merged, the following issues can be implemented:
-
-1. **#574: Message Composer** - Depends on ThreadDetail for integration
-2. **#575: Voting UI** - Can be added to MessageItem
-3. **#576: Moderation UI** - Can be added to ThreadDetailHeader
-4. **#621: Corpus Forum View** - Reuses ThreadList
-5. **#622: Document Discussions** - Reuses ThreadList/ThreadDetail
-6. **#623: Global Forum View** - Reuses ThreadList
-
-The foundation laid in #573 enables rapid development of remaining features!
-
----
-
 ## Performance Considerations
+
+> **Note**: These performance patterns apply to **all issues** (#573-577, #621-623). When implementing any discussion feature, review these strategies to ensure optimal performance, especially with large datasets.
 
 ### Optimization Strategies
 
@@ -1612,6 +1754,8 @@ const debouncedSearch = useMemo(
 
 ## Accessibility Requirements
 
+> **Note**: Accessibility is **critical** for all discussion features. These requirements apply across **all issues** (#573-577, #621-623). Every component must be keyboard-navigable, screen-reader friendly, and WCAG 2.1 AA compliant.
+
 ### WCAG 2.1 AA Compliance
 
 1. **Keyboard Navigation**:
@@ -1645,6 +1789,1760 @@ const focusTrap = useFocusTrap(modalRef, isOpen);
 
 ---
 
+## Integration with Existing Views
+
+This section provides detailed instructions for integrating the discussion system into existing OpenContracts views, following the centralized routing architecture and maintaining UI/UX consistency.
+
+### Overview: Integration Points
+
+The discussion system integrates into three main areas:
+
+1. **Corpus View** (`Corpuses.tsx`) - Full-page thread discussions
+2. **Document Viewer** (`DocumentKnowledgeBase.tsx`) - Sidebar thread discussions
+3. **Global Discussions View** - Standalone route with rich visual design
+
+### Routing Architecture
+
+Following the routing mantra in `docs/frontend/routing_system.md`, ALL routing logic is centralized in `CentralRouteManager.tsx`. The discussion system extends this architecture with minimal new routes.
+
+#### New Routes
+
+**Full-Page Thread View (Corpus Context):**
+```typescript
+// In App.tsx
+<Route
+  path="/c/:userIdent/:corpusIdent/discussions/:threadId"
+  element={<CorpusThreadRoute />}
+/>
+```
+
+**Global Discussions View:**
+```typescript
+// In App.tsx
+<Route
+  path="/discussions"
+  element={<GlobalDiscussionsRoute />}
+/>
+```
+
+**Document Thread View (Query Param):**
+- NO new route needed
+- Existing `/d/:userIdent/:docIdent` handles thread via query param
+- Example: `/d/john/my-doc?thread=abc123`
+
+#### Reactive Vars
+
+**File**: `frontend/src/graphql/cache.ts`
+
+```typescript
+// Thread selection state (set by CentralRouteManager Phase 2)
+export const selectedThreadId = makeVar<string | null>(null);
+
+// Thread list filters (local to views, NOT in URL)
+// These use Jotai atoms, not reactive vars
+// Defined in: frontend/src/atoms/threadAtoms.ts
+```
+
+**Why `selectedThreadId` is a reactive var:**
+- Needs to be in URL for deep linking
+- CentralRouteManager Phase 2 parses `?thread=` param
+- CentralRouteManager Phase 4 syncs changes back to URL
+
+**Why filters are Jotai atoms:**
+- User preferences, NOT part of URL state
+- Don't need deep linking or URL sync
+- Already have Jotai atoms defined in implementation
+
+#### CentralRouteManager Integration
+
+**Phase 2: Query Params → Reactive Vars**
+
+**File**: `frontend/src/routing/CentralRouteManager.tsx` (lines ~444-484)
+
+```typescript
+// Add to existing Phase 2 effect
+useEffect(() => {
+  // ... existing annotation/analysis param parsing
+
+  // NEW: Thread selection
+  const threadId = searchParams.get("thread");
+  const currentThreadId = selectedThreadId();
+
+  if (threadId !== currentThreadId) {
+    selectedThreadId(threadId);
+  }
+}, [searchParams]);
+```
+
+**Phase 4: Reactive Vars → URL Sync**
+
+**File**: `frontend/src/routing/CentralRouteManager.tsx` (lines ~514-544)
+
+```typescript
+// Add to existing Phase 4 dependencies
+const threadId = useReactiveVar(selectedThreadId);
+
+useEffect(() => {
+  // Don't sync on initial mount
+  if (!hasInitializedFromUrl.current) return;
+
+  // Don't sync while route is loading
+  if (routeLoading()) return;
+
+  const queryString = buildQueryParams({
+    annotationIds: annIds,
+    analysisIds,
+    extractIds,
+    threadId, // NEW: Add thread param
+    showStructural: structural,
+    showSelectedOnly: selectedOnly,
+    showBoundingBoxes: boundingBoxes,
+    labelDisplay: labels,
+  });
+
+  if (currentSearch !== queryString) {
+    navigate({ search: queryString }, { replace: true });
+  }
+}, [annIds, analysisIds, extractIds, threadId, structural, selectedOnly, boundingBoxes, labels]);
+```
+
+**Navigation Utilities**
+
+**File**: `frontend/src/utils/navigationUtils.ts`
+
+```typescript
+/**
+ * Update thread selection in URL
+ */
+export function updateThreadSelection(
+  location: { search: string },
+  navigate: (to: { search: string }, options?: { replace?: boolean }) => void,
+  threadId: string | null
+) {
+  const searchParams = new URLSearchParams(location.search);
+
+  if (threadId) {
+    searchParams.set("thread", threadId);
+  } else {
+    searchParams.delete("thread");
+  }
+
+  navigate({ search: searchParams.toString() }, { replace: true });
+}
+
+/**
+ * Clear thread selection from URL
+ */
+export function clearThreadSelection(
+  location: { search: string },
+  navigate: (to: { search: string }, options?: { replace?: boolean }) => void
+) {
+  updateThreadSelection(location, navigate, null);
+}
+
+/**
+ * Generate corpus thread URL
+ */
+export function getCorpusThreadUrl(
+  corpus: { creator: { slug: string }; slug: string },
+  threadId: string
+): string {
+  if (!corpus.creator?.slug || !corpus.slug) {
+    console.warn("Corpus missing slug data:", corpus);
+    return "#";
+  }
+  return `/c/${corpus.creator.slug}/${corpus.slug}/discussions/${threadId}`;
+}
+
+/**
+ * Navigate to corpus thread (full page)
+ */
+export function navigateToCorpusThread(
+  corpus: { creator: { slug: string }; slug: string },
+  threadId: string,
+  navigate: (path: string) => void,
+  currentPath: string
+) {
+  const url = getCorpusThreadUrl(corpus, threadId);
+  if (url !== "#" && currentPath !== url) {
+    navigate(url);
+  }
+}
+
+/**
+ * Navigate to document thread (sidebar)
+ */
+export function navigateToDocumentThread(
+  threadId: string,
+  location: { search: string },
+  navigate: (to: { search: string }, options?: { replace?: boolean }) => void
+) {
+  updateThreadSelection(location, navigate, threadId);
+}
+```
+
+### Integration 1: Corpuses View
+
+**File**: `frontend/src/views/Corpuses.tsx`
+
+#### Step 1: Add Navigation Tab
+
+**Location**: `navigationItems` array (around line 1820)
+
+```typescript
+const navigationItems = useMemo(() => {
+  return [
+    {
+      id: "home",
+      label: "Home",
+      icon: Home,
+      onClick: () => setActiveTab(0),
+    },
+    {
+      id: "documents",
+      label: "Documents",
+      icon: FileText,
+      badge: stats.totalDocs > 0 ? stats.totalDocs : undefined,
+      onClick: () => setActiveTab(1),
+    },
+    // ... existing tabs
+
+    // NEW: Discussions tab
+    {
+      id: "discussions",
+      label: "Discussions",
+      icon: MessageSquare,
+      badge: stats.totalThreads > 0 ? stats.totalThreads : undefined,
+      onClick: () => setActiveTab(DISCUSSIONS_TAB_INDEX), // Define constant
+    },
+
+    // ... remaining tabs
+  ];
+}, [stats, setActiveTab]);
+```
+
+#### Step 2: Add Tab Constant
+
+**Location**: Top of file with other constants
+
+```typescript
+const HOME_TAB_INDEX = 0;
+const DOCUMENTS_TAB_INDEX = 1;
+const ANNOTATIONS_TAB_INDEX = 2;
+const ANALYSES_TAB_INDEX = 3;
+const EXTRACTS_TAB_INDEX = 4;
+const DISCUSSIONS_TAB_INDEX = 5; // NEW
+const CHAT_TAB_INDEX = 6;
+const BADGES_TAB_INDEX = 7;
+const SETTINGS_TAB_INDEX = 8;
+```
+
+#### Step 3: Add Stats Query
+
+**File**: `frontend/src/graphql/queries.ts`
+
+```typescript
+export const GET_CORPUS_STATS = gql`
+  query GetCorpusStats($corpusId: ID!) {
+    corpusStats(corpusId: $corpusId) {
+      totalDocs
+      totalAnnotations
+      totalAnalyses
+      totalExtracts
+      totalThreads  # NEW: Add to existing query
+    }
+  }
+`;
+```
+
+#### Step 4: Render Discussions Content
+
+**Location**: Main content rendering switch (around line 2100)
+
+```typescript
+// In the main content area render logic
+{activeTab === DISCUSSIONS_TAB_INDEX && opened_corpus && (
+  <CorpusDiscussionsView corpusId={opened_corpus.id} />
+)}
+```
+
+#### Step 5: Create CorpusDiscussionsView Component
+
+**File**: `frontend/src/components/discussions/CorpusDiscussionsView.tsx`
+
+```typescript
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import { useReactiveVar } from "@apollo/client";
+import { ThreadList } from "./ThreadList";
+import { CreateThreadButton } from "./CreateThreadButton";
+import { openedCorpus } from "../../graphql/cache";
+import { navigateToCorpusThread } from "../../utils/navigationUtils";
+import styled from "styled-components";
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: 1.5rem;
+`;
+
+const Header = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.5rem;
+`;
+
+const Title = styled.h2`
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #0f172a;
+  margin: 0;
+`;
+
+interface CorpusDiscussionsViewProps {
+  corpusId: string;
+}
+
+export const CorpusDiscussionsView: React.FC<CorpusDiscussionsViewProps> = ({
+  corpusId,
+}) => {
+  const navigate = useNavigate();
+  const corpus = useReactiveVar(openedCorpus);
+
+  const handleThreadClick = (threadId: string) => {
+    if (corpus) {
+      navigateToCorpusThread(corpus, threadId, navigate, location.pathname);
+    }
+  };
+
+  return (
+    <Container>
+      <Header>
+        <Title>Corpus Discussions</Title>
+        <CreateThreadButton corpusId={corpusId} />
+      </Header>
+
+      <ThreadList
+        corpusId={corpusId}
+        conversationType="THREAD"
+        onThreadClick={handleThreadClick}
+      />
+    </Container>
+  );
+};
+```
+
+### Integration 2: DocumentKnowledgeBase
+
+**File**: `frontend/src/components/knowledge_base/document/DocumentKnowledgeBase.tsx`
+
+#### Step 1: Add Discussions to SidebarViewMode Type
+
+**Location**: Type definitions (around line 150)
+
+```typescript
+export type SidebarViewMode = "feed" | "analysis" | "extract" | "discussions"; // Add "discussions"
+```
+
+#### Step 2: Add State for Sidebar Tab
+
+**Location**: State declarations (around line 800)
+
+```typescript
+const [sidebarViewMode, setSidebarViewMode] = useState<SidebarViewMode>("feed");
+```
+
+#### Step 3: Auto-Open Sidebar on Thread Deep Link
+
+**Location**: Effects section (around line 920)
+
+```typescript
+/**
+ * Auto-open sidebar when thread param is in URL
+ */
+useEffect(() => {
+  const threadId = useReactiveVar(selectedThreadId);
+
+  if (threadId && opened_document) {
+    // Batch updates to prevent cascade of re-renders
+    unstable_batchedUpdates(() => {
+      setShowRightPanel(true);
+      setMode("half"); // 50% width
+      setSidebarViewMode("discussions");
+    });
+  }
+}, [selectedThreadId, opened_document, setShowRightPanel, setMode, setSidebarViewMode]);
+```
+
+#### Step 4: Add Discussions Tab to Sidebar
+
+**Location**: SidebarTabsContainer render (around line 2400)
+
+```typescript
+<SidebarTabsContainer>
+  <SidebarTab
+    isActive={sidebarViewMode === "feed"}
+    onClick={() => setSidebarViewMode("feed")}
+  >
+    <Layers size={18} />
+    {!isMobile && <span>Feed</span>}
+  </SidebarTab>
+
+  {/* Existing tabs... */}
+
+  {/* NEW: Discussions Tab */}
+  <SidebarTab
+    isActive={sidebarViewMode === "discussions"}
+    onClick={() => {
+      setSidebarViewMode("discussions");
+      if (!showRightPanel) {
+        setShowRightPanel(true);
+        setMode("half"); // 50% width
+      }
+    }}
+  >
+    <MessageSquare size={18} />
+    {!isMobile && <span>Discussions</span>}
+    {threadCount > 0 && (
+      <NotificationBadge>{threadCount}</NotificationBadge>
+    )}
+  </SidebarTab>
+</SidebarTabsContainer>
+```
+
+#### Step 5: Render Discussions Content in Sidebar
+
+**Location**: Sidebar content rendering (around line 2600)
+
+```typescript
+{showRightPanel && (
+  <SlidingPanel
+    isOpen={showRightPanel}
+    width={`${getPanelWidthPercentage()}%`}
+  >
+    <SidebarHeader>
+      {/* Header content */}
+    </SidebarHeader>
+
+    {/* Existing sidebar content for other tabs */}
+
+    {/* NEW: Discussions content */}
+    {sidebarViewMode === "discussions" && (
+      <DocumentDiscussionsContent
+        documentId={documentId}
+        corpusId={corpusId}
+      />
+    )}
+  </SlidingPanel>
+)}
+```
+
+#### Step 6: Create DocumentDiscussionsContent Component
+
+**File**: `frontend/src/components/discussions/DocumentDiscussionsContent.tsx`
+
+```typescript
+import React from "react";
+import { useReactiveVar } from "@apollo/client";
+import { useLocation, useNavigate } from "react-router-dom";
+import { ThreadList } from "./ThreadList";
+import { ThreadDetail } from "./ThreadDetail";
+import { CreateThreadButton } from "./CreateThreadButton";
+import { selectedThreadId } from "../../graphql/cache";
+import { updateThreadSelection, clearThreadSelection } from "../../utils/navigationUtils";
+import styled from "styled-components";
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+`;
+
+const Header = styled.div`
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid #e2e8f0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-shrink: 0;
+`;
+
+const Title = styled.h3`
+  font-size: 1rem;
+  font-weight: 600;
+  color: #0f172a;
+  margin: 0;
+`;
+
+const Content = styled.div`
+  flex: 1;
+  overflow-y: auto;
+  min-height: 0;
+`;
+
+interface DocumentDiscussionsContentProps {
+  documentId: string;
+  corpusId?: string;
+}
+
+export const DocumentDiscussionsContent: React.FC<DocumentDiscussionsContentProps> = ({
+  documentId,
+  corpusId,
+}) => {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const threadId = useReactiveVar(selectedThreadId);
+
+  const handleThreadClick = (clickedThreadId: string) => {
+    updateThreadSelection(location, navigate, clickedThreadId);
+  };
+
+  const handleBack = () => {
+    clearThreadSelection(location, navigate);
+  };
+
+  return (
+    <Container>
+      <Header>
+        <Title>
+          {threadId ? "Discussion Thread" : "Document Discussions"}
+        </Title>
+        {!threadId && <CreateThreadButton documentId={documentId} corpusId={corpusId} />}
+      </Header>
+
+      <Content>
+        {threadId ? (
+          <ThreadDetail
+            conversationId={threadId}
+            onBack={handleBack}
+          />
+        ) : (
+          <ThreadList
+            documentId={documentId}
+            conversationType="THREAD"
+            onThreadClick={handleThreadClick}
+          />
+        )}
+      </Content>
+    </Container>
+  );
+};
+```
+
+#### Step 7: Query Thread Count
+
+**Location**: Add to existing stats query or create new hook
+
+```typescript
+// In DocumentKnowledgeBase component
+const { data: threadData } = useQuery(GET_DOCUMENT_THREAD_COUNT, {
+  variables: { documentId },
+  skip: !documentId,
+});
+
+const threadCount = threadData?.documentThreads?.totalCount || 0;
+```
+
+**GraphQL Query:**
+
+```typescript
+export const GET_DOCUMENT_THREAD_COUNT = gql`
+  query GetDocumentThreadCount($documentId: ID!) {
+    documentThreads(documentId: $documentId) {
+      totalCount
+    }
+  }
+`;
+```
+
+### Integration 3: Global Discussions View
+
+This view showcases all discussions across the platform with a rich, engaging visual design.
+
+#### Step 1: Create Route Component
+
+**File**: `frontend/src/components/routes/GlobalDiscussionsRoute.tsx`
+
+```typescript
+import React from "react";
+import { GlobalDiscussions } from "../../views/GlobalDiscussions";
+import { ErrorBoundary } from "../widgets/ErrorBoundary";
+import { MetaTags } from "../widgets/MetaTags";
+
+export const GlobalDiscussionsRoute: React.FC = () => {
+  return (
+    <ErrorBoundary>
+      <MetaTags title="Discussions" type="discussions" />
+      <GlobalDiscussions />
+    </ErrorBoundary>
+  );
+};
+```
+
+#### Step 2: Create GlobalDiscussions View
+
+**File**: `frontend/src/views/GlobalDiscussions.tsx`
+
+```typescript
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import styled from "styled-components";
+import { motion, AnimatePresence } from "framer-motion";
+import { MessageSquare, Database, FileText, Plus, Search, SlidersHorizontal } from "lucide-react";
+import { ThreadList } from "../components/discussions/ThreadList";
+import { CreateThreadButton } from "../components/discussions/CreateThreadButton";
+import { CardLayout } from "../components/layout/CardLayout";
+
+const Container = styled.div`
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+
+  @media (max-width: 768px) {
+    padding: 1rem;
+  }
+`;
+
+const Header = styled.div`
+  margin-bottom: 2rem;
+`;
+
+const TitleRow = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.5rem;
+`;
+
+const Title = styled.h1`
+  font-size: 2rem;
+  font-weight: 800;
+  color: #0f172a;
+  margin: 0;
+  letter-spacing: -0.025em;
+
+  @media (max-width: 768px) {
+    font-size: 1.5rem;
+  }
+`;
+
+const FilterBar = styled.div`
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  margin-bottom: 1.5rem;
+  flex-wrap: wrap;
+`;
+
+const TabContainer = styled.div`
+  display: flex;
+  gap: 0.5rem;
+  background: #f8fafc;
+  padding: 0.375rem;
+  border-radius: 12px;
+  border: 1px solid #e2e8f0;
+`;
+
+const Tab = styled(motion.button)<{ isActive: boolean }>`
+  padding: 0.625rem 1.25rem;
+  border-radius: 8px;
+  border: none;
+  background: ${props => props.isActive ? "white" : "transparent"};
+  color: ${props => props.isActive ? "#0f172a" : "#64748b"};
+  font-weight: ${props => props.isActive ? "600" : "500"};
+  font-size: 0.9375rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  box-shadow: ${props => props.isActive ? "0 1px 3px rgba(0,0,0,0.1)" : "none"};
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+
+  &:hover {
+    background: ${props => props.isActive ? "white" : "rgba(255,255,255,0.6)"};
+  }
+`;
+
+const SearchInput = styled.input`
+  flex: 1;
+  min-width: 200px;
+  padding: 0.625rem 1rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  font-size: 0.9375rem;
+
+  &:focus {
+    outline: none;
+    border-color: #4a90e2;
+    box-shadow: 0 0 0 3px rgba(74, 144, 226, 0.1);
+  }
+`;
+
+const FAB = styled(motion.button)`
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  width: 56px;
+  height: 56px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, #4a90e2 0%, #357abd 100%);
+  border: none;
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  box-shadow: 0 8px 24px rgba(74, 144, 226, 0.4);
+  z-index: 100;
+
+  &:hover {
+    box-shadow: 0 12px 32px rgba(74, 144, 226, 0.5);
+  }
+
+  @media (max-width: 768px) {
+    bottom: 1rem;
+    right: 1rem;
+  }
+`;
+
+const SectionContainer = styled(motion.div)`
+  margin-bottom: 2.5rem;
+`;
+
+const SectionHeader = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 2px solid #e2e8f0;
+`;
+
+const SectionIcon = styled.div<{ color: string }>`
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  background: ${props => props.color};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+`;
+
+const SectionTitle = styled.h2`
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #0f172a;
+  margin: 0;
+`;
+
+const SectionCount = styled.span`
+  font-size: 0.875rem;
+  color: #64748b;
+  font-weight: 500;
+`;
+
+type FilterTab = "all" | "corpus" | "document" | "general";
+
+export const GlobalDiscussions: React.FC = () => {
+  const navigate = useNavigate();
+  const [activeTab, setActiveTab] = useState<FilterTab>("all");
+  const [searchQuery, setSearchQuery] = useState("");
+  const [showCreateModal, setShowCreateModal] = useState(false);
+
+  return (
+    <CardLayout>
+      <Container>
+        <Header>
+          <TitleRow>
+            <Title>Discussions</Title>
+          </TitleRow>
+
+          <FilterBar>
+            <TabContainer>
+              <Tab
+                isActive={activeTab === "all"}
+                onClick={() => setActiveTab("all")}
+                whileHover={{ scale: 1.02 }}
+                whileTap={{ scale: 0.98 }}
+              >
+                <MessageSquare size={16} />
+                All
+              </Tab>
+              <Tab
+                isActive={activeTab === "corpus"}
+                onClick={() => setActiveTab("corpus")}
+                whileHover={{ scale: 1.02 }}
+                whileTap={{ scale: 0.98 }}
+              >
+                <Database size={16} />
+                Corpus
+              </Tab>
+              <Tab
+                isActive={activeTab === "document"}
+                onClick={() => setActiveTab("document")}
+                whileHover={{ scale: 1.02 }}
+                whileTap={{ scale: 0.98 }}
+              >
+                <FileText size={16} />
+                Document
+              </Tab>
+              <Tab
+                isActive={activeTab === "general"}
+                onClick={() => setActiveTab("general")}
+                whileHover={{ scale: 1.02 }}
+                whileTap={{ scale: 0.98 }}
+              >
+                <MessageSquare size={16} />
+                General
+              </Tab>
+            </TabContainer>
+
+            <SearchInput
+              placeholder="Search discussions..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+            />
+          </FilterBar>
+        </Header>
+
+        <AnimatePresence mode="wait">
+          {(activeTab === "all" || activeTab === "corpus") && (
+            <SectionContainer
+              key="corpus-section"
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -20 }}
+              transition={{ duration: 0.3 }}
+            >
+              <SectionHeader>
+                <SectionIcon color="linear-gradient(135deg, #667eea 0%, #764ba2 100%)">
+                  <Database size={18} />
+                </SectionIcon>
+                <SectionTitle>Corpus Discussions</SectionTitle>
+                <SectionCount>(23)</SectionCount>
+              </SectionHeader>
+
+              <ThreadList
+                conversationType="THREAD"
+                filterByContext="corpus"
+                searchQuery={searchQuery}
+                onThreadClick={(threadId, corpus) => {
+                  if (corpus) {
+                    navigate(`/c/${corpus.creator.slug}/${corpus.slug}/discussions/${threadId}`);
+                  }
+                }}
+              />
+            </SectionContainer>
+          )}
+
+          {(activeTab === "all" || activeTab === "document") && (
+            <SectionContainer
+              key="document-section"
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -20 }}
+              transition={{ duration: 0.3, delay: 0.1 }}
+            >
+              <SectionHeader>
+                <SectionIcon color="linear-gradient(135deg, #f093fb 0%, #f5576c 100%)">
+                  <FileText size={18} />
+                </SectionIcon>
+                <SectionTitle>Document Discussions</SectionTitle>
+                <SectionCount>(15)</SectionCount>
+              </SectionHeader>
+
+              <ThreadList
+                conversationType="THREAD"
+                filterByContext="document"
+                searchQuery={searchQuery}
+                onThreadClick={(threadId, document, corpus) => {
+                  if (document && corpus) {
+                    navigate(`/d/${corpus.creator.slug}/${corpus.slug}/${document.slug}?thread=${threadId}`);
+                  } else if (document) {
+                    navigate(`/d/${document.creator.slug}/${document.slug}?thread=${threadId}`);
+                  }
+                }}
+              />
+            </SectionContainer>
+          )}
+
+          {(activeTab === "all" || activeTab === "general") && (
+            <SectionContainer
+              key="general-section"
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -20 }}
+              transition={{ duration: 0.3, delay: 0.2 }}
+            >
+              <SectionHeader>
+                <SectionIcon color="linear-gradient(135deg, #4facfe 0%, #00f2fe 100%)">
+                  <MessageSquare size={18} />
+                </SectionIcon>
+                <SectionTitle>General Discussions</SectionTitle>
+                <SectionCount>(8)</SectionCount>
+              </SectionHeader>
+
+              <ThreadList
+                conversationType="THREAD"
+                filterByContext="general"
+                searchQuery={searchQuery}
+                onThreadClick={(threadId) => {
+                  navigate(`/discussions/${threadId}`);
+                }}
+              />
+            </SectionContainer>
+          )}
+        </AnimatePresence>
+
+        <FAB
+          onClick={() => setShowCreateModal(true)}
+          whileHover={{ scale: 1.1 }}
+          whileTap={{ scale: 0.9 }}
+        >
+          <Plus size={28} />
+        </FAB>
+
+        {showCreateModal && (
+          <CreateThreadModal onClose={() => setShowCreateModal(false)} />
+        )}
+      </Container>
+    </CardLayout>
+  );
+};
+```
+
+### Feature: @ Mentions for Resources
+
+The @ mention system allows users to reference corpuses, documents, and corpus documents in messages with autocomplete and clickable navigation.
+
+#### Backend: Mentioned Resources GraphQL
+
+**File**: `config/graphql/graphene_types.py`
+
+```python
+class MentionedResourceType(graphene.ObjectType):
+    """
+    Represents a corpus or document mentioned in a message using @ syntax.
+
+    Examples:
+      @corpus:legal-contracts
+      @document:contract-template
+      @corpus:legal-contracts/document:contract-template
+    """
+    type = graphene.String(required=True)  # "corpus" or "document"
+    id = graphene.ID(required=True)
+    slug = graphene.String(required=True)
+    title = graphene.String(required=True)
+    url = graphene.String(required=True)
+
+    # Optional corpus context for documents
+    corpus = graphene.Field(lambda: MentionedResourceType)
+
+class ChatMessageType(DjangoObjectType):
+    # ... existing fields
+
+    mentioned_resources = graphene.List(
+        MentionedResourceType,
+        description="Corpuses and documents mentioned in this message using @ syntax"
+    )
+
+    def resolve_mentioned_resources(root, info):
+        """
+        Parse content for @mentions and return structured resource references.
+
+        Patterns:
+          @corpus:slug → Corpus
+          @document:slug → Document
+          @corpus:corpus-slug/document:doc-slug → Document in Corpus
+        """
+        import re
+        from opencontractserver.corpuses.models import Corpus
+        from opencontractserver.documents.models import Document
+
+        content = root.content or ""
+        mentions = []
+
+        # Pattern: @corpus:slug/document:slug
+        corpus_doc_pattern = r'@corpus:([a-z0-9-]+)/document:([a-z0-9-]+)'
+        for corpus_slug, doc_slug in re.findall(corpus_doc_pattern, content):
+            try:
+                corpus = Corpus.objects.get(slug=corpus_slug)
+                document = Document.objects.filter(
+                    slug=doc_slug,
+                    corpus=corpus
+                ).first()
+
+                if document and corpus:
+                    mentions.append(MentionedResourceType(
+                        type="document",
+                        id=document.id,
+                        slug=document.slug,
+                        title=document.title,
+                        url=f"/d/{corpus.creator.slug}/{corpus.slug}/{document.slug}",
+                        corpus=MentionedResourceType(
+                            type="corpus",
+                            id=corpus.id,
+                            slug=corpus.slug,
+                            title=corpus.title,
+                            url=f"/c/{corpus.creator.slug}/{corpus.slug}"
+                        )
+                    ))
+            except (Corpus.DoesNotExist, Document.DoesNotExist):
+                continue
+
+        # Pattern: @corpus:slug
+        corpus_pattern = r'@corpus:([a-z0-9-]+)'
+        for slug in re.findall(corpus_pattern, content):
+            # Skip if already matched in corpus/document pattern
+            if f"@corpus:{slug}/document:" in content:
+                continue
+
+            try:
+                corpus = Corpus.objects.get(slug=slug)
+                mentions.append(MentionedResourceType(
+                    type="corpus",
+                    id=corpus.id,
+                    slug=corpus.slug,
+                    title=corpus.title,
+                    url=f"/c/{corpus.creator.slug}/{corpus.slug}"
+                ))
+            except Corpus.DoesNotExist:
+                continue
+
+        # Pattern: @document:slug
+        doc_pattern = r'@document:([a-z0-9-]+)'
+        for slug in re.findall(doc_pattern, content):
+            # Skip if already matched in corpus/document pattern
+            if f"/document:{slug}" in content:
+                continue
+
+            try:
+                document = Document.objects.get(slug=slug)
+                url = f"/d/{document.creator.slug}/{document.slug}"
+
+                # Include corpus context if available
+                corpus = document.corpus.first() if hasattr(document, 'corpus') else None
+
+                mentions.append(MentionedResourceType(
+                    type="document",
+                    id=document.id,
+                    slug=document.slug,
+                    title=document.title,
+                    url=url,
+                    corpus=MentionedResourceType(
+                        type="corpus",
+                        id=corpus.id,
+                        slug=corpus.slug,
+                        title=corpus.title,
+                        url=f"/c/{corpus.creator.slug}/{corpus.slug}"
+                    ) if corpus else None
+                ))
+            except Document.DoesNotExist:
+                continue
+
+        return mentions
+```
+
+#### Frontend: TipTap Mention Extension
+
+**File**: `frontend/src/components/discussions/MessageComposer.tsx`
+
+**Add mention extension configuration:**
+
+```typescript
+import { Mention } from "@tiptap/extension-mention";
+import { ReactRenderer } from "@tiptap/react";
+import { SuggestionOptions } from "@tiptap/suggestion";
+import tippy, { Instance as TippyInstance } from "tippy.js";
+import { MentionList } from "./MentionList";
+
+// GraphQL query for mention autocomplete
+const SEARCH_RESOURCES_FOR_MENTION = gql`
+  query SearchResourcesForMention($query: String!) {
+    searchCorpuses(textSearch: $query, limit: 5) {
+      edges {
+        node {
+          id
+          slug
+          title
+          creator { slug }
+        }
+      }
+    }
+    searchDocuments(textSearch: $query, limit: 5) {
+      edges {
+        node {
+          id
+          slug
+          title
+          creator { slug }
+          corpus {
+            id
+            slug
+            creator { slug }
+          }
+        }
+      }
+    }
+  }
+`;
+
+const suggestion: Omit<SuggestionOptions, "editor"> = {
+  items: async ({ query }) => {
+    // Query both corpuses and documents
+    const { data } = await apolloClient.query({
+      query: SEARCH_RESOURCES_FOR_MENTION,
+      variables: { query },
+    });
+
+    const corpuses = data?.searchCorpuses?.edges?.map((e: any) => ({
+      type: "corpus",
+      id: e.node.id,
+      slug: e.node.slug,
+      title: e.node.title,
+      creatorSlug: e.node.creator.slug,
+    })) || [];
+
+    const documents = data?.searchDocuments?.edges?.map((e: any) => ({
+      type: "document",
+      id: e.node.id,
+      slug: e.node.slug,
+      title: e.node.title,
+      creatorSlug: e.node.creator.slug,
+      corpusSlug: e.node.corpus?.slug,
+      corpusCreatorSlug: e.node.corpus?.creator?.slug,
+    })) || [];
+
+    return [...corpuses, ...documents];
+  },
+
+  render: () => {
+    let component: ReactRenderer;
+    let popup: TippyInstance[];
+
+    return {
+      onStart: (props) => {
+        component = new ReactRenderer(MentionList, {
+          props,
+          editor: props.editor,
+        });
+
+        popup = tippy("body", {
+          getReferenceClientRect: props.clientRect as any,
+          appendTo: () => document.body,
+          content: component.element,
+          showOnCreate: true,
+          interactive: true,
+          trigger: "manual",
+          placement: "bottom-start",
+        });
+      },
+
+      onUpdate(props) {
+        component.updateProps(props);
+
+        popup[0].setProps({
+          getReferenceClientRect: props.clientRect as any,
+        });
+      },
+
+      onKeyDown(props) {
+        if (props.event.key === "Escape") {
+          popup[0].hide();
+          return true;
+        }
+        return component.ref?.onKeyDown(props);
+      },
+
+      onExit() {
+        popup[0].destroy();
+        component.destroy();
+      },
+    };
+  },
+};
+
+// In extensions array
+const extensions = [
+  // ... other extensions
+
+  Mention.configure({
+    HTMLAttributes: {
+      class: "mention",
+    },
+    suggestion,
+    renderLabel({ node }) {
+      // Format label based on resource type
+      const type = node.attrs.type;
+      const slug = node.attrs.slug;
+
+      if (type === "corpus") {
+        return `@corpus:${slug}`;
+      } else if (type === "document") {
+        const corpusSlug = node.attrs.corpusSlug;
+        if (corpusSlug) {
+          return `@corpus:${corpusSlug}/document:${slug}`;
+        }
+        return `@document:${slug}`;
+      }
+      return `@${slug}`;
+    },
+  }),
+];
+```
+
+#### Frontend: Mention Dropdown Component
+
+**File**: `frontend/src/components/discussions/MentionList.tsx`
+
+```typescript
+import React, { forwardRef, useEffect, useImperativeHandle, useState } from "react";
+import styled from "styled-components";
+import { Database, FileText } from "lucide-react";
+
+const Container = styled.div`
+  background: white;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  overflow: hidden;
+  max-height: 300px;
+  overflow-y: auto;
+  min-width: 300px;
+`;
+
+const Item = styled.div<{ isSelected: boolean }>`
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  cursor: pointer;
+  background: ${props => props.isSelected ? "#f8fafc" : "white"};
+  border-bottom: 1px solid #f1f5f9;
+
+  &:last-child {
+    border-bottom: none;
+  }
+
+  &:hover {
+    background: #f8fafc;
+  }
+`;
+
+const Icon = styled.div<{ type: string }>`
+  width: 32px;
+  height: 32px;
+  border-radius: 6px;
+  background: ${props =>
+    props.type === "corpus"
+      ? "linear-gradient(135deg, #667eea 0%, #764ba2 100%)"
+      : "linear-gradient(135deg, #f093fb 0%, #f5576c 100%)"
+  };
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+  flex-shrink: 0;
+`;
+
+const Content = styled.div`
+  flex: 1;
+  min-width: 0;
+`;
+
+const Title = styled.div`
+  font-weight: 600;
+  color: #0f172a;
+  font-size: 0.9375rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+const Subtitle = styled.div`
+  font-size: 0.8125rem;
+  color: #64748b;
+  margin-top: 0.125rem;
+`;
+
+interface MentionListProps {
+  items: any[];
+  command: (item: any) => void;
+}
+
+export const MentionList = forwardRef((props: MentionListProps, ref) => {
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  const selectItem = (index: number) => {
+    const item = props.items[index];
+    if (item) {
+      props.command(item);
+    }
+  };
+
+  const upHandler = () => {
+    setSelectedIndex((selectedIndex + props.items.length - 1) % props.items.length);
+  };
+
+  const downHandler = () => {
+    setSelectedIndex((selectedIndex + 1) % props.items.length);
+  };
+
+  const enterHandler = () => {
+    selectItem(selectedIndex);
+  };
+
+  useEffect(() => setSelectedIndex(0), [props.items]);
+
+  useImperativeHandle(ref, () => ({
+    onKeyDown: ({ event }: { event: KeyboardEvent }) => {
+      if (event.key === "ArrowUp") {
+        upHandler();
+        return true;
+      }
+      if (event.key === "ArrowDown") {
+        downHandler();
+        return true;
+      }
+      if (event.key === "Enter") {
+        enterHandler();
+        return true;
+      }
+      return false;
+    },
+  }));
+
+  return (
+    <Container>
+      {props.items.map((item, index) => (
+        <Item
+          key={item.id}
+          isSelected={index === selectedIndex}
+          onClick={() => selectItem(index)}
+        >
+          <Icon type={item.type}>
+            {item.type === "corpus" ? <Database size={16} /> : <FileText size={16} />}
+          </Icon>
+          <Content>
+            <Title>{item.title}</Title>
+            <Subtitle>
+              {item.type === "corpus"
+                ? `@corpus:${item.slug}`
+                : item.corpusSlug
+                  ? `@corpus:${item.corpusSlug}/document:${item.slug}`
+                  : `@document:${item.slug}`
+              }
+            </Subtitle>
+          </Content>
+        </Item>
+      ))}
+    </Container>
+  );
+});
+
+MentionList.displayName = "MentionList";
+```
+
+#### Frontend: Render Mentions as Links
+
+**File**: `frontend/src/components/discussions/MessageContent.tsx`
+
+```typescript
+import React from "react";
+import styled from "styled-components";
+import { Database, FileText } from "lucide-react";
+import { SafeMarkdown } from "../markdown/SafeMarkdown";
+import { useNavigate } from "react-router-dom";
+
+const MentionChip = styled.span`
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.25rem 0.625rem;
+  background: linear-gradient(135deg, #f1f5f9 0%, #e2e8f0 100%);
+  border: 1px solid #cbd5e1;
+  border-radius: 6px;
+  color: #0f172a;
+  font-weight: 600;
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+
+  &:hover {
+    background: linear-gradient(135deg, #e2e8f0 0%, #cbd5e1 100%);
+    border-color: #4a90e2;
+    transform: translateY(-1px);
+    box-shadow: 0 2px 4px rgba(74, 144, 226, 0.2);
+  }
+
+  svg {
+    width: 14px;
+    height: 14px;
+  }
+`;
+
+interface MessageContentProps {
+  content: string;
+  mentionedResources?: Array<{
+    type: "corpus" | "document";
+    id: string;
+    slug: string;
+    title: string;
+    url: string;
+    corpus?: {
+      slug: string;
+      title: string;
+      url: string;
+    };
+  }>;
+}
+
+export const MessageContent: React.FC<MessageContentProps> = ({
+  content,
+  mentionedResources = [],
+}) => {
+  const navigate = useNavigate();
+
+  // Replace @mentions in content with clickable chips
+  let processedContent = content;
+
+  mentionedResources.forEach((resource) => {
+    let pattern = "";
+
+    if (resource.type === "corpus") {
+      pattern = `@corpus:${resource.slug}`;
+    } else if (resource.type === "document") {
+      if (resource.corpus) {
+        pattern = `@corpus:${resource.corpus.slug}/document:${resource.slug}`;
+      } else {
+        pattern = `@document:${resource.slug}`;
+      }
+    }
+
+    const replacement = `<span class="mention" data-type="${resource.type}" data-url="${resource.url}" data-title="${resource.title}">${pattern}</span>`;
+    processedContent = processedContent.replace(pattern, replacement);
+  });
+
+  const handleMentionClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    const target = e.target as HTMLElement;
+    if (target.classList.contains("mention")) {
+      const url = target.getAttribute("data-url");
+      const title = target.getAttribute("data-title");
+      const type = target.getAttribute("data-type");
+
+      if (url) {
+        navigate(url);
+      }
+    }
+  };
+
+  return (
+    <div onClick={handleMentionClick}>
+      <SafeMarkdown content={processedContent} />
+    </div>
+  );
+};
+```
+
+**Add CSS for mention styling:**
+
+```css
+.mention {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.25rem 0.625rem;
+  background: linear-gradient(135deg, #f1f5f9 0%, #e2e8f0 100%);
+  border: 1px solid #cbd5e1;
+  border-radius: 6px;
+  color: #0f172a;
+  font-weight: 600;
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.mention:hover {
+  background: linear-gradient(135deg, #e2e8f0 0%, #cbd5e1 100%);
+  border-color: #4a90e2;
+  transform: translateY(-1px);
+  box-shadow: 0 2px 4px rgba(74, 144, 226, 0.2);
+}
+```
+
+### Conversation Types: Backend Agnosticism
+
+The conversation system supports multiple interaction modes determined by access method (GraphQL vs WebSocket) rather than hard-coded types.
+
+#### Backend: Flexible Conversation Model
+
+**File**: `opencontractserver/conversations/models.py`
+
+```python
+class Conversation(BaseOCModel):
+    """
+    Agnostic conversation model that supports multiple interaction modes.
+
+    Access Method determines behavior:
+      - GraphQL: Traditional threaded discussions (THREAD/COMMENT)
+      - WebSocket: Real-time chat (CHAT)
+
+    conversationType field is a hint, but backend doesn't enforce strict behavior.
+    Frontend adapts UI based on context, not type checks.
+    """
+
+    class ConversationType(models.TextChoices):
+        THREAD = "THREAD", "Thread (Forum-style discussion with title)"
+        COMMENT = "COMMENT", "Comment (Simple comment, no title)"
+        CHAT = "CHAT", "Chat (Real-time conversation)"
+
+    conversation_type = models.CharField(
+        max_length=10,
+        choices=ConversationType.choices,
+        default=ConversationType.THREAD,
+        help_text="Hint for frontend UI, not enforced backend behavior"
+    )
+
+    # Title/description optional - COMMENT type might not use them
+    title = models.CharField(
+        max_length=255,
+        blank=True,
+        help_text="Optional - used for THREAD, not COMMENT/CHAT"
+    )
+
+    description = models.TextField(
+        blank=True,
+        help_text="Optional - used for THREAD, not COMMENT/CHAT"
+    )
+
+    # Context fields determine scope
+    chat_with_corpus = models.ForeignKey(
+        "corpuses.Corpus",
+        null=True,
+        blank=True,
+        on_delete=models.CASCADE,
+        related_name="conversations",
+    )
+
+    chat_with_document = models.ForeignKey(
+        "documents.Document",
+        null=True,
+        blank=True,
+        on_delete=models.CASCADE,
+        related_name="conversations",
+    )
+
+    # ... other fields
+```
+
+**Key Design Principles:**
+
+1. **Type is a Hint, Not Enforcement**: Backend doesn't enforce different behavior for THREAD vs COMMENT vs CHAT. Frontend decides based on context.
+
+2. **Access Method Determines Interaction**:
+   - GraphQL queries/mutations → Traditional request/response
+   - WebSocket subscriptions (future) → Real-time updates
+   - Same models, different access patterns
+
+3. **Optional Fields**: Title/description are optional. COMMENT type conversations might not use them. Frontend adapts.
+
+4. **Context-Based**: `chat_with_corpus`, `chat_with_document` fields determine scope. A conversation can be corpus-level, document-level, or general.
+
+#### Frontend: Adaptive UI
+
+**File**: `frontend/src/components/discussions/ThreadList.tsx`
+
+```typescript
+// ThreadList adapts based on conversationType prop
+interface ThreadListProps {
+  corpusId?: string;
+  documentId?: string;
+  conversationType?: "THREAD" | "COMMENT" | "CHAT";
+  // ...
+}
+
+// When conversationType="COMMENT", show simpler cards without title
+// When conversationType="THREAD", show full thread cards with title/description
+// When conversationType="CHAT" (future), show chat-style UI with avatars/timestamps
+
+// But backend doesn't care - it's all Conversation model
+```
+
+**File**: `frontend/src/components/discussions/CreateThreadForm.tsx`
+
+```typescript
+// Form adapts based on context
+interface CreateThreadFormProps {
+  corpusId?: string;
+  documentId?: string;
+  conversationType?: "THREAD" | "COMMENT";
+  // ...
+}
+
+// When conversationType="COMMENT":
+//   - Hide title/description fields
+//   - Show simple content editor
+//   - Submit as COMMENT type
+//
+// When conversationType="THREAD":
+//   - Show title/description fields
+//   - Show full editor with formatting
+//   - Submit as THREAD type
+//
+// Backend stores both in same Conversation model
+```
+
+### Implementation Checklist
+
+This checklist maps to the pending issues as follows:
+- **Phase 1-2**: Issue #621 (Corpus Integration)
+- **Phase 3**: Issue #622 (Document Integration)
+- **Phase 4**: Issue #623 (Global View)
+- **Phase 5**: Issue #623 (@ Mentions, same issue)
+- **Phase 6**: Refinement across #621-623
+- **Phase 7**: Final polish for all integration work
+
+---
+
+**Phase 1: Routing Infrastructure** (Issue #621)
+- [ ] Add `selectedThreadId` reactive var to `cache.ts`
+- [ ] Update `CentralRouteManager.tsx` Phase 2 for `?thread=` param
+- [ ] Update `CentralRouteManager.tsx` Phase 4 for thread URL sync
+- [ ] Add utility functions to `navigationUtils.ts`
+- [ ] Add route to `App.tsx` for `/c/:user/:corpus/discussions/:threadId`
+- [ ] Add route to `App.tsx` for `/discussions`
+
+**Phase 2: Corpus Integration** (Issue #621)
+- [ ] Add `totalThreads` to `GET_CORPUS_STATS` query
+- [ ] Add Discussions tab to Corpuses sidebar navigation
+- [ ] Create `CorpusDiscussionsView.tsx` component
+- [ ] Wire up CreateThreadButton in corpus context
+- [ ] Test full-page thread navigation
+
+**Phase 3: Document Integration** (Issue #622)
+- [ ] Add `discussions` to `SidebarViewMode` type
+- [ ] Add Discussions tab to DocumentKnowledgeBase sidebar
+- [ ] Create `DocumentDiscussionsContent.tsx` component
+- [ ] Implement auto-open sidebar on `?thread=` param
+- [ ] Add `GET_DOCUMENT_THREAD_COUNT` query
+- [ ] Wire up CreateThreadButton in document context
+- [ ] Test sidebar thread navigation
+
+**Phase 4: Global View** (Issue #623)
+- [ ] Create `GlobalDiscussionsRoute.tsx`
+- [ ] Create `GlobalDiscussions.tsx` view
+- [ ] Implement tabbed sections (All/Corpus/Document/General)
+- [ ] Add search/filter functionality
+- [ ] Implement FAB for creating threads
+- [ ] Add smooth animations and transitions
+- [ ] Test navigation from global view to context views
+
+**Phase 5: @ Mentions** (Issue #623)
+- [ ] Add `MentionedResourceType` to GraphQL schema
+- [ ] Implement `resolve_mentioned_resources` in backend
+- [ ] Add `SEARCH_RESOURCES_FOR_MENTION` GraphQL query
+- [ ] Configure TipTap Mention extension
+- [ ] Create `MentionList.tsx` dropdown component
+- [ ] Implement mention rendering in `MessageContent.tsx`
+- [ ] Add mention click navigation
+- [ ] Test autocomplete and navigation
+
+**Phase 6: Conversation Type Flexibility** (Refinement across #621-623)
+- [ ] Review backend Conversation model for flexibility
+- [ ] Implement adaptive UI in ThreadList
+- [ ] Implement adaptive UI in CreateThreadForm
+- [ ] Test THREAD vs COMMENT types
+- [ ] Document WebSocket integration path for CHAT type (future)
+
+**Phase 7: Polish & Testing** (Final polish for #621-623)
+- [ ] Add loading states to all views
+- [ ] Add error boundaries
+- [ ] Implement keyboard shortcuts
+- [ ] Test mobile responsive design
+- [ ] Write Playwright component tests
+- [ ] Performance optimization (virtual scrolling, memoization)
+- [ ] Accessibility audit (ARIA labels, keyboard nav)
+
+---
+
+## Quick Reference: Where to Find Everything
+
+This section provides a quick lookup for developers working on specific issues.
+
+### For Issue #621 (Corpus Integration)
+
+**Primary Specifications**:
+- [Routing Architecture](#routing-architecture) - Add reactive vars and route handling
+- [Corpus View Integration](#corpus-view-integration) - Step-by-step implementation
+- [Implementation Checklist Phase 1-2](#implementation-checklist-1) - Detailed tasks
+
+**Reusable Components** (from #573-577):
+- [ThreadList.tsx](#1-threadlisttsx-issue-573) - Main thread list
+- [ThreadDetail.tsx](#3-threaddetailtsx-issue-573) - Thread detail view
+- [CreateThreadForm.tsx](#component-to-issue-mapping) - From Issue #574
+
+**Reference Material**:
+- [State Management Strategy](#state-management-strategy) - Jotai atoms
+- [Testing Strategy](#testing-strategy) - Test patterns
+- [Performance Considerations](#performance-considerations) - Optimization
+- [Accessibility Requirements](#accessibility-requirements) - A11y compliance
+
+### For Issue #622 (Document Integration)
+
+**Primary Specifications**:
+- [DocumentKnowledgeBase Integration](#documentknowledgebase-integration) - Step-by-step implementation
+- [Implementation Checklist Phase 3](#implementation-checklist-1) - Detailed tasks
+
+**Reusable Components** (from #573-577):
+- [ThreadList.tsx](#1-threadlisttsx-issue-573) - Sidebar thread list
+- [ThreadDetail.tsx](#3-threaddetailtsx-issue-573) - Thread detail in sidebar
+- [CreateThreadForm.tsx](#component-to-issue-mapping) - From Issue #574
+
+**Reference Material**:
+- [State Management Strategy](#state-management-strategy) - Sidebar state patterns
+- [Testing Strategy](#testing-strategy) - Sidebar integration tests
+- [Code Examples & Patterns](#code-examples--patterns) - Batched updates for sidebar
+
+### For Issue #623 (Global View + @ Mentions)
+
+**Primary Specifications**:
+- [Global Discussions View](#global-discussions-view) - Complete component specs
+- [@ Mentions Feature](#-mentions-feature) - TipTap configuration & backend parsing
+- [Implementation Checklist Phase 4-5](#implementation-checklist-1) - Detailed tasks
+
+**Reusable Components** (from #573-577):
+- [ThreadList.tsx](#1-threadlisttsx-issue-573) - Global thread list
+- [MessageComposer.tsx](#component-to-issue-mapping) - Enhanced with mentions (Issue #574)
+- All components from #573-577
+
+**Reference Material**:
+- [State Management Strategy](#state-management-strategy) - Global filter atoms
+- [Testing Strategy](#testing-strategy) - Full-page view tests
+- [Code Examples & Patterns](#code-examples--patterns) - Animations, autocomplete
+- [Performance Considerations](#performance-considerations) - Virtual scrolling
+
+### For All Issues (#578-580, #621-623)
+
+**Cross-Cutting Concerns**:
+- [Architecture Overview](#architecture-overview) - Overall system design
+- [Component Specifications](#component-specifications) - All foundation components
+- [Data Flow Patterns](#data-flow-patterns) - GraphQL patterns
+- [Performance Considerations](#performance-considerations) - Required for all views
+- [Accessibility Requirements](#accessibility-requirements) - Required for all components
+
+**Implementation Process**:
+1. Review [Pending Issues](#pending-issues-roadmap-to-full-integration) for your issue
+2. Check [Branch Dependency Tree](#branch-dependency-tree) for dependencies
+3. Follow [Implementation Checklist](#implementation-checklist-1) phases
+4. Reference [Component-to-Issue Mapping](#component-to-issue-mapping) for reusable parts
+5. Apply patterns from [Code Examples & Patterns](#code-examples--patterns)
+
+---
+
 ## Conclusion
 
 This implementation guide provides a comprehensive roadmap for building the commenting and discussion system frontend. Follow this guide systematically, and each component will integrate seamlessly with the existing backend APIs.
@@ -1652,8 +3550,10 @@ This implementation guide provides a comprehensive roadmap for building the comm
 **Key Takeaways**:
 - Build reusable components from the start
 - Test thoroughly with Playwright
-- Follow existing patterns in the codebase
+- Follow existing patterns in the codebase (especially routing mantra)
 - Keep accessibility in mind
 - Optimize for performance with large datasets
+- Leverage @ mentions for rich cross-referencing
+- Design for flexibility (conversation types, access methods)
 
 Ready to implement! 🚀

--- a/docs/commenting_system/IMPLEMENTATION_GUIDE.md
+++ b/docs/commenting_system/IMPLEMENTATION_GUIDE.md
@@ -1339,10 +1339,36 @@ yarn run test:ct --ui frontend/tests/threads/ThreadList.test.tsx
 
 ---
 
-### ⏳ Issue #577: Notification Center UI
+### ✅ Issue #577: Notification Center UI (COMPLETED)
 
-**Status**: ⏳ Pending (after #576)
-**Estimated**: 4 days
+**Branch**: `feature/notification-center-577` (based on #576)
+**Status**: ✅ Complete and committed
+**Commit**: `fa78527d`
+
+#### Components Created
+- [x] `NotificationBell.tsx` - Bell icon with unread count badge and dropdown trigger
+- [x] `NotificationDropdown.tsx` - Quick notification access from header
+- [x] `NotificationItem.tsx` - Individual notification display with all notification types
+- [x] `NotificationCenter.tsx` - Full page notification center with filtering
+- [x] GraphQL queries (GET_NOTIFICATIONS, GET_UNREAD_NOTIFICATION_COUNT)
+- [x] GraphQL mutations (MARK_NOTIFICATION_READ, MARK_NOTIFICATION_UNREAD, MARK_ALL_NOTIFICATIONS_READ, DELETE_NOTIFICATION)
+
+#### Features
+- Unread count badge with 99+ overflow handling
+- Real-time polling (configurable interval, default 30s)
+- Deep linking to threads/messages
+- Filter notifications (all/unread/read)
+- Mark individual or all notifications as read/unread
+- Delete notifications
+- Click-outside-to-close dropdown
+- Responsive design for mobile/desktop
+- Apollo cache refetching for instant updates
+
+#### Testing
+- [x] NotificationBell.ct.tsx (7 tests)
+- [x] NotificationItem.ct.tsx (15 tests)
+- [x] NotificationCenter.ct.tsx (11 tests)
+- 33 comprehensive tests covering all notification types and interactions
 
 ---
 
@@ -1395,9 +1421,10 @@ v3.0.0.b3 (base)
 └─ feature/thread-list-detail-573 ✅
    └─ feature/message-composer-574 ✅
       └─ feature/voting-ui-575 ✅
-         └─ feature/moderation-ui-576 ✅ (current)
-            └─ feature/notification-center-577 (next)
-               └─ ... (subsequent issues)
+         └─ feature/moderation-ui-576 ✅
+            └─ feature/notification-center-577 ✅ (current)
+               └─ feature/badge-display-578 (next)
+                  └─ ... (subsequent issues)
 ```
 
 **IMPORTANT**: Each branch builds on the previous issue's branch to maintain a clean dependency chain.

--- a/frontend/src/components/notifications/NotificationBell.tsx
+++ b/frontend/src/components/notifications/NotificationBell.tsx
@@ -1,0 +1,141 @@
+import React, { useState, useRef, useEffect } from "react";
+import styled from "styled-components";
+import { Bell } from "lucide-react";
+import { useQuery } from "@apollo/client";
+import { GET_UNREAD_NOTIFICATION_COUNT } from "../../graphql/queries";
+import { NotificationDropdown } from "./NotificationDropdown";
+
+const BellContainer = styled.div`
+  position: relative;
+  display: inline-block;
+`;
+
+const BellButton = styled.button<{ $hasUnread?: boolean }>`
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border: none;
+  background: ${({ theme, $hasUnread }) =>
+    $hasUnread ? theme.color.primary : "transparent"};
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  color: ${({ theme, $hasUnread }) =>
+    $hasUnread ? "white" : theme.color.text.primary};
+
+  &:hover {
+    background: ${({ theme }) => theme.color.background.tertiary};
+    color: ${({ theme }) => theme.color.primary};
+  }
+
+  svg {
+    width: 20px;
+    height: 20px;
+  }
+`;
+
+const Badge = styled.span`
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  background: ${({ theme }) => theme.color.error};
+  color: white;
+  font-size: 11px;
+  font-weight: 700;
+  border-radius: 9px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  pointer-events: none;
+`;
+
+export interface NotificationBellProps {
+  /** Show full notification center instead of dropdown */
+  fullPageMode?: boolean;
+  /** Callback when notification center link clicked */
+  onViewAll?: () => void;
+  /** Polling interval in ms (default: 30000 = 30s) */
+  pollInterval?: number;
+}
+
+export function NotificationBell({
+  fullPageMode = false,
+  onViewAll,
+  pollInterval = 30000,
+}: NotificationBellProps) {
+  const [showDropdown, setShowDropdown] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const { data, startPolling, stopPolling } = useQuery(
+    GET_UNREAD_NOTIFICATION_COUNT,
+    {
+      fetchPolicy: "cache-and-network",
+    }
+  );
+
+  const unreadCount = data?.unreadNotificationCount || 0;
+
+  useEffect(() => {
+    if (pollInterval > 0) {
+      startPolling(pollInterval);
+      return () => stopPolling();
+    }
+  }, [pollInterval, startPolling, stopPolling]);
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(event.target as Node)
+      ) {
+        setShowDropdown(false);
+      }
+    }
+
+    if (showDropdown) {
+      document.addEventListener("mousedown", handleClickOutside);
+      return () =>
+        document.removeEventListener("mousedown", handleClickOutside);
+    }
+  }, [showDropdown]);
+
+  const handleBellClick = () => {
+    if (fullPageMode && onViewAll) {
+      onViewAll();
+    } else {
+      setShowDropdown(!showDropdown);
+    }
+  };
+
+  return (
+    <BellContainer ref={containerRef}>
+      <BellButton
+        onClick={handleBellClick}
+        $hasUnread={unreadCount > 0}
+        title={`${unreadCount} unread notification${
+          unreadCount !== 1 ? "s" : ""
+        }`}
+        aria-label={`Notifications (${unreadCount} unread)`}
+      >
+        <Bell />
+        {unreadCount > 0 && (
+          <Badge>{unreadCount > 99 ? "99+" : unreadCount}</Badge>
+        )}
+      </BellButton>
+
+      {showDropdown && !fullPageMode && (
+        <NotificationDropdown
+          onClose={() => setShowDropdown(false)}
+          onViewAll={onViewAll}
+        />
+      )}
+    </BellContainer>
+  );
+}

--- a/frontend/src/components/notifications/NotificationBell.tsx
+++ b/frontend/src/components/notifications/NotificationBell.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect } from "react";
 import styled from "styled-components";
 import { Bell } from "lucide-react";
+import { color } from "../../theme/colors";
 import { useQuery } from "@apollo/client";
 import { GET_UNREAD_NOTIFICATION_COUNT } from "../../graphql/queries";
 import { NotificationDropdown } from "./NotificationDropdown";
@@ -19,16 +20,15 @@ const BellButton = styled.button<{ $hasUnread?: boolean }>`
   height: 40px;
   border: none;
   background: ${({ theme, $hasUnread }) =>
-    $hasUnread ? theme.color.primary : "transparent"};
+    $hasUnread ? color.B5 : "transparent"};
   border-radius: 8px;
   cursor: pointer;
   transition: all 0.2s ease;
-  color: ${({ theme, $hasUnread }) =>
-    $hasUnread ? "white" : theme.color.text.primary};
+  color: ${({ theme, $hasUnread }) => ($hasUnread ? "white" : color.N10)};
 
   &:hover {
-    background: ${({ theme }) => theme.color.background.tertiary};
-    color: ${({ theme }) => theme.color.primary};
+    background: ${({ theme }) => color.N3};
+    color: ${({ theme }) => color.B5};
   }
 
   svg {
@@ -44,7 +44,7 @@ const Badge = styled.span`
   min-width: 18px;
   height: 18px;
   padding: 0 5px;
-  background: ${({ theme }) => theme.color.error};
+  background: ${({ theme }) => color.R7};
   color: white;
   font-size: 11px;
   font-weight: 700;

--- a/frontend/src/components/notifications/NotificationCenter.tsx
+++ b/frontend/src/components/notifications/NotificationCenter.tsx
@@ -1,0 +1,311 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+import { useQuery, useMutation } from "@apollo/client";
+import { CheckCheck, Filter, X } from "lucide-react";
+import {
+  GET_NOTIFICATIONS,
+  GET_UNREAD_NOTIFICATION_COUNT,
+  type GetNotificationsOutput,
+  type GetNotificationsInput,
+} from "../../graphql/queries";
+import {
+  MARK_ALL_NOTIFICATIONS_READ,
+  type MarkAllNotificationsReadOutput,
+} from "../../graphql/mutations";
+import { NotificationItem } from "./NotificationItem";
+import { useNavigate } from "react-router-dom";
+
+const Container = styled.div`
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 24px;
+
+  @media (max-width: 640px) {
+    padding: 16px;
+  }
+`;
+
+const Header = styled.div`
+  margin-bottom: 24px;
+`;
+
+const Title = styled.h1`
+  margin: 0 0 16px 0;
+  font-size: 24px;
+  font-weight: 700;
+  color: ${({ theme }) => theme.color.text.primary};
+`;
+
+const Controls = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 12px;
+`;
+
+const FilterButtons = styled.div`
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+`;
+
+const FilterButton = styled.button<{ $active?: boolean }>`
+  padding: 8px 16px;
+  font-size: 14px;
+  font-weight: 500;
+  border: 1px solid ${({ theme }) => theme.color.borders.secondary};
+  border-radius: 6px;
+  background: ${({ theme, $active }) =>
+    $active ? theme.color.primary : "transparent"};
+  color: ${({ theme, $active }) =>
+    $active ? "white" : theme.color.text.primary};
+  cursor: pointer;
+  transition: all 0.15s ease;
+
+  &:hover {
+    background: ${({ theme, $active }) =>
+      $active ? theme.color.primary : theme.color.background.tertiary};
+    border-color: ${({ theme }) => theme.color.primary};
+  }
+`;
+
+const ActionButton = styled.button`
+  padding: 8px 16px;
+  font-size: 14px;
+  font-weight: 500;
+  border: 1px solid ${({ theme }) => theme.color.borders.secondary};
+  border-radius: 6px;
+  background: transparent;
+  color: ${({ theme }) => theme.color.primary};
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  transition: all 0.15s ease;
+
+  &:hover {
+    background: ${({ theme }) => theme.color.primary};
+    color: white;
+    border-color: ${({ theme }) => theme.color.primary};
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  svg {
+    width: 16px;
+    height: 16px;
+  }
+`;
+
+const NotificationList = styled.div`
+  background: ${({ theme }) => theme.color.background.primary};
+  border: 1px solid ${({ theme }) => theme.color.borders.tertiary};
+  border-radius: 8px;
+  overflow: hidden;
+`;
+
+const EmptyState = styled.div`
+  padding: 64px 24px;
+  text-align: center;
+  color: ${({ theme }) => theme.color.text.secondary};
+
+  h3 {
+    margin: 0 0 8px 0;
+    font-size: 18px;
+    font-weight: 600;
+    color: ${({ theme }) => theme.color.text.primary};
+  }
+
+  p {
+    margin: 0;
+    font-size: 14px;
+  }
+`;
+
+const LoadingState = styled.div`
+  padding: 64px 24px;
+  text-align: center;
+  color: ${({ theme }) => theme.color.text.secondary};
+  font-size: 14px;
+`;
+
+const LoadMoreContainer = styled.div`
+  padding: 16px;
+  text-align: center;
+  border-top: 1px solid ${({ theme }) => theme.color.borders.tertiary};
+`;
+
+const LoadMoreButton = styled.button`
+  padding: 8px 24px;
+  font-size: 14px;
+  font-weight: 500;
+  border: 1px solid ${({ theme }) => theme.color.borders.secondary};
+  border-radius: 6px;
+  background: transparent;
+  color: ${({ theme }) => theme.color.primary};
+  cursor: pointer;
+  transition: all 0.15s ease;
+
+  &:hover {
+    background: ${({ theme }) => theme.color.primary};
+    color: white;
+    border-color: ${({ theme }) => theme.color.primary};
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+`;
+
+type FilterType = "all" | "unread" | "read";
+
+export function NotificationCenter() {
+  const navigate = useNavigate();
+  const [filter, setFilter] = useState<FilterType>("all");
+
+  const queryVariables: GetNotificationsInput = {
+    limit: 50,
+    ...(filter === "unread" && { isRead: false }),
+    ...(filter === "read" && { isRead: true }),
+  };
+
+  const { data, loading, fetchMore } = useQuery<GetNotificationsOutput>(
+    GET_NOTIFICATIONS,
+    {
+      variables: queryVariables,
+      fetchPolicy: "cache-and-network",
+    }
+  );
+
+  const [markAllRead, { loading: markingAll }] =
+    useMutation<MarkAllNotificationsReadOutput>(MARK_ALL_NOTIFICATIONS_READ, {
+      refetchQueries: [GET_NOTIFICATIONS, GET_UNREAD_NOTIFICATION_COUNT],
+    });
+
+  const notifications = data?.notifications?.edges?.map((e) => e.node) || [];
+  const hasUnread = notifications.some((n) => !n.isRead);
+  const hasMore = data?.notifications?.pageInfo?.hasNextPage || false;
+
+  const handleNotificationClick = (notification: any) => {
+    // Navigate to the relevant thread/message
+    if (notification.conversation?.id) {
+      const conversationId = notification.conversation.id;
+      const corpusId = notification.conversation.chatWithCorpus?.id;
+
+      if (corpusId) {
+        navigate(
+          `/corpus/${corpusId}/discussions/thread/${conversationId}${
+            notification.message?.id
+              ? `?message=${notification.message.id}`
+              : ""
+          }`
+        );
+      } else {
+        navigate(
+          `/discussions/thread/${conversationId}${
+            notification.message?.id
+              ? `?message=${notification.message.id}`
+              : ""
+          }`
+        );
+      }
+    }
+  };
+
+  const handleMarkAllRead = () => {
+    markAllRead();
+  };
+
+  const handleLoadMore = () => {
+    if (hasMore && !loading) {
+      fetchMore({
+        variables: {
+          ...queryVariables,
+          cursor: data?.notifications?.pageInfo?.endCursor,
+        },
+      });
+    }
+  };
+
+  return (
+    <Container>
+      <Header>
+        <Title>Notifications</Title>
+        <Controls>
+          <FilterButtons>
+            <FilterButton
+              $active={filter === "all"}
+              onClick={() => setFilter("all")}
+            >
+              All
+            </FilterButton>
+            <FilterButton
+              $active={filter === "unread"}
+              onClick={() => setFilter("unread")}
+            >
+              Unread
+            </FilterButton>
+            <FilterButton
+              $active={filter === "read"}
+              onClick={() => setFilter("read")}
+            >
+              Read
+            </FilterButton>
+          </FilterButtons>
+
+          <ActionButton
+            onClick={handleMarkAllRead}
+            disabled={!hasUnread || markingAll}
+          >
+            <CheckCheck />
+            Mark all as read
+          </ActionButton>
+        </Controls>
+      </Header>
+
+      <NotificationList>
+        {loading && <LoadingState>Loading notifications...</LoadingState>}
+
+        {!loading && notifications.length === 0 && (
+          <EmptyState>
+            <h3>
+              {filter === "unread"
+                ? "No unread notifications"
+                : filter === "read"
+                ? "No read notifications"
+                : "No notifications yet"}
+            </h3>
+            <p>
+              {filter === "all"
+                ? "When you receive notifications, they'll appear here."
+                : "Try changing the filter to see other notifications."}
+            </p>
+          </EmptyState>
+        )}
+
+        {!loading &&
+          notifications.map((notification) => (
+            <NotificationItem
+              key={notification.id}
+              notification={notification}
+              onClick={handleNotificationClick}
+              showActions={true}
+            />
+          ))}
+
+        {!loading && hasMore && (
+          <LoadMoreContainer>
+            <LoadMoreButton onClick={handleLoadMore}>
+              Load more notifications
+            </LoadMoreButton>
+          </LoadMoreContainer>
+        )}
+      </NotificationList>
+    </Container>
+  );
+}

--- a/frontend/src/components/notifications/NotificationCenter.tsx
+++ b/frontend/src/components/notifications/NotificationCenter.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import styled from "styled-components";
 import { useQuery, useMutation } from "@apollo/client";
+import { color } from "../../theme/colors";
 import { CheckCheck, Filter, X } from "lucide-react";
 import {
   GET_NOTIFICATIONS,
@@ -33,7 +34,7 @@ const Title = styled.h1`
   margin: 0 0 16px 0;
   font-size: 24px;
   font-weight: 700;
-  color: ${({ theme }) => theme.color.text.primary};
+  color: ${({ theme }) => color.N10};
 `;
 
 const Controls = styled.div`
@@ -54,19 +55,16 @@ const FilterButton = styled.button<{ $active?: boolean }>`
   padding: 8px 16px;
   font-size: 14px;
   font-weight: 500;
-  border: 1px solid ${({ theme }) => theme.color.borders.secondary};
+  border: 1px solid ${({ theme }) => color.N4};
   border-radius: 6px;
-  background: ${({ theme, $active }) =>
-    $active ? theme.color.primary : "transparent"};
-  color: ${({ theme, $active }) =>
-    $active ? "white" : theme.color.text.primary};
+  background: ${({ theme, $active }) => ($active ? color.B5 : "transparent")};
+  color: ${({ theme, $active }) => ($active ? "white" : color.N10)};
   cursor: pointer;
   transition: all 0.15s ease;
 
   &:hover {
-    background: ${({ theme, $active }) =>
-      $active ? theme.color.primary : theme.color.background.tertiary};
-    border-color: ${({ theme }) => theme.color.primary};
+    background: ${({ theme, $active }) => ($active ? color.B5 : color.N3)};
+    border-color: ${({ theme }) => color.B5};
   }
 `;
 
@@ -74,10 +72,10 @@ const ActionButton = styled.button`
   padding: 8px 16px;
   font-size: 14px;
   font-weight: 500;
-  border: 1px solid ${({ theme }) => theme.color.borders.secondary};
+  border: 1px solid ${({ theme }) => color.N4};
   border-radius: 6px;
   background: transparent;
-  color: ${({ theme }) => theme.color.primary};
+  color: ${({ theme }) => color.B5};
   cursor: pointer;
   display: flex;
   align-items: center;
@@ -85,9 +83,9 @@ const ActionButton = styled.button`
   transition: all 0.15s ease;
 
   &:hover {
-    background: ${({ theme }) => theme.color.primary};
+    background: ${({ theme }) => color.B5};
     color: white;
-    border-color: ${({ theme }) => theme.color.primary};
+    border-color: ${({ theme }) => color.B5};
   }
 
   &:disabled {
@@ -102,8 +100,8 @@ const ActionButton = styled.button`
 `;
 
 const NotificationList = styled.div`
-  background: ${({ theme }) => theme.color.background.primary};
-  border: 1px solid ${({ theme }) => theme.color.borders.tertiary};
+  background: ${({ theme }) => color.N1};
+  border: 1px solid ${({ theme }) => color.N4};
   border-radius: 8px;
   overflow: hidden;
 `;
@@ -111,13 +109,13 @@ const NotificationList = styled.div`
 const EmptyState = styled.div`
   padding: 64px 24px;
   text-align: center;
-  color: ${({ theme }) => theme.color.text.secondary};
+  color: ${({ theme }) => color.N7};
 
   h3 {
     margin: 0 0 8px 0;
     font-size: 18px;
     font-weight: 600;
-    color: ${({ theme }) => theme.color.text.primary};
+    color: ${({ theme }) => color.N10};
   }
 
   p {
@@ -129,31 +127,31 @@ const EmptyState = styled.div`
 const LoadingState = styled.div`
   padding: 64px 24px;
   text-align: center;
-  color: ${({ theme }) => theme.color.text.secondary};
+  color: ${({ theme }) => color.N7};
   font-size: 14px;
 `;
 
 const LoadMoreContainer = styled.div`
   padding: 16px;
   text-align: center;
-  border-top: 1px solid ${({ theme }) => theme.color.borders.tertiary};
+  border-top: 1px solid ${({ theme }) => color.N4};
 `;
 
 const LoadMoreButton = styled.button`
   padding: 8px 24px;
   font-size: 14px;
   font-weight: 500;
-  border: 1px solid ${({ theme }) => theme.color.borders.secondary};
+  border: 1px solid ${({ theme }) => color.N4};
   border-radius: 6px;
   background: transparent;
-  color: ${({ theme }) => theme.color.primary};
+  color: ${({ theme }) => color.B5};
   cursor: pointer;
   transition: all 0.15s ease;
 
   &:hover {
-    background: ${({ theme }) => theme.color.primary};
+    background: ${({ theme }) => color.B5};
     color: white;
-    border-color: ${({ theme }) => theme.color.primary};
+    border-color: ${({ theme }) => color.B5};
   }
 
   &:disabled {

--- a/frontend/src/components/notifications/NotificationDropdown.tsx
+++ b/frontend/src/components/notifications/NotificationDropdown.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 import { useQuery, useMutation } from "@apollo/client";
+import { color } from "../../theme/colors";
 import { CheckCheck, Settings } from "lucide-react";
 import {
   GET_NOTIFICATIONS,
@@ -20,8 +21,8 @@ const DropdownContainer = styled.div`
   right: 0;
   width: 400px;
   max-height: 600px;
-  background: ${({ theme }) => theme.color.background.primary};
-  border: 1px solid ${({ theme }) => theme.color.borders.tertiary};
+  background: ${({ theme }) => color.N1};
+  border: 1px solid ${({ theme }) => color.N4};
   border-radius: 8px;
   box-shadow: 0 4px 24px rgba(0, 0, 0, 0.15);
   display: flex;
@@ -40,7 +41,7 @@ const DropdownContainer = styled.div`
 
 const Header = styled.div`
   padding: 16px;
-  border-bottom: 1px solid ${({ theme }) => theme.color.borders.tertiary};
+  border-bottom: 1px solid ${({ theme }) => color.N4};
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -50,7 +51,7 @@ const Title = styled.h3`
   margin: 0;
   font-size: 16px;
   font-weight: 600;
-  color: ${({ theme }) => theme.color.text.primary};
+  color: ${({ theme }) => color.N10};
 `;
 
 const HeaderActions = styled.div`
@@ -61,19 +62,19 @@ const HeaderActions = styled.div`
 const IconButton = styled.button`
   padding: 6px;
   background: transparent;
-  border: 1px solid ${({ theme }) => theme.color.borders.secondary};
+  border: 1px solid ${({ theme }) => color.N4};
   border-radius: 4px;
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  color: ${({ theme }) => theme.color.text.secondary};
+  color: ${({ theme }) => color.N7};
   transition: all 0.15s ease;
 
   &:hover {
-    background: ${({ theme }) => theme.color.background.tertiary};
-    border-color: ${({ theme }) => theme.color.primary};
-    color: ${({ theme }) => theme.color.primary};
+    background: ${({ theme }) => color.N3};
+    border-color: ${({ theme }) => color.B5};
+    color: ${({ theme }) => color.B5};
   }
 
   &:disabled {
@@ -96,13 +97,13 @@ const NotificationList = styled.div`
 const EmptyState = styled.div`
   padding: 48px 24px;
   text-align: center;
-  color: ${({ theme }) => theme.color.text.secondary};
+  color: ${({ theme }) => color.N7};
   font-size: 14px;
 `;
 
 const Footer = styled.div`
   padding: 12px;
-  border-top: 1px solid ${({ theme }) => theme.color.borders.tertiary};
+  border-top: 1px solid ${({ theme }) => color.N4};
   display: flex;
   justify-content: center;
 `;
@@ -110,25 +111,25 @@ const Footer = styled.div`
 const ViewAllButton = styled.button`
   padding: 8px 16px;
   background: transparent;
-  border: 1px solid ${({ theme }) => theme.color.borders.secondary};
+  border: 1px solid ${({ theme }) => color.N4};
   border-radius: 4px;
   font-size: 14px;
   font-weight: 500;
-  color: ${({ theme }) => theme.color.primary};
+  color: ${({ theme }) => color.B5};
   cursor: pointer;
   transition: all 0.15s ease;
 
   &:hover {
-    background: ${({ theme }) => theme.color.primary};
+    background: ${({ theme }) => color.B5};
     color: white;
-    border-color: ${({ theme }) => theme.color.primary};
+    border-color: ${({ theme }) => color.B5};
   }
 `;
 
 const LoadingState = styled.div`
   padding: 48px 24px;
   text-align: center;
-  color: ${({ theme }) => theme.color.text.secondary};
+  color: ${({ theme }) => color.N7};
   font-size: 14px;
 `;
 

--- a/frontend/src/components/notifications/NotificationItem.tsx
+++ b/frontend/src/components/notifications/NotificationItem.tsx
@@ -1,0 +1,345 @@
+import React from "react";
+import styled from "styled-components";
+import {
+  MessageCircle,
+  ThumbsUp,
+  Award,
+  AtSign,
+  CheckCircle,
+  Lock,
+  Unlock,
+  Pin,
+  Trash2,
+  RotateCcw,
+  MessageSquare,
+} from "lucide-react";
+import { useMutation } from "@apollo/client";
+import {
+  MARK_NOTIFICATION_READ,
+  MARK_NOTIFICATION_UNREAD,
+  DELETE_NOTIFICATION,
+  MarkNotificationReadInput,
+  MarkNotificationReadOutput,
+  MarkNotificationUnreadInput,
+  MarkNotificationUnreadOutput,
+  DeleteNotificationInput,
+  DeleteNotificationOutput,
+} from "../../graphql/mutations";
+import {
+  GET_NOTIFICATIONS,
+  GET_UNREAD_NOTIFICATION_COUNT,
+} from "../../graphql/queries";
+import { formatDistanceToNow } from "date-fns";
+import type { NotificationNode } from "../../graphql/queries";
+
+const ItemContainer = styled.div<{ $isRead?: boolean }>`
+  display: flex;
+  gap: 12px;
+  padding: 12px;
+  background: ${({ theme, $isRead }) =>
+    $isRead
+      ? theme.color.background.primary
+      : theme.color.background.secondary};
+  border-bottom: 1px solid ${({ theme }) => theme.color.borders.tertiary};
+  cursor: pointer;
+  transition: background 0.15s ease;
+
+  &:hover {
+    background: ${({ theme }) => theme.color.background.tertiary};
+  }
+
+  &:last-child {
+    border-bottom: none;
+  }
+`;
+
+const IconContainer = styled.div<{ $color: string }>`
+  flex-shrink: 0;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: ${({ $color }) => $color}15;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: ${({ $color }) => $color};
+
+  svg {
+    width: 20px;
+    height: 20px;
+  }
+`;
+
+const Content = styled.div`
+  flex: 1;
+  min-width: 0;
+`;
+
+const Header = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
+`;
+
+const Username = styled.span`
+  font-weight: 600;
+  color: ${({ theme }) => theme.color.text.primary};
+  font-size: 14px;
+`;
+
+const Time = styled.span`
+  font-size: 12px;
+  color: ${({ theme }) => theme.color.text.secondary};
+`;
+
+const UnreadDot = styled.span`
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: ${({ theme }) => theme.color.primary};
+  flex-shrink: 0;
+`;
+
+const Message = styled.p`
+  margin: 0;
+  font-size: 14px;
+  color: ${({ theme }) => theme.color.text.primary};
+  line-height: 1.4;
+`;
+
+const ThreadTitle = styled.span`
+  font-weight: 500;
+  color: ${({ theme }) => theme.color.primary};
+`;
+
+const Actions = styled.div`
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
+`;
+
+const ActionButton = styled.button`
+  padding: 4px 8px;
+  font-size: 12px;
+  background: transparent;
+  border: 1px solid ${({ theme }) => theme.color.borders.secondary};
+  border-radius: 4px;
+  color: ${({ theme }) => theme.color.text.secondary};
+  cursor: pointer;
+  transition: all 0.15s ease;
+
+  &:hover {
+    background: ${({ theme }) => theme.color.background.tertiary};
+    border-color: ${({ theme }) => theme.color.primary};
+    color: ${({ theme }) => theme.color.primary};
+  }
+`;
+
+export interface NotificationItemProps {
+  notification: NotificationNode;
+  onClick?: (notification: NotificationNode) => void;
+  showActions?: boolean;
+}
+
+const NOTIFICATION_CONFIG = {
+  REPLY: {
+    icon: MessageCircle,
+    color: "#2196F3",
+    getMessage: (n: NotificationNode) =>
+      `${n.actor?.username || "Someone"} replied to your message${
+        n.conversation?.title ? ` in "${n.conversation.title}"` : ""
+      }`,
+  },
+  VOTE: {
+    icon: ThumbsUp,
+    color: "#4CAF50",
+    getMessage: (n: NotificationNode) => {
+      const voteType =
+        n.data?.voteType === "DOWNVOTE" ? "downvoted" : "upvoted";
+      return `${n.actor?.username || "Someone"} ${voteType} your message`;
+    },
+  },
+  BADGE: {
+    icon: Award,
+    color: "#FF9800",
+    getMessage: (n: NotificationNode) =>
+      `You earned the "${n.data?.badgeName || "badge"}" badge!`,
+  },
+  MENTION: {
+    icon: AtSign,
+    color: "#9C27B0",
+    getMessage: (n: NotificationNode) =>
+      `${n.actor?.username || "Someone"} mentioned you${
+        n.conversation?.title ? ` in "${n.conversation.title}"` : ""
+      }`,
+  },
+  ACCEPTED: {
+    icon: CheckCircle,
+    color: "#4CAF50",
+    getMessage: (n: NotificationNode) =>
+      `${n.actor?.username || "Someone"} accepted your answer`,
+  },
+  THREAD_LOCKED: {
+    icon: Lock,
+    color: "#F44336",
+    getMessage: (n: NotificationNode) =>
+      `${n.actor?.username || "A moderator"} locked thread "${
+        n.conversation?.title || "a thread"
+      }"`,
+  },
+  THREAD_UNLOCKED: {
+    icon: Unlock,
+    color: "#4CAF50",
+    getMessage: (n: NotificationNode) =>
+      `${n.actor?.username || "A moderator"} unlocked thread "${
+        n.conversation?.title || "a thread"
+      }"`,
+  },
+  THREAD_PINNED: {
+    icon: Pin,
+    color: "#2196F3",
+    getMessage: (n: NotificationNode) =>
+      `${n.actor?.username || "A moderator"} pinned thread "${
+        n.conversation?.title || "a thread"
+      }"`,
+  },
+  THREAD_UNPINNED: {
+    icon: Pin,
+    color: "#757575",
+    getMessage: (n: NotificationNode) =>
+      `${n.actor?.username || "A moderator"} unpinned thread "${
+        n.conversation?.title || "a thread"
+      }"`,
+  },
+  MESSAGE_DELETED: {
+    icon: Trash2,
+    color: "#F44336",
+    getMessage: (n: NotificationNode) =>
+      `${n.actor?.username || "A moderator"} deleted your message`,
+  },
+  THREAD_DELETED: {
+    icon: Trash2,
+    color: "#F44336",
+    getMessage: (n: NotificationNode) =>
+      `${n.actor?.username || "A moderator"} deleted thread "${
+        n.conversation?.title || "a thread"
+      }"`,
+  },
+  MESSAGE_RESTORED: {
+    icon: RotateCcw,
+    color: "#4CAF50",
+    getMessage: (n: NotificationNode) =>
+      `${n.actor?.username || "A moderator"} restored your message`,
+  },
+  THREAD_RESTORED: {
+    icon: RotateCcw,
+    color: "#4CAF50",
+    getMessage: (n: NotificationNode) =>
+      `${n.actor?.username || "A moderator"} restored thread "${
+        n.conversation?.title || "a thread"
+      }"`,
+  },
+  THREAD_REPLY: {
+    icon: MessageSquare,
+    color: "#2196F3",
+    getMessage: (n: NotificationNode) =>
+      `${n.actor?.username || "Someone"} replied in thread "${
+        n.conversation?.title || "a thread"
+      }"`,
+  },
+};
+
+export function NotificationItem({
+  notification,
+  onClick,
+  showActions = true,
+}: NotificationItemProps) {
+  const config =
+    NOTIFICATION_CONFIG[
+      notification.notificationType as keyof typeof NOTIFICATION_CONFIG
+    ] || NOTIFICATION_CONFIG.REPLY;
+
+  const Icon = config.icon;
+
+  const [markRead] = useMutation<
+    MarkNotificationReadOutput,
+    MarkNotificationReadInput
+  >(MARK_NOTIFICATION_READ, {
+    refetchQueries: [GET_NOTIFICATIONS, GET_UNREAD_NOTIFICATION_COUNT],
+  });
+
+  const [markUnread] = useMutation<
+    MarkNotificationUnreadOutput,
+    MarkNotificationUnreadInput
+  >(MARK_NOTIFICATION_UNREAD, {
+    refetchQueries: [GET_NOTIFICATIONS, GET_UNREAD_NOTIFICATION_COUNT],
+  });
+
+  const [deleteNotification] = useMutation<
+    DeleteNotificationOutput,
+    DeleteNotificationInput
+  >(DELETE_NOTIFICATION, {
+    refetchQueries: [GET_NOTIFICATIONS, GET_UNREAD_NOTIFICATION_COUNT],
+  });
+
+  const handleClick = () => {
+    if (!notification.isRead) {
+      markRead({ variables: { notificationId: notification.id } });
+    }
+    onClick?.(notification);
+  };
+
+  const handleMarkAsRead = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    markRead({ variables: { notificationId: notification.id } });
+  };
+
+  const handleMarkAsUnread = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    markUnread({ variables: { notificationId: notification.id } });
+  };
+
+  const handleDelete = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (confirm("Delete this notification?")) {
+      deleteNotification({ variables: { notificationId: notification.id } });
+    }
+  };
+
+  return (
+    <ItemContainer $isRead={notification.isRead} onClick={handleClick}>
+      <IconContainer $color={config.color}>
+        <Icon />
+      </IconContainer>
+
+      <Content>
+        <Header>
+          {!notification.isRead && <UnreadDot />}
+          <Time>
+            {formatDistanceToNow(new Date(notification.createdAt), {
+              addSuffix: true,
+            })}
+          </Time>
+        </Header>
+
+        <Message>{config.getMessage(notification)}</Message>
+
+        {showActions && (
+          <Actions>
+            {notification.isRead ? (
+              <ActionButton onClick={handleMarkAsUnread}>
+                Mark as unread
+              </ActionButton>
+            ) : (
+              <ActionButton onClick={handleMarkAsRead}>
+                Mark as read
+              </ActionButton>
+            )}
+            <ActionButton onClick={handleDelete}>Delete</ActionButton>
+          </Actions>
+        )}
+      </Content>
+    </ItemContainer>
+  );
+}

--- a/frontend/src/components/notifications/NotificationItem.tsx
+++ b/frontend/src/components/notifications/NotificationItem.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import styled from "styled-components";
+import { color } from "../../theme/colors";
 import {
   MessageCircle,
   ThumbsUp,
@@ -36,16 +37,13 @@ const ItemContainer = styled.div<{ $isRead?: boolean }>`
   display: flex;
   gap: 12px;
   padding: 12px;
-  background: ${({ theme, $isRead }) =>
-    $isRead
-      ? theme.color.background.primary
-      : theme.color.background.secondary};
-  border-bottom: 1px solid ${({ theme }) => theme.color.borders.tertiary};
+  background: ${({ theme, $isRead }) => ($isRead ? color.N1 : color.N2)};
+  border-bottom: 1px solid ${({ theme }) => color.N4};
   cursor: pointer;
   transition: background 0.15s ease;
 
   &:hover {
-    background: ${({ theme }) => theme.color.background.tertiary};
+    background: ${({ theme }) => color.N3};
   }
 
   &:last-child {
@@ -84,33 +82,33 @@ const Header = styled.div`
 
 const Username = styled.span`
   font-weight: 600;
-  color: ${({ theme }) => theme.color.text.primary};
+  color: ${({ theme }) => color.N10};
   font-size: 14px;
 `;
 
 const Time = styled.span`
   font-size: 12px;
-  color: ${({ theme }) => theme.color.text.secondary};
+  color: ${({ theme }) => color.N7};
 `;
 
 const UnreadDot = styled.span`
   width: 8px;
   height: 8px;
   border-radius: 50%;
-  background: ${({ theme }) => theme.color.primary};
+  background: ${({ theme }) => color.B5};
   flex-shrink: 0;
 `;
 
 const Message = styled.p`
   margin: 0;
   font-size: 14px;
-  color: ${({ theme }) => theme.color.text.primary};
+  color: ${({ theme }) => color.N10};
   line-height: 1.4;
 `;
 
 const ThreadTitle = styled.span`
   font-weight: 500;
-  color: ${({ theme }) => theme.color.primary};
+  color: ${({ theme }) => color.B5};
 `;
 
 const Actions = styled.div`
@@ -123,16 +121,16 @@ const ActionButton = styled.button`
   padding: 4px 8px;
   font-size: 12px;
   background: transparent;
-  border: 1px solid ${({ theme }) => theme.color.borders.secondary};
+  border: 1px solid ${({ theme }) => color.N4};
   border-radius: 4px;
-  color: ${({ theme }) => theme.color.text.secondary};
+  color: ${({ theme }) => color.N7};
   cursor: pointer;
   transition: all 0.15s ease;
 
   &:hover {
-    background: ${({ theme }) => theme.color.background.tertiary};
-    border-color: ${({ theme }) => theme.color.primary};
-    color: ${({ theme }) => theme.color.primary};
+    background: ${({ theme }) => color.N3};
+    border-color: ${({ theme }) => color.B5};
+    color: ${({ theme }) => color.B5};
   }
 `;
 

--- a/frontend/src/components/notifications/index.ts
+++ b/frontend/src/components/notifications/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Notification components for the OpenContracts notification system
+ * Part of Issue #577: Notification Center UI
+ */
+
+export { NotificationBell } from "./NotificationBell";
+export { NotificationDropdown } from "./NotificationDropdown";
+export { NotificationItem } from "./NotificationItem";
+export { NotificationCenter } from "./NotificationCenter";
+
+// Export types
+export type { NotificationBellProps } from "./NotificationBell";
+export type { NotificationDropdownProps } from "./NotificationDropdown";
+export type { NotificationItemProps } from "./NotificationItem";

--- a/frontend/src/graphql/mutations.ts
+++ b/frontend/src/graphql/mutations.ts
@@ -3020,3 +3020,107 @@ export interface RestoreThreadOutput {
     } | null;
   };
 }
+
+/**
+ * ============================================================================
+ * NOTIFICATION MUTATIONS
+ * ============================================================================
+ */
+
+export const MARK_NOTIFICATION_READ = gql`
+  mutation MarkNotificationRead($notificationId: ID!) {
+    markNotificationRead(notificationId: $notificationId) {
+      ok
+      message
+      notification {
+        id
+        isRead
+        modified
+      }
+    }
+  }
+`;
+
+export interface MarkNotificationReadInput {
+  notificationId: string;
+}
+
+export interface MarkNotificationReadOutput {
+  markNotificationRead: {
+    ok: boolean;
+    message: string;
+    notification: {
+      id: string;
+      isRead: boolean;
+      modified: string;
+    } | null;
+  };
+}
+
+export const MARK_NOTIFICATION_UNREAD = gql`
+  mutation MarkNotificationUnread($notificationId: ID!) {
+    markNotificationUnread(notificationId: $notificationId) {
+      ok
+      message
+      notification {
+        id
+        isRead
+        modified
+      }
+    }
+  }
+`;
+
+export interface MarkNotificationUnreadInput {
+  notificationId: string;
+}
+
+export interface MarkNotificationUnreadOutput {
+  markNotificationUnread: {
+    ok: boolean;
+    message: string;
+    notification: {
+      id: string;
+      isRead: boolean;
+      modified: string;
+    } | null;
+  };
+}
+
+export const MARK_ALL_NOTIFICATIONS_READ = gql`
+  mutation MarkAllNotificationsRead {
+    markAllNotificationsRead {
+      ok
+      message
+      count
+    }
+  }
+`;
+
+export interface MarkAllNotificationsReadOutput {
+  markAllNotificationsRead: {
+    ok: boolean;
+    message: string;
+    count: number;
+  };
+}
+
+export const DELETE_NOTIFICATION = gql`
+  mutation DeleteNotification($notificationId: ID!) {
+    deleteNotification(notificationId: $notificationId) {
+      ok
+      message
+    }
+  }
+`;
+
+export interface DeleteNotificationInput {
+  notificationId: string;
+}
+
+export interface DeleteNotificationOutput {
+  deleteNotification: {
+    ok: boolean;
+    message: string;
+  };
+}

--- a/frontend/src/graphql/queries.ts
+++ b/frontend/src/graphql/queries.ts
@@ -3406,3 +3406,112 @@ export interface GetUserBadgesOutput {
     };
   };
 }
+
+/**
+ * ============================================================================
+ * NOTIFICATION QUERIES
+ * ============================================================================
+ */
+
+export const GET_NOTIFICATIONS = gql`
+  query GetNotifications(
+    $isRead: Boolean
+    $notificationType: String
+    $limit: Int
+    $cursor: String
+  ) {
+    notifications(
+      isRead: $isRead
+      notificationType: $notificationType
+      first: $limit
+      after: $cursor
+    ) {
+      edges {
+        node {
+          id
+          notificationType
+          isRead
+          createdAt
+          modified
+          data
+          actor {
+            id
+            username
+            email
+          }
+          message {
+            id
+            content
+          }
+          conversation {
+            id
+            title
+            conversationType
+          }
+        }
+      }
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+    }
+  }
+`;
+
+export const GET_UNREAD_NOTIFICATION_COUNT = gql`
+  query GetUnreadNotificationCount {
+    unreadNotificationCount
+  }
+`;
+
+export interface GetNotificationsInput {
+  isRead?: boolean;
+  notificationType?: string;
+  limit?: number;
+  cursor?: string;
+}
+
+export interface NotificationNode {
+  id: string;
+  notificationType: string;
+  isRead: boolean;
+  createdAt: string;
+  modified: string;
+  data?: Record<string, any>;
+  actor?: {
+    id: string;
+    username: string;
+    email: string;
+  };
+  message?: {
+    id: string;
+    content: string;
+  };
+  conversation?: {
+    id: string;
+    title: string;
+    conversationType: string;
+  };
+}
+
+export interface GetNotificationsOutput {
+  notifications: {
+    edges: Array<{
+      node: NotificationNode;
+    }>;
+    pageInfo: {
+      hasNextPage: boolean;
+      hasPreviousPage: boolean;
+      startCursor: string;
+      endCursor: string;
+    };
+    totalCount: number;
+  };
+}
+
+export interface GetUnreadNotificationCountOutput {
+  unreadNotificationCount: number;
+}

--- a/frontend/tests/NotificationBell.ct.tsx
+++ b/frontend/tests/NotificationBell.ct.tsx
@@ -1,0 +1,265 @@
+import { test, expect } from "@playwright/experimental-ct-react";
+import { NotificationBell } from "../src/components/notifications/NotificationBell";
+import { MockedProvider } from "@apollo/client/testing";
+import { GET_UNREAD_NOTIFICATION_COUNT } from "../src/graphql/queries";
+
+test.describe("NotificationBell", () => {
+  test("renders bell icon", async ({ mount }) => {
+    const mocks = [
+      {
+        request: {
+          query: GET_UNREAD_NOTIFICATION_COUNT,
+        },
+        result: {
+          data: {
+            unreadNotificationCount: 0,
+          },
+        },
+      },
+    ];
+
+    const component = await mount(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <NotificationBell pollInterval={0} />
+      </MockedProvider>
+    );
+
+    await expect(component.getByLabelText(/Notifications/i)).toBeVisible();
+  });
+
+  test("shows unread count badge when > 0", async ({ mount, page }) => {
+    const mocks = [
+      {
+        request: {
+          query: GET_UNREAD_NOTIFICATION_COUNT,
+        },
+        result: {
+          data: {
+            unreadNotificationCount: 5,
+          },
+        },
+      },
+    ];
+
+    const component = await mount(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <NotificationBell pollInterval={0} />
+      </MockedProvider>
+    );
+
+    await page.waitForTimeout(500);
+    await expect(component.getByText("5")).toBeVisible();
+  });
+
+  test("shows 99+ for counts over 99", async ({ mount, page }) => {
+    const mocks = [
+      {
+        request: {
+          query: GET_UNREAD_NOTIFICATION_COUNT,
+        },
+        result: {
+          data: {
+            unreadNotificationCount: 150,
+          },
+        },
+      },
+    ];
+
+    const component = await mount(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <NotificationBell pollInterval={0} />
+      </MockedProvider>
+    );
+
+    await page.waitForTimeout(500);
+    await expect(component.getByText("99+")).toBeVisible();
+  });
+
+  test("does not show badge when count is 0", async ({ mount, page }) => {
+    const mocks = [
+      {
+        request: {
+          query: GET_UNREAD_NOTIFICATION_COUNT,
+        },
+        result: {
+          data: {
+            unreadNotificationCount: 0,
+          },
+        },
+      },
+    ];
+
+    const component = await mount(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <NotificationBell pollInterval={0} />
+      </MockedProvider>
+    );
+
+    await page.waitForTimeout(500);
+    const bell = component.getByLabelText(/Notifications/i);
+    await expect(bell).toBeVisible();
+    // Badge should not be present
+    await expect(
+      component.locator("span").filter({ hasText: /^\d+$/ })
+    ).not.toBeVisible();
+  });
+
+  test("calls onViewAll when clicked in fullPageMode", async ({
+    mount,
+    page,
+  }) => {
+    const mocks = [
+      {
+        request: {
+          query: GET_UNREAD_NOTIFICATION_COUNT,
+        },
+        result: {
+          data: {
+            unreadNotificationCount: 3,
+          },
+        },
+      },
+    ];
+
+    let viewAllCalled = false;
+
+    const component = await mount(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <NotificationBell
+          fullPageMode={true}
+          onViewAll={() => {
+            viewAllCalled = true;
+          }}
+          pollInterval={0}
+        />
+      </MockedProvider>
+    );
+
+    await page.waitForTimeout(500);
+
+    const bell = component.getByLabelText(/Notifications/i);
+    await bell.click();
+
+    await page.waitForTimeout(100);
+    expect(viewAllCalled).toBe(true);
+  });
+
+  test("opens dropdown when clicked (not in fullPageMode)", async ({
+    mount,
+    page,
+  }) => {
+    const mocks = [
+      {
+        request: {
+          query: GET_UNREAD_NOTIFICATION_COUNT,
+        },
+        result: {
+          data: {
+            unreadNotificationCount: 3,
+          },
+        },
+      },
+      {
+        request: {
+          query: require("../src/graphql/queries").GET_NOTIFICATIONS,
+          variables: {
+            limit: 10,
+          },
+        },
+        result: {
+          data: {
+            notifications: {
+              edges: [],
+              pageInfo: {
+                hasNextPage: false,
+                hasPreviousPage: false,
+                startCursor: "",
+                endCursor: "",
+              },
+              totalCount: 0,
+            },
+          },
+        },
+      },
+    ];
+
+    const component = await mount(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <NotificationBell fullPageMode={false} pollInterval={0} />
+      </MockedProvider>
+    );
+
+    await page.waitForTimeout(500);
+
+    const bell = component.getByLabelText(/Notifications/i);
+    await bell.click();
+
+    await page.waitForTimeout(500);
+    // Dropdown should be visible with "Notifications" title
+    await expect(
+      component.getByRole("heading", { name: /Notifications/i })
+    ).toBeVisible();
+  });
+
+  test("closes dropdown when clicking outside", async ({ mount, page }) => {
+    const mocks = [
+      {
+        request: {
+          query: GET_UNREAD_NOTIFICATION_COUNT,
+        },
+        result: {
+          data: {
+            unreadNotificationCount: 3,
+          },
+        },
+      },
+      {
+        request: {
+          query: require("../src/graphql/queries").GET_NOTIFICATIONS,
+          variables: {
+            limit: 10,
+          },
+        },
+        result: {
+          data: {
+            notifications: {
+              edges: [],
+              pageInfo: {
+                hasNextPage: false,
+                hasPreviousPage: false,
+                startCursor: "",
+                endCursor: "",
+              },
+              totalCount: 0,
+            },
+          },
+        },
+      },
+    ];
+
+    const component = await mount(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <NotificationBell fullPageMode={false} pollInterval={0} />
+      </MockedProvider>
+    );
+
+    await page.waitForTimeout(500);
+
+    // Open dropdown
+    const bell = component.getByLabelText(/Notifications/i);
+    await bell.click();
+
+    await page.waitForTimeout(500);
+    await expect(
+      component.getByRole("heading", { name: /Notifications/i })
+    ).toBeVisible();
+
+    // Click outside
+    await page.mouse.click(10, 10);
+
+    await page.waitForTimeout(300);
+    await expect(
+      component.getByRole("heading", { name: /Notifications/i })
+    ).not.toBeVisible();
+  });
+});

--- a/frontend/tests/NotificationCenter.ct.tsx
+++ b/frontend/tests/NotificationCenter.ct.tsx
@@ -1,0 +1,531 @@
+import { test, expect } from "@playwright/experimental-ct-react";
+import { NotificationCenter } from "../src/components/notifications/NotificationCenter";
+import { MockedProvider } from "@apollo/client/testing";
+import { MemoryRouter } from "react-router-dom";
+import {
+  GET_NOTIFICATIONS,
+  GET_UNREAD_NOTIFICATION_COUNT,
+} from "../src/graphql/queries";
+import { MARK_ALL_NOTIFICATIONS_READ } from "../src/graphql/mutations";
+
+test.describe("NotificationCenter", () => {
+  test("renders notification center title", async ({ mount }) => {
+    const mocks = [
+      {
+        request: {
+          query: GET_NOTIFICATIONS,
+          variables: {
+            limit: 50,
+          },
+        },
+        result: {
+          data: {
+            notifications: {
+              edges: [],
+              pageInfo: {
+                hasNextPage: false,
+                hasPreviousPage: false,
+                startCursor: "",
+                endCursor: "",
+              },
+              totalCount: 0,
+            },
+          },
+        },
+      },
+    ];
+
+    const component = await mount(
+      <MemoryRouter>
+        <MockedProvider mocks={mocks} addTypename={false}>
+          <NotificationCenter />
+        </MockedProvider>
+      </MemoryRouter>
+    );
+
+    await expect(
+      component.getByRole("heading", { name: "Notifications" })
+    ).toBeVisible();
+  });
+
+  test("shows filter buttons", async ({ mount }) => {
+    const mocks = [
+      {
+        request: {
+          query: GET_NOTIFICATIONS,
+          variables: {
+            limit: 50,
+          },
+        },
+        result: {
+          data: {
+            notifications: {
+              edges: [],
+              pageInfo: {
+                hasNextPage: false,
+                hasPreviousPage: false,
+                startCursor: "",
+                endCursor: "",
+              },
+              totalCount: 0,
+            },
+          },
+        },
+      },
+    ];
+
+    const component = await mount(
+      <MemoryRouter>
+        <MockedProvider mocks={mocks} addTypename={false}>
+          <NotificationCenter />
+        </MockedProvider>
+      </MemoryRouter>
+    );
+
+    await expect(component.getByRole("button", { name: "All" })).toBeVisible();
+    await expect(
+      component.getByRole("button", { name: "Unread" })
+    ).toBeVisible();
+    await expect(component.getByRole("button", { name: "Read" })).toBeVisible();
+  });
+
+  test("shows mark all as read button", async ({ mount }) => {
+    const mocks = [
+      {
+        request: {
+          query: GET_NOTIFICATIONS,
+          variables: {
+            limit: 50,
+          },
+        },
+        result: {
+          data: {
+            notifications: {
+              edges: [],
+              pageInfo: {
+                hasNextPage: false,
+                hasPreviousPage: false,
+                startCursor: "",
+                endCursor: "",
+              },
+              totalCount: 0,
+            },
+          },
+        },
+      },
+    ];
+
+    const component = await mount(
+      <MemoryRouter>
+        <MockedProvider mocks={mocks} addTypename={false}>
+          <NotificationCenter />
+        </MockedProvider>
+      </MemoryRouter>
+    );
+
+    await expect(
+      component.getByRole("button", { name: /Mark all as read/i })
+    ).toBeVisible();
+  });
+
+  test("shows empty state when no notifications", async ({ mount, page }) => {
+    const mocks = [
+      {
+        request: {
+          query: GET_NOTIFICATIONS,
+          variables: {
+            limit: 50,
+          },
+        },
+        result: {
+          data: {
+            notifications: {
+              edges: [],
+              pageInfo: {
+                hasNextPage: false,
+                hasPreviousPage: false,
+                startCursor: "",
+                endCursor: "",
+              },
+              totalCount: 0,
+            },
+          },
+        },
+      },
+    ];
+
+    const component = await mount(
+      <MemoryRouter>
+        <MockedProvider mocks={mocks} addTypename={false}>
+          <NotificationCenter />
+        </MockedProvider>
+      </MemoryRouter>
+    );
+
+    await page.waitForTimeout(500);
+    await expect(component.getByText("No notifications yet")).toBeVisible();
+  });
+
+  test("renders notification list", async ({ mount, page }) => {
+    const mocks = [
+      {
+        request: {
+          query: GET_NOTIFICATIONS,
+          variables: {
+            limit: 50,
+          },
+        },
+        result: {
+          data: {
+            notifications: {
+              edges: [
+                {
+                  node: {
+                    id: "notif-1",
+                    notificationType: "REPLY",
+                    isRead: false,
+                    createdAt: new Date().toISOString(),
+                    modified: new Date().toISOString(),
+                    actor: {
+                      id: "user-1",
+                      username: "testuser",
+                      email: "test@example.com",
+                    },
+                    conversation: {
+                      id: "conv-1",
+                      title: "Test Thread",
+                      conversationType: "THREAD",
+                    },
+                  },
+                },
+              ],
+              pageInfo: {
+                hasNextPage: false,
+                hasPreviousPage: false,
+                startCursor: "",
+                endCursor: "",
+              },
+              totalCount: 1,
+            },
+          },
+        },
+      },
+    ];
+
+    const component = await mount(
+      <MemoryRouter>
+        <MockedProvider mocks={mocks} addTypename={false}>
+          <NotificationCenter />
+        </MockedProvider>
+      </MemoryRouter>
+    );
+
+    await page.waitForTimeout(500);
+    await expect(component.getByText(/testuser replied/i)).toBeVisible();
+  });
+
+  test("filters notifications by unread", async ({ mount, page }) => {
+    const allMock = {
+      request: {
+        query: GET_NOTIFICATIONS,
+        variables: {
+          limit: 50,
+        },
+      },
+      result: {
+        data: {
+          notifications: {
+            edges: [
+              {
+                node: {
+                  id: "notif-1",
+                  notificationType: "REPLY",
+                  isRead: false,
+                  createdAt: new Date().toISOString(),
+                  modified: new Date().toISOString(),
+                  actor: {
+                    id: "user-1",
+                    username: "testuser",
+                    email: "test@example.com",
+                  },
+                  conversation: {
+                    id: "conv-1",
+                    title: "Test Thread",
+                    conversationType: "THREAD",
+                  },
+                },
+              },
+            ],
+            pageInfo: {
+              hasNextPage: false,
+              hasPreviousPage: false,
+              startCursor: "",
+              endCursor: "",
+            },
+            totalCount: 1,
+          },
+        },
+      },
+    };
+
+    const unreadMock = {
+      request: {
+        query: GET_NOTIFICATIONS,
+        variables: {
+          limit: 50,
+          isRead: false,
+        },
+      },
+      result: {
+        data: {
+          notifications: {
+            edges: [
+              {
+                node: {
+                  id: "notif-1",
+                  notificationType: "REPLY",
+                  isRead: false,
+                  createdAt: new Date().toISOString(),
+                  modified: new Date().toISOString(),
+                  actor: {
+                    id: "user-1",
+                    username: "testuser",
+                    email: "test@example.com",
+                  },
+                  conversation: {
+                    id: "conv-1",
+                    title: "Test Thread",
+                    conversationType: "THREAD",
+                  },
+                },
+              },
+            ],
+            pageInfo: {
+              hasNextPage: false,
+              hasPreviousPage: false,
+              startCursor: "",
+              endCursor: "",
+            },
+            totalCount: 1,
+          },
+        },
+      },
+    };
+
+    const component = await mount(
+      <MemoryRouter>
+        <MockedProvider mocks={[allMock, unreadMock]} addTypename={false}>
+          <NotificationCenter />
+        </MockedProvider>
+      </MemoryRouter>
+    );
+
+    await page.waitForTimeout(500);
+
+    const unreadButton = component.getByRole("button", { name: "Unread" });
+    await unreadButton.click();
+
+    await page.waitForTimeout(500);
+    await expect(component.getByText(/testuser replied/i)).toBeVisible();
+  });
+
+  test("marks all as read", async ({ mount, page }) => {
+    const mocks = [
+      {
+        request: {
+          query: GET_NOTIFICATIONS,
+          variables: {
+            limit: 50,
+          },
+        },
+        result: {
+          data: {
+            notifications: {
+              edges: [
+                {
+                  node: {
+                    id: "notif-1",
+                    notificationType: "REPLY",
+                    isRead: false,
+                    createdAt: new Date().toISOString(),
+                    modified: new Date().toISOString(),
+                    actor: {
+                      id: "user-1",
+                      username: "testuser",
+                      email: "test@example.com",
+                    },
+                    conversation: {
+                      id: "conv-1",
+                      title: "Test Thread",
+                      conversationType: "THREAD",
+                    },
+                  },
+                },
+              ],
+              pageInfo: {
+                hasNextPage: false,
+                hasPreviousPage: false,
+                startCursor: "",
+                endCursor: "",
+              },
+              totalCount: 1,
+            },
+          },
+        },
+      },
+      {
+        request: {
+          query: MARK_ALL_NOTIFICATIONS_READ,
+        },
+        result: {
+          data: {
+            markAllNotificationsRead: {
+              ok: true,
+              message: "Marked 1 notification(s) as read",
+              count: 1,
+            },
+          },
+        },
+      },
+    ];
+
+    const component = await mount(
+      <MemoryRouter>
+        <MockedProvider mocks={mocks} addTypename={false}>
+          <NotificationCenter />
+        </MockedProvider>
+      </MemoryRouter>
+    );
+
+    await page.waitForTimeout(500);
+
+    const markAllButton = component.getByRole("button", {
+      name: /Mark all as read/i,
+    });
+    await markAllButton.click();
+
+    await page.waitForTimeout(500);
+  });
+
+  test("disables mark all as read when no unread", async ({ mount, page }) => {
+    const mocks = [
+      {
+        request: {
+          query: GET_NOTIFICATIONS,
+          variables: {
+            limit: 50,
+          },
+        },
+        result: {
+          data: {
+            notifications: {
+              edges: [
+                {
+                  node: {
+                    id: "notif-1",
+                    notificationType: "REPLY",
+                    isRead: true,
+                    createdAt: new Date().toISOString(),
+                    modified: new Date().toISOString(),
+                    actor: {
+                      id: "user-1",
+                      username: "testuser",
+                      email: "test@example.com",
+                    },
+                    conversation: {
+                      id: "conv-1",
+                      title: "Test Thread",
+                      conversationType: "THREAD",
+                    },
+                  },
+                },
+              ],
+              pageInfo: {
+                hasNextPage: false,
+                hasPreviousPage: false,
+                startCursor: "",
+                endCursor: "",
+              },
+              totalCount: 1,
+            },
+          },
+        },
+      },
+    ];
+
+    const component = await mount(
+      <MemoryRouter>
+        <MockedProvider mocks={mocks} addTypename={false}>
+          <NotificationCenter />
+        </MockedProvider>
+      </MemoryRouter>
+    );
+
+    await page.waitForTimeout(500);
+
+    const markAllButton = component.getByRole("button", {
+      name: /Mark all as read/i,
+    });
+    await expect(markAllButton).toBeDisabled();
+  });
+
+  test("shows load more button when hasNextPage", async ({ mount, page }) => {
+    const mocks = [
+      {
+        request: {
+          query: GET_NOTIFICATIONS,
+          variables: {
+            limit: 50,
+          },
+        },
+        result: {
+          data: {
+            notifications: {
+              edges: [
+                {
+                  node: {
+                    id: "notif-1",
+                    notificationType: "REPLY",
+                    isRead: false,
+                    createdAt: new Date().toISOString(),
+                    modified: new Date().toISOString(),
+                    actor: {
+                      id: "user-1",
+                      username: "testuser",
+                      email: "test@example.com",
+                    },
+                    conversation: {
+                      id: "conv-1",
+                      title: "Test Thread",
+                      conversationType: "THREAD",
+                    },
+                  },
+                },
+              ],
+              pageInfo: {
+                hasNextPage: true,
+                hasPreviousPage: false,
+                startCursor: "",
+                endCursor: "cursor-1",
+              },
+              totalCount: 100,
+            },
+          },
+        },
+      },
+    ];
+
+    const component = await mount(
+      <MemoryRouter>
+        <MockedProvider mocks={mocks} addTypename={false}>
+          <NotificationCenter />
+        </MockedProvider>
+      </MemoryRouter>
+    );
+
+    await page.waitForTimeout(500);
+    await expect(
+      component.getByRole("button", { name: /Load more/i })
+    ).toBeVisible();
+  });
+});

--- a/frontend/tests/NotificationItem.ct.tsx
+++ b/frontend/tests/NotificationItem.ct.tsx
@@ -1,0 +1,318 @@
+import { test, expect } from "@playwright/experimental-ct-react";
+import { NotificationItem } from "../src/components/notifications/NotificationItem";
+import { MockedProvider } from "@apollo/client/testing";
+import {
+  MARK_NOTIFICATION_READ,
+  MARK_NOTIFICATION_UNREAD,
+  DELETE_NOTIFICATION,
+} from "../src/graphql/mutations";
+import {
+  GET_NOTIFICATIONS,
+  GET_UNREAD_NOTIFICATION_COUNT,
+} from "../src/graphql/queries";
+import type { NotificationNode } from "../src/graphql/queries";
+
+test.describe("NotificationItem", () => {
+  const createMockNotification = (
+    overrides?: Partial<NotificationNode>
+  ): NotificationNode => ({
+    id: "notif-1",
+    notificationType: "REPLY",
+    isRead: false,
+    createdAt: new Date().toISOString(),
+    modified: new Date().toISOString(),
+    actor: {
+      id: "user-1",
+      username: "testuser",
+      email: "test@example.com",
+    },
+    conversation: {
+      id: "conv-1",
+      title: "Test Thread",
+      conversationType: "THREAD",
+    },
+    ...overrides,
+  });
+
+  test("renders notification with actor and message", async ({ mount }) => {
+    const notification = createMockNotification();
+
+    const component = await mount(
+      <MockedProvider mocks={[]} addTypename={false}>
+        <NotificationItem notification={notification} showActions={false} />
+      </MockedProvider>
+    );
+
+    await expect(component.getByText(/testuser replied/i)).toBeVisible();
+    await expect(component.getByText(/Test Thread/i)).toBeVisible();
+  });
+
+  test("shows unread indicator when isRead is false", async ({ mount }) => {
+    const notification = createMockNotification({ isRead: false });
+
+    const component = await mount(
+      <MockedProvider mocks={[]} addTypename={false}>
+        <NotificationItem notification={notification} showActions={false} />
+      </MockedProvider>
+    );
+
+    // Unread dot should be visible
+    const unreadDot = component.locator("span").filter({ hasText: "" }).first();
+    await expect(unreadDot).toBeVisible();
+  });
+
+  test("does not show unread indicator when isRead is true", async ({
+    mount,
+  }) => {
+    const notification = createMockNotification({ isRead: true });
+
+    const component = await mount(
+      <MockedProvider mocks={[]} addTypename={false}>
+        <NotificationItem notification={notification} showActions={false} />
+      </MockedProvider>
+    );
+
+    // Check that container has read style (we can't easily test for absence of unread dot)
+    await expect(component.getByText(/testuser replied/i)).toBeVisible();
+  });
+
+  test("displays different notification types correctly", async ({ mount }) => {
+    const voteNotification = createMockNotification({
+      notificationType: "VOTE",
+      data: { voteType: "UPVOTE" },
+    });
+
+    const component = await mount(
+      <MockedProvider mocks={[]} addTypename={false}>
+        <NotificationItem notification={voteNotification} showActions={false} />
+      </MockedProvider>
+    );
+
+    await expect(component.getByText(/upvoted your message/i)).toBeVisible();
+  });
+
+  test("marks notification as read when clicked", async ({ mount, page }) => {
+    const notification = createMockNotification({ isRead: false });
+
+    const mocks = [
+      {
+        request: {
+          query: MARK_NOTIFICATION_READ,
+          variables: {
+            notificationId: "notif-1",
+          },
+        },
+        result: {
+          data: {
+            markNotificationRead: {
+              ok: true,
+              message: "Notification marked as read",
+              notification: {
+                id: "notif-1",
+                isRead: true,
+                modified: new Date().toISOString(),
+              },
+            },
+          },
+        },
+      },
+    ];
+
+    let clickCalled = false;
+
+    const component = await mount(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <NotificationItem
+          notification={notification}
+          onClick={() => {
+            clickCalled = true;
+          }}
+          showActions={false}
+        />
+      </MockedProvider>
+    );
+
+    const item = component.locator("div").first();
+    await item.click();
+
+    await page.waitForTimeout(500);
+    expect(clickCalled).toBe(true);
+  });
+
+  test("shows mark as read action button", async ({ mount }) => {
+    const notification = createMockNotification({ isRead: false });
+
+    const component = await mount(
+      <MockedProvider mocks={[]} addTypename={false}>
+        <NotificationItem notification={notification} showActions={true} />
+      </MockedProvider>
+    );
+
+    await expect(component.getByText("Mark as read")).toBeVisible();
+  });
+
+  test("shows mark as unread action button when read", async ({ mount }) => {
+    const notification = createMockNotification({ isRead: true });
+
+    const component = await mount(
+      <MockedProvider mocks={[]} addTypename={false}>
+        <NotificationItem notification={notification} showActions={true} />
+      </MockedProvider>
+    );
+
+    await expect(component.getByText("Mark as unread")).toBeVisible();
+  });
+
+  test("marks notification as read via action button", async ({
+    mount,
+    page,
+  }) => {
+    const notification = createMockNotification({ isRead: false });
+
+    const mocks = [
+      {
+        request: {
+          query: MARK_NOTIFICATION_READ,
+          variables: {
+            notificationId: "notif-1",
+          },
+        },
+        result: {
+          data: {
+            markNotificationRead: {
+              ok: true,
+              message: "Notification marked as read",
+              notification: {
+                id: "notif-1",
+                isRead: true,
+                modified: new Date().toISOString(),
+              },
+            },
+          },
+        },
+      },
+    ];
+
+    const component = await mount(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <NotificationItem notification={notification} showActions={true} />
+      </MockedProvider>
+    );
+
+    const markReadButton = component.getByText("Mark as read");
+    await markReadButton.click();
+
+    await page.waitForTimeout(500);
+  });
+
+  test("marks notification as unread via action button", async ({
+    mount,
+    page,
+  }) => {
+    const notification = createMockNotification({ isRead: true });
+
+    const mocks = [
+      {
+        request: {
+          query: MARK_NOTIFICATION_UNREAD,
+          variables: {
+            notificationId: "notif-1",
+          },
+        },
+        result: {
+          data: {
+            markNotificationUnread: {
+              ok: true,
+              message: "Notification marked as unread",
+              notification: {
+                id: "notif-1",
+                isRead: false,
+                modified: new Date().toISOString(),
+              },
+            },
+          },
+        },
+      },
+    ];
+
+    const component = await mount(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <NotificationItem notification={notification} showActions={true} />
+      </MockedProvider>
+    );
+
+    const markUnreadButton = component.getByText("Mark as unread");
+    await markUnreadButton.click();
+
+    await page.waitForTimeout(500);
+  });
+
+  test("shows delete button", async ({ mount }) => {
+    const notification = createMockNotification();
+
+    const component = await mount(
+      <MockedProvider mocks={[]} addTypename={false}>
+        <NotificationItem notification={notification} showActions={true} />
+      </MockedProvider>
+    );
+
+    await expect(component.getByText("Delete")).toBeVisible();
+  });
+
+  test("formats relative time", async ({ mount }) => {
+    const notification = createMockNotification({
+      createdAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(), // 2 hours ago
+    });
+
+    const component = await mount(
+      <MockedProvider mocks={[]} addTypename={false}>
+        <NotificationItem notification={notification} showActions={false} />
+      </MockedProvider>
+    );
+
+    await expect(component.getByText(/hours ago/i)).toBeVisible();
+  });
+
+  test("renders badge notification correctly", async ({ mount }) => {
+    const notification = createMockNotification({
+      notificationType: "BADGE",
+      data: { badgeName: "Expert Contributor" },
+    });
+
+    const component = await mount(
+      <MockedProvider mocks={[]} addTypename={false}>
+        <NotificationItem notification={notification} showActions={false} />
+      </MockedProvider>
+    );
+
+    await expect(component.getByText(/Expert Contributor/i)).toBeVisible();
+  });
+
+  test("renders mention notification correctly", async ({ mount }) => {
+    const notification = createMockNotification({
+      notificationType: "MENTION",
+    });
+
+    const component = await mount(
+      <MockedProvider mocks={[]} addTypename={false}>
+        <NotificationItem notification={notification} showActions={false} />
+      </MockedProvider>
+    );
+
+    await expect(component.getByText(/mentioned you/i)).toBeVisible();
+  });
+
+  test("renders moderation notifications correctly", async ({ mount }) => {
+    const notification = createMockNotification({
+      notificationType: "THREAD_LOCKED",
+    });
+
+    const component = await mount(
+      <MockedProvider mocks={[]} addTypename={false}>
+        <NotificationItem notification={notification} showActions={false} />
+      </MockedProvider>
+    );
+
+    await expect(component.getByText(/locked thread/i)).toBeVisible();
+  });
+});


### PR DESCRIPTION
Implements #577

## Changes
- Add notification bell with unread count badge
- Create notification dropdown for quick access
- Build full notification center page with filtering
- Implement all 14 notification types with custom icons
- Add real-time polling for new notifications
- Support deep linking to threads/messages

## Components
- NotificationBell.tsx - Bell icon with unread badge and dropdown
- NotificationDropdown.tsx - Quick notification list
- NotificationItem.tsx - Individual notification display
- NotificationCenter.tsx - Full page with filtering

## Features
- Unread count badge (shows 99+ for counts >99)
- Real-time polling (configurable, default 30s)
- Filter notifications (all/unread/read)
- Mark as read/unread (individual or bulk)
- Delete notifications
- Click-outside-to-close dropdown
- Deep linking to relevant threads/messages
- Responsive mobile/desktop design

## GraphQL
- GET_NOTIFICATIONS, GET_UNREAD_NOTIFICATION_COUNT queries
- MARK_NOTIFICATION_READ, MARK_NOTIFICATION_UNREAD, MARK_ALL_NOTIFICATIONS_READ, DELETE_NOTIFICATION mutations

## Testing
- 33 comprehensive component tests
- Tests cover all notification types and user interactions

Closes #577