### PR TITLE
fix: Permission audit remediation - Add query optimizers for user, badge, and document actions

### DIFF
--- a/docs/permissioning/query_permission_remediation_plan.md
+++ b/docs/permissioning/query_permission_remediation_plan.md
@@ -1,0 +1,1303 @@
+# GraphQL Query Permission Remediation Plan
+
+> **Status**: Planning
+> **Created**: 2025-01-24
+> **Priority**: Critical
+
+## Executive Summary
+
+This document outlines a systematic plan to fix permission violations identified in `config/graphql/queries.py`. The approach creates centralized permission infrastructure following the successful patterns in `AnnotationQueryOptimizer`, ensuring developers can retrieve objects safely without understanding the permissioning system.
+
+## Design Principles
+
+1. **Centralized Logic**: All permission logic in dedicated optimizers/managers
+2. **Developer Ergonomics**: Simple API like `.visible_to_user(user)` or `Optimizer.get_visible_X(user)`
+3. **Performance First**: Use Django ORM optimizations (prefetch, select_related, subqueries)
+4. **Fail Secure**: Default to most restrictive permissions when uncertain
+5. **Corpus Membership Rule**: Users with > READ permission on the same corpus can see each other
+
+---
+
+## Phase 1: Create User Visibility Infrastructure
+
+### 1.1 Create `UserQueryOptimizer`
+
+**Location**: `opencontractserver/users/query_optimizer.py`
+
+**Purpose**: Handle user visibility based on:
+- Own profile is always visible
+- `is_profile_public=True` profiles are visible to everyone
+- Users with > READ permission on the same corpus can see each other
+- Active users only (`is_active=True`)
+
+```python
+class UserQueryOptimizer:
+    """
+    Optimized user queries with profile privacy filtering.
+
+    Visibility model:
+    - Own profile: always visible
+    - Public profiles (is_profile_public=True): visible to all
+    - Private profiles: visible to users who share corpus membership with > READ permission
+    - Inactive users: never visible (except to self and superusers)
+    """
+
+    @classmethod
+    def get_visible_users(
+        cls,
+        requesting_user,
+        corpus_id: Optional[int] = None,
+        include_self: bool = True,
+    ) -> QuerySet:
+        """
+        Get users visible to requesting_user.
+
+        Args:
+            requesting_user: The user making the request
+            corpus_id: Optional corpus to scope visibility (users with shared access)
+            include_self: Whether to include the requesting user (default True)
+        """
+        from django.contrib.auth import get_user_model
+        from opencontractserver.corpuses.models import CorpusUserObjectPermission
+
+        User = get_user_model()
+
+        # Superusers see all active users
+        if requesting_user.is_superuser:
+            return User.objects.filter(is_active=True)
+
+        # Anonymous users see only public profiles
+        if requesting_user.is_anonymous:
+            return User.objects.filter(is_active=True, is_profile_public=True)
+
+        # Build visibility query
+        # 1. Own profile (always visible)
+        # 2. Public profiles
+        # 3. Users who share corpus membership with > READ permission
+
+        # Get corpuses where requesting user has > READ permission
+        write_perm_codenames = ['create_corpus', 'update_corpus', 'remove_corpus']
+        user_writable_corpuses = CorpusUserObjectPermission.objects.filter(
+            user=requesting_user,
+            permission__codename__in=write_perm_codenames
+        ).values_list('content_object_id', flat=True)
+
+        # Get users who are creators or have > READ on those corpuses
+        users_in_shared_corpuses = CorpusUserObjectPermission.objects.filter(
+            content_object_id__in=user_writable_corpuses,
+            permission__codename__in=write_perm_codenames
+        ).values_list('user_id', flat=True)
+
+        # Also include corpus creators
+        from opencontractserver.corpuses.models import Corpus
+        corpus_creators = Corpus.objects.filter(
+            id__in=user_writable_corpuses
+        ).values_list('creator_id', flat=True)
+
+        # Build final query
+        qs = User.objects.filter(
+            Q(is_active=True) & (
+                Q(id=requesting_user.id) |  # Own profile
+                Q(is_profile_public=True) |  # Public profiles
+                Q(id__in=users_in_shared_corpuses) |  # Shared corpus membership
+                Q(id__in=corpus_creators)  # Corpus creators
+            )
+        ).distinct()
+
+        # Optimize query
+        qs = qs.select_related().only(
+            'id', 'username', 'email', 'is_profile_public', 'is_active', 'slug'
+        )
+
+        return qs
+
+    @classmethod
+    def check_user_visibility(cls, requesting_user, target_user_id: int) -> bool:
+        """Check if requesting_user can see target_user."""
+        return cls.get_visible_users(requesting_user).filter(id=target_user_id).exists()
+```
+
+### 1.2 Update `UserProfileManager` in `users/models.py`
+
+**Current** (lines 34-67): Already has `visible_to_user` but doesn't handle corpus membership.
+
+**Changes**: Integrate with `UserQueryOptimizer` or enhance directly.
+
+```python
+class UserProfileManager(DjangoUserManager):
+    def visible_to_user(self, user=None, corpus_id=None):
+        """
+        Returns users visible to the requesting user.
+
+        Privacy rules:
+        - Own profile: always visible
+        - Public profiles: visible to all
+        - Private profiles: visible if share corpus with > READ permission
+        - Inactive users: not visible (except self/superuser)
+        """
+        from opencontractserver.users.query_optimizer import UserQueryOptimizer
+        return UserQueryOptimizer.get_visible_users(user, corpus_id=corpus_id)
+```
+
+---
+
+## Phase 2: Create Badge Visibility Infrastructure
+
+### 2.1 Create `BadgeQueryOptimizer`
+
+**Location**: `opencontractserver/badges/query_optimizer.py`
+
+**Purpose**: Handle badge/user_badge visibility based on recipient's profile visibility.
+
+```python
+class BadgeQueryOptimizer:
+    """
+    Optimized badge queries with profile privacy filtering.
+
+    Visibility model for UserBadge:
+    - Badge awards are visible if the recipient's profile is visible
+    - Follows UserQueryOptimizer's visibility rules
+    - Corpus-specific badges: visible to users with access to that corpus
+    """
+
+    @classmethod
+    def get_visible_user_badges(
+        cls,
+        requesting_user,
+        corpus_id: Optional[int] = None,
+        user_id: Optional[int] = None,  # Filter to specific user's badges
+    ) -> QuerySet:
+        """Get user badge awards visible to requesting_user."""
+        from opencontractserver.badges.models import UserBadge
+        from opencontractserver.users.query_optimizer import UserQueryOptimizer
+
+        # Superuser sees all
+        if requesting_user.is_superuser:
+            qs = UserBadge.objects.all()
+        else:
+            # Get visible users
+            visible_users = UserQueryOptimizer.get_visible_users(
+                requesting_user, corpus_id=corpus_id
+            )
+
+            # Filter to badges of visible users
+            qs = UserBadge.objects.filter(user__in=visible_users)
+
+            # For corpus-specific badges, also check corpus permission
+            if not requesting_user.is_anonymous:
+                # Include badges from corpuses user can access
+                from opencontractserver.corpuses.models import Corpus
+                visible_corpuses = Corpus.objects.visible_to_user(requesting_user)
+
+                qs = qs.filter(
+                    Q(corpus__isnull=True) |  # Global badges
+                    Q(corpus__in=visible_corpuses)  # Corpus badges user can see
+                )
+
+        if user_id:
+            qs = qs.filter(user_id=user_id)
+
+        # Optimize
+        return qs.select_related('user', 'badge', 'awarded_by', 'corpus')
+
+    @classmethod
+    def check_user_badge_visibility(
+        cls, requesting_user, user_badge_id: int
+    ) -> tuple[bool, Optional['UserBadge']]:
+        """Check if requesting_user can see a specific user_badge."""
+        from opencontractserver.badges.models import UserBadge
+
+        try:
+            user_badge = cls.get_visible_user_badges(requesting_user).get(id=user_badge_id)
+            return True, user_badge
+        except UserBadge.DoesNotExist:
+            return False, None
+```
+
+---
+
+## Phase 3: Create Document/Corpus Actions Optimizer
+
+### 3.1 Create `DocumentActionsQueryOptimizer`
+
+**Location**: `opencontractserver/documents/query_optimizer.py`
+
+**Purpose**: Replace the broken `resolve_document_corpus_actions` logic.
+
+```python
+class DocumentActionsQueryOptimizer:
+    """
+    Optimized queries for document-related actions (extracts, analysis rows, corpus actions).
+
+    Follows the least-privilege model from AnnotationQueryOptimizer:
+    - Document permissions are primary
+    - Corpus permissions are secondary
+    - Effective permission = MIN(document_permission, corpus_permission)
+    """
+
+    @classmethod
+    def get_document_actions(
+        cls,
+        user,
+        document_id: int,
+        corpus_id: Optional[int] = None,
+    ) -> dict:
+        """
+        Get all actions/extracts/analyses for a document with proper permission filtering.
+
+        Returns dict with:
+        - corpus_actions: CorpusAction objects
+        - extracts: Extract objects
+        - analysis_rows: DocumentAnalysisRow objects
+        """
+        from opencontractserver.annotations.query_optimizer import (
+            AnalysisQueryOptimizer,
+            ExtractQueryOptimizer,
+        )
+        from opencontractserver.corpuses.models import Corpus, CorpusAction
+        from opencontractserver.documents.models import Document
+        from opencontractserver.types.enums import PermissionTypes
+        from opencontractserver.utils.permissioning import user_has_permission_for_obj
+
+        result = {
+            'corpus_actions': [],
+            'extracts': [],
+            'analysis_rows': [],
+        }
+
+        # Check document permission first
+        try:
+            document = Document.objects.get(id=document_id)
+        except Document.DoesNotExist:
+            return result
+
+        # Check document READ permission
+        if not user.is_superuser:
+            if user.is_anonymous:
+                if not document.is_public:
+                    return result
+            elif not user_has_permission_for_obj(
+                user, document, PermissionTypes.READ, include_group_permissions=True
+            ):
+                return result
+
+        # Get corpus if provided
+        corpus = None
+        if corpus_id:
+            try:
+                corpus = Corpus.objects.get(id=corpus_id)
+                # Check corpus READ permission
+                if not user.is_superuser:
+                    if user.is_anonymous:
+                        if not corpus.is_public:
+                            return result
+                    elif not user_has_permission_for_obj(
+                        user, corpus, PermissionTypes.READ, include_group_permissions=True
+                    ):
+                        return result
+            except Corpus.DoesNotExist:
+                pass
+
+        # Get corpus actions (using proper visible_to_user)
+        if corpus:
+            result['corpus_actions'] = list(
+                CorpusAction.objects.visible_to_user(user).filter(corpus=corpus)
+            )
+
+        # Get extracts using ExtractQueryOptimizer
+        visible_extracts = ExtractQueryOptimizer.get_visible_extracts(
+            user, corpus_id=corpus_id
+        )
+        result['extracts'] = list(
+            visible_extracts.filter(documents=document)
+        )
+
+        # Get analysis rows
+        # Filter to analyses user can see, then get their rows for this document
+        visible_analyses = AnalysisQueryOptimizer.get_visible_analyses(
+            user, corpus_id=corpus_id
+        )
+        result['analysis_rows'] = list(
+            document.rows.filter(analysis__in=visible_analyses)
+            .select_related('analysis', 'analysis__analyzer')
+        )
+
+        return result
+```
+
+---
+
+## Phase 4: Fix Individual Resolvers
+
+### 4.1 Fix `resolve_user_by_slug` (CRITICAL)
+
+**File**: `config/graphql/queries.py:163-170`
+
+**Current**:
+```python
+def resolve_user_by_slug(self, info, slug):
+    User = get_user_model()
+    return User.objects.get(slug=slug)
+```
+
+**Fixed**:
+```python
+def resolve_user_by_slug(self, info, slug):
+    from opencontractserver.users.query_optimizer import UserQueryOptimizer
+
+    User = get_user_model()
+    try:
+        # Use visibility filtering
+        return UserQueryOptimizer.get_visible_users(
+            info.context.user
+        ).get(slug=slug)
+    except User.DoesNotExist:
+        return None
+```
+
+### 4.2 Fix `resolve_search_users_for_mention` (HIGH)
+
+**File**: `config/graphql/queries.py:1134-1176`
+
+**Current**: Ignores `is_profile_public`.
+
+**Fixed**:
+```python
+@graphql_ratelimit_dynamic(get_rate=get_user_tier_rate("READ_LIGHT"))
+def resolve_search_users_for_mention(self, info, text_search=None, **kwargs):
+    """
+    Search users for @ mention autocomplete.
+
+    SECURITY: Respects user profile privacy settings.
+    Users are visible if:
+    - Profile is public
+    - Requesting user shares corpus membership with > READ permission
+    """
+    from opencontractserver.users.query_optimizer import UserQueryOptimizer
+
+    user = info.context.user
+
+    # Anonymous users cannot mention
+    if user.is_anonymous:
+        return User.objects.none()
+
+    # Get visible users using optimizer
+    qs = UserQueryOptimizer.get_visible_users(user)
+
+    if text_search:
+        qs = qs.filter(
+            Q(username__icontains=text_search) | Q(email__icontains=text_search)
+        )
+
+    return qs.order_by("username")
+```
+
+### 4.3 Fix `resolve_user_badges` / `resolve_user_badge` (HIGH)
+
+**File**: `config/graphql/queries.py:2447-2456`
+
+**Current**: No permission filtering.
+
+**Fixed**:
+```python
+def resolve_user_badges(self, info, **kwargs):
+    """Resolve user badge awards with profile privacy filtering."""
+    from opencontractserver.badges.query_optimizer import BadgeQueryOptimizer
+
+    return BadgeQueryOptimizer.get_visible_user_badges(info.context.user)
+
+def resolve_user_badge(self, info, **kwargs):
+    """Resolve a single user badge with visibility check and IDOR protection."""
+    from opencontractserver.badges.query_optimizer import BadgeQueryOptimizer
+
+    django_pk = from_global_id(kwargs.get("id", None))[1]
+
+    has_permission, user_badge = BadgeQueryOptimizer.check_user_badge_visibility(
+        info.context.user, django_pk
+    )
+
+    if not has_permission:
+        # Same error whether doesn't exist or no permission (IDOR protection)
+        raise GraphQLError("User badge not found")
+
+    return user_badge
+```
+
+### 4.4 Fix `resolve_document_corpus_actions` (CRITICAL)
+
+**File**: `config/graphql/queries.py:1488-1527`
+
+**Current**: Bypasses permission system entirely.
+
+**Fixed**:
+```python
+def resolve_document_corpus_actions(self, info, document_id, corpus_id=None):
+    from opencontractserver.documents.query_optimizer import DocumentActionsQueryOptimizer
+
+    doc_django_pk = from_global_id(document_id)[1]
+    corpus_django_pk = from_global_id(corpus_id)[1] if corpus_id else None
+
+    actions = DocumentActionsQueryOptimizer.get_document_actions(
+        user=info.context.user,
+        document_id=doc_django_pk,
+        corpus_id=corpus_django_pk,
+    )
+
+    return DocumentCorpusActionsType(
+        corpus_actions=actions['corpus_actions'],
+        extracts=actions['extracts'],
+        analysis_rows=actions['analysis_rows'],
+    )
+```
+
+### 4.5 Fix `resolve_assignments` / `resolve_assignment` (LOW - Not Used)
+
+**Option A: Mark as Deprecated**
+```python
+def resolve_assignments(self, info, **kwargs):
+    """
+    DEPRECATED: Assignment feature is not currently used.
+    See opencontractserver/users/models.py:203-206
+    """
+    import warnings
+    warnings.warn("Assignment feature is deprecated and not in use", DeprecationWarning)
+
+    # Keep existing behavior for backwards compatibility
+    if info.context.user.is_superuser:
+        return Assignment.objects.all()
+    return Assignment.objects.filter(assignor=info.context.user)
+
+def resolve_assignment(self, info, **kwargs):
+    """DEPRECATED: Assignment feature is not currently used."""
+    import warnings
+    warnings.warn("Assignment feature is deprecated and not in use", DeprecationWarning)
+
+    django_pk = from_global_id(kwargs.get("id", None))[1]
+    # Fix the AttributeError by using direct query instead of broken visible_to_user
+    if info.context.user.is_superuser:
+        return Assignment.objects.get(id=django_pk)
+    return Assignment.objects.get(
+        Q(id=django_pk) & (Q(assignor=info.context.user) | Q(assignee=info.context.user))
+    )
+```
+
+**Option B: Full Fix** (if feature will be used later)
+Create `AssignmentQueryOptimizer` following same pattern.
+
+### 4.6 Fix `resolve_bulk_document_upload_status` (MEDIUM)
+
+**File**: `config/graphql/queries.py:2197-2288`
+
+**Issue**: Any authenticated user can check any job's status.
+
+**Fix Strategy**: Store job ownership in Redis alongside the job.
+
+```python
+# When creating the job (in mutation):
+redis_client.set(f"bulk_upload_job:{job_id}:owner", user.id, ex=86400)  # 24h TTL
+
+# In resolver:
+@login_required
+def resolve_bulk_document_upload_status(self, info, job_id):
+    # Verify job ownership
+    expected_owner = redis_client.get(f"bulk_upload_job:{job_id}:owner")
+    if expected_owner and int(expected_owner) != info.context.user.id:
+        if not info.context.user.is_superuser:
+            return BulkDocumentUploadStatusType(
+                job_id=job_id,
+                success=False,
+                completed=False,
+                errors=["Job not found"],  # Same error for IDOR protection
+            )
+
+    # ... rest of existing logic
+```
+
+---
+
+## Phase 5: Testing Strategy
+
+### 5.1 Test Files to Create
+
+1. `opencontractserver/tests/test_user_visibility.py`
+   - Test profile privacy respected
+   - Test corpus membership visibility
+   - Test anonymous user restrictions
+
+2. `opencontractserver/tests/test_badge_visibility.py`
+   - Test badge visibility follows profile privacy
+   - Test corpus-specific badge visibility
+
+3. `opencontractserver/tests/test_document_actions_permissions.py`
+   - Test proper permission inheritance
+   - Test hybrid model for extracts/analyses
+
+### 5.2 Test Cases
+
+```python
+class TestUserVisibility(TestCase):
+    def test_private_profile_not_visible_to_strangers(self):
+        """User with is_profile_public=False should not be visible to unrelated users."""
+
+    def test_private_profile_visible_to_corpus_members(self):
+        """User with is_profile_public=False visible to users with > READ on shared corpus."""
+
+    def test_public_profile_visible_to_all(self):
+        """User with is_profile_public=True visible to all authenticated users."""
+
+    def test_inactive_user_not_visible(self):
+        """Inactive users (is_active=False) should not be visible except to self/superuser."""
+
+    def test_own_profile_always_visible(self):
+        """User can always see their own profile regardless of settings."""
+
+class TestBadgeVisibility(TestCase):
+    def test_badge_visibility_follows_profile_privacy(self):
+        """Badge awards only visible if recipient's profile is visible."""
+
+    def test_corpus_badge_requires_corpus_access(self):
+        """Corpus-specific badges require access to that corpus."""
+```
+
+---
+
+## Implementation Order
+
+| Priority | Task | Effort | Files |
+|----------|------|--------|-------|
+| 1 | Create `UserQueryOptimizer` | Medium | `users/query_optimizer.py` |
+| 2 | Create `BadgeQueryOptimizer` | Low | `badges/query_optimizer.py` |
+| 3 | Create `DocumentActionsQueryOptimizer` | Medium | `documents/query_optimizer.py` |
+| 4 | Fix `resolve_user_by_slug` | Low | `config/graphql/queries.py` |
+| 5 | Fix `resolve_search_users_for_mention` | Low | `config/graphql/queries.py` |
+| 6 | Fix `resolve_user_badges` / `resolve_user_badge` | Low | `config/graphql/queries.py` |
+| 7 | Fix `resolve_document_corpus_actions` | Low | `config/graphql/queries.py` |
+| 8 | Fix `resolve_assignments` | Low | `config/graphql/queries.py` |
+| 9 | Add job ownership to bulk upload | Medium | Multiple files |
+| 10 | Write tests | High | `tests/` |
+
+---
+
+## Performance Considerations
+
+### Query Optimization Patterns Used
+
+1. **Subqueries over JOINs**: Use `values_list(..., flat=True)` + `__in` instead of JOINs for permission checks
+2. **Prefetch Related**: Use `select_related` and `prefetch_related` to avoid N+1
+3. **Only/Defer**: Use `.only()` to limit fields when full model not needed
+4. **Exists Subqueries**: Use `Exists(OuterRef(...))` for permission checks instead of JOINs
+
+### Example Optimized Query
+
+```python
+# BAD - Multiple queries per user
+for user in users:
+    if UserQueryOptimizer.check_user_visibility(requesting_user, user.id):
+        visible_users.append(user)
+
+# GOOD - Single optimized query
+visible_users = UserQueryOptimizer.get_visible_users(requesting_user)
+```
+
+---
+
+## Backwards Compatibility
+
+1. **Deprecation Warnings**: Add warnings for deprecated resolvers
+2. **Graceful Fallbacks**: New optimizers return empty querysets on permission denial
+3. **Consistent Error Messages**: Same error for "not found" and "no permission" (IDOR protection)
+
+---
+
+## Detailed Test Specifications
+
+All tests should be realistic, human-readable, and prove the changes work.
+
+### Test File: `opencontractserver/tests/permissioning/test_user_visibility.py`
+
+```python
+"""
+Tests for User Profile Visibility System
+
+These tests verify that user profiles respect privacy settings and corpus membership rules.
+"""
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+from opencontractserver.corpuses.models import Corpus
+from opencontractserver.types.enums import PermissionTypes
+from opencontractserver.utils.permissioning import set_permissions_for_obj_to_user
+from opencontractserver.users.query_optimizer import UserQueryOptimizer
+
+User = get_user_model()
+
+
+class TestUserProfilePrivacy(TestCase):
+    """Tests that verify user profile privacy settings are respected."""
+
+    def setUp(self):
+        """Create test users with different privacy settings."""
+        self.public_user = User.objects.create_user(
+            username="public_alice",
+            email="alice@example.com",
+            password="testpass123",
+            is_profile_public=True,
+        )
+        self.private_user = User.objects.create_user(
+            username="private_bob",
+            email="bob@example.com",
+            password="testpass123",
+            is_profile_public=False,
+        )
+        self.viewer = User.objects.create_user(
+            username="viewer_carol",
+            email="carol@example.com",
+            password="testpass123",
+        )
+
+    def test_public_profile_visible_to_any_authenticated_user(self):
+        """
+        GIVEN: A user (Alice) with is_profile_public=True
+        WHEN: Another user (Carol) queries for visible users
+        THEN: Alice's profile should be in the results
+        """
+        visible_users = UserQueryOptimizer.get_visible_users(self.viewer)
+
+        self.assertIn(
+            self.public_user,
+            visible_users,
+            "Public profiles should be visible to any authenticated user"
+        )
+
+    def test_private_profile_not_visible_to_unrelated_user(self):
+        """
+        GIVEN: A user (Bob) with is_profile_public=False
+        AND: A viewer (Carol) who does NOT share any corpus membership with Bob
+        WHEN: Carol queries for visible users
+        THEN: Bob's profile should NOT be in the results
+        """
+        visible_users = UserQueryOptimizer.get_visible_users(self.viewer)
+
+        self.assertNotIn(
+            self.private_user,
+            visible_users,
+            "Private profiles should NOT be visible to unrelated users"
+        )
+
+    def test_own_profile_always_visible_regardless_of_privacy_setting(self):
+        """
+        GIVEN: A user (Bob) with is_profile_public=False
+        WHEN: Bob queries for visible users
+        THEN: Bob should see his own profile in the results
+        """
+        visible_users = UserQueryOptimizer.get_visible_users(self.private_user)
+
+        self.assertIn(
+            self.private_user,
+            visible_users,
+            "Users should always see their own profile regardless of privacy setting"
+        )
+
+
+class TestUserVisibilityViaCorpusMembership(TestCase):
+    """Tests that verify corpus membership enables user visibility."""
+
+    def setUp(self):
+        """Create test users and a shared corpus."""
+        self.corpus_owner = User.objects.create_user(
+            username="owner",
+            email="owner@example.com",
+            password="testpass123",
+        )
+        self.private_collaborator = User.objects.create_user(
+            username="collaborator",
+            email="collab@example.com",
+            password="testpass123",
+            is_profile_public=False,  # Private profile
+        )
+        self.outsider = User.objects.create_user(
+            username="outsider",
+            email="outsider@example.com",
+            password="testpass123",
+        )
+
+        # Create a corpus
+        self.shared_corpus = Corpus.objects.create(
+            title="Shared Legal Corpus",
+            creator=self.corpus_owner,
+        )
+
+        # Give collaborator UPDATE permission (> READ) on the corpus
+        set_permissions_for_obj_to_user(
+            self.private_collaborator,
+            self.shared_corpus,
+            [PermissionTypes.READ, PermissionTypes.UPDATE],
+        )
+
+    def test_private_user_visible_to_corpus_member_with_write_permission(self):
+        """
+        GIVEN: A user (collaborator) with is_profile_public=False
+        AND: Another user (owner) who shares a corpus with collaborator
+        AND: Collaborator has > READ permission on that corpus
+        WHEN: Owner queries for visible users
+        THEN: Collaborator's profile should be visible
+        """
+        visible_users = UserQueryOptimizer.get_visible_users(self.corpus_owner)
+
+        self.assertIn(
+            self.private_collaborator,
+            visible_users,
+            "Private profiles should be visible to users who share corpus with > READ"
+        )
+
+    def test_private_user_not_visible_to_outsider(self):
+        """
+        GIVEN: A user (collaborator) with is_profile_public=False
+        AND: A user (outsider) who does NOT have access to any shared corpus
+        WHEN: Outsider queries for visible users
+        THEN: Collaborator's profile should NOT be visible
+        """
+        visible_users = UserQueryOptimizer.get_visible_users(self.outsider)
+
+        self.assertNotIn(
+            self.private_collaborator,
+            visible_users,
+            "Private profiles should NOT be visible to users outside shared corpuses"
+        )
+
+    def test_read_only_corpus_member_cannot_see_private_profiles(self):
+        """
+        GIVEN: A corpus with two members
+        AND: One member (viewer) has only READ permission
+        AND: Another member (collaborator) has is_profile_public=False
+        WHEN: Viewer queries for visible users
+        THEN: Collaborator's profile should NOT be visible (READ is not enough)
+        """
+        read_only_user = User.objects.create_user(
+            username="readonly",
+            email="readonly@example.com",
+            password="testpass123",
+        )
+        # Give only READ permission (not > READ)
+        set_permissions_for_obj_to_user(
+            read_only_user,
+            self.shared_corpus,
+            [PermissionTypes.READ],
+        )
+
+        visible_users = UserQueryOptimizer.get_visible_users(read_only_user)
+
+        self.assertNotIn(
+            self.private_collaborator,
+            visible_users,
+            "READ-only permission should NOT enable seeing private profiles"
+        )
+
+
+class TestUserVisibilityAnonymousUser(TestCase):
+    """Tests for anonymous user visibility rules."""
+
+    def setUp(self):
+        """Create test users."""
+        self.public_user = User.objects.create_user(
+            username="public",
+            email="public@example.com",
+            password="testpass123",
+            is_profile_public=True,
+        )
+        self.private_user = User.objects.create_user(
+            username="private",
+            email="private@example.com",
+            password="testpass123",
+            is_profile_public=False,
+        )
+
+    def test_anonymous_user_can_see_public_profiles(self):
+        """
+        GIVEN: A public user profile
+        WHEN: An anonymous user queries for visible users
+        THEN: Public profiles should be visible
+        """
+        from django.contrib.auth.models import AnonymousUser
+
+        anonymous = AnonymousUser()
+        visible_users = UserQueryOptimizer.get_visible_users(anonymous)
+
+        self.assertIn(
+            self.public_user,
+            visible_users,
+            "Anonymous users should see public profiles"
+        )
+
+    def test_anonymous_user_cannot_see_private_profiles(self):
+        """
+        GIVEN: A private user profile
+        WHEN: An anonymous user queries for visible users
+        THEN: Private profiles should NOT be visible
+        """
+        from django.contrib.auth.models import AnonymousUser
+
+        anonymous = AnonymousUser()
+        visible_users = UserQueryOptimizer.get_visible_users(anonymous)
+
+        self.assertNotIn(
+            self.private_user,
+            visible_users,
+            "Anonymous users should NOT see private profiles"
+        )
+
+
+class TestInactiveUserVisibility(TestCase):
+    """Tests that inactive users are properly hidden."""
+
+    def setUp(self):
+        """Create active and inactive users."""
+        self.active_user = User.objects.create_user(
+            username="active",
+            email="active@example.com",
+            password="testpass123",
+            is_active=True,
+        )
+        self.inactive_user = User.objects.create_user(
+            username="inactive",
+            email="inactive@example.com",
+            password="testpass123",
+            is_active=False,  # Deactivated account
+            is_profile_public=True,  # Even public profiles should be hidden
+        )
+        self.viewer = User.objects.create_user(
+            username="viewer",
+            email="viewer@example.com",
+            password="testpass123",
+        )
+
+    def test_inactive_user_not_visible_even_with_public_profile(self):
+        """
+        GIVEN: A user account that has been deactivated (is_active=False)
+        AND: That user had is_profile_public=True
+        WHEN: Another user queries for visible users
+        THEN: The inactive user should NOT be visible
+        """
+        visible_users = UserQueryOptimizer.get_visible_users(self.viewer)
+
+        self.assertNotIn(
+            self.inactive_user,
+            visible_users,
+            "Inactive users should NOT be visible even with public profile"
+        )
+
+    def test_superuser_can_see_inactive_users(self):
+        """
+        GIVEN: An inactive user
+        AND: A superuser
+        WHEN: Superuser queries for visible users
+        THEN: The inactive user should be visible (for admin purposes)
+        """
+        superuser = User.objects.create_superuser(
+            username="admin",
+            email="admin@example.com",
+            password="adminpass123",
+        )
+        # Note: Superuser sees all ACTIVE users - inactive may or may not be included
+        # depending on design decision. This test documents expected behavior.
+        visible_users = UserQueryOptimizer.get_visible_users(superuser)
+
+        # Active users should definitely be visible
+        self.assertIn(self.active_user, visible_users)
+```
+
+### Test File: `opencontractserver/tests/permissioning/test_badge_visibility.py`
+
+```python
+"""
+Tests for Badge/UserBadge Visibility System
+
+These tests verify that badge awards respect the recipient's profile privacy.
+"""
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+from opencontractserver.badges.models import Badge, UserBadge
+from opencontractserver.badges.query_optimizer import BadgeQueryOptimizer
+from opencontractserver.corpuses.models import Corpus
+from opencontractserver.types.enums import PermissionTypes
+from opencontractserver.utils.permissioning import set_permissions_for_obj_to_user
+
+User = get_user_model()
+
+
+class TestUserBadgeVisibility(TestCase):
+    """Tests that user badge visibility follows profile privacy rules."""
+
+    def setUp(self):
+        """Create test users, badges, and awards."""
+        self.badge_owner = User.objects.create_user(
+            username="badgeholder",
+            email="badge@example.com",
+            password="testpass123",
+            is_profile_public=False,  # Private profile
+        )
+        self.viewer = User.objects.create_user(
+            username="viewer",
+            email="viewer@example.com",
+            password="testpass123",
+        )
+
+        # Create a badge
+        self.achievement_badge = Badge.objects.create(
+            name="First Annotation",
+            description="Awarded for creating your first annotation",
+            icon="Star",
+            creator=self.viewer,  # Badge definition creator
+        )
+
+        # Award the badge
+        self.badge_award = UserBadge.objects.create(
+            user=self.badge_owner,  # Private user receives badge
+            badge=self.achievement_badge,
+        )
+
+    def test_badge_of_private_user_not_visible_to_unrelated_viewer(self):
+        """
+        GIVEN: A badge awarded to a user (badgeholder) with is_profile_public=False
+        AND: A viewer who does NOT share corpus membership with badgeholder
+        WHEN: Viewer queries for visible user badges
+        THEN: The badge award should NOT be visible
+        """
+        visible_badges = BadgeQueryOptimizer.get_visible_user_badges(self.viewer)
+
+        self.assertNotIn(
+            self.badge_award,
+            visible_badges,
+            "Badges of private users should NOT be visible to unrelated viewers"
+        )
+
+    def test_own_badges_always_visible(self):
+        """
+        GIVEN: A user (badgeholder) with badge awards
+        WHEN: badgeholder queries for their own badges
+        THEN: Their badges should be visible regardless of profile privacy
+        """
+        visible_badges = BadgeQueryOptimizer.get_visible_user_badges(self.badge_owner)
+
+        self.assertIn(
+            self.badge_award,
+            visible_badges,
+            "Users should always see their own badges"
+        )
+
+
+class TestCorpusSpecificBadgeVisibility(TestCase):
+    """Tests for corpus-specific badge visibility."""
+
+    def setUp(self):
+        """Create corpus-specific badge scenario."""
+        self.corpus_owner = User.objects.create_user(
+            username="corpusowner",
+            email="owner@example.com",
+            password="testpass123",
+        )
+        self.badge_recipient = User.objects.create_user(
+            username="recipient",
+            email="recipient@example.com",
+            password="testpass123",
+            is_profile_public=True,  # Public profile
+        )
+        self.outsider = User.objects.create_user(
+            username="outsider",
+            email="outsider@example.com",
+            password="testpass123",
+        )
+
+        # Create private corpus
+        self.private_corpus = Corpus.objects.create(
+            title="Private Legal Corpus",
+            creator=self.corpus_owner,
+            is_public=False,
+        )
+
+        # Give recipient access to corpus
+        set_permissions_for_obj_to_user(
+            self.badge_recipient,
+            self.private_corpus,
+            [PermissionTypes.READ, PermissionTypes.UPDATE],
+        )
+
+        # Create corpus-specific badge
+        self.corpus_badge = Badge.objects.create(
+            name="Top Contributor",
+            description="Top contributor in this corpus",
+            icon="Trophy",
+            badge_type="CORPUS",
+            corpus=self.private_corpus,
+            creator=self.corpus_owner,
+        )
+
+        # Award corpus badge
+        self.corpus_badge_award = UserBadge.objects.create(
+            user=self.badge_recipient,
+            badge=self.corpus_badge,
+            corpus=self.private_corpus,
+        )
+
+    def test_corpus_badge_visible_to_corpus_member(self):
+        """
+        GIVEN: A corpus-specific badge awarded in a private corpus
+        AND: A user who has access to that corpus
+        WHEN: User queries for visible badges
+        THEN: The corpus badge should be visible
+        """
+        visible_badges = BadgeQueryOptimizer.get_visible_user_badges(self.corpus_owner)
+
+        self.assertIn(
+            self.corpus_badge_award,
+            visible_badges,
+            "Corpus-specific badges should be visible to corpus members"
+        )
+
+    def test_corpus_badge_not_visible_to_outsider(self):
+        """
+        GIVEN: A corpus-specific badge awarded in a private corpus
+        AND: A user who does NOT have access to that corpus
+        WHEN: User queries for visible badges
+        THEN: The corpus badge should NOT be visible
+        """
+        visible_badges = BadgeQueryOptimizer.get_visible_user_badges(self.outsider)
+
+        self.assertNotIn(
+            self.corpus_badge_award,
+            visible_badges,
+            "Corpus-specific badges should NOT be visible to non-members"
+        )
+```
+
+### Test File: `opencontractserver/tests/permissioning/test_document_actions_permissions.py`
+
+```python
+"""
+Tests for Document Actions Permission System
+
+These tests verify that document_corpus_actions follows the least-privilege model.
+"""
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+from opencontractserver.corpuses.models import Corpus, CorpusAction
+from opencontractserver.documents.models import Document
+from opencontractserver.documents.query_optimizer import DocumentActionsQueryOptimizer
+from opencontractserver.extracts.models import Extract, Fieldset
+from opencontractserver.types.enums import PermissionTypes
+from opencontractserver.utils.permissioning import set_permissions_for_obj_to_user
+
+User = get_user_model()
+
+
+class TestDocumentActionsPermissions(TestCase):
+    """Tests for document actions with proper permission inheritance."""
+
+    def setUp(self):
+        """Create test scenario with document, corpus, and extracts."""
+        self.owner = User.objects.create_user(
+            username="owner",
+            email="owner@example.com",
+            password="testpass123",
+        )
+        self.reader = User.objects.create_user(
+            username="reader",
+            email="reader@example.com",
+            password="testpass123",
+        )
+        self.outsider = User.objects.create_user(
+            username="outsider",
+            email="outsider@example.com",
+            password="testpass123",
+        )
+
+        # Create corpus and document
+        self.corpus = Corpus.objects.create(
+            title="Test Corpus",
+            creator=self.owner,
+            is_public=False,
+        )
+        self.document = Document.objects.create(
+            title="Test Document",
+            creator=self.owner,
+        )
+
+        # Give reader READ permission on both
+        set_permissions_for_obj_to_user(
+            self.reader,
+            self.corpus,
+            [PermissionTypes.READ],
+        )
+        set_permissions_for_obj_to_user(
+            self.reader,
+            self.document,
+            [PermissionTypes.READ],
+        )
+
+        # Create a fieldset and extract
+        self.fieldset = Fieldset.objects.create(
+            name="Test Fieldset",
+            creator=self.owner,
+        )
+        self.extract = Extract.objects.create(
+            name="Test Extract",
+            corpus=self.corpus,
+            fieldset=self.fieldset,
+            creator=self.owner,
+        )
+        self.extract.documents.add(self.document)
+
+    def test_owner_can_see_all_document_actions(self):
+        """
+        GIVEN: A document owner with full permissions
+        WHEN: Owner queries for document actions
+        THEN: All extracts and actions should be visible
+        """
+        actions = DocumentActionsQueryOptimizer.get_document_actions(
+            user=self.owner,
+            document_id=self.document.id,
+            corpus_id=self.corpus.id,
+        )
+
+        self.assertIn(
+            self.extract,
+            actions['extracts'],
+            "Owner should see all extracts on their document"
+        )
+
+    def test_reader_with_explicit_permission_can_see_document(self):
+        """
+        GIVEN: A user (reader) with explicit READ permission on document AND corpus
+        WHEN: Reader queries for document actions
+        THEN: Reader should see extracts they have permission to
+        """
+        # Give reader explicit permission on extract too
+        set_permissions_for_obj_to_user(
+            self.reader,
+            self.extract,
+            [PermissionTypes.READ],
+        )
+
+        actions = DocumentActionsQueryOptimizer.get_document_actions(
+            user=self.reader,
+            document_id=self.document.id,
+            corpus_id=self.corpus.id,
+        )
+
+        self.assertIn(
+            self.extract,
+            actions['extracts'],
+            "Reader with explicit permission should see the extract"
+        )
+
+    def test_outsider_cannot_see_any_document_actions(self):
+        """
+        GIVEN: A user (outsider) with NO permissions on document or corpus
+        WHEN: Outsider queries for document actions
+        THEN: All actions should be empty (permission denied)
+        """
+        actions = DocumentActionsQueryOptimizer.get_document_actions(
+            user=self.outsider,
+            document_id=self.document.id,
+            corpus_id=self.corpus.id,
+        )
+
+        self.assertEqual(
+            actions['extracts'],
+            [],
+            "Outsider should NOT see any extracts"
+        )
+        self.assertEqual(
+            actions['corpus_actions'],
+            [],
+            "Outsider should NOT see any corpus actions"
+        )
+
+    def test_user_with_only_document_permission_cannot_see_corpus_actions(self):
+        """
+        GIVEN: A user with READ permission on document but NOT corpus
+        WHEN: User queries for document actions
+        THEN: Corpus actions should be empty (corpus permission required)
+        """
+        doc_only_user = User.objects.create_user(
+            username="doconly",
+            email="doconly@example.com",
+            password="testpass123",
+        )
+        set_permissions_for_obj_to_user(
+            doc_only_user,
+            self.document,
+            [PermissionTypes.READ],
+        )
+        # No corpus permission!
+
+        actions = DocumentActionsQueryOptimizer.get_document_actions(
+            user=doc_only_user,
+            document_id=self.document.id,
+            corpus_id=self.corpus.id,
+        )
+
+        self.assertEqual(
+            actions['corpus_actions'],
+            [],
+            "User without corpus permission should NOT see corpus actions"
+        )
+
+
+class TestDocumentActionsIDORProtection(TestCase):
+    """Tests for IDOR protection in document actions."""
+
+    def setUp(self):
+        """Create scenario for IDOR testing."""
+        self.user_a = User.objects.create_user(
+            username="user_a",
+            email="a@example.com",
+            password="testpass123",
+        )
+        self.user_b = User.objects.create_user(
+            username="user_b",
+            email="b@example.com",
+            password="testpass123",
+        )
+
+        # User A's private document
+        self.private_document = Document.objects.create(
+            title="Private Document",
+            creator=self.user_a,
+            is_public=False,
+        )
+
+    def test_cannot_enumerate_private_documents(self):
+        """
+        GIVEN: User B who does NOT have permission to User A's document
+        WHEN: User B queries for document actions on User A's document
+        THEN: Empty results should be returned (same as if document didn't exist)
+        """
+        actions = DocumentActionsQueryOptimizer.get_document_actions(
+            user=self.user_b,
+            document_id=self.private_document.id,
+            corpus_id=None,
+        )
+
+        # Should return empty dict, not error with "permission denied"
+        self.assertEqual(actions['extracts'], [])
+        self.assertEqual(actions['corpus_actions'], [])
+        self.assertEqual(actions['analysis_rows'], [])
+```
+
+---
+
+## Security Audit Checklist
+
+After implementation, verify:
+
+- [ ] `resolve_user_by_slug` respects `is_profile_public`
+- [ ] `resolve_search_users_for_mention` respects profile privacy
+- [ ] `resolve_user_badges` respects recipient's profile privacy
+- [ ] `resolve_user_badge` has IDOR protection
+- [ ] `resolve_document_corpus_actions` uses proper permission model
+- [ ] `resolve_assignments` doesn't cause AttributeError
+- [ ] Bulk upload job ownership is verified
+- [ ] All new optimizers handle anonymous users correctly
+- [ ] All new optimizers handle superusers correctly
+- [ ] No N+1 query issues introduced
+- [ ] All tests pass and prove the security requirements

--- a/opencontractserver/badges/query_optimizer.py
+++ b/opencontractserver/badges/query_optimizer.py
@@ -1,0 +1,157 @@
+"""
+Badge Query Optimizer for OpenContracts.
+
+Provides optimized badge queries with profile privacy filtering.
+Badge visibility follows the recipient's profile visibility rules.
+"""
+
+from typing import TYPE_CHECKING, Optional
+
+from django.db.models import Q, QuerySet
+
+if TYPE_CHECKING:
+    from opencontractserver.badges.models import UserBadge
+
+
+class BadgeQueryOptimizer:
+    """
+    Optimized badge queries with profile privacy filtering.
+
+    Visibility model for UserBadge:
+    - Badge awards are visible if the recipient's profile is visible
+    - Follows UserQueryOptimizer's visibility rules
+    - Corpus-specific badges: visible to users with access to that corpus
+    - Own badges: always visible regardless of profile privacy
+
+    The key insight is that badge visibility derives from user profile visibility,
+    not from direct badge permissions.
+    """
+
+    @classmethod
+    def get_visible_user_badges(
+        cls,
+        requesting_user,
+        corpus_id: Optional[int] = None,
+        user_id: Optional[int] = None,
+    ) -> QuerySet:
+        """
+        Get user badge awards visible to requesting_user.
+
+        Args:
+            requesting_user: The user making the request
+            corpus_id: Optional corpus to filter badges (for corpus-specific badges)
+            user_id: Optional user ID to filter to a specific user's badges
+
+        Returns:
+            QuerySet of UserBadge objects visible to the requesting user
+        """
+        from django.contrib.auth.models import AnonymousUser
+
+        from opencontractserver.badges.models import UserBadge
+        from opencontractserver.corpuses.models import Corpus
+        from opencontractserver.users.query_optimizer import UserQueryOptimizer
+
+        # Superuser sees all badges
+        if hasattr(requesting_user, "is_superuser") and requesting_user.is_superuser:
+            qs = UserBadge.objects.all()
+        else:
+            # Get visible users based on profile privacy
+            visible_users = UserQueryOptimizer.get_visible_users(
+                requesting_user, corpus_id=corpus_id
+            )
+
+            # Filter to badges of visible users
+            qs = UserBadge.objects.filter(user__in=visible_users)
+
+            # For corpus-specific badges, also check corpus permission
+            if requesting_user is not None and not isinstance(
+                requesting_user, AnonymousUser
+            ):
+                # Include badges from corpuses user can access
+                visible_corpuses = Corpus.objects.visible_to_user(requesting_user)
+
+                qs = qs.filter(
+                    Q(corpus__isnull=True)  # Global badges
+                    | Q(corpus__in=visible_corpuses)  # Corpus badges user can see
+                )
+            else:
+                # Anonymous users can only see global badges or public corpus badges
+                qs = qs.filter(
+                    Q(corpus__isnull=True)  # Global badges
+                    | Q(corpus__is_public=True)  # Public corpus badges
+                )
+
+        # Filter to specific user if requested
+        if user_id:
+            qs = qs.filter(user_id=user_id)
+
+        # Optimize query with select_related
+        return qs.select_related("user", "badge", "awarded_by", "corpus")
+
+    @classmethod
+    def check_user_badge_visibility(
+        cls, requesting_user, user_badge_id: int
+    ) -> tuple[bool, Optional["UserBadge"]]:
+        """
+        Check if requesting_user can see a specific user_badge.
+
+        This method provides IDOR protection by returning the same result
+        whether the badge doesn't exist or the user doesn't have permission.
+
+        Args:
+            requesting_user: The user making the request
+            user_badge_id: The ID of the UserBadge to check
+
+        Returns:
+            Tuple of (has_permission, user_badge_object)
+            - (True, UserBadge) if visible
+            - (False, None) if not visible or doesn't exist
+        """
+        from opencontractserver.badges.models import UserBadge
+
+        try:
+            user_badge = cls.get_visible_user_badges(requesting_user).get(
+                id=user_badge_id
+            )
+            return True, user_badge
+        except UserBadge.DoesNotExist:
+            return False, None
+
+    @classmethod
+    def get_badges_for_user(
+        cls,
+        requesting_user,
+        target_user_id: int,
+        include_corpus_badges: bool = True,
+    ) -> QuerySet:
+        """
+        Get all visible badges for a specific user.
+
+        This is a convenience method for displaying a user's badge collection.
+
+        Args:
+            requesting_user: The user making the request
+            target_user_id: The ID of the user whose badges to retrieve
+            include_corpus_badges: Whether to include corpus-specific badges
+
+        Returns:
+            QuerySet of UserBadge objects for the target user
+        """
+        from opencontractserver.users.query_optimizer import UserQueryOptimizer
+
+        # First check if the target user is visible
+        if not UserQueryOptimizer.check_user_visibility(
+            requesting_user, target_user_id
+        ):
+            from opencontractserver.badges.models import UserBadge
+
+            return UserBadge.objects.none()
+
+        # Get badges for that user
+        qs = cls.get_visible_user_badges(requesting_user, user_id=target_user_id)
+
+        # Optionally filter out corpus-specific badges
+        if not include_corpus_badges:
+            qs = qs.filter(corpus__isnull=True)
+
+        return qs.order_by("-awarded_at")

--- a/opencontractserver/documents/query_optimizer.py
+++ b/opencontractserver/documents/query_optimizer.py
@@ -1,0 +1,311 @@
+"""
+Document Query Optimizer for OpenContracts.
+
+Provides optimized queries for document-related actions (extracts, analysis rows, corpus actions).
+Follows the least-privilege permission model.
+"""
+
+from typing import TYPE_CHECKING, Optional
+
+from django.db.models import QuerySet
+
+if TYPE_CHECKING:
+    pass
+
+
+class DocumentActionsQueryOptimizer:
+    """
+    Optimized queries for document-related actions (extracts, analysis rows, corpus actions).
+
+    Follows the least-privilege model from AnnotationQueryOptimizer:
+    - Document permissions are primary
+    - Corpus permissions are secondary
+    - Effective permission = MIN(document_permission, corpus_permission)
+
+    This optimizer centralizes permission logic so developers don't need to
+    understand the permissioning system when retrieving document-related objects.
+    """
+
+    @classmethod
+    def get_document_actions(
+        cls,
+        user,
+        document_id: int,
+        corpus_id: Optional[int] = None,
+    ) -> dict:
+        """
+        Get all actions/extracts/analyses for a document with proper permission filtering.
+
+        This method follows the least-privilege model:
+        1. First checks document permission
+        2. If corpus_id provided, also checks corpus permission
+        3. Returns only objects the user has access to
+
+        Args:
+            user: The requesting user
+            document_id: The document ID to get actions for
+            corpus_id: Optional corpus ID to filter by
+
+        Returns:
+            dict with:
+            - corpus_actions: list of CorpusAction objects
+            - extracts: list of Extract objects
+            - analysis_rows: list of DocumentAnalysisRow objects
+        """
+        from opencontractserver.annotations.query_optimizer import (
+            AnalysisQueryOptimizer,
+            ExtractQueryOptimizer,
+        )
+        from opencontractserver.corpuses.models import Corpus, CorpusAction
+        from opencontractserver.documents.models import Document
+
+        result = {
+            "corpus_actions": [],
+            "extracts": [],
+            "analysis_rows": [],
+        }
+
+        # Get document first
+        try:
+            document = Document.objects.get(id=document_id)
+        except Document.DoesNotExist:
+            return result
+
+        # Check document permission
+        if not cls._check_document_permission(user, document):
+            return result
+
+        # Get corpus if provided and check permission
+        corpus = None
+        if corpus_id:
+            try:
+                corpus = Corpus.objects.get(id=corpus_id)
+                if not cls._check_corpus_permission(user, corpus):
+                    return result
+            except Corpus.DoesNotExist:
+                # No corpus found, but document permission passed
+                # Return document-only results (no corpus actions)
+                pass
+
+        # Get corpus actions (only if corpus is provided and accessible)
+        if corpus:
+            result["corpus_actions"] = list(
+                CorpusAction.objects.visible_to_user(user).filter(corpus=corpus)
+            )
+
+        # Get extracts using ExtractQueryOptimizer
+        visible_extracts = ExtractQueryOptimizer.get_visible_extracts(
+            user, corpus_id=corpus_id
+        )
+        # Filter to extracts that include this document
+        result["extracts"] = list(visible_extracts.filter(documents=document))
+
+        # Get analysis rows
+        # Filter to analyses user can see, then get their rows for this document
+        visible_analyses = AnalysisQueryOptimizer.get_visible_analyses(
+            user, corpus_id=corpus_id
+        )
+        result["analysis_rows"] = list(
+            document.rows.filter(analysis__in=visible_analyses).select_related(
+                "analysis", "analysis__analyzer"
+            )
+        )
+
+        return result
+
+    @classmethod
+    def _check_document_permission(cls, user, document) -> bool:
+        """
+        Check if user has READ permission on document.
+
+        Users can read a document if:
+        - They are superuser
+        - Document is public
+        - They are the creator
+        - They have explicit READ permission
+
+        Args:
+            user: The requesting user
+            document: The Document object
+
+        Returns:
+            True if user can read the document, False otherwise
+        """
+        from opencontractserver.types.enums import PermissionTypes
+        from opencontractserver.utils.permissioning import user_has_permission_for_obj
+
+        # Superusers can access everything
+        if hasattr(user, "is_superuser") and user.is_superuser:
+            return True
+
+        # Anonymous users can only access public documents
+        if user is None or (hasattr(user, "is_anonymous") and user.is_anonymous):
+            return document.is_public
+
+        # Public documents are accessible to all authenticated users
+        if document.is_public:
+            return True
+
+        # Creators can always access their own documents
+        if hasattr(document, "creator_id") and document.creator_id == user.id:
+            return True
+
+        # Check explicit READ permission
+        return user_has_permission_for_obj(
+            user, document, PermissionTypes.READ, include_group_permissions=True
+        )
+
+    @classmethod
+    def _check_corpus_permission(cls, user, corpus) -> bool:
+        """
+        Check if user has READ permission on corpus.
+
+        Users can read a corpus if:
+        - They are superuser
+        - Corpus is public
+        - They are the creator
+        - They have explicit READ permission
+
+        Args:
+            user: The requesting user
+            corpus: The Corpus object
+
+        Returns:
+            True if user can read the corpus, False otherwise
+        """
+        from opencontractserver.types.enums import PermissionTypes
+        from opencontractserver.utils.permissioning import user_has_permission_for_obj
+
+        # Superusers can access everything
+        if hasattr(user, "is_superuser") and user.is_superuser:
+            return True
+
+        # Anonymous users can only access public corpuses
+        if user is None or (hasattr(user, "is_anonymous") and user.is_anonymous):
+            return corpus.is_public
+
+        # Public corpuses are accessible to all authenticated users
+        if corpus.is_public:
+            return True
+
+        # Creators can always access their own corpuses
+        if hasattr(corpus, "creator_id") and corpus.creator_id == user.id:
+            return True
+
+        # Check explicit READ permission
+        return user_has_permission_for_obj(
+            user, corpus, PermissionTypes.READ, include_group_permissions=True
+        )
+
+    @classmethod
+    def get_corpus_actions_for_corpus(
+        cls,
+        user,
+        corpus_id: int,
+    ) -> QuerySet:
+        """
+        Get all corpus actions for a corpus with permission filtering.
+
+        Args:
+            user: The requesting user
+            corpus_id: The corpus ID
+
+        Returns:
+            QuerySet of CorpusAction objects
+        """
+        from opencontractserver.corpuses.models import Corpus, CorpusAction
+
+        # Check corpus permission first
+        try:
+            corpus = Corpus.objects.get(id=corpus_id)
+        except Corpus.DoesNotExist:
+            return CorpusAction.objects.none()
+
+        if not cls._check_corpus_permission(user, corpus):
+            return CorpusAction.objects.none()
+
+        # Use visible_to_user manager method
+        return CorpusAction.objects.visible_to_user(user).filter(corpus=corpus)
+
+    @classmethod
+    def get_extracts_for_document(
+        cls,
+        user,
+        document_id: int,
+        corpus_id: Optional[int] = None,
+    ) -> QuerySet:
+        """
+        Get extracts that include a specific document.
+
+        Args:
+            user: The requesting user
+            document_id: The document ID
+            corpus_id: Optional corpus to filter by
+
+        Returns:
+            QuerySet of Extract objects
+        """
+        from opencontractserver.annotations.query_optimizer import (
+            ExtractQueryOptimizer,
+        )
+        from opencontractserver.documents.models import Document
+        from opencontractserver.extracts.models import Extract
+
+        # Check document permission
+        try:
+            document = Document.objects.get(id=document_id)
+        except Document.DoesNotExist:
+            return Extract.objects.none()
+
+        if not cls._check_document_permission(user, document):
+            return Extract.objects.none()
+
+        # Get visible extracts
+        visible_extracts = ExtractQueryOptimizer.get_visible_extracts(
+            user, corpus_id=corpus_id
+        )
+
+        # Filter to those that include this document
+        return visible_extracts.filter(documents=document)
+
+    @classmethod
+    def get_analysis_rows_for_document(
+        cls,
+        user,
+        document_id: int,
+        corpus_id: Optional[int] = None,
+    ) -> QuerySet:
+        """
+        Get analysis rows for a specific document.
+
+        Args:
+            user: The requesting user
+            document_id: The document ID
+            corpus_id: Optional corpus to filter by
+
+        Returns:
+            QuerySet of DocumentAnalysisRow objects
+        """
+        from opencontractserver.annotations.query_optimizer import (
+            AnalysisQueryOptimizer,
+        )
+        from opencontractserver.documents.models import Document, DocumentAnalysisRow
+
+        # Check document permission
+        try:
+            document = Document.objects.get(id=document_id)
+        except Document.DoesNotExist:
+            return DocumentAnalysisRow.objects.none()
+
+        if not cls._check_document_permission(user, document):
+            return DocumentAnalysisRow.objects.none()
+
+        # Get visible analyses
+        visible_analyses = AnalysisQueryOptimizer.get_visible_analyses(
+            user, corpus_id=corpus_id
+        )
+
+        # Get rows for this document from visible analyses
+        return document.rows.filter(analysis__in=visible_analyses).select_related(
+            "analysis", "analysis__analyzer"
+        )

--- a/opencontractserver/tests/permissioning/test_badge_visibility.py
+++ b/opencontractserver/tests/permissioning/test_badge_visibility.py
@@ -1,0 +1,460 @@
+"""
+Tests for Badge/UserBadge Visibility System
+
+These tests verify that badge awards respect the recipient's profile privacy.
+Badge visibility follows the same rules as user profile visibility.
+
+Visibility Rules:
+- Badge awards are visible if the recipient's profile is visible
+- Corpus-specific badges: visible to users with access to that corpus
+- Own badges: always visible regardless of profile privacy
+
+Issue: Permission audit remediation
+"""
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AnonymousUser
+from django.test import TestCase
+
+from opencontractserver.badges.models import Badge, UserBadge
+from opencontractserver.badges.query_optimizer import BadgeQueryOptimizer
+from opencontractserver.corpuses.models import Corpus
+from opencontractserver.types.enums import PermissionTypes
+from opencontractserver.utils.permissioning import set_permissions_for_obj_to_user
+
+User = get_user_model()
+
+
+class TestUserBadgeVisibility(TestCase):
+    """Tests that user badge visibility follows profile privacy rules."""
+
+    def setUp(self):
+        """Create test users, badges, and awards."""
+        self.badge_owner = User.objects.create_user(
+            username="badgeholder",
+            email="badge@example.com",
+            password="testpass123",
+            is_profile_public=False,  # Private profile
+        )
+        self.viewer = User.objects.create_user(
+            username="viewer",
+            email="viewer@example.com",
+            password="testpass123",
+        )
+
+        # Create a badge
+        self.achievement_badge = Badge.objects.create(
+            name="First Annotation Badge",
+            description="Awarded for creating your first annotation",
+            icon="Star",
+            creator=self.viewer,  # Badge definition creator
+        )
+
+        # Award the badge
+        self.badge_award = UserBadge.objects.create(
+            user=self.badge_owner,  # Private user receives badge
+            badge=self.achievement_badge,
+        )
+
+    def test_badge_of_private_user_not_visible_to_unrelated_viewer(self):
+        """
+        GIVEN: A badge awarded to a user (badgeholder) with is_profile_public=False
+        AND: A viewer who does NOT share corpus membership with badgeholder
+        WHEN: Viewer queries for visible user badges
+        THEN: The badge award should NOT be visible
+        """
+        visible_badges = BadgeQueryOptimizer.get_visible_user_badges(self.viewer)
+
+        self.assertNotIn(
+            self.badge_award,
+            visible_badges,
+            "Badges of private users should NOT be visible to unrelated viewers",
+        )
+
+    def test_own_badges_always_visible(self):
+        """
+        GIVEN: A user (badgeholder) with badge awards
+        WHEN: badgeholder queries for their own badges
+        THEN: Their badges should be visible regardless of profile privacy
+        """
+        visible_badges = BadgeQueryOptimizer.get_visible_user_badges(self.badge_owner)
+
+        self.assertIn(
+            self.badge_award,
+            visible_badges,
+            "Users should always see their own badges",
+        )
+
+    def test_badge_of_public_user_visible_to_viewer(self):
+        """
+        GIVEN: A badge awarded to a public user
+        WHEN: Another user queries for visible badges
+        THEN: The badge should be visible
+        """
+        public_user = User.objects.create_user(
+            username="publicuser",
+            email="public@example.com",
+            password="testpass123",
+            is_profile_public=True,
+        )
+        public_badge_award = UserBadge.objects.create(
+            user=public_user,
+            badge=self.achievement_badge,
+        )
+
+        visible_badges = BadgeQueryOptimizer.get_visible_user_badges(self.viewer)
+
+        self.assertIn(
+            public_badge_award,
+            visible_badges,
+            "Badges of public users should be visible",
+        )
+
+
+class TestBadgeVisibilityViaCorpusMembership(TestCase):
+    """Tests that corpus membership enables badge visibility."""
+
+    def setUp(self):
+        """Create scenario with corpus collaborators."""
+        self.corpus_owner = User.objects.create_user(
+            username="corpusowner",
+            email="owner@example.com",
+            password="testpass123",
+        )
+        self.private_collaborator = User.objects.create_user(
+            username="collaborator",
+            email="collab@example.com",
+            password="testpass123",
+            is_profile_public=False,  # Private profile
+        )
+        self.outsider = User.objects.create_user(
+            username="outsider",
+            email="outsider@example.com",
+            password="testpass123",
+        )
+
+        # Create corpus and set up permissions
+        self.shared_corpus = Corpus.objects.create(
+            title="Shared Corpus",
+            creator=self.corpus_owner,
+        )
+
+        # Give collaborator UPDATE permission (> READ)
+        set_permissions_for_obj_to_user(
+            self.private_collaborator,
+            self.shared_corpus,
+            [PermissionTypes.READ, PermissionTypes.UPDATE],
+        )
+
+        # Create badge and award to collaborator
+        self.badge = Badge.objects.create(
+            name="Team Player Badge",
+            description="For great collaboration",
+            icon="Users",
+            creator=self.corpus_owner,
+        )
+        self.badge_award = UserBadge.objects.create(
+            user=self.private_collaborator,
+            badge=self.badge,
+        )
+
+    def test_badge_visible_via_corpus_membership(self):
+        """
+        GIVEN: A badge awarded to a private user
+        AND: The private user has > READ permission on a shared corpus
+        WHEN: Corpus owner queries for visible badges
+        THEN: The badge should be visible
+        """
+        visible_badges = BadgeQueryOptimizer.get_visible_user_badges(self.corpus_owner)
+
+        self.assertIn(
+            self.badge_award,
+            visible_badges,
+            "Badges should be visible via corpus membership",
+        )
+
+    def test_badge_not_visible_to_outsider(self):
+        """
+        GIVEN: A badge awarded to a private user
+        AND: An outsider with no shared corpus membership
+        WHEN: Outsider queries for visible badges
+        THEN: The badge should NOT be visible
+        """
+        visible_badges = BadgeQueryOptimizer.get_visible_user_badges(self.outsider)
+
+        self.assertNotIn(
+            self.badge_award,
+            visible_badges,
+            "Badges should NOT be visible to outsiders",
+        )
+
+
+class TestCorpusSpecificBadgeVisibility(TestCase):
+    """Tests for corpus-specific badge visibility."""
+
+    def setUp(self):
+        """Create corpus-specific badge scenario."""
+        self.corpus_owner = User.objects.create_user(
+            username="corpusowner",
+            email="owner@example.com",
+            password="testpass123",
+        )
+        self.badge_recipient = User.objects.create_user(
+            username="recipient",
+            email="recipient@example.com",
+            password="testpass123",
+            is_profile_public=True,  # Public profile
+        )
+        self.outsider = User.objects.create_user(
+            username="outsider",
+            email="outsider@example.com",
+            password="testpass123",
+        )
+
+        # Create private corpus
+        self.private_corpus = Corpus.objects.create(
+            title="Private Legal Corpus",
+            creator=self.corpus_owner,
+            is_public=False,
+        )
+
+        # Give recipient access to corpus
+        set_permissions_for_obj_to_user(
+            self.badge_recipient,
+            self.private_corpus,
+            [PermissionTypes.READ, PermissionTypes.UPDATE],
+        )
+
+        # Create corpus-specific badge
+        self.corpus_badge = Badge.objects.create(
+            name="Top Contributor",
+            description="Top contributor in this corpus",
+            icon="Trophy",
+            badge_type="CORPUS",
+            corpus=self.private_corpus,
+            creator=self.corpus_owner,
+        )
+
+        # Award corpus badge
+        self.corpus_badge_award = UserBadge.objects.create(
+            user=self.badge_recipient,
+            badge=self.corpus_badge,
+            corpus=self.private_corpus,
+        )
+
+    def test_corpus_badge_visible_to_corpus_member(self):
+        """
+        GIVEN: A corpus-specific badge awarded in a private corpus
+        AND: A user who has access to that corpus
+        WHEN: User queries for visible badges
+        THEN: The corpus badge should be visible
+        """
+        visible_badges = BadgeQueryOptimizer.get_visible_user_badges(self.corpus_owner)
+
+        self.assertIn(
+            self.corpus_badge_award,
+            visible_badges,
+            "Corpus-specific badges should be visible to corpus members",
+        )
+
+    def test_corpus_badge_not_visible_to_outsider(self):
+        """
+        GIVEN: A corpus-specific badge awarded in a private corpus
+        AND: A user who does NOT have access to that corpus
+        WHEN: User queries for visible badges
+        THEN: The corpus badge should NOT be visible
+        """
+        visible_badges = BadgeQueryOptimizer.get_visible_user_badges(self.outsider)
+
+        self.assertNotIn(
+            self.corpus_badge_award,
+            visible_badges,
+            "Corpus-specific badges should NOT be visible to non-members",
+        )
+
+
+class TestBadgeVisibilityIDORProtection(TestCase):
+    """Tests for IDOR protection in badge visibility."""
+
+    def setUp(self):
+        """Create scenario for IDOR testing."""
+        self.user_a = User.objects.create_user(
+            username="user_a",
+            email="a@example.com",
+            password="testpass123",
+            is_profile_public=False,
+        )
+        self.user_b = User.objects.create_user(
+            username="user_b",
+            email="b@example.com",
+            password="testpass123",
+        )
+
+        self.badge = Badge.objects.create(
+            name="Secret Badge",
+            description="A private badge",
+            icon="Lock",
+            creator=self.user_a,
+        )
+
+        # Award badge to private user
+        self.private_badge_award = UserBadge.objects.create(
+            user=self.user_a,
+            badge=self.badge,
+        )
+
+    def test_check_visibility_returns_false_for_inaccessible_badge(self):
+        """
+        GIVEN: A badge awarded to a private user
+        AND: A viewer with no access to that user
+        WHEN: Checking badge visibility directly
+        THEN: Returns (False, None) - cannot enumerate badge IDs
+        """
+        has_permission, badge = BadgeQueryOptimizer.check_user_badge_visibility(
+            self.user_b, self.private_badge_award.id
+        )
+
+        self.assertFalse(has_permission, "Should return False for inaccessible badge")
+        self.assertIsNone(badge, "Should return None badge object")
+
+    def test_check_visibility_returns_true_for_own_badge(self):
+        """
+        GIVEN: A user's own badge
+        WHEN: Checking badge visibility
+        THEN: Returns (True, badge_object)
+        """
+        has_permission, badge = BadgeQueryOptimizer.check_user_badge_visibility(
+            self.user_a, self.private_badge_award.id
+        )
+
+        self.assertTrue(has_permission, "Should return True for own badge")
+        self.assertEqual(
+            badge, self.private_badge_award, "Should return the badge object"
+        )
+
+    def test_check_visibility_returns_false_for_nonexistent_badge(self):
+        """
+        GIVEN: A non-existent badge ID
+        WHEN: Checking badge visibility
+        THEN: Returns (False, None) - same as access denied (IDOR protection)
+        """
+        has_permission, badge = BadgeQueryOptimizer.check_user_badge_visibility(
+            self.user_a, 999999  # Non-existent ID
+        )
+
+        self.assertFalse(
+            has_permission,
+            "Should return False for non-existent badge (same as access denied)",
+        )
+        self.assertIsNone(badge, "Should return None for non-existent badge")
+
+
+class TestBadgeVisibilityAnonymousUser(TestCase):
+    """Tests for anonymous user badge visibility."""
+
+    def setUp(self):
+        """Create test users and badges."""
+        self.public_user = User.objects.create_user(
+            username="public",
+            email="public@example.com",
+            password="testpass123",
+            is_profile_public=True,
+        )
+        self.private_user = User.objects.create_user(
+            username="private",
+            email="private@example.com",
+            password="testpass123",
+            is_profile_public=False,
+        )
+
+        self.badge = Badge.objects.create(
+            name="Achievement Badge",
+            description="For achievements",
+            icon="Award",
+            creator=self.public_user,
+        )
+
+        self.public_badge_award = UserBadge.objects.create(
+            user=self.public_user,
+            badge=self.badge,
+        )
+        self.private_badge_award = UserBadge.objects.create(
+            user=self.private_user,
+            badge=self.badge,
+        )
+
+    def test_anonymous_user_sees_public_user_badges(self):
+        """
+        GIVEN: A badge awarded to a public user
+        WHEN: An anonymous user queries for badges
+        THEN: The badge should be visible
+        """
+        anonymous = AnonymousUser()
+        visible_badges = BadgeQueryOptimizer.get_visible_user_badges(anonymous)
+
+        self.assertIn(
+            self.public_badge_award,
+            visible_badges,
+            "Anonymous users should see badges of public users",
+        )
+
+    def test_anonymous_user_cannot_see_private_user_badges(self):
+        """
+        GIVEN: A badge awarded to a private user
+        WHEN: An anonymous user queries for badges
+        THEN: The badge should NOT be visible
+        """
+        anonymous = AnonymousUser()
+        visible_badges = BadgeQueryOptimizer.get_visible_user_badges(anonymous)
+
+        self.assertNotIn(
+            self.private_badge_award,
+            visible_badges,
+            "Anonymous users should NOT see badges of private users",
+        )
+
+
+class TestSuperuserBadgeVisibility(TestCase):
+    """Tests for superuser badge visibility."""
+
+    def setUp(self):
+        """Create test scenario."""
+        import uuid
+
+        self.superuser = User.objects.create_superuser(
+            username=f"admin_{uuid.uuid4().hex[:8]}",
+            email=f"admin_{uuid.uuid4().hex[:8]}@example.com",
+            password="adminpass123",
+        )
+        self.private_user = User.objects.create_user(
+            username="private",
+            email="private@example.com",
+            password="testpass123",
+            is_profile_public=False,
+        )
+
+        self.badge = Badge.objects.create(
+            name="Hidden Badge",
+            description="A private badge",
+            icon="EyeOff",
+            creator=self.superuser,
+        )
+
+        self.badge_award = UserBadge.objects.create(
+            user=self.private_user,
+            badge=self.badge,
+        )
+
+    def test_superuser_sees_all_badges(self):
+        """
+        GIVEN: A badge awarded to a private user
+        WHEN: A superuser queries for badges
+        THEN: All badges should be visible
+        """
+        visible_badges = BadgeQueryOptimizer.get_visible_user_badges(self.superuser)
+
+        self.assertIn(
+            self.badge_award,
+            visible_badges,
+            "Superusers should see all badges",
+        )

--- a/opencontractserver/tests/permissioning/test_document_actions_permissions.py
+++ b/opencontractserver/tests/permissioning/test_document_actions_permissions.py
@@ -805,8 +805,11 @@ class TestGetAnalysisRowsForDocument(TestCase):
         )
 
         # Create analyzer and analysis
+        # Note: Analyzer has a constraint requiring either host_gremlin or task_name
         self.analyzer = Analyzer.objects.create(
+            id="test.analyzer.for.document.actions",
             description="Test Analyzer",
+            task_name="test.task.name",
             creator=self.owner,
         )
         self.analysis = Analysis.objects.create(

--- a/opencontractserver/tests/permissioning/test_document_actions_permissions.py
+++ b/opencontractserver/tests/permissioning/test_document_actions_permissions.py
@@ -819,10 +819,10 @@ class TestGetAnalysisRowsForDocument(TestCase):
         )
 
         # Create analysis row
+        # Note: `data` field is a ManyToManyField to Datacell, not a JSON field
         self.analysis_row = DocumentAnalysisRow.objects.create(
             document=self.document,
             analysis=self.analysis,
-            data={"test": "data"},
             creator=self.owner,
         )
 

--- a/opencontractserver/tests/permissioning/test_document_actions_permissions.py
+++ b/opencontractserver/tests/permissioning/test_document_actions_permissions.py
@@ -1,0 +1,470 @@
+"""
+Tests for Document Actions Permission System
+
+These tests verify that document_corpus_actions follows the least-privilege model.
+This ensures proper permission inheritance from documents and corpuses.
+
+Permission Model:
+- Document permissions are primary
+- Corpus permissions are secondary
+- Effective permission = MIN(document_permission, corpus_permission)
+
+Issue: Permission audit remediation
+"""
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AnonymousUser
+from django.test import TestCase
+
+from opencontractserver.corpuses.models import Corpus, CorpusAction
+from opencontractserver.documents.models import Document
+from opencontractserver.documents.query_optimizer import DocumentActionsQueryOptimizer
+from opencontractserver.extracts.models import Fieldset
+from opencontractserver.types.enums import PermissionTypes
+from opencontractserver.utils.permissioning import set_permissions_for_obj_to_user
+
+User = get_user_model()
+
+
+class TestDocumentActionsPermissions(TestCase):
+    """Tests for document actions with proper permission inheritance."""
+
+    def setUp(self):
+        """Create test scenario with document, corpus, and corpus actions."""
+        self.owner = User.objects.create_user(
+            username="owner",
+            email="owner@example.com",
+            password="testpass123",
+        )
+        self.reader = User.objects.create_user(
+            username="reader",
+            email="reader@example.com",
+            password="testpass123",
+        )
+        self.outsider = User.objects.create_user(
+            username="outsider",
+            email="outsider@example.com",
+            password="testpass123",
+        )
+
+        # Create corpus and document
+        self.corpus = Corpus.objects.create(
+            title="Test Corpus",
+            creator=self.owner,
+            is_public=False,
+        )
+        self.document = Document.objects.create(
+            title="Test Document",
+            creator=self.owner,
+            is_public=False,
+        )
+
+        # Give reader READ permission on both corpus and document
+        set_permissions_for_obj_to_user(
+            self.reader,
+            self.corpus,
+            [PermissionTypes.READ],
+        )
+        set_permissions_for_obj_to_user(
+            self.reader,
+            self.document,
+            [PermissionTypes.READ],
+        )
+
+        # Create a fieldset for corpus action
+        self.fieldset = Fieldset.objects.create(
+            name="Test Fieldset",
+            description="Test Fieldset Description",
+            creator=self.owner,
+        )
+
+        # Create a corpus action
+        self.corpus_action = CorpusAction.objects.create(
+            name="Test Action",
+            corpus=self.corpus,
+            fieldset=self.fieldset,
+            trigger="add_document",
+            creator=self.owner,
+        )
+
+    def test_owner_can_see_document_actions(self):
+        """
+        GIVEN: A document and corpus owner with full permissions
+        WHEN: Owner queries for document actions
+        THEN: Corpus actions should be visible
+        """
+        actions = DocumentActionsQueryOptimizer.get_document_actions(
+            user=self.owner,
+            document_id=self.document.id,
+            corpus_id=self.corpus.id,
+        )
+
+        self.assertIn(
+            self.corpus_action,
+            actions["corpus_actions"],
+            "Owner should see corpus actions",
+        )
+
+    def test_reader_with_permission_can_see_corpus_actions(self):
+        """
+        GIVEN: A user (reader) with explicit READ permission on document AND corpus
+        WHEN: Reader queries for document actions
+        THEN: Reader should see corpus actions they have permission to access
+        """
+        # Give reader read permission on corpus action
+        set_permissions_for_obj_to_user(
+            self.reader,
+            self.corpus_action,
+            [PermissionTypes.READ],
+        )
+
+        actions = DocumentActionsQueryOptimizer.get_document_actions(
+            user=self.reader,
+            document_id=self.document.id,
+            corpus_id=self.corpus.id,
+        )
+
+        self.assertIn(
+            self.corpus_action,
+            actions["corpus_actions"],
+            "Reader with explicit permission should see corpus actions",
+        )
+
+    def test_outsider_cannot_see_any_document_actions(self):
+        """
+        GIVEN: A user (outsider) with NO permissions on document or corpus
+        WHEN: Outsider queries for document actions
+        THEN: All actions should be empty (permission denied)
+        """
+        actions = DocumentActionsQueryOptimizer.get_document_actions(
+            user=self.outsider,
+            document_id=self.document.id,
+            corpus_id=self.corpus.id,
+        )
+
+        self.assertEqual(
+            actions["corpus_actions"],
+            [],
+            "Outsider should NOT see any corpus actions",
+        )
+        self.assertEqual(
+            actions["extracts"],
+            [],
+            "Outsider should NOT see any extracts",
+        )
+        self.assertEqual(
+            actions["analysis_rows"],
+            [],
+            "Outsider should NOT see any analysis rows",
+        )
+
+
+class TestDocumentActionsWithoutCorpus(TestCase):
+    """Tests for document actions without corpus context."""
+
+    def setUp(self):
+        """Create scenario for document-only queries."""
+        self.owner = User.objects.create_user(
+            username="owner",
+            email="owner@example.com",
+            password="testpass123",
+        )
+        self.viewer = User.objects.create_user(
+            username="viewer",
+            email="viewer@example.com",
+            password="testpass123",
+        )
+
+        # Create document without corpus association
+        self.document = Document.objects.create(
+            title="Standalone Document",
+            creator=self.owner,
+            is_public=False,
+        )
+
+    def test_document_actions_without_corpus_returns_empty_corpus_actions(self):
+        """
+        GIVEN: A document query without corpus_id
+        WHEN: Querying for document actions
+        THEN: corpus_actions should be empty (no corpus context)
+        """
+        actions = DocumentActionsQueryOptimizer.get_document_actions(
+            user=self.owner,
+            document_id=self.document.id,
+            corpus_id=None,
+        )
+
+        self.assertEqual(
+            actions["corpus_actions"],
+            [],
+            "Corpus actions should be empty when no corpus context",
+        )
+
+    def test_document_without_permission_returns_empty(self):
+        """
+        GIVEN: A user without permission to the document
+        WHEN: Querying for document actions
+        THEN: All fields should be empty
+        """
+        actions = DocumentActionsQueryOptimizer.get_document_actions(
+            user=self.viewer,
+            document_id=self.document.id,
+            corpus_id=None,
+        )
+
+        self.assertEqual(
+            actions["corpus_actions"],
+            [],
+            "Should return empty corpus_actions",
+        )
+        self.assertEqual(
+            actions["extracts"],
+            [],
+            "Should return empty extracts",
+        )
+        self.assertEqual(
+            actions["analysis_rows"],
+            [],
+            "Should return empty analysis_rows",
+        )
+
+
+class TestDocumentActionsIDORProtection(TestCase):
+    """Tests for IDOR protection in document actions."""
+
+    def setUp(self):
+        """Create scenario for IDOR testing."""
+        self.user_a = User.objects.create_user(
+            username="user_a",
+            email="a@example.com",
+            password="testpass123",
+        )
+        self.user_b = User.objects.create_user(
+            username="user_b",
+            email="b@example.com",
+            password="testpass123",
+        )
+
+        # User A's private document
+        self.private_document = Document.objects.create(
+            title="Private Document",
+            creator=self.user_a,
+            is_public=False,
+        )
+
+    def test_cannot_enumerate_private_documents(self):
+        """
+        GIVEN: User B who does NOT have permission to User A's document
+        WHEN: User B queries for document actions on User A's document
+        THEN: Empty results should be returned (same as if document didn't exist)
+        """
+        actions = DocumentActionsQueryOptimizer.get_document_actions(
+            user=self.user_b,
+            document_id=self.private_document.id,
+            corpus_id=None,
+        )
+
+        # Should return empty dict, not error with "permission denied"
+        self.assertEqual(actions["extracts"], [])
+        self.assertEqual(actions["corpus_actions"], [])
+        self.assertEqual(actions["analysis_rows"], [])
+
+    def test_nonexistent_document_returns_empty(self):
+        """
+        GIVEN: A non-existent document ID
+        WHEN: Querying for document actions
+        THEN: Empty results should be returned
+        """
+        actions = DocumentActionsQueryOptimizer.get_document_actions(
+            user=self.user_a,
+            document_id=999999,  # Non-existent
+            corpus_id=None,
+        )
+
+        self.assertEqual(actions["extracts"], [])
+        self.assertEqual(actions["corpus_actions"], [])
+        self.assertEqual(actions["analysis_rows"], [])
+
+
+class TestDocumentActionsAnonymousUser(TestCase):
+    """Tests for anonymous user access to document actions."""
+
+    def setUp(self):
+        """Create public and private documents."""
+        self.owner = User.objects.create_user(
+            username="owner",
+            email="owner@example.com",
+            password="testpass123",
+        )
+
+        self.public_document = Document.objects.create(
+            title="Public Document",
+            creator=self.owner,
+            is_public=True,
+        )
+        self.private_document = Document.objects.create(
+            title="Private Document",
+            creator=self.owner,
+            is_public=False,
+        )
+
+        self.public_corpus = Corpus.objects.create(
+            title="Public Corpus",
+            creator=self.owner,
+            is_public=True,
+        )
+
+    def test_anonymous_can_access_public_document_actions(self):
+        """
+        GIVEN: A public document
+        WHEN: An anonymous user queries for document actions
+        THEN: Should not get permission denied (document is accessible)
+        """
+        anonymous = AnonymousUser()
+        actions = DocumentActionsQueryOptimizer.get_document_actions(
+            user=anonymous,
+            document_id=self.public_document.id,
+            corpus_id=self.public_corpus.id,
+        )
+
+        # Should not fail - just may have empty results if no actions exist
+        self.assertIsInstance(actions, dict)
+        self.assertIn("corpus_actions", actions)
+        self.assertIn("extracts", actions)
+        self.assertIn("analysis_rows", actions)
+
+    def test_anonymous_cannot_access_private_document_actions(self):
+        """
+        GIVEN: A private document
+        WHEN: An anonymous user queries for document actions
+        THEN: Empty results should be returned
+        """
+        anonymous = AnonymousUser()
+        actions = DocumentActionsQueryOptimizer.get_document_actions(
+            user=anonymous,
+            document_id=self.private_document.id,
+            corpus_id=None,
+        )
+
+        self.assertEqual(actions["corpus_actions"], [])
+        self.assertEqual(actions["extracts"], [])
+        self.assertEqual(actions["analysis_rows"], [])
+
+
+class TestDocumentActionsCorpusPermission(TestCase):
+    """Tests for corpus permission requirements."""
+
+    def setUp(self):
+        """Create scenario with corpus permission requirements."""
+        self.owner = User.objects.create_user(
+            username="owner",
+            email="owner@example.com",
+            password="testpass123",
+        )
+        self.doc_only_user = User.objects.create_user(
+            username="doconly",
+            email="doconly@example.com",
+            password="testpass123",
+        )
+
+        # Create corpus and document
+        self.corpus = Corpus.objects.create(
+            title="Test Corpus",
+            creator=self.owner,
+            is_public=False,
+        )
+        self.document = Document.objects.create(
+            title="Test Document",
+            creator=self.owner,
+            is_public=False,
+        )
+
+        # Give doc_only_user permission ONLY on document, not corpus
+        set_permissions_for_obj_to_user(
+            self.doc_only_user,
+            self.document,
+            [PermissionTypes.READ],
+        )
+        # Explicitly NOT giving corpus permission
+
+    def test_user_with_only_document_permission_cannot_see_corpus_actions(self):
+        """
+        GIVEN: A user with READ permission on document but NOT corpus
+        WHEN: User queries for document actions with corpus_id
+        THEN: Should return empty results (corpus permission required)
+        """
+        actions = DocumentActionsQueryOptimizer.get_document_actions(
+            user=self.doc_only_user,
+            document_id=self.document.id,
+            corpus_id=self.corpus.id,
+        )
+
+        # Should return empty because corpus permission is required
+        self.assertEqual(
+            actions["corpus_actions"],
+            [],
+            "User without corpus permission should NOT see corpus actions",
+        )
+
+
+class TestDocumentActionsSuperuser(TestCase):
+    """Tests for superuser access to document actions."""
+
+    def setUp(self):
+        """Create scenario for superuser testing."""
+        import uuid
+
+        self.superuser = User.objects.create_superuser(
+            username=f"admin_{uuid.uuid4().hex[:8]}",
+            email=f"admin_{uuid.uuid4().hex[:8]}@example.com",
+            password="adminpass123",
+        )
+        self.owner = User.objects.create_user(
+            username="owner",
+            email="owner@example.com",
+            password="testpass123",
+        )
+
+        # Create private corpus and document
+        self.corpus = Corpus.objects.create(
+            title="Private Corpus",
+            creator=self.owner,
+            is_public=False,
+        )
+        self.document = Document.objects.create(
+            title="Private Document",
+            creator=self.owner,
+            is_public=False,
+        )
+
+        # Create fieldset and corpus action
+        self.fieldset = Fieldset.objects.create(
+            name="Test Fieldset",
+            description="Test",
+            creator=self.owner,
+        )
+        self.corpus_action = CorpusAction.objects.create(
+            name="Test Action",
+            corpus=self.corpus,
+            fieldset=self.fieldset,
+            trigger="add_document",
+            creator=self.owner,
+        )
+
+    def test_superuser_can_see_all_document_actions(self):
+        """
+        GIVEN: A superuser
+        WHEN: Querying for document actions on private document/corpus
+        THEN: All actions should be visible
+        """
+        actions = DocumentActionsQueryOptimizer.get_document_actions(
+            user=self.superuser,
+            document_id=self.document.id,
+            corpus_id=self.corpus.id,
+        )
+
+        self.assertIn(
+            self.corpus_action,
+            actions["corpus_actions"],
+            "Superuser should see all corpus actions",
+        )

--- a/opencontractserver/tests/permissioning/test_user_visibility.py
+++ b/opencontractserver/tests/permissioning/test_user_visibility.py
@@ -1,0 +1,415 @@
+"""
+Tests for User Profile Visibility System
+
+These tests verify that user profiles respect privacy settings and corpus membership rules.
+The UserQueryOptimizer provides centralized logic for determining user visibility.
+
+Visibility Rules:
+- Own profile: always visible
+- Public profiles (is_profile_public=True): visible to all
+- Private profiles: visible to users who share corpus membership with > READ permission
+- Inactive users: never visible (except to superusers)
+
+Issue: Permission audit remediation
+"""
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AnonymousUser
+from django.test import TestCase
+
+from opencontractserver.corpuses.models import Corpus
+from opencontractserver.types.enums import PermissionTypes
+from opencontractserver.users.query_optimizer import UserQueryOptimizer
+from opencontractserver.utils.permissioning import set_permissions_for_obj_to_user
+
+User = get_user_model()
+
+
+class TestUserProfilePrivacy(TestCase):
+    """Tests that verify user profile privacy settings are respected."""
+
+    def setUp(self):
+        """Create test users with different privacy settings."""
+        self.public_user = User.objects.create_user(
+            username="public_alice",
+            email="alice@example.com",
+            password="testpass123",
+            is_profile_public=True,
+        )
+        self.private_user = User.objects.create_user(
+            username="private_bob",
+            email="bob@example.com",
+            password="testpass123",
+            is_profile_public=False,
+        )
+        self.viewer = User.objects.create_user(
+            username="viewer_carol",
+            email="carol@example.com",
+            password="testpass123",
+        )
+
+    def test_public_profile_visible_to_any_authenticated_user(self):
+        """
+        GIVEN: A user (Alice) with is_profile_public=True
+        WHEN: Another user (Carol) queries for visible users
+        THEN: Alice's profile should be in the results
+        """
+        visible_users = UserQueryOptimizer.get_visible_users(self.viewer)
+
+        self.assertIn(
+            self.public_user,
+            visible_users,
+            "Public profiles should be visible to any authenticated user",
+        )
+
+    def test_private_profile_not_visible_to_unrelated_user(self):
+        """
+        GIVEN: A user (Bob) with is_profile_public=False
+        AND: A viewer (Carol) who does NOT share any corpus membership with Bob
+        WHEN: Carol queries for visible users
+        THEN: Bob's profile should NOT be in the results
+        """
+        visible_users = UserQueryOptimizer.get_visible_users(self.viewer)
+
+        self.assertNotIn(
+            self.private_user,
+            visible_users,
+            "Private profiles should NOT be visible to unrelated users",
+        )
+
+    def test_own_profile_always_visible_regardless_of_privacy_setting(self):
+        """
+        GIVEN: A user (Bob) with is_profile_public=False
+        WHEN: Bob queries for visible users
+        THEN: Bob should see his own profile in the results
+        """
+        visible_users = UserQueryOptimizer.get_visible_users(self.private_user)
+
+        self.assertIn(
+            self.private_user,
+            visible_users,
+            "Users should always see their own profile regardless of privacy setting",
+        )
+
+    def test_check_user_visibility_returns_correct_boolean(self):
+        """
+        GIVEN: Different visibility scenarios
+        WHEN: Using check_user_visibility method
+        THEN: Returns correct boolean values
+        """
+        # Public user is visible to viewer
+        self.assertTrue(
+            UserQueryOptimizer.check_user_visibility(self.viewer, self.public_user.id),
+            "Public user should be visible",
+        )
+
+        # Private user is not visible to unrelated viewer
+        self.assertFalse(
+            UserQueryOptimizer.check_user_visibility(self.viewer, self.private_user.id),
+            "Private user should not be visible to unrelated user",
+        )
+
+        # User can see themselves
+        self.assertTrue(
+            UserQueryOptimizer.check_user_visibility(
+                self.private_user, self.private_user.id
+            ),
+            "User should always be able to see themselves",
+        )
+
+
+class TestUserVisibilityViaCorpusMembership(TestCase):
+    """Tests that verify corpus membership enables user visibility."""
+
+    def setUp(self):
+        """Create test users and a shared corpus."""
+        self.corpus_owner = User.objects.create_user(
+            username="owner",
+            email="owner@example.com",
+            password="testpass123",
+        )
+        self.private_collaborator = User.objects.create_user(
+            username="collaborator",
+            email="collab@example.com",
+            password="testpass123",
+            is_profile_public=False,  # Private profile
+        )
+        self.outsider = User.objects.create_user(
+            username="outsider",
+            email="outsider@example.com",
+            password="testpass123",
+        )
+
+        # Create a corpus
+        self.shared_corpus = Corpus.objects.create(
+            title="Shared Legal Corpus",
+            creator=self.corpus_owner,
+        )
+
+        # Give collaborator UPDATE permission (> READ) on the corpus
+        set_permissions_for_obj_to_user(
+            self.private_collaborator,
+            self.shared_corpus,
+            [PermissionTypes.READ, PermissionTypes.UPDATE],
+        )
+
+    def test_private_user_visible_to_corpus_member_with_write_permission(self):
+        """
+        GIVEN: A user (collaborator) with is_profile_public=False
+        AND: Another user (owner) who shares a corpus with collaborator
+        AND: Collaborator has > READ permission on that corpus
+        WHEN: Owner queries for visible users
+        THEN: Collaborator's profile should be visible
+        """
+        visible_users = UserQueryOptimizer.get_visible_users(self.corpus_owner)
+
+        self.assertIn(
+            self.private_collaborator,
+            visible_users,
+            "Private profiles should be visible to users who share corpus with > READ",
+        )
+
+    def test_private_user_not_visible_to_outsider(self):
+        """
+        GIVEN: A user (collaborator) with is_profile_public=False
+        AND: A user (outsider) who does NOT have access to any shared corpus
+        WHEN: Outsider queries for visible users
+        THEN: Collaborator's profile should NOT be visible
+        """
+        visible_users = UserQueryOptimizer.get_visible_users(self.outsider)
+
+        self.assertNotIn(
+            self.private_collaborator,
+            visible_users,
+            "Private profiles should NOT be visible to users outside shared corpuses",
+        )
+
+    def test_read_only_corpus_member_cannot_see_private_profiles(self):
+        """
+        GIVEN: A corpus with two members
+        AND: One member (viewer) has only READ permission
+        AND: Another member (collaborator) has is_profile_public=False
+        WHEN: Viewer queries for visible users
+        THEN: Collaborator's profile should NOT be visible (READ is not enough)
+        """
+        read_only_user = User.objects.create_user(
+            username="readonly",
+            email="readonly@example.com",
+            password="testpass123",
+        )
+        # Give only READ permission (not > READ)
+        set_permissions_for_obj_to_user(
+            read_only_user,
+            self.shared_corpus,
+            [PermissionTypes.READ],
+        )
+
+        visible_users = UserQueryOptimizer.get_visible_users(read_only_user)
+
+        self.assertNotIn(
+            self.private_collaborator,
+            visible_users,
+            "READ-only permission should NOT enable seeing private profiles",
+        )
+
+    def test_corpus_owner_can_see_collaborators(self):
+        """
+        GIVEN: A corpus owner
+        AND: A private collaborator with > READ permission on the corpus
+        WHEN: Owner queries for visible users
+        THEN: The collaborator should be visible (owner has implicit full access)
+        """
+        visible_users = UserQueryOptimizer.get_visible_users(self.corpus_owner)
+
+        self.assertIn(
+            self.private_collaborator,
+            visible_users,
+            "Corpus owner should see collaborators with > READ permission",
+        )
+
+
+class TestUserVisibilityAnonymousUser(TestCase):
+    """Tests for anonymous user visibility rules."""
+
+    def setUp(self):
+        """Create test users."""
+        self.public_user = User.objects.create_user(
+            username="public",
+            email="public@example.com",
+            password="testpass123",
+            is_profile_public=True,
+        )
+        self.private_user = User.objects.create_user(
+            username="private",
+            email="private@example.com",
+            password="testpass123",
+            is_profile_public=False,
+        )
+
+    def test_anonymous_user_can_see_public_profiles(self):
+        """
+        GIVEN: A public user profile
+        WHEN: An anonymous user queries for visible users
+        THEN: Public profiles should be visible
+        """
+        anonymous = AnonymousUser()
+        visible_users = UserQueryOptimizer.get_visible_users(anonymous)
+
+        self.assertIn(
+            self.public_user,
+            visible_users,
+            "Anonymous users should see public profiles",
+        )
+
+    def test_anonymous_user_cannot_see_private_profiles(self):
+        """
+        GIVEN: A private user profile
+        WHEN: An anonymous user queries for visible users
+        THEN: Private profiles should NOT be visible
+        """
+        anonymous = AnonymousUser()
+        visible_users = UserQueryOptimizer.get_visible_users(anonymous)
+
+        self.assertNotIn(
+            self.private_user,
+            visible_users,
+            "Anonymous users should NOT see private profiles",
+        )
+
+    def test_none_user_treated_as_anonymous(self):
+        """
+        GIVEN: None passed as user
+        WHEN: Querying for visible users
+        THEN: Should behave same as anonymous user
+        """
+        visible_users = UserQueryOptimizer.get_visible_users(None)
+
+        self.assertIn(
+            self.public_user,
+            visible_users,
+            "None user should see public profiles like anonymous",
+        )
+        self.assertNotIn(
+            self.private_user,
+            visible_users,
+            "None user should NOT see private profiles",
+        )
+
+
+class TestInactiveUserVisibility(TestCase):
+    """Tests that inactive users are properly hidden."""
+
+    def setUp(self):
+        """Create active and inactive users."""
+        self.active_user = User.objects.create_user(
+            username="active",
+            email="active@example.com",
+            password="testpass123",
+            is_active=True,
+        )
+        self.inactive_user = User.objects.create_user(
+            username="inactive",
+            email="inactive@example.com",
+            password="testpass123",
+            is_active=False,  # Deactivated account
+            is_profile_public=True,  # Even public profiles should be hidden
+        )
+        self.viewer = User.objects.create_user(
+            username="viewer",
+            email="viewer@example.com",
+            password="testpass123",
+        )
+
+    def test_inactive_user_not_visible_even_with_public_profile(self):
+        """
+        GIVEN: A user account that has been deactivated (is_active=False)
+        AND: That user had is_profile_public=True
+        WHEN: Another user queries for visible users
+        THEN: The inactive user should NOT be visible
+        """
+        visible_users = UserQueryOptimizer.get_visible_users(self.viewer)
+
+        self.assertNotIn(
+            self.inactive_user,
+            visible_users,
+            "Inactive users should NOT be visible even with public profile",
+        )
+
+    def test_superuser_can_see_all_active_users(self):
+        """
+        GIVEN: A superuser
+        WHEN: Superuser queries for visible users
+        THEN: All active users should be visible
+        """
+        import uuid
+
+        superuser = User.objects.create_superuser(
+            username=f"admin_{uuid.uuid4().hex[:8]}",
+            email=f"admin_{uuid.uuid4().hex[:8]}@example.com",
+            password="adminpass123",
+        )
+        visible_users = UserQueryOptimizer.get_visible_users(superuser)
+
+        # Active users should definitely be visible
+        self.assertIn(self.active_user, visible_users)
+        self.assertIn(self.viewer, visible_users)
+
+
+class TestUserSearchForMention(TestCase):
+    """Tests for the get_users_for_mention convenience method."""
+
+    def setUp(self):
+        """Create test users."""
+        self.searcher = User.objects.create_user(
+            username="searcher",
+            email="searcher@example.com",
+            password="testpass123",
+        )
+        self.alice = User.objects.create_user(
+            username="alice_public",
+            email="alice@example.com",
+            password="testpass123",
+            is_profile_public=True,
+        )
+        self.bob = User.objects.create_user(
+            username="bob_private",
+            email="bob@example.com",
+            password="testpass123",
+            is_profile_public=False,
+        )
+
+    def test_search_filters_by_username(self):
+        """
+        GIVEN: Users with different usernames
+        WHEN: Searching by username substring
+        THEN: Only matching public users are returned
+        """
+        results = UserQueryOptimizer.get_users_for_mention(self.searcher, "alice")
+
+        self.assertIn(self.alice, results, "Alice should be found by username search")
+        self.assertNotIn(self.bob, results, "Bob is private and should not be found")
+
+    def test_search_filters_by_email(self):
+        """
+        GIVEN: Users with different emails
+        WHEN: Searching by email substring
+        THEN: Only matching visible users are returned
+        """
+        results = UserQueryOptimizer.get_users_for_mention(
+            self.searcher, "alice@example"
+        )
+
+        self.assertIn(self.alice, results, "Alice should be found by email search")
+
+    def test_anonymous_user_cannot_search(self):
+        """
+        GIVEN: An anonymous user
+        WHEN: Attempting to search for mentions
+        THEN: Empty queryset is returned
+        """
+        anonymous = AnonymousUser()
+        results = UserQueryOptimizer.get_users_for_mention(anonymous, "alice")
+
+        self.assertEqual(
+            results.count(), 0, "Anonymous users cannot search for mentions"
+        )

--- a/opencontractserver/users/query_optimizer.py
+++ b/opencontractserver/users/query_optimizer.py
@@ -1,0 +1,231 @@
+"""
+User Query Optimizer for OpenContracts.
+
+Provides optimized user queries with profile privacy filtering and corpus membership visibility.
+"""
+
+from typing import TYPE_CHECKING, Optional
+
+from django.db.models import Q, QuerySet
+
+if TYPE_CHECKING:
+    pass
+
+
+class UserQueryOptimizer:
+    """
+    Optimized user queries with profile privacy filtering.
+
+    Visibility model:
+    - Own profile: always visible
+    - Public profiles (is_profile_public=True): visible to all
+    - Private profiles: visible to users who share corpus membership with > READ permission
+    - Inactive users: never visible (except to superusers)
+
+    Permission model for corpus membership visibility:
+    - Users with any of these permission codenames on the same corpus can see each other:
+      - create_corpus (CREATE permission)
+      - update_corpus (UPDATE permission)
+      - remove_corpus (DELETE permission)
+    - READ-only permission does NOT enable seeing private profiles
+    """
+
+    # Permission codenames that indicate > READ access
+    WRITE_PERMISSION_CODENAMES = ["create_corpus", "update_corpus", "remove_corpus"]
+
+    @classmethod
+    def get_visible_users(
+        cls,
+        requesting_user,
+        corpus_id: Optional[int] = None,
+        include_self: bool = True,
+    ) -> QuerySet:
+        """
+        Get users visible to requesting_user.
+
+        Args:
+            requesting_user: The user making the request
+            corpus_id: Optional corpus to scope visibility (users with shared access)
+            include_self: Whether to include the requesting user (default True)
+
+        Returns:
+            QuerySet of User objects visible to the requesting user
+        """
+        from django.contrib.auth import get_user_model
+        from django.contrib.auth.models import AnonymousUser
+
+        from opencontractserver.corpuses.models import (
+            Corpus,
+            CorpusUserObjectPermission,
+        )
+
+        User = get_user_model()
+
+        # Superusers see all active users
+        if hasattr(requesting_user, "is_superuser") and requesting_user.is_superuser:
+            return User.objects.filter(is_active=True)
+
+        # Anonymous users see only public profiles
+        if requesting_user is None or isinstance(requesting_user, AnonymousUser):
+            return User.objects.filter(is_active=True, is_profile_public=True)
+
+        # Build visibility query for authenticated users
+        # Start with base query for active users
+        base_q = Q(is_active=True)
+
+        # 1. Own profile (always visible if include_self is True)
+        own_profile_q = Q(id=requesting_user.id) if include_self else Q()
+
+        # 2. Public profiles
+        public_profiles_q = Q(is_profile_public=True)
+
+        # 3. Users who share corpus membership with > READ permission
+        # Get corpuses where requesting user has > READ permission
+        user_writable_corpus_ids = (
+            CorpusUserObjectPermission.objects.filter(
+                user=requesting_user,
+                permission__codename__in=cls.WRITE_PERMISSION_CODENAMES,
+            )
+            .values_list("content_object_id", flat=True)
+            .distinct()
+        )
+
+        # Also include corpuses where requesting user is the creator
+        # (creators have implicit full permissions)
+        user_owned_corpus_ids = Corpus.objects.filter(
+            creator=requesting_user
+        ).values_list("id", flat=True)
+
+        # Combine both sources of writable corpuses
+        all_writable_corpus_ids = list(user_writable_corpus_ids) + list(
+            user_owned_corpus_ids
+        )
+
+        if all_writable_corpus_ids:
+            # Find users who also have > READ on these corpuses
+            users_with_write_access = (
+                CorpusUserObjectPermission.objects.filter(
+                    content_object_id__in=all_writable_corpus_ids,
+                    permission__codename__in=cls.WRITE_PERMISSION_CODENAMES,
+                )
+                .values_list("user_id", flat=True)
+                .distinct()
+            )
+
+            # Also include corpus creators
+            corpus_creator_ids = Corpus.objects.filter(
+                id__in=all_writable_corpus_ids
+            ).values_list("creator_id", flat=True)
+
+            # Build the shared membership query
+            shared_membership_q = Q(id__in=users_with_write_access) | Q(
+                id__in=corpus_creator_ids
+            )
+        else:
+            shared_membership_q = Q()
+
+        # Combine all visibility conditions
+        visibility_q = own_profile_q | public_profiles_q | shared_membership_q
+
+        # Build final query
+        qs = User.objects.filter(base_q & visibility_q).distinct()
+
+        # If corpus_id is specified, further filter to users with access to that corpus
+        if corpus_id:
+            corpus_user_ids = (
+                CorpusUserObjectPermission.objects.filter(
+                    content_object_id=corpus_id,
+                    permission__codename__in=cls.WRITE_PERMISSION_CODENAMES,
+                )
+                .values_list("user_id", flat=True)
+                .distinct()
+            )
+
+            # Include corpus creator
+            try:
+                corpus = Corpus.objects.get(id=corpus_id)
+                corpus_creator_id = corpus.creator_id
+            except Corpus.DoesNotExist:
+                corpus_creator_id = None
+
+            corpus_scope_q = Q(id__in=corpus_user_ids)
+            if corpus_creator_id:
+                corpus_scope_q |= Q(id=corpus_creator_id)
+
+            # Also include self if in scope
+            if include_self:
+                corpus_scope_q |= Q(id=requesting_user.id)
+
+            qs = qs.filter(corpus_scope_q)
+
+        # Optimize query - only select needed fields for typical use cases
+        qs = qs.only(
+            "id",
+            "username",
+            "email",
+            "is_profile_public",
+            "is_active",
+            "slug",
+            "name",
+            "first_name",
+            "last_name",
+        )
+
+        return qs
+
+    @classmethod
+    def check_user_visibility(cls, requesting_user, target_user_id: int) -> bool:
+        """
+        Check if requesting_user can see target_user.
+
+        Args:
+            requesting_user: The user making the request
+            target_user_id: The ID of the user to check visibility for
+
+        Returns:
+            True if target_user is visible to requesting_user, False otherwise
+        """
+        return cls.get_visible_users(requesting_user).filter(id=target_user_id).exists()
+
+    @classmethod
+    def get_users_for_mention(
+        cls,
+        requesting_user,
+        text_search: Optional[str] = None,
+        corpus_id: Optional[int] = None,
+        limit: int = 20,
+    ) -> QuerySet:
+        """
+        Get users for @ mention autocomplete.
+
+        This is a convenience method that combines visibility filtering with search.
+
+        Args:
+            requesting_user: The user making the request
+            text_search: Optional text to filter by username or email
+            corpus_id: Optional corpus to scope visibility
+            limit: Maximum number of results to return
+
+        Returns:
+            QuerySet of User objects matching the search criteria
+        """
+        from django.contrib.auth.models import AnonymousUser
+
+        # Anonymous users cannot mention
+        if requesting_user is None or isinstance(requesting_user, AnonymousUser):
+            from django.contrib.auth import get_user_model
+
+            User = get_user_model()
+            return User.objects.none()
+
+        # Get visible users
+        qs = cls.get_visible_users(requesting_user, corpus_id=corpus_id)
+
+        # Apply text search if provided
+        if text_search:
+            qs = qs.filter(
+                Q(username__icontains=text_search) | Q(email__icontains=text_search)
+            )
+
+        # Order by username and limit results
+        return qs.order_by("username")[:limit]


### PR DESCRIPTION
## Summary

- Add three new query optimizers to centralize permission logic:
  - `UserQueryOptimizer` - handles user profile privacy (`is_profile_public`, corpus membership visibility)
  - `BadgeQueryOptimizer` - badge visibility follows recipient's profile privacy rules
  - `DocumentActionsQueryOptimizer` - least-privilege model for corpus actions, extracts, and analysis rows
- Fix 6 GraphQL resolvers to use centralized permission logic instead of ad-hoc checks
- Add 40 comprehensive permission tests covering visibility rules and IDOR protection
- Update `consolidated_permissioning_guide.md` with new sections documenting the optimizers

## Test plan

- [x] Run permission test suite: `docker compose -f test.yml run django python manage.py test opencontractserver.tests.permissioning.test_user_visibility opencontractserver.tests.permissioning.test_badge_visibility opencontractserver.tests.permissioning.test_document_actions_permissions --keepdb`
- [x] Verify all 40 tests pass
- [x] Run pre-commit checks
- [x] Review updated documentation in `consolidated_permissioning_guide.md`