### PR TITLE
feat: Add admin settings panel and corpus agent management

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -64,6 +64,7 @@ import { LabelDisplayBehavior } from "./types/graphql-api";
 import { CookieConsentDialog } from "./components/cookies/CookieConsent";
 import { Extracts } from "./views/Extracts";
 import { BadgeManagement } from "./components/badges/BadgeManagement";
+import { GlobalSettingsPanel, GlobalAgentManagement } from "./components/admin";
 import { useEnv } from "./components/hooks/UseEnv";
 import { EditExtractModal } from "./components/widgets/modals/EditExtractModal";
 import { SelectAnalyzerOrFieldsetModal } from "./components/widgets/modals/SelectCorpusAnalyzerOrFieldsetAnalyzer";
@@ -439,6 +440,14 @@ export const App = () => {
                   />
                   <Route path="/extracts" element={<Extracts />} />
                   <Route path="/admin/badges" element={<BadgeManagement />} />
+                  <Route
+                    path="/admin/settings"
+                    element={<GlobalSettingsPanel />}
+                  />
+                  <Route
+                    path="/admin/agents"
+                    element={<GlobalAgentManagement />}
+                  />
 
                   {/* Community Routes (Issue #613) */}
                   <Route path="/leaderboard" element={<LeaderboardRoute />} />

--- a/frontend/src/components/admin/GlobalAgentManagement.tsx
+++ b/frontend/src/components/admin/GlobalAgentManagement.tsx
@@ -1,0 +1,765 @@
+import React, { useState } from "react";
+import { useQuery, useMutation } from "@apollo/client";
+import {
+  Button,
+  Table,
+  Header,
+  Message,
+  Dimmer,
+  Loader,
+  Segment,
+  Icon,
+  Modal,
+  Form,
+  Input,
+  TextArea,
+  Checkbox,
+  Label,
+} from "semantic-ui-react";
+import styled from "styled-components";
+import { gql } from "@apollo/client";
+import { toast } from "react-toastify";
+import { ConfirmModal } from "../widgets/modals/ConfirmModal";
+import { AgentConfigurationType } from "../../types/graphql-api";
+
+// GraphQL Queries and Mutations
+const GET_GLOBAL_AGENTS = gql`
+  query GetGlobalAgents {
+    agentConfigurations(scope: "GLOBAL") {
+      edges {
+        node {
+          id
+          name
+          slug
+          description
+          systemInstructions
+          availableTools
+          permissionRequiredTools
+          badgeConfig
+          avatarUrl
+          scope
+          isActive
+          isPublic
+          creator {
+            id
+            username
+          }
+          created
+          modified
+        }
+      }
+    }
+  }
+`;
+
+const CREATE_AGENT_CONFIGURATION = gql`
+  mutation CreateAgentConfiguration(
+    $name: String!
+    $description: String!
+    $systemInstructions: String!
+    $availableTools: [String]
+    $permissionRequiredTools: [String]
+    $badgeConfig: JSONString
+    $avatarUrl: String
+    $scope: String!
+    $isPublic: Boolean
+  ) {
+    createAgentConfiguration(
+      name: $name
+      description: $description
+      systemInstructions: $systemInstructions
+      availableTools: $availableTools
+      permissionRequiredTools: $permissionRequiredTools
+      badgeConfig: $badgeConfig
+      avatarUrl: $avatarUrl
+      scope: $scope
+      isPublic: $isPublic
+    ) {
+      ok
+      message
+      agent {
+        id
+        name
+        slug
+        description
+      }
+    }
+  }
+`;
+
+const UPDATE_AGENT_CONFIGURATION = gql`
+  mutation UpdateAgentConfiguration(
+    $agentId: ID!
+    $name: String
+    $description: String
+    $systemInstructions: String
+    $availableTools: [String]
+    $permissionRequiredTools: [String]
+    $badgeConfig: JSONString
+    $avatarUrl: String
+    $isActive: Boolean
+    $isPublic: Boolean
+  ) {
+    updateAgentConfiguration(
+      agentId: $agentId
+      name: $name
+      description: $description
+      systemInstructions: $systemInstructions
+      availableTools: $availableTools
+      permissionRequiredTools: $permissionRequiredTools
+      badgeConfig: $badgeConfig
+      avatarUrl: $avatarUrl
+      isActive: $isActive
+      isPublic: $isPublic
+    ) {
+      ok
+      message
+      agent {
+        id
+        name
+        slug
+        description
+      }
+    }
+  }
+`;
+
+const DELETE_AGENT_CONFIGURATION = gql`
+  mutation DeleteAgentConfiguration($agentId: ID!) {
+    deleteAgentConfiguration(agentId: $agentId) {
+      ok
+      message
+    }
+  }
+`;
+
+const Container = styled.div`
+  padding: 2rem;
+  max-width: 1400px;
+  margin: 0 auto;
+`;
+
+const PageHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 2rem;
+`;
+
+const PageTitle = styled(Header)`
+  &.ui.header {
+    margin: 0;
+    color: #1e293b;
+  }
+`;
+
+const StyledSegment = styled(Segment)`
+  &.ui.segment {
+    border-radius: 12px;
+    background: white;
+    border: 1px solid rgba(226, 232, 240, 0.8);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+  }
+`;
+
+const StatusBadge = styled(Label)<{ $active: boolean }>`
+  &.ui.label {
+    background: ${(props) => (props.$active ? "#dcfce7" : "#fef3c7")};
+    color: ${(props) => (props.$active ? "#166534" : "#92400e")};
+    font-weight: 500;
+  }
+`;
+
+const ToolsList = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+`;
+
+const ToolBadge = styled(Label)`
+  &.ui.label {
+    font-size: 0.75rem;
+    background: #f1f5f9;
+    color: #475569;
+  }
+`;
+
+interface AgentNode {
+  id: string;
+  name: string;
+  slug?: string;
+  description?: string;
+  systemInstructions: string;
+  availableTools?: string[];
+  permissionRequiredTools?: string[];
+  badgeConfig?: Record<string, any>;
+  avatarUrl?: string;
+  scope: string;
+  isActive: boolean;
+  isPublic?: boolean;
+  creator: { id: string; username: string };
+  created: string;
+  modified: string;
+}
+
+interface FormState {
+  name: string;
+  description: string;
+  systemInstructions: string;
+  availableTools: string;
+  permissionRequiredTools: string;
+  badgeConfig: string;
+  avatarUrl: string;
+  isPublic: boolean;
+  isActive: boolean;
+}
+
+const initialFormState: FormState = {
+  name: "",
+  description: "",
+  systemInstructions: "",
+  availableTools: "",
+  permissionRequiredTools: "",
+  badgeConfig: '{"icon": "robot", "color": "#6366f1", "label": "AI"}',
+  avatarUrl: "",
+  isPublic: true,
+  isActive: true,
+};
+
+export const GlobalAgentManagement: React.FC = () => {
+  const [showCreateModal, setShowCreateModal] = useState(false);
+  const [showEditModal, setShowEditModal] = useState(false);
+  const [deleteModalOpen, setDeleteModalOpen] = useState(false);
+  const [agentToDelete, setAgentToDelete] = useState<AgentNode | null>(null);
+  const [agentToEdit, setAgentToEdit] = useState<AgentNode | null>(null);
+  const [formState, setFormState] = useState<FormState>(initialFormState);
+
+  const { loading, error, data, refetch } = useQuery(GET_GLOBAL_AGENTS);
+
+  const [createAgent, { loading: creating }] = useMutation(
+    CREATE_AGENT_CONFIGURATION,
+    {
+      onCompleted: (data) => {
+        if (data.createAgentConfiguration.ok) {
+          toast.success("Agent created successfully");
+          setShowCreateModal(false);
+          setFormState(initialFormState);
+          refetch();
+        } else {
+          toast.error(data.createAgentConfiguration.message);
+        }
+      },
+      onError: (err) => toast.error(err.message),
+    }
+  );
+
+  const [updateAgent, { loading: updating }] = useMutation(
+    UPDATE_AGENT_CONFIGURATION,
+    {
+      onCompleted: (data) => {
+        if (data.updateAgentConfiguration.ok) {
+          toast.success("Agent updated successfully");
+          setShowEditModal(false);
+          setAgentToEdit(null);
+          refetch();
+        } else {
+          toast.error(data.updateAgentConfiguration.message);
+        }
+      },
+      onError: (err) => toast.error(err.message),
+    }
+  );
+
+  const [deleteAgent, { loading: deleting }] = useMutation(
+    DELETE_AGENT_CONFIGURATION,
+    {
+      onCompleted: (data) => {
+        if (data.deleteAgentConfiguration.ok) {
+          toast.success("Agent deleted successfully");
+          setDeleteModalOpen(false);
+          setAgentToDelete(null);
+          refetch();
+        } else {
+          toast.error(data.deleteAgentConfiguration.message);
+        }
+      },
+      onError: (err) => toast.error(err.message),
+    }
+  );
+
+  const handleCreate = () => {
+    const tools = formState.availableTools
+      .split(",")
+      .map((t) => t.trim())
+      .filter(Boolean);
+    const permTools = formState.permissionRequiredTools
+      .split(",")
+      .map((t) => t.trim())
+      .filter(Boolean);
+
+    let badgeConfig = {};
+    try {
+      badgeConfig = JSON.parse(formState.badgeConfig || "{}");
+    } catch (e) {
+      toast.error("Invalid badge config JSON");
+      return;
+    }
+
+    createAgent({
+      variables: {
+        name: formState.name,
+        description: formState.description,
+        systemInstructions: formState.systemInstructions,
+        availableTools: tools.length > 0 ? tools : null,
+        permissionRequiredTools: permTools.length > 0 ? permTools : null,
+        badgeConfig: JSON.stringify(badgeConfig),
+        avatarUrl: formState.avatarUrl || null,
+        scope: "GLOBAL",
+        isPublic: formState.isPublic,
+      },
+    });
+  };
+
+  const handleUpdate = () => {
+    if (!agentToEdit) return;
+
+    const tools = formState.availableTools
+      .split(",")
+      .map((t) => t.trim())
+      .filter(Boolean);
+    const permTools = formState.permissionRequiredTools
+      .split(",")
+      .map((t) => t.trim())
+      .filter(Boolean);
+
+    let badgeConfig = {};
+    try {
+      badgeConfig = JSON.parse(formState.badgeConfig || "{}");
+    } catch (e) {
+      toast.error("Invalid badge config JSON");
+      return;
+    }
+
+    updateAgent({
+      variables: {
+        agentId: agentToEdit.id,
+        name: formState.name,
+        description: formState.description,
+        systemInstructions: formState.systemInstructions,
+        availableTools: tools,
+        permissionRequiredTools: permTools,
+        badgeConfig: JSON.stringify(badgeConfig),
+        avatarUrl: formState.avatarUrl || null,
+        isActive: formState.isActive,
+        isPublic: formState.isPublic,
+      },
+    });
+  };
+
+  const openEditModal = (agent: AgentNode) => {
+    setAgentToEdit(agent);
+    setFormState({
+      name: agent.name,
+      description: agent.description || "",
+      systemInstructions: agent.systemInstructions,
+      availableTools: (agent.availableTools || []).join(", "),
+      permissionRequiredTools: (agent.permissionRequiredTools || []).join(", "),
+      badgeConfig: JSON.stringify(agent.badgeConfig || {}, null, 2),
+      avatarUrl: agent.avatarUrl || "",
+      isPublic: agent.isPublic ?? true,
+      isActive: agent.isActive,
+    });
+    setShowEditModal(true);
+  };
+
+  const agents: AgentNode[] =
+    data?.agentConfigurations?.edges?.map((e: any) => e.node) || [];
+
+  if (loading) {
+    return (
+      <Container>
+        <Dimmer active inverted>
+          <Loader>Loading agents...</Loader>
+        </Dimmer>
+      </Container>
+    );
+  }
+
+  if (error) {
+    return (
+      <Container>
+        <Message negative>
+          <Message.Header>Error loading agents</Message.Header>
+          <p>{error.message}</p>
+        </Message>
+      </Container>
+    );
+  }
+
+  return (
+    <Container>
+      <PageHeader>
+        <PageTitle as="h1">
+          <Icon name="robot" /> Global Agent Management
+        </PageTitle>
+        <Button
+          primary
+          icon
+          labelPosition="left"
+          onClick={() => {
+            setFormState(initialFormState);
+            setShowCreateModal(true);
+          }}
+        >
+          <Icon name="plus" />
+          Create Agent
+        </Button>
+      </PageHeader>
+
+      <StyledSegment>
+        {agents.length === 0 ? (
+          <Message info>
+            <Message.Header>No Global Agents</Message.Header>
+            <p>
+              Create your first global agent to make it available across all
+              corpuses.
+            </p>
+          </Message>
+        ) : (
+          <Table basic="very" celled>
+            <Table.Header>
+              <Table.Row>
+                <Table.HeaderCell>Name</Table.HeaderCell>
+                <Table.HeaderCell>Slug</Table.HeaderCell>
+                <Table.HeaderCell>Description</Table.HeaderCell>
+                <Table.HeaderCell>Tools</Table.HeaderCell>
+                <Table.HeaderCell>Status</Table.HeaderCell>
+                <Table.HeaderCell>Actions</Table.HeaderCell>
+              </Table.Row>
+            </Table.Header>
+            <Table.Body>
+              {agents.map((agent) => (
+                <Table.Row key={agent.id}>
+                  <Table.Cell>
+                    <strong>{agent.name}</strong>
+                  </Table.Cell>
+                  <Table.Cell>
+                    <code>{agent.slug || "-"}</code>
+                  </Table.Cell>
+                  <Table.Cell>
+                    {agent.description?.substring(0, 100)}
+                    {(agent.description?.length || 0) > 100 ? "..." : ""}
+                  </Table.Cell>
+                  <Table.Cell>
+                    <ToolsList>
+                      {(agent.availableTools || []).slice(0, 3).map((tool) => (
+                        <ToolBadge key={tool} size="tiny">
+                          {tool}
+                        </ToolBadge>
+                      ))}
+                      {(agent.availableTools || []).length > 3 && (
+                        <ToolBadge size="tiny">
+                          +{(agent.availableTools || []).length - 3}
+                        </ToolBadge>
+                      )}
+                    </ToolsList>
+                  </Table.Cell>
+                  <Table.Cell>
+                    <StatusBadge $active={agent.isActive}>
+                      {agent.isActive ? "Active" : "Inactive"}
+                    </StatusBadge>
+                  </Table.Cell>
+                  <Table.Cell>
+                    <Button
+                      icon
+                      size="tiny"
+                      onClick={() => openEditModal(agent)}
+                    >
+                      <Icon name="edit" />
+                    </Button>
+                    <Button
+                      icon
+                      size="tiny"
+                      negative
+                      onClick={() => {
+                        setAgentToDelete(agent);
+                        setDeleteModalOpen(true);
+                      }}
+                    >
+                      <Icon name="trash" />
+                    </Button>
+                  </Table.Cell>
+                </Table.Row>
+              ))}
+            </Table.Body>
+          </Table>
+        )}
+      </StyledSegment>
+
+      {/* Create Modal */}
+      <Modal
+        open={showCreateModal}
+        onClose={() => setShowCreateModal(false)}
+        size="large"
+      >
+        <Modal.Header>Create Global Agent</Modal.Header>
+        <Modal.Content scrolling>
+          <Form>
+            <Form.Field required>
+              <label>Name</label>
+              <Input
+                placeholder="Agent name"
+                value={formState.name}
+                onChange={(e) =>
+                  setFormState({ ...formState, name: e.target.value })
+                }
+              />
+            </Form.Field>
+            <Form.Field required>
+              <label>Description</label>
+              <TextArea
+                placeholder="Brief description of what this agent does"
+                value={formState.description}
+                onChange={(e) =>
+                  setFormState({ ...formState, description: e.target.value })
+                }
+                rows={2}
+              />
+            </Form.Field>
+            <Form.Field required>
+              <label>System Instructions</label>
+              <TextArea
+                placeholder="System prompt for the agent..."
+                value={formState.systemInstructions}
+                onChange={(e) =>
+                  setFormState({
+                    ...formState,
+                    systemInstructions: e.target.value,
+                  })
+                }
+                rows={6}
+                style={{ fontFamily: "monospace" }}
+              />
+            </Form.Field>
+            <Form.Field>
+              <label>Available Tools (comma-separated)</label>
+              <Input
+                placeholder="similarity_search, load_document_text, search_exact_text"
+                value={formState.availableTools}
+                onChange={(e) =>
+                  setFormState({ ...formState, availableTools: e.target.value })
+                }
+              />
+            </Form.Field>
+            <Form.Field>
+              <label>Permission Required Tools (comma-separated)</label>
+              <Input
+                placeholder="Tools that require explicit permission"
+                value={formState.permissionRequiredTools}
+                onChange={(e) =>
+                  setFormState({
+                    ...formState,
+                    permissionRequiredTools: e.target.value,
+                  })
+                }
+              />
+            </Form.Field>
+            <Form.Field>
+              <label>Badge Config (JSON)</label>
+              <TextArea
+                placeholder='{"icon": "robot", "color": "#6366f1", "label": "AI"}'
+                value={formState.badgeConfig}
+                onChange={(e) =>
+                  setFormState({ ...formState, badgeConfig: e.target.value })
+                }
+                rows={3}
+                style={{ fontFamily: "monospace" }}
+              />
+            </Form.Field>
+            <Form.Field>
+              <label>Avatar URL</label>
+              <Input
+                placeholder="https://example.com/avatar.png"
+                value={formState.avatarUrl}
+                onChange={(e) =>
+                  setFormState({ ...formState, avatarUrl: e.target.value })
+                }
+              />
+            </Form.Field>
+            <Form.Field>
+              <Checkbox
+                label="Publicly visible"
+                checked={formState.isPublic}
+                onChange={(_, data) =>
+                  setFormState({ ...formState, isPublic: !!data.checked })
+                }
+              />
+            </Form.Field>
+          </Form>
+        </Modal.Content>
+        <Modal.Actions>
+          <Button onClick={() => setShowCreateModal(false)}>Cancel</Button>
+          <Button
+            primary
+            loading={creating}
+            disabled={
+              !formState.name ||
+              !formState.description ||
+              !formState.systemInstructions
+            }
+            onClick={handleCreate}
+          >
+            Create Agent
+          </Button>
+        </Modal.Actions>
+      </Modal>
+
+      {/* Edit Modal */}
+      <Modal
+        open={showEditModal}
+        onClose={() => setShowEditModal(false)}
+        size="large"
+      >
+        <Modal.Header>Edit Agent: {agentToEdit?.name}</Modal.Header>
+        <Modal.Content scrolling>
+          <Form>
+            <Form.Field required>
+              <label>Name</label>
+              <Input
+                placeholder="Agent name"
+                value={formState.name}
+                onChange={(e) =>
+                  setFormState({ ...formState, name: e.target.value })
+                }
+              />
+            </Form.Field>
+            <Form.Field required>
+              <label>Description</label>
+              <TextArea
+                placeholder="Brief description of what this agent does"
+                value={formState.description}
+                onChange={(e) =>
+                  setFormState({ ...formState, description: e.target.value })
+                }
+                rows={2}
+              />
+            </Form.Field>
+            <Form.Field required>
+              <label>System Instructions</label>
+              <TextArea
+                placeholder="System prompt for the agent..."
+                value={formState.systemInstructions}
+                onChange={(e) =>
+                  setFormState({
+                    ...formState,
+                    systemInstructions: e.target.value,
+                  })
+                }
+                rows={6}
+                style={{ fontFamily: "monospace" }}
+              />
+            </Form.Field>
+            <Form.Field>
+              <label>Available Tools (comma-separated)</label>
+              <Input
+                placeholder="similarity_search, load_document_text, search_exact_text"
+                value={formState.availableTools}
+                onChange={(e) =>
+                  setFormState({ ...formState, availableTools: e.target.value })
+                }
+              />
+            </Form.Field>
+            <Form.Field>
+              <label>Permission Required Tools (comma-separated)</label>
+              <Input
+                placeholder="Tools that require explicit permission"
+                value={formState.permissionRequiredTools}
+                onChange={(e) =>
+                  setFormState({
+                    ...formState,
+                    permissionRequiredTools: e.target.value,
+                  })
+                }
+              />
+            </Form.Field>
+            <Form.Field>
+              <label>Badge Config (JSON)</label>
+              <TextArea
+                placeholder='{"icon": "robot", "color": "#6366f1", "label": "AI"}'
+                value={formState.badgeConfig}
+                onChange={(e) =>
+                  setFormState({ ...formState, badgeConfig: e.target.value })
+                }
+                rows={3}
+                style={{ fontFamily: "monospace" }}
+              />
+            </Form.Field>
+            <Form.Field>
+              <label>Avatar URL</label>
+              <Input
+                placeholder="https://example.com/avatar.png"
+                value={formState.avatarUrl}
+                onChange={(e) =>
+                  setFormState({ ...formState, avatarUrl: e.target.value })
+                }
+              />
+            </Form.Field>
+            <Form.Group>
+              <Form.Field>
+                <Checkbox
+                  label="Active"
+                  checked={formState.isActive}
+                  onChange={(_, data) =>
+                    setFormState({ ...formState, isActive: !!data.checked })
+                  }
+                />
+              </Form.Field>
+              <Form.Field>
+                <Checkbox
+                  label="Publicly visible"
+                  checked={formState.isPublic}
+                  onChange={(_, data) =>
+                    setFormState({ ...formState, isPublic: !!data.checked })
+                  }
+                />
+              </Form.Field>
+            </Form.Group>
+          </Form>
+        </Modal.Content>
+        <Modal.Actions>
+          <Button onClick={() => setShowEditModal(false)}>Cancel</Button>
+          <Button
+            primary
+            loading={updating}
+            disabled={
+              !formState.name ||
+              !formState.description ||
+              !formState.systemInstructions
+            }
+            onClick={handleUpdate}
+          >
+            Save Changes
+          </Button>
+        </Modal.Actions>
+      </Modal>
+
+      {/* Delete Confirmation */}
+      <ConfirmModal
+        open={deleteModalOpen}
+        message={`Are you sure you want to delete the agent "${agentToDelete?.name}"? This action cannot be undone.`}
+        onConfirm={() => {
+          if (agentToDelete) {
+            deleteAgent({ variables: { agentId: agentToDelete.id } });
+          }
+        }}
+        onCancel={() => {
+          setDeleteModalOpen(false);
+          setAgentToDelete(null);
+        }}
+        loading={deleting}
+      />
+    </Container>
+  );
+};
+
+export default GlobalAgentManagement;

--- a/frontend/src/components/admin/GlobalAgentManagement.tsx
+++ b/frontend/src/components/admin/GlobalAgentManagement.tsx
@@ -400,7 +400,7 @@ export const GlobalAgentManagement: React.FC = () => {
     <Container>
       <PageHeader>
         <PageTitle as="h1">
-          <Icon name="robot" /> Global Agent Management
+          <Icon name="microchip" /> Global Agent Management
         </PageTitle>
         <Button
           primary
@@ -745,18 +745,18 @@ export const GlobalAgentManagement: React.FC = () => {
 
       {/* Delete Confirmation */}
       <ConfirmModal
-        open={deleteModalOpen}
+        visible={deleteModalOpen}
         message={`Are you sure you want to delete the agent "${agentToDelete?.name}"? This action cannot be undone.`}
-        onConfirm={() => {
+        yesAction={() => {
           if (agentToDelete) {
             deleteAgent({ variables: { agentId: agentToDelete.id } });
           }
         }}
-        onCancel={() => {
+        noAction={() => {
           setDeleteModalOpen(false);
           setAgentToDelete(null);
         }}
-        loading={deleting}
+        toggleModal={() => setDeleteModalOpen(false)}
       />
     </Container>
   );

--- a/frontend/src/components/admin/GlobalSettingsPanel.tsx
+++ b/frontend/src/components/admin/GlobalSettingsPanel.tsx
@@ -1,0 +1,190 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import { Header, Segment, Card, Icon } from "semantic-ui-react";
+import styled from "styled-components";
+
+const Container = styled.div`
+  padding: 2rem;
+  max-width: 1200px;
+  margin: 0 auto;
+`;
+
+const PageHeader = styled.div`
+  margin-bottom: 2rem;
+`;
+
+const PageTitle = styled(Header)`
+  &.ui.header {
+    margin-bottom: 0.5rem;
+    color: #1e293b;
+  }
+`;
+
+const PageDescription = styled.p`
+  color: #64748b;
+  font-size: 1rem;
+  margin: 0;
+`;
+
+const SettingsGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 1.5rem;
+`;
+
+const SettingsCard = styled(Card)`
+  &.ui.card {
+    border-radius: 12px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    transition: all 0.2s ease;
+    cursor: pointer;
+
+    &:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    }
+
+    .content {
+      padding: 1.5rem;
+    }
+  }
+`;
+
+const CardIcon = styled.div<{ $color: string }>`
+  width: 48px;
+  height: 48px;
+  border-radius: 12px;
+  background: ${(props) => props.$color};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 1rem;
+
+  i.icon {
+    color: white;
+    margin: 0;
+  }
+`;
+
+const CardTitle = styled.h3`
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: #1e293b;
+  margin: 0 0 0.5rem 0;
+`;
+
+const CardDescription = styled.p`
+  font-size: 0.875rem;
+  color: #64748b;
+  margin: 0;
+  line-height: 1.5;
+`;
+
+const ComingSoonBadge = styled.span`
+  display: inline-block;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: #8b5cf6;
+  background: #f3e8ff;
+  padding: 0.25rem 0.75rem;
+  border-radius: 9999px;
+  margin-left: 0.5rem;
+`;
+
+interface SettingItem {
+  id: string;
+  title: string;
+  description: string;
+  icon: string;
+  color: string;
+  route?: string;
+  comingSoon?: boolean;
+}
+
+const settingsItems: SettingItem[] = [
+  {
+    id: "badges",
+    title: "Badge Management",
+    description:
+      "Create and manage badges that can be awarded to users for achievements and contributions.",
+    icon: "trophy",
+    color: "linear-gradient(135deg, #f59e0b 0%, #d97706 100%)",
+    route: "/admin/badges",
+  },
+  {
+    id: "global-agents",
+    title: "Global Agents",
+    description:
+      "Configure global AI agents available across all corpuses for document and corpus analysis.",
+    icon: "robot",
+    color: "linear-gradient(135deg, #6366f1 0%, #4f46e5 100%)",
+    route: "/admin/agents",
+  },
+  {
+    id: "system-settings",
+    title: "System Settings",
+    description:
+      "Configure system-wide settings including defaults, limits, and feature flags.",
+    icon: "cog",
+    color: "linear-gradient(135deg, #64748b 0%, #475569 100%)",
+    comingSoon: true,
+  },
+  {
+    id: "user-management",
+    title: "User Management",
+    description:
+      "View and manage user accounts, permissions, and access controls.",
+    icon: "users",
+    color: "linear-gradient(135deg, #10b981 0%, #059669 100%)",
+    comingSoon: true,
+  },
+];
+
+export const GlobalSettingsPanel: React.FC = () => {
+  const navigate = useNavigate();
+
+  const handleCardClick = (item: SettingItem) => {
+    if (item.route && !item.comingSoon) {
+      navigate(item.route);
+    }
+  };
+
+  return (
+    <Container>
+      <PageHeader>
+        <PageTitle as="h1">
+          <Icon name="settings" /> Admin Settings
+        </PageTitle>
+        <PageDescription>
+          Manage global settings, configurations, and administrative features
+          for OpenContracts.
+        </PageDescription>
+      </PageHeader>
+
+      <SettingsGrid>
+        {settingsItems.map((item) => (
+          <SettingsCard
+            key={item.id}
+            onClick={() => handleCardClick(item)}
+            style={{ opacity: item.comingSoon ? 0.7 : 1 }}
+          >
+            <Card.Content>
+              <CardIcon $color={item.color}>
+                <Icon name={item.icon as any} size="large" />
+              </CardIcon>
+              <CardTitle>
+                {item.title}
+                {item.comingSoon && (
+                  <ComingSoonBadge>Coming Soon</ComingSoonBadge>
+                )}
+              </CardTitle>
+              <CardDescription>{item.description}</CardDescription>
+            </Card.Content>
+          </SettingsCard>
+        ))}
+      </SettingsGrid>
+    </Container>
+  );
+};
+
+export default GlobalSettingsPanel;

--- a/frontend/src/components/admin/index.ts
+++ b/frontend/src/components/admin/index.ts
@@ -1,0 +1,2 @@
+export { GlobalSettingsPanel } from "./GlobalSettingsPanel";
+export { GlobalAgentManagement } from "./GlobalAgentManagement";

--- a/frontend/src/components/corpuses/CorpusAgentManagement.tsx
+++ b/frontend/src/components/corpuses/CorpusAgentManagement.tsx
@@ -1,0 +1,846 @@
+import React, { useState } from "react";
+import { useQuery, useMutation, gql } from "@apollo/client";
+import {
+  Button,
+  Table,
+  Header,
+  Message,
+  Dimmer,
+  Loader,
+  Icon,
+  Modal,
+  Form,
+  Input,
+  TextArea,
+  Checkbox,
+  Label,
+} from "semantic-ui-react";
+import styled from "styled-components";
+import { toast } from "react-toastify";
+import { ConfirmModal } from "../widgets/modals/ConfirmModal";
+
+// GraphQL Queries and Mutations
+const GET_CORPUS_AGENTS = gql`
+  query GetCorpusAgents($corpusId: ID!) {
+    agentConfigurations(corpusId: $corpusId) {
+      edges {
+        node {
+          id
+          name
+          slug
+          description
+          systemInstructions
+          availableTools
+          permissionRequiredTools
+          badgeConfig
+          avatarUrl
+          scope
+          isActive
+          isPublic
+          creator {
+            id
+            username
+          }
+          created
+          modified
+        }
+      }
+    }
+  }
+`;
+
+const CREATE_AGENT_CONFIGURATION = gql`
+  mutation CreateAgentConfiguration(
+    $name: String!
+    $description: String!
+    $systemInstructions: String!
+    $availableTools: [String]
+    $permissionRequiredTools: [String]
+    $badgeConfig: JSONString
+    $avatarUrl: String
+    $scope: String!
+    $corpusId: ID
+    $isPublic: Boolean
+  ) {
+    createAgentConfiguration(
+      name: $name
+      description: $description
+      systemInstructions: $systemInstructions
+      availableTools: $availableTools
+      permissionRequiredTools: $permissionRequiredTools
+      badgeConfig: $badgeConfig
+      avatarUrl: $avatarUrl
+      scope: $scope
+      corpusId: $corpusId
+      isPublic: $isPublic
+    ) {
+      ok
+      message
+      agent {
+        id
+        name
+        slug
+        description
+      }
+    }
+  }
+`;
+
+const UPDATE_AGENT_CONFIGURATION = gql`
+  mutation UpdateAgentConfiguration(
+    $agentId: ID!
+    $name: String
+    $description: String
+    $systemInstructions: String
+    $availableTools: [String]
+    $permissionRequiredTools: [String]
+    $badgeConfig: JSONString
+    $avatarUrl: String
+    $isActive: Boolean
+    $isPublic: Boolean
+  ) {
+    updateAgentConfiguration(
+      agentId: $agentId
+      name: $name
+      description: $description
+      systemInstructions: $systemInstructions
+      availableTools: $availableTools
+      permissionRequiredTools: $permissionRequiredTools
+      badgeConfig: $badgeConfig
+      avatarUrl: $avatarUrl
+      isActive: $isActive
+      isPublic: $isPublic
+    ) {
+      ok
+      message
+      agent {
+        id
+        name
+        slug
+        description
+      }
+    }
+  }
+`;
+
+const DELETE_AGENT_CONFIGURATION = gql`
+  mutation DeleteAgentConfiguration($agentId: ID!) {
+    deleteAgentConfiguration(agentId: $agentId) {
+      ok
+      message
+    }
+  }
+`;
+
+const Container = styled.div`
+  padding: 1.5rem;
+  background: white;
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+`;
+
+const SectionHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.5rem;
+`;
+
+const SectionTitle = styled(Header)`
+  &.ui.header {
+    margin: 0;
+    color: #1e293b;
+    font-size: 1.25rem;
+  }
+`;
+
+const HelperText = styled.p`
+  color: #64748b;
+  font-size: 0.875rem;
+  margin: 0.5rem 0 1.5rem 0;
+  line-height: 1.5;
+`;
+
+const StatusBadge = styled(Label)<{ $active: boolean }>`
+  &.ui.label {
+    background: ${(props) => (props.$active ? "#dcfce7" : "#fef3c7")};
+    color: ${(props) => (props.$active ? "#166534" : "#92400e")};
+    font-weight: 500;
+    font-size: 0.75rem;
+  }
+`;
+
+const ToolsList = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+`;
+
+const ToolBadge = styled(Label)`
+  &.ui.label {
+    font-size: 0.7rem;
+    background: #f1f5f9;
+    color: #475569;
+    padding: 0.25rem 0.5rem;
+  }
+`;
+
+const EmptyState = styled.div`
+  text-align: center;
+  padding: 3rem 1.5rem;
+  background: #f8fafc;
+  border-radius: 8px;
+  border: 1px dashed #e2e8f0;
+`;
+
+const EmptyStateIcon = styled.div`
+  width: 64px;
+  height: 64px;
+  margin: 0 auto 1rem;
+  background: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);
+  border-radius: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  i.icon {
+    color: white;
+    margin: 0;
+  }
+`;
+
+const EmptyStateTitle = styled.h3`
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: #1e293b;
+  margin: 0 0 0.5rem 0;
+`;
+
+const EmptyStateDescription = styled.p`
+  font-size: 0.875rem;
+  color: #64748b;
+  margin: 0 0 1.5rem 0;
+  max-width: 400px;
+  margin-left: auto;
+  margin-right: auto;
+`;
+
+interface CorpusAgentManagementProps {
+  corpusId: string;
+  canUpdate: boolean;
+}
+
+interface AgentNode {
+  id: string;
+  name: string;
+  slug?: string;
+  description?: string;
+  systemInstructions: string;
+  availableTools?: string[];
+  permissionRequiredTools?: string[];
+  badgeConfig?: Record<string, any>;
+  avatarUrl?: string;
+  scope: string;
+  isActive: boolean;
+  isPublic?: boolean;
+  creator: { id: string; username: string };
+  created: string;
+  modified: string;
+}
+
+interface FormState {
+  name: string;
+  description: string;
+  systemInstructions: string;
+  availableTools: string;
+  permissionRequiredTools: string;
+  badgeConfig: string;
+  avatarUrl: string;
+  isPublic: boolean;
+  isActive: boolean;
+}
+
+const initialFormState: FormState = {
+  name: "",
+  description: "",
+  systemInstructions: "",
+  availableTools: "",
+  permissionRequiredTools: "",
+  badgeConfig: '{"icon": "robot", "color": "#8b5cf6", "label": "AI"}',
+  avatarUrl: "",
+  isPublic: false,
+  isActive: true,
+};
+
+export const CorpusAgentManagement: React.FC<CorpusAgentManagementProps> = ({
+  corpusId,
+  canUpdate,
+}) => {
+  const [showCreateModal, setShowCreateModal] = useState(false);
+  const [showEditModal, setShowEditModal] = useState(false);
+  const [deleteModalOpen, setDeleteModalOpen] = useState(false);
+  const [agentToDelete, setAgentToDelete] = useState<AgentNode | null>(null);
+  const [agentToEdit, setAgentToEdit] = useState<AgentNode | null>(null);
+  const [formState, setFormState] = useState<FormState>(initialFormState);
+
+  const { loading, error, data, refetch } = useQuery(GET_CORPUS_AGENTS, {
+    variables: { corpusId },
+  });
+
+  const [createAgent, { loading: creating }] = useMutation(
+    CREATE_AGENT_CONFIGURATION,
+    {
+      onCompleted: (data) => {
+        if (data.createAgentConfiguration.ok) {
+          toast.success("Agent created successfully");
+          setShowCreateModal(false);
+          setFormState(initialFormState);
+          refetch();
+        } else {
+          toast.error(data.createAgentConfiguration.message);
+        }
+      },
+      onError: (err) => toast.error(err.message),
+    }
+  );
+
+  const [updateAgent, { loading: updating }] = useMutation(
+    UPDATE_AGENT_CONFIGURATION,
+    {
+      onCompleted: (data) => {
+        if (data.updateAgentConfiguration.ok) {
+          toast.success("Agent updated successfully");
+          setShowEditModal(false);
+          setAgentToEdit(null);
+          refetch();
+        } else {
+          toast.error(data.updateAgentConfiguration.message);
+        }
+      },
+      onError: (err) => toast.error(err.message),
+    }
+  );
+
+  const [deleteAgent, { loading: deleting }] = useMutation(
+    DELETE_AGENT_CONFIGURATION,
+    {
+      onCompleted: (data) => {
+        if (data.deleteAgentConfiguration.ok) {
+          toast.success("Agent deleted successfully");
+          setDeleteModalOpen(false);
+          setAgentToDelete(null);
+          refetch();
+        } else {
+          toast.error(data.deleteAgentConfiguration.message);
+        }
+      },
+      onError: (err) => toast.error(err.message),
+    }
+  );
+
+  const handleCreate = () => {
+    const tools = formState.availableTools
+      .split(",")
+      .map((t) => t.trim())
+      .filter(Boolean);
+    const permTools = formState.permissionRequiredTools
+      .split(",")
+      .map((t) => t.trim())
+      .filter(Boolean);
+
+    let badgeConfig = {};
+    try {
+      badgeConfig = JSON.parse(formState.badgeConfig || "{}");
+    } catch (e) {
+      toast.error("Invalid badge config JSON");
+      return;
+    }
+
+    createAgent({
+      variables: {
+        name: formState.name,
+        description: formState.description,
+        systemInstructions: formState.systemInstructions,
+        availableTools: tools.length > 0 ? tools : null,
+        permissionRequiredTools: permTools.length > 0 ? permTools : null,
+        badgeConfig: JSON.stringify(badgeConfig),
+        avatarUrl: formState.avatarUrl || null,
+        scope: "CORPUS",
+        corpusId: corpusId,
+        isPublic: formState.isPublic,
+      },
+    });
+  };
+
+  const handleUpdate = () => {
+    if (!agentToEdit) return;
+
+    const tools = formState.availableTools
+      .split(",")
+      .map((t) => t.trim())
+      .filter(Boolean);
+    const permTools = formState.permissionRequiredTools
+      .split(",")
+      .map((t) => t.trim())
+      .filter(Boolean);
+
+    let badgeConfig = {};
+    try {
+      badgeConfig = JSON.parse(formState.badgeConfig || "{}");
+    } catch (e) {
+      toast.error("Invalid badge config JSON");
+      return;
+    }
+
+    updateAgent({
+      variables: {
+        agentId: agentToEdit.id,
+        name: formState.name,
+        description: formState.description,
+        systemInstructions: formState.systemInstructions,
+        availableTools: tools,
+        permissionRequiredTools: permTools,
+        badgeConfig: JSON.stringify(badgeConfig),
+        avatarUrl: formState.avatarUrl || null,
+        isActive: formState.isActive,
+        isPublic: formState.isPublic,
+      },
+    });
+  };
+
+  const openEditModal = (agent: AgentNode) => {
+    setAgentToEdit(agent);
+    setFormState({
+      name: agent.name,
+      description: agent.description || "",
+      systemInstructions: agent.systemInstructions,
+      availableTools: (agent.availableTools || []).join(", "),
+      permissionRequiredTools: (agent.permissionRequiredTools || []).join(", "),
+      badgeConfig: JSON.stringify(agent.badgeConfig || {}, null, 2),
+      avatarUrl: agent.avatarUrl || "",
+      isPublic: agent.isPublic ?? false,
+      isActive: agent.isActive,
+    });
+    setShowEditModal(true);
+  };
+
+  if (!canUpdate) {
+    return (
+      <Container>
+        <Message info>
+          You do not have permission to manage agents for this corpus.
+        </Message>
+      </Container>
+    );
+  }
+
+  if (loading) {
+    return (
+      <Container>
+        <Dimmer active inverted>
+          <Loader>Loading agents...</Loader>
+        </Dimmer>
+      </Container>
+    );
+  }
+
+  if (error) {
+    return (
+      <Container>
+        <Message negative>
+          <Message.Header>Error loading agents</Message.Header>
+          <p>{error.message}</p>
+        </Message>
+      </Container>
+    );
+  }
+
+  const agents: AgentNode[] =
+    data?.agentConfigurations?.edges?.map((e: any) => e.node) || [];
+
+  return (
+    <Container>
+      <SectionHeader>
+        <SectionTitle as="h3">
+          <Icon name="robot" /> Corpus Agents
+        </SectionTitle>
+        <Button
+          primary
+          size="small"
+          icon
+          labelPosition="left"
+          onClick={() => {
+            setFormState(initialFormState);
+            setShowCreateModal(true);
+          }}
+        >
+          <Icon name="plus" />
+          Create Agent
+        </Button>
+      </SectionHeader>
+
+      <HelperText>
+        Create custom AI agents specifically for this corpus. Corpus agents can
+        be tailored with specialized instructions and tools for analyzing
+        documents in this collection.
+      </HelperText>
+
+      {agents.length === 0 ? (
+        <EmptyState>
+          <EmptyStateIcon>
+            <Icon name="robot" size="large" />
+          </EmptyStateIcon>
+          <EmptyStateTitle>No Corpus Agents</EmptyStateTitle>
+          <EmptyStateDescription>
+            Create your first corpus-specific agent to provide specialized AI
+            assistance for documents in this corpus.
+          </EmptyStateDescription>
+          <Button
+            primary
+            icon
+            labelPosition="left"
+            onClick={() => {
+              setFormState(initialFormState);
+              setShowCreateModal(true);
+            }}
+          >
+            <Icon name="plus" />
+            Create Agent
+          </Button>
+        </EmptyState>
+      ) : (
+        <Table basic="very" celled compact>
+          <Table.Header>
+            <Table.Row>
+              <Table.HeaderCell>Name</Table.HeaderCell>
+              <Table.HeaderCell>Description</Table.HeaderCell>
+              <Table.HeaderCell>Tools</Table.HeaderCell>
+              <Table.HeaderCell>Status</Table.HeaderCell>
+              <Table.HeaderCell>Actions</Table.HeaderCell>
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            {agents.map((agent) => (
+              <Table.Row key={agent.id}>
+                <Table.Cell>
+                  <strong>{agent.name}</strong>
+                  {agent.slug && (
+                    <div style={{ fontSize: "0.75rem", color: "#64748b" }}>
+                      <code>{agent.slug}</code>
+                    </div>
+                  )}
+                </Table.Cell>
+                <Table.Cell>
+                  <span style={{ fontSize: "0.875rem" }}>
+                    {agent.description?.substring(0, 80)}
+                    {(agent.description?.length || 0) > 80 ? "..." : ""}
+                  </span>
+                </Table.Cell>
+                <Table.Cell>
+                  <ToolsList>
+                    {(agent.availableTools || []).slice(0, 2).map((tool) => (
+                      <ToolBadge key={tool} size="tiny">
+                        {tool}
+                      </ToolBadge>
+                    ))}
+                    {(agent.availableTools || []).length > 2 && (
+                      <ToolBadge size="tiny">
+                        +{(agent.availableTools || []).length - 2}
+                      </ToolBadge>
+                    )}
+                  </ToolsList>
+                </Table.Cell>
+                <Table.Cell>
+                  <StatusBadge $active={agent.isActive}>
+                    {agent.isActive ? "Active" : "Inactive"}
+                  </StatusBadge>
+                </Table.Cell>
+                <Table.Cell>
+                  <Button icon size="tiny" onClick={() => openEditModal(agent)}>
+                    <Icon name="edit" />
+                  </Button>
+                  <Button
+                    icon
+                    size="tiny"
+                    negative
+                    onClick={() => {
+                      setAgentToDelete(agent);
+                      setDeleteModalOpen(true);
+                    }}
+                  >
+                    <Icon name="trash" />
+                  </Button>
+                </Table.Cell>
+              </Table.Row>
+            ))}
+          </Table.Body>
+        </Table>
+      )}
+
+      {/* Create Modal */}
+      <Modal
+        open={showCreateModal}
+        onClose={() => setShowCreateModal(false)}
+        size="large"
+      >
+        <Modal.Header>Create Corpus Agent</Modal.Header>
+        <Modal.Content scrolling>
+          <Form>
+            <Form.Field required>
+              <label>Name</label>
+              <Input
+                placeholder="Agent name"
+                value={formState.name}
+                onChange={(e) =>
+                  setFormState({ ...formState, name: e.target.value })
+                }
+              />
+            </Form.Field>
+            <Form.Field required>
+              <label>Description</label>
+              <TextArea
+                placeholder="Brief description of what this agent does"
+                value={formState.description}
+                onChange={(e) =>
+                  setFormState({ ...formState, description: e.target.value })
+                }
+                rows={2}
+              />
+            </Form.Field>
+            <Form.Field required>
+              <label>System Instructions</label>
+              <TextArea
+                placeholder="System prompt for the agent..."
+                value={formState.systemInstructions}
+                onChange={(e) =>
+                  setFormState({
+                    ...formState,
+                    systemInstructions: e.target.value,
+                  })
+                }
+                rows={6}
+                style={{ fontFamily: "monospace" }}
+              />
+            </Form.Field>
+            <Form.Field>
+              <label>Available Tools (comma-separated)</label>
+              <Input
+                placeholder="similarity_search, load_document_text, search_exact_text"
+                value={formState.availableTools}
+                onChange={(e) =>
+                  setFormState({ ...formState, availableTools: e.target.value })
+                }
+              />
+            </Form.Field>
+            <Form.Field>
+              <label>Permission Required Tools (comma-separated)</label>
+              <Input
+                placeholder="Tools that require explicit permission"
+                value={formState.permissionRequiredTools}
+                onChange={(e) =>
+                  setFormState({
+                    ...formState,
+                    permissionRequiredTools: e.target.value,
+                  })
+                }
+              />
+            </Form.Field>
+            <Form.Field>
+              <label>Badge Config (JSON)</label>
+              <TextArea
+                placeholder='{"icon": "robot", "color": "#8b5cf6", "label": "AI"}'
+                value={formState.badgeConfig}
+                onChange={(e) =>
+                  setFormState({ ...formState, badgeConfig: e.target.value })
+                }
+                rows={3}
+                style={{ fontFamily: "monospace" }}
+              />
+            </Form.Field>
+            <Form.Field>
+              <label>Avatar URL</label>
+              <Input
+                placeholder="https://example.com/avatar.png"
+                value={formState.avatarUrl}
+                onChange={(e) =>
+                  setFormState({ ...formState, avatarUrl: e.target.value })
+                }
+              />
+            </Form.Field>
+            <Form.Field>
+              <Checkbox
+                label="Publicly visible (visible to users with corpus access)"
+                checked={formState.isPublic}
+                onChange={(_, data) =>
+                  setFormState({ ...formState, isPublic: !!data.checked })
+                }
+              />
+            </Form.Field>
+          </Form>
+        </Modal.Content>
+        <Modal.Actions>
+          <Button onClick={() => setShowCreateModal(false)}>Cancel</Button>
+          <Button
+            primary
+            loading={creating}
+            disabled={
+              !formState.name ||
+              !formState.description ||
+              !formState.systemInstructions
+            }
+            onClick={handleCreate}
+          >
+            Create Agent
+          </Button>
+        </Modal.Actions>
+      </Modal>
+
+      {/* Edit Modal */}
+      <Modal
+        open={showEditModal}
+        onClose={() => setShowEditModal(false)}
+        size="large"
+      >
+        <Modal.Header>Edit Agent: {agentToEdit?.name}</Modal.Header>
+        <Modal.Content scrolling>
+          <Form>
+            <Form.Field required>
+              <label>Name</label>
+              <Input
+                placeholder="Agent name"
+                value={formState.name}
+                onChange={(e) =>
+                  setFormState({ ...formState, name: e.target.value })
+                }
+              />
+            </Form.Field>
+            <Form.Field required>
+              <label>Description</label>
+              <TextArea
+                placeholder="Brief description of what this agent does"
+                value={formState.description}
+                onChange={(e) =>
+                  setFormState({ ...formState, description: e.target.value })
+                }
+                rows={2}
+              />
+            </Form.Field>
+            <Form.Field required>
+              <label>System Instructions</label>
+              <TextArea
+                placeholder="System prompt for the agent..."
+                value={formState.systemInstructions}
+                onChange={(e) =>
+                  setFormState({
+                    ...formState,
+                    systemInstructions: e.target.value,
+                  })
+                }
+                rows={6}
+                style={{ fontFamily: "monospace" }}
+              />
+            </Form.Field>
+            <Form.Field>
+              <label>Available Tools (comma-separated)</label>
+              <Input
+                placeholder="similarity_search, load_document_text, search_exact_text"
+                value={formState.availableTools}
+                onChange={(e) =>
+                  setFormState({ ...formState, availableTools: e.target.value })
+                }
+              />
+            </Form.Field>
+            <Form.Field>
+              <label>Permission Required Tools (comma-separated)</label>
+              <Input
+                placeholder="Tools that require explicit permission"
+                value={formState.permissionRequiredTools}
+                onChange={(e) =>
+                  setFormState({
+                    ...formState,
+                    permissionRequiredTools: e.target.value,
+                  })
+                }
+              />
+            </Form.Field>
+            <Form.Field>
+              <label>Badge Config (JSON)</label>
+              <TextArea
+                placeholder='{"icon": "robot", "color": "#8b5cf6", "label": "AI"}'
+                value={formState.badgeConfig}
+                onChange={(e) =>
+                  setFormState({ ...formState, badgeConfig: e.target.value })
+                }
+                rows={3}
+                style={{ fontFamily: "monospace" }}
+              />
+            </Form.Field>
+            <Form.Field>
+              <label>Avatar URL</label>
+              <Input
+                placeholder="https://example.com/avatar.png"
+                value={formState.avatarUrl}
+                onChange={(e) =>
+                  setFormState({ ...formState, avatarUrl: e.target.value })
+                }
+              />
+            </Form.Field>
+            <Form.Group>
+              <Form.Field>
+                <Checkbox
+                  label="Active"
+                  checked={formState.isActive}
+                  onChange={(_, data) =>
+                    setFormState({ ...formState, isActive: !!data.checked })
+                  }
+                />
+              </Form.Field>
+              <Form.Field>
+                <Checkbox
+                  label="Publicly visible"
+                  checked={formState.isPublic}
+                  onChange={(_, data) =>
+                    setFormState({ ...formState, isPublic: !!data.checked })
+                  }
+                />
+              </Form.Field>
+            </Form.Group>
+          </Form>
+        </Modal.Content>
+        <Modal.Actions>
+          <Button onClick={() => setShowEditModal(false)}>Cancel</Button>
+          <Button
+            primary
+            loading={updating}
+            disabled={
+              !formState.name ||
+              !formState.description ||
+              !formState.systemInstructions
+            }
+            onClick={handleUpdate}
+          >
+            Save Changes
+          </Button>
+        </Modal.Actions>
+      </Modal>
+
+      {/* Delete Confirmation */}
+      <ConfirmModal
+        open={deleteModalOpen}
+        message={`Are you sure you want to delete the agent "${agentToDelete?.name}"? This action cannot be undone.`}
+        onConfirm={() => {
+          if (agentToDelete) {
+            deleteAgent({ variables: { agentId: agentToDelete.id } });
+          }
+        }}
+        onCancel={() => {
+          setDeleteModalOpen(false);
+          setAgentToDelete(null);
+        }}
+        loading={deleting}
+      />
+    </Container>
+  );
+};
+
+export default CorpusAgentManagement;

--- a/frontend/src/components/corpuses/CorpusAgentManagement.tsx
+++ b/frontend/src/components/corpuses/CorpusAgentManagement.tsx
@@ -462,7 +462,7 @@ export const CorpusAgentManagement: React.FC<CorpusAgentManagementProps> = ({
     <Container>
       <SectionHeader>
         <SectionTitle as="h3">
-          <Icon name="robot" /> Corpus Agents
+          <Icon name="microchip" /> Corpus Agents
         </SectionTitle>
         <Button
           primary
@@ -488,7 +488,7 @@ export const CorpusAgentManagement: React.FC<CorpusAgentManagementProps> = ({
       {agents.length === 0 ? (
         <EmptyState>
           <EmptyStateIcon>
-            <Icon name="robot" size="large" />
+            <Icon name="microchip" size="large" />
           </EmptyStateIcon>
           <EmptyStateTitle>No Corpus Agents</EmptyStateTitle>
           <EmptyStateDescription>
@@ -826,18 +826,18 @@ export const CorpusAgentManagement: React.FC<CorpusAgentManagementProps> = ({
 
       {/* Delete Confirmation */}
       <ConfirmModal
-        open={deleteModalOpen}
+        visible={deleteModalOpen}
         message={`Are you sure you want to delete the agent "${agentToDelete?.name}"? This action cannot be undone.`}
-        onConfirm={() => {
+        yesAction={() => {
           if (agentToDelete) {
             deleteAgent({ variables: { agentId: agentToDelete.id } });
           }
         }}
-        onCancel={() => {
+        noAction={() => {
           setDeleteModalOpen(false);
           setAgentToDelete(null);
         }}
-        loading={deleting}
+        toggleModal={() => setDeleteModalOpen(false)}
       />
     </Container>
   );

--- a/frontend/src/components/corpuses/CorpusSettings.tsx
+++ b/frontend/src/components/corpuses/CorpusSettings.tsx
@@ -26,6 +26,7 @@ import {
 import { CreateCorpusActionModal } from "./CreateCorpusActionModal";
 import { CorpusMetadataSettings } from "./CorpusMetadataSettings";
 import { CorpusAgentSettings } from "./CorpusAgentSettings";
+import { CorpusAgentManagement } from "./CorpusAgentManagement";
 import {
   UPDATE_CORPUS,
   UpdateCorpusInputs,
@@ -1187,6 +1188,15 @@ export const CorpusSettings: React.FC<CorpusSettingsProps> = ({ corpus }) => {
               }
               canUpdate={canUpdate}
             />
+          </MetadataContent>
+        </InfoSection>
+
+        <InfoSection>
+          <SectionHeader>
+            <SectionTitle>Corpus Agents</SectionTitle>
+          </SectionHeader>
+          <MetadataContent>
+            <CorpusAgentManagement corpusId={corpus.id} canUpdate={canUpdate} />
           </MetadataContent>
         </InfoSection>
 

--- a/frontend/src/components/layout/MobileNavMenu.tsx
+++ b/frontend/src/components/layout/MobileNavMenu.tsx
@@ -8,6 +8,7 @@ import user_logo from "../../assets/icons/noun-person-113116-FFFFFF.png";
 import { showExportModal } from "../../graphql/cache";
 import "./MobileNavMenu.css";
 import { useNavMenu } from "./useNavMenu";
+import { useNavigate } from "react-router-dom";
 
 const MiniImage = styled.img`
   width: 35px;
@@ -40,9 +41,12 @@ export const MobileNavMenu = () => {
     loginWithPopup,
     loginWithRedirect,
   } = useNavMenu();
+  const navigate = useNavigate();
 
   // Note: CentralRouteManager automatically clears openedCorpus/openedDocument when navigating
   // No need to manually clear on menu clicks
+
+  const isSuperuser = user && (user as any).isSuperuser;
 
   const items = public_header_items.map((item) => (
     <Dropdown.Item
@@ -128,16 +132,18 @@ export const MobileNavMenu = () => {
                       onClick={() => showExportModal(!show_export_modal)}
                       icon={<Icon name="download" />}
                     />
+                    {isSuperuser && (
+                      <Dropdown.Item
+                        text="Admin Settings"
+                        onClick={() => navigate("/admin/settings")}
+                        icon={<Icon name="settings" />}
+                      />
+                    )}
                     <Dropdown.Item
                       text="Logout"
                       onClick={() => requestLogout()}
                       icon={<Icon name="log out" />}
                     />
-                    {/* <Dropdown.Item
-                                            text='Settings'
-                                            onClick={() => console.log("Do nothing yet...")}
-                                            icon={<Icon name='settings'/>}
-                                        /> */}
                   </Dropdown.Menu>
                 </Dropdown>
               </Menu.Item>
@@ -229,16 +235,18 @@ export const MobileNavMenu = () => {
                       onClick={() => showExportModal(!show_export_modal)}
                       icon={<Icon name="download" />}
                     />
+                    {isSuperuser && (
+                      <Dropdown.Item
+                        text="Admin Settings"
+                        onClick={() => navigate("/admin/settings")}
+                        icon={<Icon name="settings" />}
+                      />
+                    )}
                     <Dropdown.Item
                       text="Logout"
                       onClick={() => requestLogout()}
                       icon={<Icon name="log out" />}
                     />
-                    {/* <Dropdown.Item
-                                            text='Settings'
-                                            onClick={() => console.log("Do nothing yet...")}
-                                            icon={<Icon name='settings'/>}
-                                        /> */}
                   </Dropdown.Menu>
                 </Dropdown>
               </Menu.Item>

--- a/frontend/src/components/layout/NavMenu.tsx
+++ b/frontend/src/components/layout/NavMenu.tsx
@@ -10,6 +10,7 @@ import UserSettingsModal from "../modals/UserSettingsModal";
 import { useReactiveVar } from "@apollo/client";
 import { VERSION_TAG } from "../../assets/configurations/constants";
 import { useNavMenu } from "./useNavMenu";
+import { useNavigate } from "react-router-dom";
 
 const MiniImage = styled.img`
   width: 35px;
@@ -40,9 +41,12 @@ export const NavMenu = () => {
     requestLogout,
     doLogin,
   } = useNavMenu();
+  const navigate = useNavigate();
 
   // Note: CentralRouteManager automatically clears openedCorpus/openedDocument when navigating
   // No need to manually clear on menu clicks
+
+  const isSuperuser = user && (user as any).isSuperuser;
 
   const items = public_header_items.map((item) => (
     <Menu.Item
@@ -124,16 +128,18 @@ export const NavMenu = () => {
                         onClick={() => showUserSettingsModal(true)}
                         icon={<Icon name="user circle" />}
                       />
+                      {isSuperuser && (
+                        <Dropdown.Item
+                          text="Admin Settings"
+                          onClick={() => navigate("/admin/settings")}
+                          icon={<Icon name="settings" />}
+                        />
+                      )}
                       <Dropdown.Item
                         text="Logout"
                         onClick={() => requestLogout()}
                         icon={<Icon name="log out" />}
                       />
-                      {/* <Dropdown.Item 
-                                            text='Settings'
-                                            onClick={() => console.log("Do nothing yet...")}
-                                            icon={<Icon name='settings'/>}
-                                        /> */}
                     </Dropdown.Menu>
                   </Dropdown>
                 </Menu.Item>
@@ -199,16 +205,18 @@ export const NavMenu = () => {
                         onClick={() => showUserSettingsModal(true)}
                         icon={<Icon name="user circle" />}
                       />
+                      {isSuperuser && (
+                        <Dropdown.Item
+                          text="Admin Settings"
+                          onClick={() => navigate("/admin/settings")}
+                          icon={<Icon name="settings" />}
+                        />
+                      )}
                       <Dropdown.Item
                         text="Logout"
                         onClick={() => requestLogout()}
                         icon={<Icon name="log out" />}
                       />
-                      {/* <Dropdown.Item 
-                                            text='Settings'
-                                            onClick={() => console.log("Do nothing yet...")}
-                                            icon={<Icon name='settings'/>}
-                                        /> */}
                     </Dropdown.Menu>
                   </Dropdown>
                 </Menu.Item>

--- a/frontend/src/graphql/cache.ts
+++ b/frontend/src/graphql/cache.ts
@@ -322,6 +322,7 @@ export const showDeleteDocumentsModal = makeVar<boolean>(false);
 export const showNewLabelsetModal = makeVar<boolean>(false);
 export const showExportModal = makeVar<boolean>(false);
 export const showUserSettingsModal = makeVar<boolean>(false);
+export const showGlobalSettingsModal = makeVar<boolean>(false);
 export const showKnowledgeBaseModal = persistentVar<{
   isOpen: boolean;
   documentId: string | null;

--- a/frontend/tests/AdminComponentsTestWrapper.tsx
+++ b/frontend/tests/AdminComponentsTestWrapper.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { MockedProvider, MockedResponse } from "@apollo/client/testing";
+import { MemoryRouter } from "react-router-dom";
+import { GlobalSettingsPanel } from "../src/components/admin/GlobalSettingsPanel";
+import { GlobalAgentManagement } from "../src/components/admin/GlobalAgentManagement";
+import { CorpusAgentManagement } from "../src/components/corpuses/CorpusAgentManagement";
+
+// Wrapper for GlobalSettingsPanel with routing context
+export const GlobalSettingsPanelWrapper: React.FC = () => (
+  <MemoryRouter>
+    <GlobalSettingsPanel />
+  </MemoryRouter>
+);
+
+// Wrapper for GlobalAgentManagement with Apollo mocking
+interface GlobalAgentManagementWrapperProps {
+  mocks?: MockedResponse[];
+}
+
+export const GlobalAgentManagementWrapper: React.FC<
+  GlobalAgentManagementWrapperProps
+> = ({ mocks = [] }) => (
+  <MockedProvider mocks={mocks} addTypename={false}>
+    <GlobalAgentManagement />
+  </MockedProvider>
+);
+
+// Wrapper for CorpusAgentManagement with Apollo mocking
+interface CorpusAgentManagementWrapperProps {
+  corpusId: string;
+  canUpdate: boolean;
+  mocks?: MockedResponse[];
+}
+
+export const CorpusAgentManagementWrapper: React.FC<
+  CorpusAgentManagementWrapperProps
+> = ({ corpusId, canUpdate, mocks = [] }) => (
+  <MockedProvider mocks={mocks} addTypename={false}>
+    <CorpusAgentManagement corpusId={corpusId} canUpdate={canUpdate} />
+  </MockedProvider>
+);

--- a/frontend/tests/admin-components.ct.tsx
+++ b/frontend/tests/admin-components.ct.tsx
@@ -1,0 +1,484 @@
+// Playwright Component Test for Admin Components (Settings Panel, Agent Management)
+import React from "react";
+import { test, expect } from "@playwright/experimental-ct-react";
+import { gql } from "@apollo/client";
+import {
+  GlobalSettingsPanelWrapper,
+  GlobalAgentManagementWrapper,
+  CorpusAgentManagementWrapper,
+} from "./AdminComponentsTestWrapper";
+
+// GraphQL queries/mutations used by GlobalAgentManagement
+const GET_GLOBAL_AGENTS = gql`
+  query GetGlobalAgents {
+    agentConfigurations(scope: "GLOBAL") {
+      edges {
+        node {
+          id
+          name
+          slug
+          description
+          systemInstructions
+          availableTools
+          permissionRequiredTools
+          badgeConfig
+          avatarUrl
+          scope
+          isActive
+          isPublic
+          creator {
+            id
+            username
+          }
+          created
+          modified
+        }
+      }
+    }
+  }
+`;
+
+const GET_CORPUS_AGENTS = gql`
+  query GetCorpusAgents($corpusId: ID!) {
+    agentConfigurations(corpusId: $corpusId) {
+      edges {
+        node {
+          id
+          name
+          slug
+          description
+          systemInstructions
+          availableTools
+          permissionRequiredTools
+          badgeConfig
+          avatarUrl
+          scope
+          isActive
+          isPublic
+          creator {
+            id
+            username
+          }
+          created
+          modified
+        }
+      }
+    }
+  }
+`;
+
+// Mock data
+const mockGlobalAgent = {
+  id: "QWdlbnRDb25maWd1cmF0aW9uVHlwZTox",
+  name: "Research Assistant",
+  slug: "research-assistant",
+  description: "AI assistant for research and document analysis",
+  systemInstructions: "You are a helpful research assistant...",
+  availableTools: ["similarity_search", "load_document_text"],
+  permissionRequiredTools: [],
+  badgeConfig: { icon: "robot", color: "#6366f1", label: "AI" },
+  avatarUrl: null,
+  scope: "GLOBAL",
+  isActive: true,
+  isPublic: true,
+  creator: { id: "VXNlclR5cGU6MQ==", username: "admin" },
+  created: "2024-01-15T10:30:00Z",
+  modified: "2024-01-15T10:30:00Z",
+};
+
+const mockCorpusAgent = {
+  id: "QWdlbnRDb25maWd1cmF0aW9uVHlwZToy",
+  name: "Legal Analyst",
+  slug: "legal-analyst",
+  description: "AI assistant specialized for legal document review",
+  systemInstructions: "You are a legal analyst...",
+  availableTools: ["similarity_search", "search_exact_text"],
+  permissionRequiredTools: ["create_annotation"],
+  badgeConfig: { icon: "gavel", color: "#8b5cf6", label: "Legal" },
+  avatarUrl: null,
+  scope: "CORPUS",
+  isActive: true,
+  isPublic: false,
+  creator: { id: "VXNlclR5cGU6MQ==", username: "admin" },
+  created: "2024-01-15T10:30:00Z",
+  modified: "2024-01-15T10:30:00Z",
+};
+
+test.describe("GlobalSettingsPanel Component", () => {
+  test("should render the settings panel with all settings cards", async ({
+    mount,
+    page,
+  }) => {
+    const component = await mount(<GlobalSettingsPanelWrapper />);
+
+    // Check page title
+    await expect(page.locator("text=Admin Settings")).toBeVisible();
+
+    // Check all settings cards are present
+    await expect(page.locator("text=Badge Management")).toBeVisible();
+    await expect(page.locator("text=Global Agents")).toBeVisible();
+    await expect(page.locator("text=System Settings")).toBeVisible();
+    await expect(page.locator("text=User Management")).toBeVisible();
+
+    await component.unmount();
+  });
+
+  test("should show Coming Soon badge for unavailable features", async ({
+    mount,
+    page,
+  }) => {
+    const component = await mount(<GlobalSettingsPanelWrapper />);
+
+    // Coming Soon badges should be visible
+    const comingSoonBadges = page.locator("text=Coming Soon");
+    await expect(comingSoonBadges).toHaveCount(2);
+
+    await component.unmount();
+  });
+
+  test("should display descriptions for each settings card", async ({
+    mount,
+    page,
+  }) => {
+    const component = await mount(<GlobalSettingsPanelWrapper />);
+
+    // Check descriptions are present
+    await expect(
+      page.locator("text=Create and manage badges that can be awarded")
+    ).toBeVisible();
+    await expect(
+      page.locator("text=Configure global AI agents available")
+    ).toBeVisible();
+
+    await component.unmount();
+  });
+});
+
+test.describe("GlobalAgentManagement Component", () => {
+  test("should display list of global agents", async ({ mount, page }) => {
+    const getGlobalAgentsMock = {
+      request: {
+        query: GET_GLOBAL_AGENTS,
+      },
+      result: {
+        data: {
+          agentConfigurations: {
+            edges: [{ node: mockGlobalAgent }],
+          },
+        },
+      },
+    };
+
+    const component = await mount(
+      <GlobalAgentManagementWrapper mocks={[getGlobalAgentsMock]} />
+    );
+
+    // Wait for agents to load
+    await expect(page.locator("text=Research Assistant")).toBeVisible({
+      timeout: 5000,
+    });
+
+    // Check slug is displayed
+    await expect(page.locator("text=research-assistant")).toBeVisible();
+
+    // Check status badge
+    await expect(page.locator("text=Active")).toBeVisible();
+
+    await component.unmount();
+  });
+
+  test("should show empty state when no agents exist", async ({
+    mount,
+    page,
+  }) => {
+    const emptyAgentsMock = {
+      request: {
+        query: GET_GLOBAL_AGENTS,
+      },
+      result: {
+        data: {
+          agentConfigurations: {
+            edges: [],
+          },
+        },
+      },
+    };
+
+    const component = await mount(
+      <GlobalAgentManagementWrapper mocks={[emptyAgentsMock]} />
+    );
+
+    // Check for empty state message
+    await expect(page.locator("text=No Global Agents")).toBeVisible({
+      timeout: 5000,
+    });
+    await expect(
+      page.locator("text=Create your first global agent")
+    ).toBeVisible();
+
+    await component.unmount();
+  });
+
+  test("should open create agent modal", async ({ mount, page }) => {
+    const emptyAgentsMock = {
+      request: {
+        query: GET_GLOBAL_AGENTS,
+      },
+      result: {
+        data: {
+          agentConfigurations: {
+            edges: [],
+          },
+        },
+      },
+    };
+
+    const component = await mount(
+      <GlobalAgentManagementWrapper mocks={[emptyAgentsMock]} />
+    );
+
+    // Wait for content to load
+    await expect(page.locator("text=No Global Agents")).toBeVisible({
+      timeout: 5000,
+    });
+
+    // Click create agent button
+    await page.locator('button:has-text("Create Agent")').first().click();
+
+    // Modal should open
+    await expect(page.locator("text=Create Global Agent")).toBeVisible();
+
+    // Form fields should be present
+    await expect(page.locator("label:has-text('Name')")).toBeVisible();
+    await expect(page.locator("label:has-text('Description')")).toBeVisible();
+    await expect(
+      page.locator("label:has-text('System Instructions')")
+    ).toBeVisible();
+
+    await component.unmount();
+  });
+
+  test("should display tools as badges", async ({ mount, page }) => {
+    const getGlobalAgentsMock = {
+      request: {
+        query: GET_GLOBAL_AGENTS,
+      },
+      result: {
+        data: {
+          agentConfigurations: {
+            edges: [{ node: mockGlobalAgent }],
+          },
+        },
+      },
+    };
+
+    const component = await mount(
+      <GlobalAgentManagementWrapper mocks={[getGlobalAgentsMock]} />
+    );
+
+    // Wait for agents to load
+    await expect(page.locator("text=Research Assistant")).toBeVisible({
+      timeout: 5000,
+    });
+
+    // Tools should be displayed as badges
+    await expect(page.locator("text=similarity_search")).toBeVisible();
+    await expect(page.locator("text=load_document_text")).toBeVisible();
+
+    await component.unmount();
+  });
+
+  test("should have edit and delete buttons", async ({ mount, page }) => {
+    const getGlobalAgentsMock = {
+      request: {
+        query: GET_GLOBAL_AGENTS,
+      },
+      result: {
+        data: {
+          agentConfigurations: {
+            edges: [{ node: mockGlobalAgent }],
+          },
+        },
+      },
+    };
+
+    const component = await mount(
+      <GlobalAgentManagementWrapper mocks={[getGlobalAgentsMock]} />
+    );
+
+    // Wait for agents to load
+    await expect(page.locator("text=Research Assistant")).toBeVisible({
+      timeout: 5000,
+    });
+
+    // Edit and delete buttons should be present
+    await expect(page.locator("button i.edit.icon")).toBeVisible();
+    await expect(page.locator("button i.trash.icon")).toBeVisible();
+
+    await component.unmount();
+  });
+});
+
+test.describe("CorpusAgentManagement Component", () => {
+  test("should display list of corpus agents", async ({ mount, page }) => {
+    const getCorpusAgentsMock = {
+      request: {
+        query: GET_CORPUS_AGENTS,
+        variables: { corpusId: "Q29ycHVzVHlwZTox" },
+      },
+      result: {
+        data: {
+          agentConfigurations: {
+            edges: [{ node: mockCorpusAgent }],
+          },
+        },
+      },
+    };
+
+    const component = await mount(
+      <CorpusAgentManagementWrapper
+        corpusId="Q29ycHVzVHlwZTox"
+        canUpdate={true}
+        mocks={[getCorpusAgentsMock]}
+      />
+    );
+
+    // Wait for agents to load
+    await expect(page.locator("text=Legal Analyst")).toBeVisible({
+      timeout: 5000,
+    });
+
+    // Check slug is displayed
+    await expect(page.locator("text=legal-analyst")).toBeVisible();
+
+    await component.unmount();
+  });
+
+  test("should show empty state when no corpus agents exist", async ({
+    mount,
+    page,
+  }) => {
+    const emptyAgentsMock = {
+      request: {
+        query: GET_CORPUS_AGENTS,
+        variables: { corpusId: "Q29ycHVzVHlwZTox" },
+      },
+      result: {
+        data: {
+          agentConfigurations: {
+            edges: [],
+          },
+        },
+      },
+    };
+
+    const component = await mount(
+      <CorpusAgentManagementWrapper
+        corpusId="Q29ycHVzVHlwZTox"
+        canUpdate={true}
+        mocks={[emptyAgentsMock]}
+      />
+    );
+
+    // Check for empty state
+    await expect(page.locator("text=No Corpus Agents")).toBeVisible({
+      timeout: 5000,
+    });
+    await expect(
+      page.locator("text=Create your first corpus-specific agent")
+    ).toBeVisible();
+
+    await component.unmount();
+  });
+
+  test("should show permission message when canUpdate is false", async ({
+    mount,
+    page,
+  }) => {
+    const component = await mount(
+      <CorpusAgentManagementWrapper
+        corpusId="Q29ycHVzVHlwZTox"
+        canUpdate={false}
+        mocks={[]}
+      />
+    );
+
+    // Should show permission denied message
+    await expect(
+      page.locator("text=You do not have permission to manage agents")
+    ).toBeVisible({ timeout: 5000 });
+
+    await component.unmount();
+  });
+
+  test("should open create modal with corpus-specific title", async ({
+    mount,
+    page,
+  }) => {
+    const emptyAgentsMock = {
+      request: {
+        query: GET_CORPUS_AGENTS,
+        variables: { corpusId: "Q29ycHVzVHlwZTox" },
+      },
+      result: {
+        data: {
+          agentConfigurations: {
+            edges: [],
+          },
+        },
+      },
+    };
+
+    const component = await mount(
+      <CorpusAgentManagementWrapper
+        corpusId="Q29ycHVzVHlwZTox"
+        canUpdate={true}
+        mocks={[emptyAgentsMock]}
+      />
+    );
+
+    // Wait for content to load
+    await expect(page.locator("text=No Corpus Agents")).toBeVisible({
+      timeout: 5000,
+    });
+
+    // Click create agent button
+    await page.locator('button:has-text("Create Agent")').first().click();
+
+    // Modal should open with corpus-specific title
+    await expect(page.locator("text=Create Corpus Agent")).toBeVisible();
+
+    await component.unmount();
+  });
+
+  test("should display helper text", async ({ mount, page }) => {
+    const emptyAgentsMock = {
+      request: {
+        query: GET_CORPUS_AGENTS,
+        variables: { corpusId: "Q29ycHVzVHlwZTox" },
+      },
+      result: {
+        data: {
+          agentConfigurations: {
+            edges: [],
+          },
+        },
+      },
+    };
+
+    const component = await mount(
+      <CorpusAgentManagementWrapper
+        corpusId="Q29ycHVzVHlwZTox"
+        canUpdate={true}
+        mocks={[emptyAgentsMock]}
+      />
+    );
+
+    // Check helper text is displayed
+    await expect(
+      page.locator("text=Create custom AI agents specifically for this corpus")
+    ).toBeVisible({ timeout: 5000 });
+
+    await component.unmount();
+  });
+});


### PR DESCRIPTION
## Summary
- Add GlobalSettingsPanel component for superusers with centralized admin hub
- Add GlobalAgentManagement component for managing global AI agents
- Add CorpusAgentManagement component for corpus-specific agents
- Add Admin Settings menu item to NavMenu and MobileNavMenu dropdowns
- Add /admin/settings and /admin/agents routes
- Integrate CorpusAgentManagement into CorpusSettings view

## Features

### Admin Settings Panel
Superusers can now access a centralized admin hub via the user dropdown menu with:
- Badge Management (existing feature)
- Global Agents (new)
- System Settings (coming soon placeholder)
- User Management (coming soon placeholder)

### Global Agent Management
Full CRUD interface for global AI agents available across all corpuses:
- Create/edit agents with name, description, system instructions
- Configure available tools and permission-required tools
- Set badge config, avatar URL, and visibility settings

### Corpus Agent Management
Corpus owners can now create custom AI agents for their specific corpus:
- Accessible via Corpus Settings view
- Permission-aware (respects canUpdate permission)
- Agents scoped to specific corpus for specialized document analysis

## Test plan
- [x] 13 Playwright component tests added and passing
- [ ] Manual test: Log in as superuser, verify Admin Settings appears in dropdown
- [ ] Manual test: Navigate to /admin/settings, verify cards display correctly
- [ ] Manual test: Navigate to /admin/agents, create/edit/delete a global agent
- [ ] Manual test: Navigate to corpus settings, verify Corpus Agents section appears
- [ ] Manual test: Create/edit/delete a corpus-specific agent