### PR TITLE
feat: Add visual tool selector and badge configurator for agent management

### DIFF
--- a/config/graphql/conversation_mutations.py
+++ b/config/graphql/conversation_mutations.py
@@ -18,7 +18,11 @@ from graphql_relay import from_global_id
 
 from config.graphql.graphene_types import ConversationType, MessageType
 from config.graphql.ratelimits import RateLimits, graphql_ratelimit
-from opencontractserver.conversations.models import ChatMessage, Conversation
+from opencontractserver.conversations.models import (
+    ChatMessage,
+    Conversation,
+    MessageTypeChoices,
+)
 from opencontractserver.corpuses.models import Corpus
 from opencontractserver.tasks.agent_tasks import trigger_agent_responses_for_message
 from opencontractserver.types.enums import PermissionTypes
@@ -95,7 +99,7 @@ class CreateThreadMutation(graphene.Mutation):
             # Create the initial message
             chat_message = ChatMessage.objects.create(
                 conversation=conversation,
-                msg_type="HUMAN",
+                msg_type=MessageTypeChoices.HUMAN,
                 content=initial_message,
                 creator=user,
             )
@@ -180,7 +184,7 @@ class CreateThreadMessageMutation(graphene.Mutation):
             # Create the message
             chat_message = ChatMessage.objects.create(
                 conversation=conversation,
-                msg_type="HUMAN",
+                msg_type=MessageTypeChoices.HUMAN,
                 content=content,
                 creator=user,
             )
@@ -279,7 +283,7 @@ class ReplyToMessageMutation(graphene.Mutation):
             # Create the reply message
             reply_message = ChatMessage.objects.create(
                 conversation=conversation,
-                msg_type="HUMAN",
+                msg_type=MessageTypeChoices.HUMAN,
                 content=content,
                 parent_message=parent_message,
                 creator=user,

--- a/config/graphql/graphene_types.py
+++ b/config/graphql/graphene_types.py
@@ -2126,6 +2126,15 @@ class MessageType(AnnotatePermissionsForReadMixin, DjangoObjectType):
         "Only includes resources visible to the requesting user.",
     )
 
+    def resolve_msg_type(self, info):
+        """Convert msg_type to string for GraphQL enum compatibility."""
+        if self.msg_type:
+            # Handle both string values and enum members
+            if hasattr(self.msg_type, "value"):
+                return self.msg_type.value
+            return self.msg_type
+        return None
+
     def resolve_agent_type(self, info):
         """Convert string agent_type from model to enum."""
         if self.agent_type:

--- a/config/graphql/graphene_types.py
+++ b/config/graphql/graphene_types.py
@@ -166,10 +166,13 @@ class UserType(AnnotatePermissionsForReadMixin, DjangoObjectType):
 
         Issue: #611 - User Profile Page
         """
-        from opencontractserver.conversations.models import ChatMessage
+        from opencontractserver.conversations.models import (
+            ChatMessage,
+            MessageTypeChoices,
+        )
 
         return (
-            ChatMessage.objects.filter(creator=self, msg_type="HUMAN")
+            ChatMessage.objects.filter(creator=self, msg_type=MessageTypeChoices.HUMAN)
             .visible_to_user(info.context.user)
             .count()
         )
@@ -2576,6 +2579,49 @@ class AgentConfigurationType(AnnotatePermissionsForReadMixin, DjangoObjectType):
         if self.slug:
             return f"@agent:{self.slug}"
         return None
+
+
+# ---------------- Agent Tool Types ----------------
+class ToolParameterType(graphene.ObjectType):
+    """GraphQL type for tool parameter definitions."""
+
+    name = graphene.String(required=True, description="Parameter name")
+    description = graphene.String(required=True, description="Parameter description")
+    required = graphene.Boolean(
+        required=True, description="Whether the parameter is required"
+    )
+
+
+class AvailableToolType(graphene.ObjectType):
+    """
+    GraphQL type for available tools that can be assigned to agents.
+
+    This provides metadata about each tool, including its description,
+    category, and requirements.
+    """
+
+    name = graphene.String(
+        required=True, description="Tool name (used in configuration)"
+    )
+    description = graphene.String(
+        required=True, description="Human-readable description of the tool"
+    )
+    category = graphene.String(
+        required=True,
+        description="Tool category (search, document, corpus, notes, annotations, coordination)",
+    )
+    requires_corpus = graphene.Boolean(
+        required=True, description="Whether this tool requires a corpus context"
+    )
+    requires_approval = graphene.Boolean(
+        required=True,
+        description="Whether this tool requires user approval before execution",
+    )
+    parameters = graphene.List(
+        graphene.NonNull(ToolParameterType),
+        required=True,
+        description="List of parameters accepted by this tool",
+    )
 
 
 class NotificationType(DjangoObjectType):

--- a/config/graphql/queries.py
+++ b/config/graphql/queries.py
@@ -2135,8 +2135,8 @@ class Query(graphene.ObjectType):
 
         # Apply msg_type filter if provided
         if msg_type:
-            # Validate msg_type against ChatMessage.TYPE_CHOICES
-            valid_types = [choice[0] for choice in ChatMessage.TYPE_CHOICES]
+            # Validate msg_type against MessageTypeChoices
+            valid_types = [choice.value for choice in MessageTypeChoices]
             if msg_type in valid_types:
                 queryset = queryset.filter(msg_type=msg_type)
 

--- a/config/graphql/queries.py
+++ b/config/graphql/queries.py
@@ -114,14 +114,6 @@ from opencontractserver.documents.models import Document, DocumentRelationship
 from opencontractserver.extracts.models import Column, Datacell, Fieldset
 from opencontractserver.feedback.models import UserFeedback
 from opencontractserver.notifications.models import Notification
-from opencontractserver.pipeline.utils import (
-    get_all_embedders,
-    get_all_parsers,
-    get_all_post_processors,
-    get_all_thumbnailers,
-    get_components_by_mimetype,
-    get_metadata_for_component,
-)
 from opencontractserver.types.enums import LabelType, PermissionTypes
 from opencontractserver.users.models import Assignment, UserExport, UserImport
 from opencontractserver.utils.permissioning import user_has_permission_for_obj
@@ -1600,6 +1592,9 @@ class Query(graphene.ObjectType):
         """
         Resolver for the pipeline_components query.
 
+        Uses cached registry for fast response times. The registry is
+        initialized once on first access and cached permanently.
+
         Args:
             info: GraphQL execution info.
             mimetype (Optional[FileTypeEnum]): MIME type to filter pipeline components.
@@ -1607,8 +1602,9 @@ class Query(graphene.ObjectType):
         Returns:
             PipelineComponentsType: The pipeline components grouped by type.
         """
-        from opencontractserver.pipeline.base.file_types import (
-            FileTypeEnum as FileTypeEnumModel,
+        from opencontractserver.pipeline.registry import (
+            get_all_components_cached,
+            get_components_by_mimetype_cached,
         )
 
         if mimetype:
@@ -1620,70 +1616,43 @@ class Query(graphene.ObjectType):
             }
             mime_type_str = mime_type_mapping.get(mimetype.value)
 
-            # If mimetype is provided, get compatible components
-            components_data = get_components_by_mimetype(mime_type_str, detailed=True)
+            # Get compatible components from cached registry
+            components_data = get_components_by_mimetype_cached(mime_type_str)
         else:
-            # Get all components
-            components_data = {
-                "parsers": get_all_parsers(),
-                "embedders": get_all_embedders(),
-                "thumbnailers": get_all_thumbnailers(),
-                "post_processors": get_all_post_processors(),
-            }
+            # Get all components from cached registry
+            components_data = get_all_components_cached()
 
-        components = {
-            "parsers": [],
-            "embedders": [],
-            "thumbnailers": [],
-            "post_processors": [],
-        }
-
-        for component_type in [
-            "parsers",
-            "embedders",
-            "thumbnailers",
-            "post_processors",
-        ]:
-            for component in components_data.get(component_type, []):
-                if isinstance(component, dict):
-                    # If detailed=True, component is a dict with metadata
-                    metadata = component
-                    component_cls = metadata.get("class")
-                else:
-                    component_cls = component
-                    metadata = get_metadata_for_component(component_cls)
-                if component_cls:
-                    # Filter out any file types that are no longer supported
-                    supported_file_types = []
-                    for ft in metadata.get("supported_file_types", []):
-                        try:
-                            # Only include file types that are still defined in FileTypeEnum
-                            supported_file_types.append(FileTypeEnumModel(ft).value)
-                        except (ValueError, AttributeError):
-                            # Skip file types that are no longer supported
-                            pass
-
-                    component_info = PipelineComponentType(
-                        name=component_cls.__name__,
-                        class_name=f"{component_cls.__module__}.{component_cls.__name__}",
-                        title=metadata.get("title", ""),
-                        module_name=metadata.get("module_name", ""),
-                        description=metadata.get("description", ""),
-                        author=metadata.get("author", ""),
-                        dependencies=metadata.get("dependencies", []),
-                        supported_file_types=supported_file_types,
-                        component_type=component_type[:-1],
-                        input_schema=metadata.get("input_schema", {}),
-                    )
-                    if component_type == "embedders":
-                        component_info.vector_size = metadata.get("vector_size", 0)
-                    components[component_type].append(component_info)
+        # Convert PipelineComponentDefinition objects to GraphQL types
+        def to_graphql_type(defn, component_type: str) -> PipelineComponentType:
+            component_info = PipelineComponentType(
+                name=defn.name,
+                class_name=defn.class_name,
+                title=defn.title,
+                module_name=defn.module_name,
+                description=defn.description,
+                author=defn.author,
+                dependencies=list(defn.dependencies),
+                supported_file_types=list(defn.supported_file_types),
+                component_type=component_type,
+                input_schema=defn.input_schema,
+            )
+            if defn.vector_size is not None:
+                component_info.vector_size = defn.vector_size
+            return component_info
 
         return PipelineComponentsType(
-            parsers=components["parsers"],
-            embedders=components["embedders"],
-            thumbnailers=components["thumbnailers"],
-            post_processors=components["post_processors"],
+            parsers=[to_graphql_type(d, "parser") for d in components_data["parsers"]],
+            embedders=[
+                to_graphql_type(d, "embedder") for d in components_data["embedders"]
+            ],
+            thumbnailers=[
+                to_graphql_type(d, "thumbnailer")
+                for d in components_data["thumbnailers"]
+            ],
+            post_processors=[
+                to_graphql_type(d, "post_processor")
+                for d in components_data["post_processors"]
+            ],
         )
 
     conversations = DjangoFilterConnectionField(

--- a/frontend/src/components/agents/BadgeConfigurator.tsx
+++ b/frontend/src/components/agents/BadgeConfigurator.tsx
@@ -1,0 +1,346 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+import { Form, Input, Label } from "semantic-ui-react";
+import {
+  Bot,
+  Brain,
+  FileText,
+  Database,
+  Search,
+  MessageSquare,
+  Sparkles,
+  Zap,
+  BookOpen,
+  Code,
+  Lightbulb,
+  Target,
+  Microscope,
+  Wrench,
+  Shield,
+  Globe,
+  type LucideIcon,
+} from "lucide-react";
+
+// Available icons for agent badges
+const AVAILABLE_ICONS: { name: string; icon: LucideIcon; label: string }[] = [
+  { name: "bot", icon: Bot, label: "Robot" },
+  { name: "brain", icon: Brain, label: "Brain" },
+  { name: "sparkles", icon: Sparkles, label: "Sparkles" },
+  { name: "zap", icon: Zap, label: "Lightning" },
+  { name: "file-text", icon: FileText, label: "Document" },
+  { name: "database", icon: Database, label: "Database" },
+  { name: "search", icon: Search, label: "Search" },
+  { name: "message-square", icon: MessageSquare, label: "Chat" },
+  { name: "book-open", icon: BookOpen, label: "Book" },
+  { name: "code", icon: Code, label: "Code" },
+  { name: "lightbulb", icon: Lightbulb, label: "Idea" },
+  { name: "target", icon: Target, label: "Target" },
+  { name: "microscope", icon: Microscope, label: "Research" },
+  { name: "wrench", icon: Wrench, label: "Tools" },
+  { name: "shield", icon: Shield, label: "Shield" },
+  { name: "globe", icon: Globe, label: "Global" },
+];
+
+// Preset colors for badges
+const PRESET_COLORS = [
+  { name: "Blue", value: "#3b82f6" },
+  { name: "Purple", value: "#8b5cf6" },
+  { name: "Indigo", value: "#6366f1" },
+  { name: "Pink", value: "#ec4899" },
+  { name: "Rose", value: "#f43f5e" },
+  { name: "Orange", value: "#f97316" },
+  { name: "Amber", value: "#f59e0b" },
+  { name: "Green", value: "#22c55e" },
+  { name: "Teal", value: "#14b8a6" },
+  { name: "Cyan", value: "#06b6d4" },
+  { name: "Slate", value: "#64748b" },
+  { name: "Gray", value: "#6b7280" },
+];
+
+export interface BadgeConfig {
+  icon: string;
+  color: string;
+  label: string;
+}
+
+interface BadgeConfiguratorProps {
+  value: BadgeConfig;
+  onChange: (config: BadgeConfig) => void;
+}
+
+const Container = styled.div`
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 1rem;
+  background: #f8fafc;
+`;
+
+const PreviewSection = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid #e2e8f0;
+`;
+
+const BadgePreview = styled.div<{ $color: string }>`
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.25rem 0.625rem;
+  border-radius: 9999px;
+  background: ${(props) => props.$color}20;
+  color: ${(props) => props.$color};
+  font-size: 0.75rem;
+  font-weight: 600;
+  border: 1px solid ${(props) => props.$color}40;
+
+  svg {
+    width: 14px;
+    height: 14px;
+  }
+`;
+
+const PreviewLabel = styled.span`
+  font-size: 0.8rem;
+  color: #64748b;
+`;
+
+const SectionTitle = styled.h4`
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #475569;
+  margin: 0 0 0.5rem 0;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+`;
+
+const IconGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+
+  @media (max-width: 768px) {
+    grid-template-columns: repeat(4, 1fr);
+  }
+`;
+
+const IconButton = styled.button<{ $selected: boolean; $color: string }>`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  padding: 0.5rem;
+  border: 2px solid ${(props) => (props.$selected ? props.$color : "#e2e8f0")};
+  border-radius: 8px;
+  background: ${(props) => (props.$selected ? `${props.$color}10` : "white")};
+  cursor: pointer;
+  transition: all 0.15s ease;
+
+  &:hover {
+    border-color: ${(props) => props.$color};
+    background: ${(props) => `${props.$color}10`};
+  }
+
+  svg {
+    width: 20px;
+    height: 20px;
+    color: ${(props) => (props.$selected ? props.$color : "#64748b")};
+  }
+
+  span {
+    font-size: 0.65rem;
+    color: ${(props) => (props.$selected ? props.$color : "#94a3b8")};
+  }
+`;
+
+const ColorGrid = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+`;
+
+const ColorButton = styled.button<{ $color: string; $selected: boolean }>`
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  background: ${(props) => props.$color};
+  border: 3px solid ${(props) => (props.$selected ? "#1e293b" : "transparent")};
+  cursor: pointer;
+  transition: all 0.15s ease;
+  position: relative;
+
+  &:hover {
+    transform: scale(1.1);
+  }
+
+  ${(props) =>
+    props.$selected &&
+    `
+    &::after {
+      content: "✓";
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      color: white;
+      font-size: 14px;
+      font-weight: bold;
+      text-shadow: 0 1px 2px rgba(0,0,0,0.3);
+    }
+  `}
+`;
+
+const CustomColorInput = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+`;
+
+const ColorInputWrapper = styled.div`
+  position: relative;
+  width: 32px;
+  height: 32px;
+
+  input[type="color"] {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    opacity: 0;
+    cursor: pointer;
+  }
+`;
+
+const ColorSwatch = styled.div<{ $color: string }>`
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  background: ${(props) => props.$color};
+  border: 2px dashed #cbd5e1;
+`;
+
+const LabelInputWrapper = styled.div`
+  margin-top: 0.5rem;
+
+  .ui.input {
+    width: 200px;
+  }
+`;
+
+// Helper to get icon component by name
+const getIconComponent = (name: string): LucideIcon => {
+  const found = AVAILABLE_ICONS.find((i) => i.name === name);
+  return found?.icon || Bot;
+};
+
+export const BadgeConfigurator: React.FC<BadgeConfiguratorProps> = ({
+  value,
+  onChange,
+}) => {
+  const [showCustomColor, setShowCustomColor] = useState(
+    !PRESET_COLORS.some((c) => c.value === value.color)
+  );
+
+  const IconComponent = getIconComponent(value.icon);
+
+  const handleIconChange = (iconName: string) => {
+    onChange({ ...value, icon: iconName });
+  };
+
+  const handleColorChange = (color: string) => {
+    onChange({ ...value, color });
+    setShowCustomColor(false);
+  };
+
+  const handleCustomColorChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    onChange({ ...value, color: e.target.value });
+    setShowCustomColor(true);
+  };
+
+  const handleLabelChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    onChange({ ...value, label: e.target.value });
+  };
+
+  return (
+    <Container>
+      {/* Preview */}
+      <PreviewSection>
+        <PreviewLabel>Preview:</PreviewLabel>
+        <BadgePreview $color={value.color}>
+          <IconComponent />
+          <span>{value.label || "Agent"}</span>
+        </BadgePreview>
+      </PreviewSection>
+
+      {/* Icon Selection */}
+      <SectionTitle>Icon</SectionTitle>
+      <IconGrid>
+        {AVAILABLE_ICONS.map(({ name, icon: Icon, label }) => (
+          <IconButton
+            key={name}
+            type="button"
+            $selected={value.icon === name}
+            $color={value.color}
+            onClick={() => handleIconChange(name)}
+            title={label}
+          >
+            <Icon />
+            <span>{label}</span>
+          </IconButton>
+        ))}
+      </IconGrid>
+
+      {/* Color Selection */}
+      <SectionTitle>Color</SectionTitle>
+      <ColorGrid>
+        {PRESET_COLORS.map(({ name, value: colorValue }) => (
+          <ColorButton
+            key={colorValue}
+            type="button"
+            $color={colorValue}
+            $selected={value.color === colorValue && !showCustomColor}
+            onClick={() => handleColorChange(colorValue)}
+            title={name}
+          />
+        ))}
+        <CustomColorInput>
+          <ColorInputWrapper>
+            <ColorSwatch $color={showCustomColor ? value.color : "#cbd5e1"} />
+            <input
+              type="color"
+              value={value.color}
+              onChange={handleCustomColorChange}
+              title="Custom color"
+            />
+          </ColorInputWrapper>
+        </CustomColorInput>
+      </ColorGrid>
+
+      {/* Label Input */}
+      <SectionTitle>Label Text</SectionTitle>
+      <LabelInputWrapper>
+        <Form.Field>
+          <Input
+            placeholder="AI Assistant"
+            value={value.label}
+            onChange={handleLabelChange}
+            maxLength={20}
+          />
+          <small
+            style={{ color: "#64748b", marginTop: "0.25rem", display: "block" }}
+          >
+            Short label shown on the badge (max 20 chars)
+          </small>
+        </Form.Field>
+      </LabelInputWrapper>
+    </Container>
+  );
+};
+
+export default BadgeConfigurator;

--- a/frontend/src/components/threads/ReplyForm.tsx
+++ b/frontend/src/components/threads/ReplyForm.tsx
@@ -150,6 +150,9 @@ export function ReplyForm({
   const [error, setError] = useState("");
   const [showQuote, setShowQuote] = useState(false);
 
+  // Submission guard to prevent double submissions
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
   // Determine which mutation to use
   const isTopLevel = !parentMessageId && conversationId;
   const isNestedReply = !!parentMessageId;
@@ -216,12 +219,21 @@ export function ReplyForm({
   const loading = createLoading || replyLoading;
 
   const handleSubmit = async (content: string) => {
+    // Guard against double submissions
+    if (isSubmitting) {
+      console.warn("[ReplyForm] Blocked duplicate submission");
+      return;
+    }
+
     setError("");
 
     if (!content.trim()) {
       setError("Please write a message.");
       return;
     }
+
+    // Set submission guard
+    setIsSubmitting(true);
 
     try {
       if (isTopLevel && conversationId) {
@@ -243,6 +255,9 @@ export function ReplyForm({
       }
     } catch (err) {
       // Error already handled in mutation callbacks
+    } finally {
+      // Reset submission guard after a short delay to prevent rapid re-submissions
+      setTimeout(() => setIsSubmitting(false), 500);
     }
   };
 
@@ -303,7 +318,7 @@ export function ReplyForm({
             : "Write your message..."
         }
         onSubmit={handleSubmit}
-        disabled={loading}
+        disabled={loading || isSubmitting}
         error={error}
         autoFocus={autoFocus}
         maxLength={10000}

--- a/frontend/src/components/threads/ThreadDetail.tsx
+++ b/frontend/src/components/threads/ThreadDetail.tsx
@@ -390,7 +390,8 @@ export function ThreadDetail({
           <ReplyForm
             conversationId={conversationId}
             onSuccess={() => {
-              refetch();
+              // Apollo's refetchQueries in ReplyForm handles refetching
+              // No additional refetch needed here to avoid double-fetch issues
             }}
             onCancel={() => {
               // No-op for bottom composer - it's always visible

--- a/local.yml
+++ b/local.yml
@@ -61,7 +61,7 @@ services:
     container_name: docling-parser
 
   vector-embedder:
-    image: jscrudato/vector-embedder-microservice
+    image: ghcr.io/jsv4/vectorembeddermicroservice:latest
     container_name: vector-embedder
     environment:
       PORT: 8000

--- a/opencontractserver/agents/migrations/0005_generate_missing_slugs.py
+++ b/opencontractserver/agents/migrations/0005_generate_missing_slugs.py
@@ -1,0 +1,48 @@
+# Generated manually for agent mentions feature
+# Ensures ALL agents have slugs
+
+from django.db import migrations
+from django.utils.text import slugify
+
+
+def generate_slugs_for_all_agents(apps, schema_editor):  # pragma: no cover
+    """
+    Generate slugs for any agents that don't have one.
+    Uses the agent name to create a URL-friendly slug.
+    """
+    AgentConfiguration = apps.get_model("agents", "AgentConfiguration")
+
+    # Find all agents without slugs
+    agents_without_slugs = AgentConfiguration.objects.filter(slug__isnull=True)
+
+    for agent in agents_without_slugs:
+        base_slug = slugify(agent.name) if agent.name else "agent"
+
+        # Ensure uniqueness by appending a number if needed
+        slug = base_slug
+        counter = 1
+        while AgentConfiguration.objects.filter(slug=slug).exclude(pk=agent.pk).exists():
+            slug = f"{base_slug}-{counter}"
+            counter += 1
+
+        agent.slug = slug
+        agent.save(update_fields=["slug"])
+        print(f"  Generated slug '{slug}' for agent '{agent.name}' (id={agent.pk})")
+
+
+def reverse_migration(apps, schema_editor):  # pragma: no cover
+    """
+    Reverse is a no-op - we don't want to remove slugs.
+    """
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("agents", "0004_ensure_default_agents"),
+    ]
+
+    operations = [
+        migrations.RunPython(generate_slugs_for_all_agents, reverse_migration),
+    ]

--- a/opencontractserver/conversations/models.py
+++ b/opencontractserver/conversations/models.py
@@ -18,7 +18,20 @@ from opencontractserver.shared.Models import BaseOCModel
 User = get_user_model()
 
 
-MessageType = Literal["ASYNC_START", "ASYNC_CONTENT", "ASYNC_FINISH", "SYNC_CONTENT"]
+# Legacy type hint for streaming message events (used in async handlers)
+StreamingMessageType = Literal[
+    "ASYNC_START", "ASYNC_CONTENT", "ASYNC_FINISH", "SYNC_CONTENT"
+]
+
+# For backwards compatibility - alias to the new name
+MessageType = StreamingMessageType
+
+
+# Message type choices for ChatMessage.msg_type field
+class MessageTypeChoices(models.TextChoices):
+    SYSTEM = "SYSTEM", "System"
+    HUMAN = "HUMAN", "Human"
+    LLM = "LLM", "LLM"
 
 
 # NEW – persisted lifecycle state so the frontend does not have to
@@ -623,12 +636,6 @@ class ChatMessage(BaseOCModel, HasEmbeddingMixin):
             ("comment_chatmessage", "comment chatmessage"),
         )
 
-    TYPE_CHOICES = (
-        ("SYSTEM", "SYSTEM"),
-        ("HUMAN", "HUMAN"),
-        ("LLM", "LLM"),
-    )
-
     conversation = models.ForeignKey(
         Conversation,
         on_delete=models.CASCADE,
@@ -637,7 +644,7 @@ class ChatMessage(BaseOCModel, HasEmbeddingMixin):
     )
     msg_type = models.CharField(
         max_length=32,
-        choices=TYPE_CHOICES,
+        choices=MessageTypeChoices.choices,
         help_text="The type of message (SYSTEM, HUMAN, or LLM)",
     )
     agent_type = models.CharField(

--- a/opencontractserver/llms/agents/core_agents.py
+++ b/opencontractserver/llms/agents/core_agents.py
@@ -23,6 +23,7 @@ from opencontractserver.conversations.models import (
     ChatMessage,
     Conversation,
     MessageStateChoices,
+    MessageTypeChoices,
 )
 from opencontractserver.corpuses.models import Corpus
 from opencontractserver.documents.models import Document
@@ -1318,7 +1319,7 @@ class CoreConversationManager:
         message = await ChatMessage.objects.acreate(
             conversation=self.conversation,
             content=content,
-            msg_type="HUMAN",
+            msg_type=MessageTypeChoices.HUMAN,
             creator_id=self.user_id,
             data={
                 "state": MessageState.COMPLETED,
@@ -1352,7 +1353,7 @@ class CoreConversationManager:
         message = await ChatMessage.objects.acreate(
             conversation=self.conversation,
             content=content,
-            msg_type="LLM",
+            msg_type=MessageTypeChoices.LLM,
             creator_id=self.user_id,
             data=data,
             state=MessageStateChoices.COMPLETED,

--- a/opencontractserver/llms/agents/pydantic_ai_agents.py
+++ b/opencontractserver/llms/agents/pydantic_ai_agents.py
@@ -1296,12 +1296,13 @@ class PydanticAICoreAgent(CoreAgentBase, TimelineStreamMixin):
             user_message_id: int | None = None
             from opencontractserver.conversations.models import (  # local import to avoid cycles
                 ChatMessage,
+                MessageTypeChoices,
             )
 
             if paused_msg.conversation_id:
                 async for _m in ChatMessage.objects.filter(
                     conversation_id=paused_msg.conversation_id,
-                    msg_type="HUMAN",
+                    msg_type=MessageTypeChoices.HUMAN,
                 ).order_by("-created"):
                     user_message_id = _m.id
                     break

--- a/opencontractserver/llms/tools/tool_registry.py
+++ b/opencontractserver/llms/tools/tool_registry.py
@@ -158,7 +158,11 @@ AVAILABLE_TOOLS: tuple[ToolDefinition, ...] = (
         category=ToolCategory.DOCUMENT,
         requires_corpus=True,
         parameters=(
-            ("limit", "Maximum number of versions to return (most recent first)", False),
+            (
+                "limit",
+                "Maximum number of versions to return (most recent first)",
+                False,
+            ),
         ),
     ),
     ToolDefinition(
@@ -226,8 +230,16 @@ AVAILABLE_TOOLS: tuple[ToolDefinition, ...] = (
         requires_approval=True,
         parameters=(
             ("note_id", "ID of the note to update", True),
-            ("new_content", "Full new content (mutually exclusive with diff_text)", False),
-            ("diff_text", "ndiff format diff to apply (mutually exclusive with new_content)", False),
+            (
+                "new_content",
+                "Full new content (mutually exclusive with diff_text)",
+                False,
+            ),
+            (
+                "diff_text",
+                "ndiff format diff to apply (mutually exclusive with new_content)",
+                False,
+            ),
         ),
     ),
     # -------------------------------------------------------------------------
@@ -274,7 +286,11 @@ AVAILABLE_TOOLS: tuple[ToolDefinition, ...] = (
         category=ToolCategory.COORDINATION,
         requires_corpus=True,
         parameters=(
-            ("document_id", "ID of the target document (must belong to this corpus)", True),
+            (
+                "document_id",
+                "ID of the target document (must belong to this corpus)",
+                True,
+            ),
             ("question", "The natural-language question to forward", True),
         ),
     ),

--- a/opencontractserver/llms/tools/tool_registry.py
+++ b/opencontractserver/llms/tools/tool_registry.py
@@ -1,0 +1,356 @@
+"""
+Central registry of all available tools for agent configurations.
+
+This module provides a structured listing of all tools that can be assigned
+to agents, including their metadata, descriptions, and categorization.
+"""
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class ToolCategory(str, Enum):
+    """Categories for agent tools."""
+
+    SEARCH = "search"
+    DOCUMENT = "document"
+    CORPUS = "corpus"
+    NOTES = "notes"
+    ANNOTATIONS = "annotations"
+    COORDINATION = "coordination"
+
+
+@dataclass(frozen=True)
+class ToolDefinition:
+    """Definition of an available tool for agents."""
+
+    name: str
+    description: str
+    category: ToolCategory
+    requires_corpus: bool = False
+    requires_approval: bool = False
+    parameters: tuple[tuple[str, str, bool], ...] = ()  # (name, description, required)
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary for GraphQL response."""
+        return {
+            "name": self.name,
+            "description": self.description,
+            "category": self.category.value,
+            "requires_corpus": self.requires_corpus,
+            "requires_approval": self.requires_approval,
+            "parameters": [
+                {"name": p[0], "description": p[1], "required": p[2]}
+                for p in self.parameters
+            ],
+        }
+
+
+# =============================================================================
+# AVAILABLE TOOLS REGISTRY
+# =============================================================================
+
+AVAILABLE_TOOLS: tuple[ToolDefinition, ...] = (
+    # -------------------------------------------------------------------------
+    # SEARCH TOOLS
+    # -------------------------------------------------------------------------
+    ToolDefinition(
+        name="similarity_search",
+        description=(
+            "Search for semantically similar content using vector embeddings. "
+            "Returns relevant passages from annotations with similarity scores."
+        ),
+        category=ToolCategory.SEARCH,
+        parameters=(
+            ("query", "The search query text", True),
+            ("k", "Number of results to return (default 5)", False),
+        ),
+    ),
+    ToolDefinition(
+        name="search_exact_text",
+        description=(
+            "Find exact text matches in a document and return them as source nodes "
+            "with page numbers and bounding boxes. Essential for creating proper citations."
+        ),
+        category=ToolCategory.SEARCH,
+        parameters=(
+            (
+                "search_strings",
+                "List of exact strings to find (all occurrences will be found)",
+                True,
+            ),
+        ),
+    ),
+    # -------------------------------------------------------------------------
+    # DOCUMENT TOOLS
+    # -------------------------------------------------------------------------
+    ToolDefinition(
+        name="load_document_summary",
+        description=(
+            "Load the markdown summary of a document. Optionally truncate by length "
+            "and direction (from start or end)."
+        ),
+        category=ToolCategory.DOCUMENT,
+        parameters=(
+            ("truncate_length", "Optional number of characters to truncate to", False),
+            ("from_start", "If True, truncate from start; if False, from end", False),
+        ),
+    ),
+    ToolDefinition(
+        name="get_summary_token_length",
+        description="Get the approximate token length of a document's markdown summary.",
+        category=ToolCategory.DOCUMENT,
+    ),
+    ToolDefinition(
+        name="get_document_text_length",
+        description=(
+            "Get the total character length of the document's plain-text extract. "
+            "Use this BEFORE loading text to plan your chunking strategy."
+        ),
+        category=ToolCategory.DOCUMENT,
+    ),
+    ToolDefinition(
+        name="load_document_text",
+        description=(
+            "Load a slice of the document's plain-text extract. Always use "
+            "get_document_text_length first to plan chunking. Load in chunks of "
+            "5K-50K chars to avoid context overflow. After reading, call "
+            "search_exact_text on key passages to create citations."
+        ),
+        category=ToolCategory.DOCUMENT,
+        parameters=(
+            ("start", "Inclusive start character index (default 0)", False),
+            ("end", "Exclusive end character index (defaults to end of file)", False),
+            ("refresh", "If true, refresh the cached content from disk", False),
+        ),
+    ),
+    ToolDefinition(
+        name="get_page_image",
+        description=(
+            "Get a visual image of a specific page from a PDF document as base64. "
+            "Useful for inspecting diagrams, tables, images, and other visual content."
+        ),
+        category=ToolCategory.DOCUMENT,
+        parameters=(
+            ("page_number", "The page number to render (1-indexed)", True),
+            ("image_format", "Image format: 'jpeg' or 'png' (default 'jpeg')", False),
+            ("dpi", "Resolution in DPI (default 150)", False),
+        ),
+    ),
+    # -------------------------------------------------------------------------
+    # DOCUMENT SUMMARY VERSIONING TOOLS
+    # -------------------------------------------------------------------------
+    ToolDefinition(
+        name="get_document_summary",
+        description=(
+            "Get the latest summary content for a document in a specific corpus."
+        ),
+        category=ToolCategory.DOCUMENT,
+        requires_corpus=True,
+        parameters=(
+            ("truncate_length", "Optional max characters to return", False),
+            ("from_start", "If True truncate from beginning, else from end", False),
+        ),
+    ),
+    ToolDefinition(
+        name="get_document_summary_versions",
+        description="Get the version history for a document's summaries in a corpus.",
+        category=ToolCategory.DOCUMENT,
+        requires_corpus=True,
+        parameters=(
+            ("limit", "Maximum number of versions to return (most recent first)", False),
+        ),
+    ),
+    ToolDefinition(
+        name="get_document_summary_diff",
+        description="Get the diff between two summary versions.",
+        category=ToolCategory.DOCUMENT,
+        requires_corpus=True,
+        parameters=(
+            ("from_version", "Starting version number", True),
+            ("to_version", "Ending version number", True),
+        ),
+    ),
+    ToolDefinition(
+        name="update_document_summary",
+        description=(
+            "Create a new summary revision for a document. "
+            "Returns version information about the created revision."
+        ),
+        category=ToolCategory.DOCUMENT,
+        requires_corpus=True,
+        requires_approval=True,
+        parameters=(("new_content", "The new summary content", True),),
+    ),
+    # -------------------------------------------------------------------------
+    # NOTES TOOLS
+    # -------------------------------------------------------------------------
+    ToolDefinition(
+        name="get_document_notes",
+        description=(
+            "Retrieve all notes attached to a document in the current corpus. "
+            "Returns metadata and first 512-char preview of each note."
+        ),
+        category=ToolCategory.NOTES,
+        requires_corpus=True,
+    ),
+    ToolDefinition(
+        name="search_document_notes",
+        description=(
+            "Search notes by title or content (case-insensitive). "
+            "Returns matching notes for a document."
+        ),
+        category=ToolCategory.NOTES,
+        parameters=(
+            ("search_term", "Text to search for in title or content", True),
+            ("limit", "Maximum number of notes to return", False),
+        ),
+    ),
+    ToolDefinition(
+        name="add_document_note",
+        description="Create a new note attached to a document.",
+        category=ToolCategory.NOTES,
+        requires_approval=True,
+        parameters=(
+            ("title", "Note title", True),
+            ("content", "Note content", True),
+        ),
+    ),
+    ToolDefinition(
+        name="update_document_note",
+        description=(
+            "Update an existing note, creating a new revision. "
+            "Provide either new_content or diff_text (ndiff format)."
+        ),
+        category=ToolCategory.NOTES,
+        requires_approval=True,
+        parameters=(
+            ("note_id", "ID of the note to update", True),
+            ("new_content", "Full new content (mutually exclusive with diff_text)", False),
+            ("diff_text", "ndiff format diff to apply (mutually exclusive with new_content)", False),
+        ),
+    ),
+    # -------------------------------------------------------------------------
+    # CORPUS TOOLS
+    # -------------------------------------------------------------------------
+    ToolDefinition(
+        name="get_corpus_description",
+        description="Retrieve the latest markdown description for this corpus.",
+        category=ToolCategory.CORPUS,
+        requires_corpus=True,
+        parameters=(
+            ("truncate_length", "Optionally truncate to this many characters", False),
+            ("from_start", "If true, truncate from beginning else from end", False),
+        ),
+    ),
+    ToolDefinition(
+        name="update_corpus_description",
+        description=(
+            "Update corpus description with new markdown text, creating a revision if changed."
+        ),
+        category=ToolCategory.CORPUS,
+        requires_corpus=True,
+        requires_approval=True,
+        parameters=(("new_content", "Full markdown content", True),),
+    ),
+    # -------------------------------------------------------------------------
+    # COORDINATION TOOLS (for corpus agents)
+    # -------------------------------------------------------------------------
+    ToolDefinition(
+        name="list_documents",
+        description=(
+            "List all documents in the current corpus with their IDs, titles, and descriptions. "
+            "Use this to decide which document to query with ask_document."
+        ),
+        category=ToolCategory.COORDINATION,
+        requires_corpus=True,
+    ),
+    ToolDefinition(
+        name="ask_document",
+        description=(
+            "Ask a question to a document-specific agent within this corpus. "
+            "The sub-agent has full access to document tools (search, summary, notes, etc.)."
+        ),
+        category=ToolCategory.COORDINATION,
+        requires_corpus=True,
+        parameters=(
+            ("document_id", "ID of the target document (must belong to this corpus)", True),
+            ("question", "The natural-language question to forward", True),
+        ),
+    ),
+    # -------------------------------------------------------------------------
+    # ANNOTATION TOOLS
+    # -------------------------------------------------------------------------
+    ToolDefinition(
+        name="duplicate_annotations_with_label",
+        description=(
+            "Duplicate existing annotations with a new label. "
+            "Creates copies of annotations with the specified label applied."
+        ),
+        category=ToolCategory.ANNOTATIONS,
+        requires_corpus=True,
+        requires_approval=True,
+        parameters=(
+            ("annotation_ids", "List of annotation IDs to duplicate", True),
+            ("new_label_text", "Text of the label to apply to duplicates", True),
+            ("label_type", "Optional label type (defaults to TOKEN_LABEL)", False),
+        ),
+    ),
+    ToolDefinition(
+        name="add_annotations_from_exact_strings",
+        description=(
+            "Create annotations for exact string matches in documents. "
+            "For PDFs: creates token-level annotations. For text: creates span annotations."
+        ),
+        category=ToolCategory.ANNOTATIONS,
+        requires_corpus=True,
+        requires_approval=True,
+        parameters=(
+            (
+                "items",
+                "List of (label_text, exact_string, document_id, corpus_id) tuples",
+                True,
+            ),
+        ),
+    ),
+)
+
+
+def get_all_tools() -> list[dict]:
+    """Get all available tools as a list of dictionaries."""
+    return [tool.to_dict() for tool in AVAILABLE_TOOLS]
+
+
+def get_tools_by_category(category: str) -> list[dict]:
+    """Get tools filtered by category."""
+    try:
+        cat = ToolCategory(category)
+    except ValueError:
+        return []
+    return [tool.to_dict() for tool in AVAILABLE_TOOLS if tool.category == cat]
+
+
+def get_tool_by_name(name: str) -> dict | None:
+    """Get a single tool by name."""
+    for tool in AVAILABLE_TOOLS:
+        if tool.name == name:
+            return tool.to_dict()
+    return None
+
+
+def get_tool_names() -> list[str]:
+    """Get just the names of all available tools."""
+    return [tool.name for tool in AVAILABLE_TOOLS]
+
+
+def validate_tool_names(names: list[str]) -> tuple[list[str], list[str]]:
+    """
+    Validate a list of tool names against the registry.
+
+    Returns:
+        Tuple of (valid_names, invalid_names)
+    """
+    valid_names = get_tool_names()
+    valid = [n for n in names if n in valid_names]
+    invalid = [n for n in names if n not in valid_names]
+    return valid, invalid

--- a/opencontractserver/pipeline/registry.py
+++ b/opencontractserver/pipeline/registry.py
@@ -1,0 +1,409 @@
+"""
+Central registry of all pipeline components with lazy initialization.
+
+This module provides an efficient, cached registry of pipeline components
+(parsers, embedders, thumbnailers, post-processors) that:
+1. Auto-discovers components on first access (no manual registration needed)
+2. Caches the registry at module level for zero-overhead subsequent access
+3. Exposes fast lookup functions similar to the tool_registry pattern
+
+Performance:
+- First access: ~50-100ms (module scanning)
+- Subsequent accesses: ~0ms (cached dict lookup)
+"""
+
+import importlib
+import inspect
+import logging
+import pkgutil
+from dataclasses import dataclass, field
+from enum import Enum
+from functools import lru_cache
+from typing import Any, Optional
+
+from opencontractserver.pipeline.base.embedder import BaseEmbedder
+from opencontractserver.pipeline.base.file_types import FileTypeEnum
+from opencontractserver.pipeline.base.parser import BaseParser
+from opencontractserver.pipeline.base.post_processor import BasePostProcessor
+from opencontractserver.pipeline.base.thumbnailer import BaseThumbnailGenerator
+
+logger = logging.getLogger(__name__)
+
+
+class ComponentType(str, Enum):
+    """Types of pipeline components."""
+
+    PARSER = "parser"
+    EMBEDDER = "embedder"
+    THUMBNAILER = "thumbnailer"
+    POST_PROCESSOR = "post_processor"
+
+
+@dataclass(frozen=True)
+class PipelineComponentDefinition:
+    """
+    Immutable definition of a pipeline component for fast registry access.
+
+    This captures the component's metadata at registration time, avoiding
+    repeated attribute lookups on the class.
+    """
+
+    name: str
+    class_name: str  # Full module.ClassName path
+    component_type: ComponentType
+    title: str
+    module_name: str
+    description: str
+    author: str
+    dependencies: tuple[str, ...]
+    supported_file_types: tuple[str, ...]  # FileTypeEnum values as strings
+    input_schema: dict = field(default_factory=dict)
+    vector_size: Optional[int] = None  # Only for embedders
+    component_class: Optional[type] = field(
+        default=None, compare=False, hash=False
+    )  # Reference to actual class
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for GraphQL response."""
+        result = {
+            "name": self.name,
+            "class_name": self.class_name,
+            "component_type": self.component_type.value,
+            "title": self.title,
+            "module_name": self.module_name,
+            "description": self.description,
+            "author": self.author,
+            "dependencies": list(self.dependencies),
+            "supported_file_types": list(self.supported_file_types),
+            "input_schema": self.input_schema,
+        }
+        if self.vector_size is not None:
+            result["vector_size"] = self.vector_size
+        return result
+
+
+class PipelineComponentRegistry:
+    """
+    Singleton registry for all pipeline components.
+
+    Uses lazy initialization - components are discovered on first access
+    and cached for all subsequent accesses.
+    """
+
+    _instance: Optional["PipelineComponentRegistry"] = None
+    _initialized: bool = False
+
+    def __new__(cls) -> "PipelineComponentRegistry":
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __init__(self):
+        # Only initialize once (singleton pattern)
+        if PipelineComponentRegistry._initialized:
+            return
+        PipelineComponentRegistry._initialized = True
+
+        # Initialize storage
+        self._parsers: tuple[PipelineComponentDefinition, ...] = ()
+        self._embedders: tuple[PipelineComponentDefinition, ...] = ()
+        self._thumbnailers: tuple[PipelineComponentDefinition, ...] = ()
+        self._post_processors: tuple[PipelineComponentDefinition, ...] = ()
+
+        # Name -> Definition lookup for fast access
+        self._by_name: dict[str, PipelineComponentDefinition] = {}
+        self._by_class_name: dict[str, PipelineComponentDefinition] = {}
+
+        # File type -> Components lookup for filtering
+        self._parsers_by_filetype: dict[str, list[PipelineComponentDefinition]] = {}
+        self._thumbnailers_by_filetype: dict[str, list[PipelineComponentDefinition]] = (
+            {}
+        )
+        self._post_processors_by_filetype: dict[
+            str, list[PipelineComponentDefinition]
+        ] = {}
+
+        # Perform discovery
+        self._discover_all_components()
+
+    def _discover_subclasses(self, module_name: str, base_class: type) -> list[type]:
+        """
+        Discover all subclasses of base_class in the given module package.
+
+        This is called ONCE during initialization.
+        """
+        subclasses = []
+        try:
+            package = importlib.import_module(module_name)
+            prefix = package.__name__ + "."
+
+            for _, modname, ispkg in pkgutil.iter_modules(package.__path__, prefix):
+                if not ispkg:
+                    try:
+                        module = importlib.import_module(modname)
+                        for name, obj in inspect.getmembers(module, inspect.isclass):
+                            if issubclass(obj, base_class) and obj != base_class:
+                                subclasses.append(obj)
+                    except Exception as e:
+                        logger.warning(f"Failed to import {modname}: {e}")
+        except Exception as e:
+            logger.error(f"Failed to discover components in {module_name}: {e}")
+
+        return subclasses
+
+    def _create_definition(
+        self, component_class: type, component_type: ComponentType
+    ) -> PipelineComponentDefinition:
+        """Create a PipelineComponentDefinition from a component class."""
+        module_name = component_class.__module__.split(".")[-1]
+
+        # Get supported file types, filtering to valid ones
+        # Store as the enum value (e.g., "pdf") for consistency
+        supported_file_types = []
+        if hasattr(component_class, "supported_file_types"):
+            for ft in component_class.supported_file_types:
+                if ft in [FileTypeEnum.PDF, FileTypeEnum.TXT, FileTypeEnum.DOCX]:
+                    # Store the enum value ("pdf", "txt", "docx")
+                    supported_file_types.append(ft.value)
+
+        # Build definition
+        definition = PipelineComponentDefinition(
+            name=component_class.__name__,
+            class_name=f"{component_class.__module__}.{component_class.__name__}",
+            component_type=component_type,
+            title=getattr(component_class, "title", ""),
+            module_name=module_name,
+            description=getattr(component_class, "description", ""),
+            author=getattr(component_class, "author", ""),
+            dependencies=tuple(getattr(component_class, "dependencies", [])),
+            supported_file_types=tuple(supported_file_types),
+            input_schema=dict(getattr(component_class, "input_schema", {})),
+            vector_size=getattr(component_class, "vector_size", None),
+            component_class=component_class,
+        )
+
+        return definition
+
+    def _discover_all_components(self) -> None:
+        """
+        Discover and register all pipeline components.
+
+        Called once during singleton initialization.
+        """
+        logger.info("Initializing pipeline component registry...")
+
+        # Discover parsers
+        parser_classes = self._discover_subclasses(
+            "opencontractserver.pipeline.parsers", BaseParser
+        )
+        parsers = []
+        for cls in parser_classes:
+            defn = self._create_definition(cls, ComponentType.PARSER)
+            parsers.append(defn)
+            self._by_name[defn.name] = defn
+            self._by_class_name[defn.class_name] = defn
+            for ft in defn.supported_file_types:
+                self._parsers_by_filetype.setdefault(ft, []).append(defn)
+        self._parsers = tuple(parsers)
+
+        # Discover embedders
+        embedder_classes = self._discover_subclasses(
+            "opencontractserver.pipeline.embedders", BaseEmbedder
+        )
+        embedders = []
+        for cls in embedder_classes:
+            defn = self._create_definition(cls, ComponentType.EMBEDDER)
+            embedders.append(defn)
+            self._by_name[defn.name] = defn
+            self._by_class_name[defn.class_name] = defn
+        self._embedders = tuple(embedders)
+
+        # Discover thumbnailers
+        thumbnailer_classes = self._discover_subclasses(
+            "opencontractserver.pipeline.thumbnailers", BaseThumbnailGenerator
+        )
+        thumbnailers = []
+        for cls in thumbnailer_classes:
+            defn = self._create_definition(cls, ComponentType.THUMBNAILER)
+            thumbnailers.append(defn)
+            self._by_name[defn.name] = defn
+            self._by_class_name[defn.class_name] = defn
+            for ft in defn.supported_file_types:
+                self._thumbnailers_by_filetype.setdefault(ft, []).append(defn)
+        self._thumbnailers = tuple(thumbnailers)
+
+        # Discover post-processors
+        post_processor_classes = self._discover_subclasses(
+            "opencontractserver.pipeline.post_processors", BasePostProcessor
+        )
+        post_processors = []
+        for cls in post_processor_classes:
+            defn = self._create_definition(cls, ComponentType.POST_PROCESSOR)
+            post_processors.append(defn)
+            self._by_name[defn.name] = defn
+            self._by_class_name[defn.class_name] = defn
+            for ft in defn.supported_file_types:
+                self._post_processors_by_filetype.setdefault(ft, []).append(defn)
+        self._post_processors = tuple(post_processors)
+
+        logger.info(
+            f"Pipeline registry initialized: "
+            f"{len(self._parsers)} parsers, "
+            f"{len(self._embedders)} embedders, "
+            f"{len(self._thumbnailers)} thumbnailers, "
+            f"{len(self._post_processors)} post-processors"
+        )
+
+    # -------------------------------------------------------------------------
+    # PUBLIC API - Fast cached access
+    # -------------------------------------------------------------------------
+
+    @property
+    def parsers(self) -> tuple[PipelineComponentDefinition, ...]:
+        """Get all registered parsers."""
+        return self._parsers
+
+    @property
+    def embedders(self) -> tuple[PipelineComponentDefinition, ...]:
+        """Get all registered embedders."""
+        return self._embedders
+
+    @property
+    def thumbnailers(self) -> tuple[PipelineComponentDefinition, ...]:
+        """Get all registered thumbnailers."""
+        return self._thumbnailers
+
+    @property
+    def post_processors(self) -> tuple[PipelineComponentDefinition, ...]:
+        """Get all registered post-processors."""
+        return self._post_processors
+
+    def get_by_name(self, name: str) -> Optional[PipelineComponentDefinition]:
+        """Get a component definition by class name (e.g., 'DoclingParser')."""
+        return self._by_name.get(name)
+
+    def get_by_class_name(
+        self, class_name: str
+    ) -> Optional[PipelineComponentDefinition]:
+        """
+        Get a component by full class path.
+
+        E.g., 'opencontractserver.pipeline.parsers.docling_parser_rest.DoclingParser'
+        """
+        return self._by_class_name.get(class_name)
+
+    def get_parsers_for_filetype(
+        self, file_type: str
+    ) -> list[PipelineComponentDefinition]:
+        """Get parsers compatible with a file type (e.g., 'application/pdf')."""
+        return self._parsers_by_filetype.get(file_type, [])
+
+    def get_thumbnailers_for_filetype(
+        self, file_type: str
+    ) -> list[PipelineComponentDefinition]:
+        """Get thumbnailers compatible with a file type."""
+        return self._thumbnailers_by_filetype.get(file_type, [])
+
+    def get_post_processors_for_filetype(
+        self, file_type: str
+    ) -> list[PipelineComponentDefinition]:
+        """Get post-processors compatible with a file type."""
+        return self._post_processors_by_filetype.get(file_type, [])
+
+
+# =============================================================================
+# MODULE-LEVEL CONVENIENCE FUNCTIONS
+# =============================================================================
+
+
+# Lazy singleton access
+@lru_cache(maxsize=1)
+def get_registry() -> PipelineComponentRegistry:
+    """
+    Get the singleton pipeline component registry.
+
+    The registry is initialized on first access and cached permanently.
+    """
+    return PipelineComponentRegistry()
+
+
+def get_all_parsers_cached() -> tuple[PipelineComponentDefinition, ...]:
+    """Get all registered parsers (cached)."""
+    return get_registry().parsers
+
+
+def get_all_embedders_cached() -> tuple[PipelineComponentDefinition, ...]:
+    """Get all registered embedders (cached)."""
+    return get_registry().embedders
+
+
+def get_all_thumbnailers_cached() -> tuple[PipelineComponentDefinition, ...]:
+    """Get all registered thumbnailers (cached)."""
+    return get_registry().thumbnailers
+
+
+def get_all_post_processors_cached() -> tuple[PipelineComponentDefinition, ...]:
+    """Get all registered post-processors (cached)."""
+    return get_registry().post_processors
+
+
+def get_component_by_name_cached(name: str) -> Optional[PipelineComponentDefinition]:
+    """Get a component definition by name (cached)."""
+    return get_registry().get_by_name(name)
+
+
+def get_components_by_mimetype_cached(
+    mimetype: str,
+) -> dict[str, list[PipelineComponentDefinition]]:
+    """
+    Get all components compatible with a MIME type (cached).
+
+    Args:
+        mimetype: MIME type string (e.g., "application/pdf")
+
+    Returns dict with keys: parsers, embedders, thumbnailers, post_processors
+    """
+    registry = get_registry()
+
+    # Convert MIME type to FileTypeEnum value for lookup
+    # FileTypeEnum values are "pdf", "txt", "docx" - not MIME types
+    mime_to_enum_value = {
+        "application/pdf": "pdf",
+        "text/plain": "txt",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document": "docx",
+    }
+
+    file_type_value = mime_to_enum_value.get(mimetype, mimetype)
+
+    return {
+        "parsers": registry.get_parsers_for_filetype(file_type_value),
+        "embedders": list(registry.embedders),  # Embedders work on all text
+        "thumbnailers": registry.get_thumbnailers_for_filetype(file_type_value),
+        "post_processors": registry.get_post_processors_for_filetype(file_type_value),
+    }
+
+
+def get_all_components_cached() -> dict[str, tuple[PipelineComponentDefinition, ...]]:
+    """
+    Get all components grouped by type (cached).
+
+    Returns dict with keys: parsers, embedders, thumbnailers, post_processors
+    """
+    registry = get_registry()
+    return {
+        "parsers": registry.parsers,
+        "embedders": registry.embedders,
+        "thumbnailers": registry.thumbnailers,
+        "post_processors": registry.post_processors,
+    }
+
+
+def reset_registry() -> None:
+    """
+    Reset the registry singleton.
+
+    Useful for testing or if components are dynamically added.
+    """
+    PipelineComponentRegistry._instance = None
+    PipelineComponentRegistry._initialized = False
+    get_registry.cache_clear()

--- a/opencontractserver/tasks/__init__.py
+++ b/opencontractserver/tasks/__init__.py
@@ -1,3 +1,4 @@
+from .agent_tasks import generate_agent_response, trigger_agent_responses_for_message
 from .badge_tasks import check_auto_badges, check_badges_for_all_users
 from .cleanup_tasks import delete_analysis_and_annotations_task
 from .corpus_tasks import *  # noqa: F403, F401
@@ -37,4 +38,6 @@ __all__ = [
     "delete_analysis_and_annotations_task",
     "check_auto_badges",
     "check_badges_for_all_users",
+    "generate_agent_response",
+    "trigger_agent_responses_for_message",
 ]

--- a/opencontractserver/tests/test_agent_tasks.py
+++ b/opencontractserver/tests/test_agent_tasks.py
@@ -1,0 +1,286 @@
+"""
+Tests for agent task functions in opencontractserver/tasks/agent_tasks.py.
+
+These tests cover:
+- Helper functions (get_thread_channel_group, broadcast_to_thread)
+- The trigger_agent_responses_for_message Celery task
+- Error handling paths in generate_agent_response
+"""
+
+from unittest.mock import MagicMock, patch
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from opencontractserver.agents.models import AgentConfiguration
+from opencontractserver.conversations.models import (
+    ChatMessage,
+    Conversation,
+    MessageTypeChoices,
+)
+from opencontractserver.corpuses.models import Corpus
+from opencontractserver.tasks.agent_tasks import (
+    broadcast_to_thread,
+    generate_agent_response,
+    get_thread_channel_group,
+    trigger_agent_responses_for_message,
+)
+from opencontractserver.types.enums import PermissionTypes
+from opencontractserver.utils.permissioning import set_permissions_for_obj_to_user
+
+User = get_user_model()
+
+
+class TestGetThreadChannelGroup(TestCase):
+    """Tests for get_thread_channel_group helper function."""
+
+    def test_returns_correct_format(self):
+        """Test that channel group name follows expected format."""
+        result = get_thread_channel_group(123)
+        self.assertEqual(result, "thread_123")
+
+    def test_handles_different_ids(self):
+        """Test with various conversation IDs."""
+        self.assertEqual(get_thread_channel_group(1), "thread_1")
+        self.assertEqual(get_thread_channel_group(999999), "thread_999999")
+        self.assertEqual(get_thread_channel_group(0), "thread_0")
+
+
+class TestBroadcastToThread(TestCase):
+    """Tests for broadcast_to_thread helper function."""
+
+    @patch("opencontractserver.tasks.agent_tasks.get_channel_layer")
+    def test_no_channel_layer_logs_warning(self, mock_get_channel_layer):
+        """Test that missing channel layer logs warning and returns early."""
+        mock_get_channel_layer.return_value = None
+
+        # Should not raise, just log and return
+        broadcast_to_thread(123, "agent.stream", {"key": "value"})
+
+        mock_get_channel_layer.assert_called_once()
+
+    @patch("opencontractserver.tasks.agent_tasks.get_channel_layer")
+    @patch("opencontractserver.tasks.agent_tasks.async_to_sync")
+    def test_broadcasts_with_converted_message_type(
+        self, mock_async_to_sync, mock_get_channel_layer
+    ):
+        """Test that message type dots are converted to underscores."""
+        mock_channel_layer = MagicMock()
+        mock_get_channel_layer.return_value = mock_channel_layer
+        mock_async_to_sync.return_value = MagicMock()
+
+        broadcast_to_thread(123, "agent.stream_start", {"message_id": "456"})
+
+        # Check async_to_sync was called with group_send
+        mock_async_to_sync.assert_called_once_with(mock_channel_layer.group_send)
+
+    @patch("opencontractserver.tasks.agent_tasks.get_channel_layer")
+    @patch("opencontractserver.tasks.agent_tasks.async_to_sync")
+    def test_uses_correct_group_name(self, mock_async_to_sync, mock_get_channel_layer):
+        """Test that correct group name is used for broadcast."""
+        mock_channel_layer = MagicMock()
+        mock_get_channel_layer.return_value = mock_channel_layer
+        mock_send = MagicMock()
+        mock_async_to_sync.return_value = mock_send
+
+        broadcast_to_thread(789, "test.event", {"data": "test"})
+
+        # Verify the call arguments
+        mock_send.assert_called_once()
+        call_args = mock_send.call_args[0]
+        self.assertEqual(call_args[0], "thread_789")
+        self.assertEqual(call_args[1]["type"], "test_event")
+        self.assertEqual(call_args[1]["data"], "test")
+
+
+class TestTriggerAgentResponsesForMessage(TestCase):
+    """Tests for trigger_agent_responses_for_message Celery task."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """Set up test data."""
+        cls.user = User.objects.create_user(
+            username="agent_task_test_user",
+            email="agent_task@example.com",
+            password="testpass123",
+        )
+        cls.corpus = Corpus.objects.create(
+            title="Test Corpus",
+            creator=cls.user,
+        )
+        set_permissions_for_obj_to_user(cls.user, cls.corpus, [PermissionTypes.CRUD])
+
+        cls.conversation = Conversation.objects.create(
+            title="Test Conversation",
+            conversation_type="thread",
+            chat_with_corpus=cls.corpus,
+            creator=cls.user,
+        )
+        set_permissions_for_obj_to_user(
+            cls.user, cls.conversation, [PermissionTypes.CRUD]
+        )
+
+        cls.agent = AgentConfiguration.objects.create(
+            name="Test Agent",
+            slug="test-agent",
+            description="A test agent",
+            system_instructions="You are a test agent.",
+            scope="CORPUS",
+            corpus=cls.corpus,
+            creator=cls.user,
+            is_active=True,
+        )
+        set_permissions_for_obj_to_user(cls.user, cls.agent, [PermissionTypes.CRUD])
+
+    def test_message_not_found_returns_error(self):
+        """Test handling of non-existent message."""
+        result = trigger_agent_responses_for_message(999999, self.user.pk)
+
+        self.assertEqual(result["agents_triggered"], 0)
+        self.assertEqual(result["task_ids"], [])
+        self.assertEqual(result["error"], "Message not found")
+
+    def test_no_mentioned_agents_returns_zero(self):
+        """Test message with no agent mentions."""
+        message = ChatMessage.objects.create(
+            conversation=self.conversation,
+            msg_type=MessageTypeChoices.HUMAN,
+            content="Hello, no agents mentioned here",
+            creator=self.user,
+        )
+
+        result = trigger_agent_responses_for_message(message.pk, self.user.pk)
+
+        self.assertEqual(result["agents_triggered"], 0)
+        self.assertEqual(result["task_ids"], [])
+
+    @patch("opencontractserver.tasks.agent_tasks.generate_agent_response.delay")
+    def test_triggers_response_for_mentioned_agent(self, mock_delay):
+        """Test that mentioning an agent triggers a response task."""
+        mock_task = MagicMock()
+        mock_task.id = "test-task-id-123"
+        mock_delay.return_value = mock_task
+
+        message = ChatMessage.objects.create(
+            conversation=self.conversation,
+            msg_type=MessageTypeChoices.HUMAN,
+            content="Hello @test-agent, how are you?",
+            creator=self.user,
+        )
+        # Manually add the agent mention (normally done by mention parser)
+        message.mentioned_agents.add(self.agent)
+
+        result = trigger_agent_responses_for_message(message.pk, self.user.pk)
+
+        self.assertEqual(result["agents_triggered"], 1)
+        self.assertEqual(result["task_ids"], ["test-task-id-123"])
+        mock_delay.assert_called_once_with(
+            source_message_id=message.pk,
+            agent_config_id=self.agent.pk,
+            user_id=self.user.pk,
+        )
+
+    @patch("opencontractserver.tasks.agent_tasks.generate_agent_response.delay")
+    def test_inactive_agent_not_triggered(self, mock_delay):
+        """Test that inactive agents are not triggered."""
+        # Create an inactive agent
+        inactive_agent = AgentConfiguration.objects.create(
+            name="Inactive Agent",
+            slug="inactive-agent",
+            description="An inactive agent",
+            system_instructions="You are inactive.",
+            scope="CORPUS",
+            corpus=self.corpus,
+            creator=self.user,
+            is_active=False,
+        )
+
+        message = ChatMessage.objects.create(
+            conversation=self.conversation,
+            msg_type=MessageTypeChoices.HUMAN,
+            content="Hello @inactive-agent",
+            creator=self.user,
+        )
+        message.mentioned_agents.add(inactive_agent)
+
+        result = trigger_agent_responses_for_message(message.pk, self.user.pk)
+
+        self.assertEqual(result["agents_triggered"], 0)
+        self.assertEqual(result["task_ids"], [])
+        mock_delay.assert_not_called()
+
+
+class TestGenerateAgentResponseErrors(TestCase):
+    """Tests for error handling in generate_agent_response task."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """Set up test data."""
+        cls.user = User.objects.create_user(
+            username="agent_response_test_user",
+            email="agent_response@example.com",
+            password="testpass123",
+        )
+        cls.corpus = Corpus.objects.create(
+            title="Test Corpus for Response",
+            creator=cls.user,
+        )
+        set_permissions_for_obj_to_user(cls.user, cls.corpus, [PermissionTypes.CRUD])
+
+        cls.conversation = Conversation.objects.create(
+            title="Test Conversation",
+            conversation_type="thread",
+            chat_with_corpus=cls.corpus,
+            creator=cls.user,
+        )
+
+        cls.agent = AgentConfiguration.objects.create(
+            name="Response Test Agent",
+            slug="response-test-agent",
+            description="A test agent for response testing",
+            system_instructions="You are a test agent.",
+            scope="CORPUS",
+            corpus=cls.corpus,
+            creator=cls.user,
+            is_active=True,
+        )
+
+        cls.message = ChatMessage.objects.create(
+            conversation=cls.conversation,
+            msg_type=MessageTypeChoices.HUMAN,
+            content="Test message",
+            creator=cls.user,
+        )
+
+    def test_user_not_found_returns_error(self):
+        """Test handling when user doesn't exist."""
+        result = generate_agent_response(
+            self.message.pk,
+            self.agent.pk,
+            999999,  # Non-existent user ID
+        )
+
+        self.assertEqual(result["status"], "error")
+        self.assertEqual(result["error"], "User not found")
+
+    def test_message_not_found_returns_error(self):
+        """Test handling when source message doesn't exist."""
+        result = generate_agent_response(
+            999999,  # Non-existent message ID
+            self.agent.pk,
+            self.user.pk,
+        )
+
+        self.assertEqual(result["status"], "error")
+        self.assertEqual(result["error"], "Source message not found")
+
+    def test_agent_config_not_found_returns_error(self):
+        """Test handling when agent configuration doesn't exist."""
+        result = generate_agent_response(
+            self.message.pk,
+            999999,  # Non-existent agent config ID
+            self.user.pk,
+        )
+
+        self.assertEqual(result["status"], "error")
+        self.assertEqual(result["error"], "Agent configuration not found")

--- a/opencontractserver/tests/test_agents.py
+++ b/opencontractserver/tests/test_agents.py
@@ -169,6 +169,63 @@ class TestAgentConfigurationModel(TestCase):
         self.assertEqual(agent.badge_config["icon"], "Bot")
         self.assertEqual(agent.badge_config["color"], "#4A5568")
 
+    def test_slug_auto_generation(self):
+        """Test that slug is auto-generated from name if not provided."""
+        agent = AgentConfiguration.objects.create(
+            name="My Test Agent",
+            description="Test agent",
+            system_instructions="Test instructions",
+            scope="GLOBAL",
+            creator=self.admin_user,
+        )
+
+        self.assertEqual(agent.slug, "my-test-agent")
+
+    def test_slug_uniqueness_with_counter(self):
+        """Test that duplicate slugs get a counter appended."""
+        # Create first agent
+        agent1 = AgentConfiguration.objects.create(
+            name="Duplicate Name",
+            description="First agent",
+            system_instructions="Test",
+            scope="GLOBAL",
+            creator=self.admin_user,
+        )
+        self.assertEqual(agent1.slug, "duplicate-name")
+
+        # Create second agent with same name - should get -1 suffix
+        agent2 = AgentConfiguration.objects.create(
+            name="Duplicate Name",
+            description="Second agent",
+            system_instructions="Test",
+            scope="GLOBAL",
+            creator=self.admin_user,
+        )
+        self.assertEqual(agent2.slug, "duplicate-name-1")
+
+        # Create third agent - should get -2 suffix
+        agent3 = AgentConfiguration.objects.create(
+            name="Duplicate Name",
+            description="Third agent",
+            system_instructions="Test",
+            scope="GLOBAL",
+            creator=self.admin_user,
+        )
+        self.assertEqual(agent3.slug, "duplicate-name-2")
+
+    def test_explicit_slug_preserved(self):
+        """Test that explicitly provided slug is not overwritten."""
+        agent = AgentConfiguration.objects.create(
+            name="Some Agent Name",
+            slug="custom-slug-value",
+            description="Test agent",
+            system_instructions="Test",
+            scope="GLOBAL",
+            creator=self.admin_user,
+        )
+
+        self.assertEqual(agent.slug, "custom-slug-value")
+
     def test_agent_string_representation(self):
         """Test agent string representation."""
         global_agent = AgentConfiguration.objects.create(

--- a/opencontractserver/tests/test_available_tools_graphql.py
+++ b/opencontractserver/tests/test_available_tools_graphql.py
@@ -1,0 +1,179 @@
+"""
+Tests for the availableTools GraphQL query.
+"""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from graphene_django.utils.testing import GraphQLTestCase
+
+from opencontractserver.llms.tools.tool_registry import get_all_tools
+
+User = get_user_model()
+
+
+class AvailableToolsQueryTests(GraphQLTestCase):
+    """Tests for the availableTools GraphQL query."""
+
+    GRAPHQL_URL = "/graphql/"
+
+    @classmethod
+    def setUpTestData(cls):
+        """Set up test data."""
+        cls.user = User.objects.create_user(
+            username="testuser",
+            email="test@example.com",
+            password="testpass123",
+        )
+
+    def test_available_tools_query(self):
+        """Test that availableTools query returns all tools."""
+        self.client.force_login(self.user)
+
+        response = self.query(
+            """
+            query {
+                availableTools {
+                    name
+                    description
+                    category
+                    requiresCorpus
+                    requiresApproval
+                }
+            }
+            """
+        )
+
+        content = response.json()
+        self.assertResponseNoErrors(response)
+
+        tools = content["data"]["availableTools"]
+        self.assertIsInstance(tools, list)
+        self.assertGreater(len(tools), 0)
+
+        # Check structure of first tool
+        first_tool = tools[0]
+        self.assertIn("name", first_tool)
+        self.assertIn("description", first_tool)
+        self.assertIn("category", first_tool)
+        self.assertIn("requiresCorpus", first_tool)
+        self.assertIn("requiresApproval", first_tool)
+
+    def test_available_tools_query_with_category_filter(self):
+        """Test filtering tools by category."""
+        self.client.force_login(self.user)
+
+        response = self.query(
+            """
+            query {
+                availableTools(category: "search") {
+                    name
+                    category
+                }
+            }
+            """
+        )
+
+        content = response.json()
+        self.assertResponseNoErrors(response)
+
+        tools = content["data"]["availableTools"]
+        self.assertIsInstance(tools, list)
+        self.assertGreater(len(tools), 0)
+
+        # All tools should be in search category
+        for tool in tools:
+            self.assertEqual(tool["category"], "search")
+
+    def test_available_tools_query_invalid_category(self):
+        """Test filtering by invalid category returns empty list."""
+        self.client.force_login(self.user)
+
+        response = self.query(
+            """
+            query {
+                availableTools(category: "invalid_category") {
+                    name
+                }
+            }
+            """
+        )
+
+        content = response.json()
+        self.assertResponseNoErrors(response)
+
+        tools = content["data"]["availableTools"]
+        self.assertEqual(tools, [])
+
+    def test_available_tool_categories_query(self):
+        """Test that availableToolCategories returns all categories."""
+        self.client.force_login(self.user)
+
+        response = self.query(
+            """
+            query {
+                availableToolCategories
+            }
+            """
+        )
+
+        content = response.json()
+        self.assertResponseNoErrors(response)
+
+        categories = content["data"]["availableToolCategories"]
+        self.assertIsInstance(categories, list)
+        self.assertGreater(len(categories), 0)
+
+        # Check expected categories
+        expected = ["search", "document", "corpus", "notes", "annotations", "coordination"]
+        for cat in expected:
+            self.assertIn(cat, categories)
+
+    def test_available_tools_contains_expected_tools(self):
+        """Test that specific expected tools are returned."""
+        self.client.force_login(self.user)
+
+        response = self.query(
+            """
+            query {
+                availableTools {
+                    name
+                }
+            }
+            """
+        )
+
+        content = response.json()
+        self.assertResponseNoErrors(response)
+
+        tool_names = [t["name"] for t in content["data"]["availableTools"]]
+
+        # Check for some expected tools
+        expected_tools = [
+            "similarity_search",
+            "search_exact_text",
+            "load_document_text",
+            "list_documents",
+            "ask_document",
+        ]
+        for tool_name in expected_tools:
+            self.assertIn(tool_name, tool_names)
+
+    def test_available_tools_anonymous_user(self):
+        """Test that anonymous users can still query available tools."""
+        # Note: This query is informational and doesn't require auth
+        response = self.query(
+            """
+            query {
+                availableTools {
+                    name
+                }
+            }
+            """
+        )
+
+        content = response.json()
+        # This should work for anonymous users as it's just static metadata
+        # If it fails with auth error, the design decision was to require auth
+        tools = content.get("data", {}).get("availableTools")
+        if tools is not None:
+            self.assertIsInstance(tools, list)

--- a/opencontractserver/tests/test_available_tools_graphql.py
+++ b/opencontractserver/tests/test_available_tools_graphql.py
@@ -3,10 +3,7 @@ Tests for the availableTools GraphQL query.
 """
 
 from django.contrib.auth import get_user_model
-from django.test import TestCase
 from graphene_django.utils.testing import GraphQLTestCase
-
-from opencontractserver.llms.tools.tool_registry import get_all_tools
 
 User = get_user_model()
 
@@ -124,7 +121,14 @@ class AvailableToolsQueryTests(GraphQLTestCase):
         self.assertGreater(len(categories), 0)
 
         # Check expected categories
-        expected = ["search", "document", "corpus", "notes", "annotations", "coordination"]
+        expected = [
+            "search",
+            "document",
+            "corpus",
+            "notes",
+            "annotations",
+            "coordination",
+        ]
         for cat in expected:
             self.assertIn(cat, categories)
 

--- a/opencontractserver/tests/test_long_conversation_api.py
+++ b/opencontractserver/tests/test_long_conversation_api.py
@@ -14,7 +14,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 
-from opencontractserver.conversations.models import ChatMessage, Conversation
+from opencontractserver.conversations.models import (
+    ChatMessage,
+    Conversation,
+    MessageTypeChoices,
+)
 from opencontractserver.corpuses.models import Corpus
 from opencontractserver.documents.models import Document
 from opencontractserver.llms.api import agents
@@ -325,7 +329,9 @@ class TestLongConversationAPI(TestCase):
             )
 
             # Find our message
-            user_messages = [msg for msg in messages if msg.msg_type == "HUMAN"]
+            user_messages = [
+                msg for msg in messages if msg.msg_type == MessageTypeChoices.HUMAN
+            ]
             self.assertTrue(
                 any("First session message" in msg.content for msg in user_messages),
                 "Should preserve message history across sessions",

--- a/opencontractserver/tests/test_pipeline_registry.py
+++ b/opencontractserver/tests/test_pipeline_registry.py
@@ -1,0 +1,306 @@
+"""
+Tests for the pipeline component registry.
+
+Tests the cached registry pattern that provides efficient access to
+pipeline components (parsers, embedders, thumbnailers, post-processors).
+"""
+
+from django.test import TestCase
+
+from opencontractserver.pipeline.registry import (
+    ComponentType,
+    PipelineComponentDefinition,
+    get_all_components_cached,
+    get_all_embedders_cached,
+    get_all_parsers_cached,
+    get_all_post_processors_cached,
+    get_all_thumbnailers_cached,
+    get_component_by_name_cached,
+    get_components_by_mimetype_cached,
+    get_registry,
+    reset_registry,
+)
+
+
+class TestPipelineComponentDefinition(TestCase):
+    """Tests for PipelineComponentDefinition dataclass."""
+
+    def test_to_dict_basic(self):
+        """Test basic conversion to dictionary."""
+        defn = PipelineComponentDefinition(
+            name="TestParser",
+            class_name="test.module.TestParser",
+            component_type=ComponentType.PARSER,
+            title="Test Parser",
+            module_name="test_module",
+            description="A test parser",
+            author="Test Author",
+            dependencies=("dep1", "dep2"),
+            supported_file_types=("application/pdf",),
+            input_schema={"type": "object"},
+        )
+
+        result = defn.to_dict()
+
+        self.assertEqual(result["name"], "TestParser")
+        self.assertEqual(result["class_name"], "test.module.TestParser")
+        self.assertEqual(result["component_type"], "parser")
+        self.assertEqual(result["title"], "Test Parser")
+        self.assertEqual(result["dependencies"], ["dep1", "dep2"])
+        self.assertEqual(result["supported_file_types"], ["application/pdf"])
+        self.assertNotIn("vector_size", result)
+
+    def test_to_dict_with_vector_size(self):
+        """Test that embedders include vector_size."""
+        defn = PipelineComponentDefinition(
+            name="TestEmbedder",
+            class_name="test.module.TestEmbedder",
+            component_type=ComponentType.EMBEDDER,
+            title="Test Embedder",
+            module_name="test_module",
+            description="A test embedder",
+            author="Test Author",
+            dependencies=(),
+            supported_file_types=(),
+            vector_size=768,
+        )
+
+        result = defn.to_dict()
+
+        self.assertEqual(result["vector_size"], 768)
+
+    def test_frozen_dataclass(self):
+        """Test that definition is immutable."""
+        defn = PipelineComponentDefinition(
+            name="TestParser",
+            class_name="test.module.TestParser",
+            component_type=ComponentType.PARSER,
+            title="Test Parser",
+            module_name="test_module",
+            description="A test parser",
+            author="Test Author",
+            dependencies=(),
+            supported_file_types=(),
+        )
+
+        with self.assertRaises(Exception):
+            defn.name = "ChangedName"
+
+
+class TestPipelineComponentRegistry(TestCase):
+    """Tests for PipelineComponentRegistry singleton."""
+
+    def setUp(self):
+        """Reset registry before each test."""
+        reset_registry()
+
+    def tearDown(self):
+        """Reset registry after each test."""
+        reset_registry()
+
+    def test_singleton_pattern(self):
+        """Test that registry is a singleton."""
+        registry1 = get_registry()
+        registry2 = get_registry()
+        self.assertIs(registry1, registry2)
+
+    def test_registry_has_parsers(self):
+        """Test that registry discovers parsers."""
+        registry = get_registry()
+        self.assertIsInstance(registry.parsers, tuple)
+        # Should have at least one parser (DoclingParser, NLMIngestParser, etc.)
+        self.assertGreater(len(registry.parsers), 0)
+
+    def test_registry_has_embedders(self):
+        """Test that registry discovers embedders."""
+        registry = get_registry()
+        self.assertIsInstance(registry.embedders, tuple)
+        # Should have at least one embedder
+        self.assertGreater(len(registry.embedders), 0)
+
+    def test_registry_has_thumbnailers(self):
+        """Test that registry discovers thumbnailers."""
+        registry = get_registry()
+        self.assertIsInstance(registry.thumbnailers, tuple)
+        # Should have at least one thumbnailer
+        self.assertGreater(len(registry.thumbnailers), 0)
+
+    def test_get_by_name(self):
+        """Test looking up component by name."""
+        registry = get_registry()
+        # Get first parser name
+        if registry.parsers:
+            parser_name = registry.parsers[0].name
+            result = registry.get_by_name(parser_name)
+            self.assertIsNotNone(result)
+            self.assertEqual(result.name, parser_name)
+
+    def test_get_by_name_not_found(self):
+        """Test looking up non-existent component."""
+        registry = get_registry()
+        result = registry.get_by_name("NonExistentParser")
+        self.assertIsNone(result)
+
+    def test_get_by_class_name(self):
+        """Test looking up component by full class name."""
+        registry = get_registry()
+        if registry.parsers:
+            class_name = registry.parsers[0].class_name
+            result = registry.get_by_class_name(class_name)
+            self.assertIsNotNone(result)
+            self.assertEqual(result.class_name, class_name)
+
+    def test_get_parsers_for_filetype_pdf(self):
+        """Test getting parsers for PDF files."""
+        registry = get_registry()
+        # FileTypeEnum.PDF.value is "pdf", not the MIME type
+        pdf_parsers = registry.get_parsers_for_filetype("pdf")
+        self.assertIsInstance(pdf_parsers, list)
+        # Should have at least one PDF parser
+        self.assertGreater(len(pdf_parsers), 0)
+
+    def test_get_parsers_for_filetype_unknown(self):
+        """Test getting parsers for unknown file type."""
+        registry = get_registry()
+        result = registry.get_parsers_for_filetype("application/unknown")
+        self.assertEqual(result, [])
+
+
+class TestModuleLevelFunctions(TestCase):
+    """Tests for module-level convenience functions."""
+
+    def setUp(self):
+        """Reset registry before each test."""
+        reset_registry()
+
+    def tearDown(self):
+        """Reset registry after each test."""
+        reset_registry()
+
+    def test_get_all_parsers_cached(self):
+        """Test cached parser retrieval."""
+        parsers = get_all_parsers_cached()
+        self.assertIsInstance(parsers, tuple)
+        self.assertGreater(len(parsers), 0)
+        # All should be PipelineComponentDefinition
+        for p in parsers:
+            self.assertIsInstance(p, PipelineComponentDefinition)
+            self.assertEqual(p.component_type, ComponentType.PARSER)
+
+    def test_get_all_embedders_cached(self):
+        """Test cached embedder retrieval."""
+        embedders = get_all_embedders_cached()
+        self.assertIsInstance(embedders, tuple)
+        self.assertGreater(len(embedders), 0)
+        for e in embedders:
+            self.assertIsInstance(e, PipelineComponentDefinition)
+            self.assertEqual(e.component_type, ComponentType.EMBEDDER)
+
+    def test_get_all_thumbnailers_cached(self):
+        """Test cached thumbnailer retrieval."""
+        thumbnailers = get_all_thumbnailers_cached()
+        self.assertIsInstance(thumbnailers, tuple)
+        for t in thumbnailers:
+            self.assertIsInstance(t, PipelineComponentDefinition)
+            self.assertEqual(t.component_type, ComponentType.THUMBNAILER)
+
+    def test_get_all_post_processors_cached(self):
+        """Test cached post-processor retrieval."""
+        post_processors = get_all_post_processors_cached()
+        self.assertIsInstance(post_processors, tuple)
+        for p in post_processors:
+            self.assertIsInstance(p, PipelineComponentDefinition)
+            self.assertEqual(p.component_type, ComponentType.POST_PROCESSOR)
+
+    def test_get_component_by_name_cached(self):
+        """Test cached component lookup by name."""
+        # First, get a known parser name
+        parsers = get_all_parsers_cached()
+        if parsers:
+            parser_name = parsers[0].name
+            result = get_component_by_name_cached(parser_name)
+            self.assertIsNotNone(result)
+            self.assertEqual(result.name, parser_name)
+
+    def test_get_components_by_mimetype_cached_pdf(self):
+        """Test getting components for PDF MIME type."""
+        result = get_components_by_mimetype_cached("application/pdf")
+
+        self.assertIn("parsers", result)
+        self.assertIn("embedders", result)
+        self.assertIn("thumbnailers", result)
+        self.assertIn("post_processors", result)
+
+        # Should have PDF-compatible parsers
+        self.assertGreater(len(result["parsers"]), 0)
+
+    def test_get_all_components_cached(self):
+        """Test getting all components grouped by type."""
+        result = get_all_components_cached()
+
+        self.assertIn("parsers", result)
+        self.assertIn("embedders", result)
+        self.assertIn("thumbnailers", result)
+        self.assertIn("post_processors", result)
+
+        # Each should be a tuple
+        self.assertIsInstance(result["parsers"], tuple)
+        self.assertIsInstance(result["embedders"], tuple)
+
+    def test_caching_is_effective(self):
+        """Test that registry is only initialized once."""
+        # Get first registry
+        reset_registry()
+        registry1 = get_registry()
+
+        # Get second registry - should be same instance
+        registry2 = get_registry()
+
+        # Singleton should return same instance
+        self.assertIs(registry1, registry2)
+
+    def test_reset_registry(self):
+        """Test that reset_registry clears the singleton."""
+        _ = get_registry()  # First access
+        reset_registry()
+        registry_after_reset = get_registry()
+        # Should be a new instance after reset
+        self.assertIsNotNone(registry_after_reset)
+
+
+class TestRegistryPerformance(TestCase):
+    """Tests for registry performance characteristics."""
+
+    def setUp(self):
+        """Reset registry before each test."""
+        reset_registry()
+
+    def tearDown(self):
+        """Reset registry after each test."""
+        reset_registry()
+
+    def test_subsequent_access_is_fast(self):
+        """Test that subsequent registry access doesn't re-scan."""
+        import time
+
+        # First access (cold)
+        start = time.perf_counter()
+        _ = get_registry()
+        first_access = time.perf_counter() - start
+
+        # Multiple subsequent accesses (should be near-instant)
+        total_subsequent = 0
+        for _ in range(100):
+            start = time.perf_counter()
+            _ = get_registry()
+            total_subsequent += time.perf_counter() - start
+
+        avg_subsequent = total_subsequent / 100
+
+        # Subsequent accesses should be much faster than first
+        # (This is more of a sanity check than a strict assertion)
+        self.assertLess(
+            avg_subsequent,
+            first_access * 0.1,  # At least 10x faster
+            "Subsequent access should be much faster than first access",
+        )

--- a/opencontractserver/tests/test_tool_registry.py
+++ b/opencontractserver/tests/test_tool_registry.py
@@ -1,0 +1,205 @@
+"""
+Tests for the agent tool registry.
+"""
+
+import pytest
+
+from opencontractserver.llms.tools.tool_registry import (
+    AVAILABLE_TOOLS,
+    ToolCategory,
+    ToolDefinition,
+    get_all_tools,
+    get_tool_by_name,
+    get_tool_names,
+    get_tools_by_category,
+    validate_tool_names,
+)
+
+
+class TestToolRegistry:
+    """Tests for the tool registry module."""
+
+    def test_tool_definition_to_dict(self):
+        """Test ToolDefinition.to_dict() returns correct structure."""
+        tool = ToolDefinition(
+            name="test_tool",
+            description="A test tool",
+            category=ToolCategory.SEARCH,
+            requires_corpus=True,
+            requires_approval=True,
+            parameters=(
+                ("query", "Search query", True),
+                ("limit", "Max results", False),
+            ),
+        )
+
+        result = tool.to_dict()
+
+        assert result["name"] == "test_tool"
+        assert result["description"] == "A test tool"
+        assert result["category"] == "search"
+        assert result["requires_corpus"] is True
+        assert result["requires_approval"] is True
+        assert len(result["parameters"]) == 2
+        assert result["parameters"][0] == {
+            "name": "query",
+            "description": "Search query",
+            "required": True,
+        }
+        assert result["parameters"][1] == {
+            "name": "limit",
+            "description": "Max results",
+            "required": False,
+        }
+
+    def test_available_tools_not_empty(self):
+        """Test that AVAILABLE_TOOLS contains tools."""
+        assert len(AVAILABLE_TOOLS) > 0
+
+    def test_all_tools_have_required_fields(self):
+        """Test that all tools have required fields."""
+        for tool in AVAILABLE_TOOLS:
+            assert tool.name, f"Tool missing name: {tool}"
+            assert tool.description, f"Tool missing description: {tool.name}"
+            assert tool.category, f"Tool missing category: {tool.name}"
+            # requires_corpus and requires_approval have defaults
+
+    def test_get_all_tools(self):
+        """Test get_all_tools returns all tools as dicts."""
+        tools = get_all_tools()
+
+        assert len(tools) == len(AVAILABLE_TOOLS)
+        assert all(isinstance(t, dict) for t in tools)
+        assert all("name" in t for t in tools)
+        assert all("description" in t for t in tools)
+        assert all("category" in t for t in tools)
+
+    def test_get_tool_names(self):
+        """Test get_tool_names returns list of names."""
+        names = get_tool_names()
+
+        assert len(names) == len(AVAILABLE_TOOLS)
+        assert all(isinstance(n, str) for n in names)
+        # Check some known tools exist
+        assert "similarity_search" in names
+        assert "load_document_text" in names
+
+    def test_get_tool_by_name_found(self):
+        """Test get_tool_by_name returns tool when found."""
+        tool = get_tool_by_name("similarity_search")
+
+        assert tool is not None
+        assert tool["name"] == "similarity_search"
+        assert "description" in tool
+
+    def test_get_tool_by_name_not_found(self):
+        """Test get_tool_by_name returns None when not found."""
+        tool = get_tool_by_name("nonexistent_tool")
+
+        assert tool is None
+
+    def test_get_tools_by_category_search(self):
+        """Test filtering tools by search category."""
+        tools = get_tools_by_category("search")
+
+        assert len(tools) > 0
+        assert all(t["category"] == "search" for t in tools)
+        # similarity_search should be in search category
+        tool_names = [t["name"] for t in tools]
+        assert "similarity_search" in tool_names
+
+    def test_get_tools_by_category_document(self):
+        """Test filtering tools by document category."""
+        tools = get_tools_by_category("document")
+
+        assert len(tools) > 0
+        assert all(t["category"] == "document" for t in tools)
+        tool_names = [t["name"] for t in tools]
+        assert "load_document_text" in tool_names
+
+    def test_get_tools_by_category_invalid(self):
+        """Test filtering by invalid category returns empty list."""
+        tools = get_tools_by_category("invalid_category")
+
+        assert tools == []
+
+    def test_validate_tool_names_all_valid(self):
+        """Test validating all valid tool names."""
+        names = ["similarity_search", "load_document_text"]
+        valid, invalid = validate_tool_names(names)
+
+        assert valid == names
+        assert invalid == []
+
+    def test_validate_tool_names_some_invalid(self):
+        """Test validating mix of valid and invalid names."""
+        names = ["similarity_search", "fake_tool", "load_document_text", "not_real"]
+        valid, invalid = validate_tool_names(names)
+
+        assert set(valid) == {"similarity_search", "load_document_text"}
+        assert set(invalid) == {"fake_tool", "not_real"}
+
+    def test_validate_tool_names_all_invalid(self):
+        """Test validating all invalid tool names."""
+        names = ["fake1", "fake2"]
+        valid, invalid = validate_tool_names(names)
+
+        assert valid == []
+        assert invalid == names
+
+    def test_validate_tool_names_empty(self):
+        """Test validating empty list."""
+        valid, invalid = validate_tool_names([])
+
+        assert valid == []
+        assert invalid == []
+
+    def test_tool_categories_enum(self):
+        """Test ToolCategory enum values."""
+        assert ToolCategory.SEARCH.value == "search"
+        assert ToolCategory.DOCUMENT.value == "document"
+        assert ToolCategory.CORPUS.value == "corpus"
+        assert ToolCategory.NOTES.value == "notes"
+        assert ToolCategory.ANNOTATIONS.value == "annotations"
+        assert ToolCategory.COORDINATION.value == "coordination"
+
+    def test_known_tools_exist(self):
+        """Test that expected tools exist in registry."""
+        expected_tools = [
+            "similarity_search",
+            "search_exact_text",
+            "load_document_summary",
+            "load_document_text",
+            "get_document_text_length",
+            "get_corpus_description",
+            "list_documents",
+            "ask_document",
+        ]
+
+        existing_names = get_tool_names()
+        for tool_name in expected_tools:
+            assert tool_name in existing_names, f"Expected tool {tool_name} not found"
+
+    def test_approval_required_tools_marked(self):
+        """Test that tools requiring approval are marked correctly."""
+        # update_corpus_description should require approval
+        tool = get_tool_by_name("update_corpus_description")
+        assert tool is not None
+        assert tool["requires_approval"] is True
+
+        # similarity_search should not require approval
+        tool = get_tool_by_name("similarity_search")
+        assert tool is not None
+        assert tool["requires_approval"] is False
+
+    def test_corpus_required_tools_marked(self):
+        """Test that tools requiring corpus are marked correctly."""
+        # get_corpus_description requires corpus
+        tool = get_tool_by_name("get_corpus_description")
+        assert tool is not None
+        assert tool["requires_corpus"] is True
+
+        # similarity_search doesn't require corpus
+        tool = get_tool_by_name("similarity_search")
+        assert tool is not None
+        assert tool["requires_corpus"] is False

--- a/opencontractserver/tests/test_tool_registry.py
+++ b/opencontractserver/tests/test_tool_registry.py
@@ -2,8 +2,6 @@
 Tests for the agent tool registry.
 """
 
-import pytest
-
 from opencontractserver.llms.tools.tool_registry import (
     AVAILABLE_TOOLS,
     ToolCategory,

--- a/test.yml
+++ b/test.yml
@@ -32,7 +32,8 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
-      # - vector-embedder  # Temporarily disabled - connection issues
+      # vector-embedder:  # Temporarily disabled - connection issues
+      #   condition: service_started
       # Note: celeryworker removed from here to avoid circular dependency
       docling-parser:
         condition: service_started


### PR DESCRIPTION
## Summary

- Add tool registry with all available agent tools and metadata
- Add GraphQL queries for available tools and tool categories  
- Replace free-form text inputs with checkbox-based tool selection UI
- Add BadgeConfigurator component for visual badge customization
- Use GenericScalar instead of JSONString for direct JSON upload
- Update mutation responses to include all fields for proper cache updates
- Add slug field to AgentConfiguration with auto-generation
- Add migration to generate slugs for existing agents