### PR TITLE
fix: Address PR #666 high-priority issues for v3.0.0.b3 release

### DIFF
--- a/frontend/src/components/threads/MessageItem.tsx
+++ b/frontend/src/components/threads/MessageItem.tsx
@@ -363,9 +363,10 @@ const SourceItem = styled.div`
 `;
 
 /**
- * Individual message component with support for nested replies
+ * Individual message component with support for nested replies.
+ * Memoized to prevent unnecessary re-renders when parent thread updates.
  */
-export function MessageItem({
+export const MessageItem = React.memo(function MessageItem({
   message,
   isHighlighted = false,
   onReply,
@@ -543,4 +544,4 @@ export function MessageItem({
       )}
     </MessageContainer>
   );
-}
+});

--- a/frontend/src/components/threads/MessageTree.tsx
+++ b/frontend/src/components/threads/MessageTree.tsx
@@ -15,10 +15,11 @@ interface MessageTreeProps {
 }
 
 /**
- * Recursive component for rendering hierarchical message tree
- * Handles nested replies with proper indentation
+ * Recursive component for rendering hierarchical message tree.
+ * Handles nested replies with proper indentation.
+ * Memoized to prevent unnecessary re-renders when sibling threads update.
  */
-export function MessageTree({
+export const MessageTree = React.memo(function MessageTree({
   messages,
   highlightedMessageId,
   onReply,
@@ -89,4 +90,4 @@ export function MessageTree({
       })}
     </>
   );
-}
+});

--- a/frontend/src/components/threads/ThreadListItem.tsx
+++ b/frontend/src/components/threads/ThreadListItem.tsx
@@ -111,9 +111,10 @@ const Separator = styled.span`
 `;
 
 /**
- * Individual thread card in list view
+ * Individual thread card in list view.
+ * Memoized to prevent unnecessary re-renders when thread list updates.
  */
-export function ThreadListItem({
+export const ThreadListItem = React.memo(function ThreadListItem({
   thread,
   corpusId,
   compact = false,
@@ -207,4 +208,4 @@ export function ThreadListItem({
       </ThreadMeta>
     </ThreadCard>
   );
-}
+});

--- a/frontend/src/graphql/mutations.ts
+++ b/frontend/src/graphql/mutations.ts
@@ -2671,16 +2671,20 @@ export interface DeleteMessageOutput {
 // Voting Mutations
 // ============================================================================
 
+/**
+ * Upvote a message. Uses the backend vote_message mutation with vote_type="upvote".
+ * Returns the updated message with vote counts and current user's vote status.
+ */
 export const UPVOTE_MESSAGE = gql`
   mutation UpvoteMessage($messageId: ID!) {
-    upvoteMessage(messageId: $messageId) {
+    voteMessage(messageId: $messageId, voteType: "upvote") {
       ok
       message
-      chatMessage {
+      obj {
         id
         upvoteCount
         downvoteCount
-        # userVote  # TODO: Backend field not implemented yet
+        userVote
       }
     }
   }
@@ -2690,29 +2694,36 @@ export interface UpvoteMessageInput {
   messageId: string;
 }
 
-export interface UpvoteMessageOutput {
-  upvoteMessage: {
-    ok: boolean;
-    message: string;
-    chatMessage: {
-      id: string;
-      upvoteCount: number;
-      downvoteCount: number;
-      userVote?: string;
-    } | null;
-  };
+/** Response shape for vote mutations (upvote uses voteMessage mutation) */
+export interface VoteMessageResponse {
+  ok: boolean;
+  message: string;
+  obj: {
+    id: string;
+    upvoteCount: number;
+    downvoteCount: number;
+    userVote: string | null;
+  } | null;
 }
 
+export interface UpvoteMessageOutput {
+  voteMessage: VoteMessageResponse;
+}
+
+/**
+ * Downvote a message. Uses the backend vote_message mutation with vote_type="downvote".
+ * Returns the updated message with vote counts and current user's vote status.
+ */
 export const DOWNVOTE_MESSAGE = gql`
   mutation DownvoteMessage($messageId: ID!) {
-    downvoteMessage(messageId: $messageId) {
+    voteMessage(messageId: $messageId, voteType: "downvote") {
       ok
       message
-      chatMessage {
+      obj {
         id
         upvoteCount
         downvoteCount
-        # userVote  # TODO: Backend field not implemented yet
+        userVote
       }
     }
   }
@@ -2723,28 +2734,23 @@ export interface DownvoteMessageInput {
 }
 
 export interface DownvoteMessageOutput {
-  downvoteMessage: {
-    ok: boolean;
-    message: string;
-    chatMessage: {
-      id: string;
-      upvoteCount: number;
-      downvoteCount: number;
-      userVote?: string;
-    } | null;
-  };
+  voteMessage: VoteMessageResponse;
 }
 
+/**
+ * Remove a vote from a message.
+ * Returns the updated message with vote counts and current user's vote status (null after removal).
+ */
 export const REMOVE_VOTE = gql`
   mutation RemoveVote($messageId: ID!) {
     removeVote(messageId: $messageId) {
       ok
       message
-      chatMessage {
+      obj {
         id
         upvoteCount
         downvoteCount
-        # userVote  # TODO: Backend field not implemented yet
+        userVote
       }
     }
   }
@@ -2755,16 +2761,7 @@ export interface RemoveVoteInput {
 }
 
 export interface RemoveVoteOutput {
-  removeVote: {
-    ok: boolean;
-    message: string;
-    chatMessage: {
-      id: string;
-      upvoteCount: number;
-      downvoteCount: number;
-      userVote?: string;
-    } | null;
-  };
+  removeVote: VoteMessageResponse;
 }
 
 // ============================================================================

--- a/frontend/tests/VoteButtons.ct.tsx
+++ b/frontend/tests/VoteButtons.ct.tsx
@@ -95,10 +95,10 @@ test.describe("VoteButtons", () => {
         },
         result: {
           data: {
-            upvoteMessage: {
+            voteMessage: {
               ok: true,
               message: "Message upvoted",
-              chatMessage: {
+              obj: {
                 id: "msg-1",
                 upvoteCount: 6,
                 downvoteCount: 2,
@@ -140,10 +140,10 @@ test.describe("VoteButtons", () => {
         },
         result: {
           data: {
-            downvoteMessage: {
+            voteMessage: {
               ok: true,
               message: "Message downvoted",
-              chatMessage: {
+              obj: {
                 id: "msg-1",
                 upvoteCount: 5,
                 downvoteCount: 3,
@@ -188,7 +188,7 @@ test.describe("VoteButtons", () => {
             removeVote: {
               ok: true,
               message: "Vote removed",
-              chatMessage: {
+              obj: {
                 id: "msg-1",
                 upvoteCount: 4,
                 downvoteCount: 2,
@@ -254,10 +254,10 @@ test.describe("VoteButtons", () => {
         },
         result: {
           data: {
-            upvoteMessage: {
+            voteMessage: {
               ok: false,
               message: "Rate limit exceeded. Please try again later.",
-              chatMessage: null,
+              obj: null,
             },
           } as UpvoteMessageOutput,
         },
@@ -321,10 +321,10 @@ test.describe("VoteButtons", () => {
         },
         result: {
           data: {
-            upvoteMessage: {
+            voteMessage: {
               ok: true,
               message: "Message upvoted",
-              chatMessage: {
+              obj: {
                 id: "msg-1",
                 upvoteCount: 6,
                 downvoteCount: 2,
@@ -375,10 +375,10 @@ test.describe("VoteButtons", () => {
         delay: 1000, // Delay to observe optimistic update
         result: {
           data: {
-            upvoteMessage: {
+            voteMessage: {
               ok: true,
               message: "Message upvoted",
-              chatMessage: {
+              obj: {
                 id: "msg-1",
                 upvoteCount: 6,
                 downvoteCount: 2,


### PR DESCRIPTION
## Summary

Fixes the 4 high-priority issues identified in the PR #666 code review before merging v3.0.0.b3 into main.

- **VoteButtons: Add Apollo cache updates** - Votes now propagate to all components showing the same message
- **VoteButtons: Add userVote field** - UI can now show which vote is active for the current user
- **MessageItem/MessageTree/ThreadListItem: Add React.memo** - Prevents unnecessary re-renders (50 messages won't all re-render on one vote)
- **ReplyForm: Submission guard** - Already implemented, no changes needed

## Test plan

- [x] All 14 backend voting mutation tests pass
- [x] Added 4 new tests specifically for `userVote` field behavior
- [x] Pre-commit hooks pass (black, isort, flake8, prettier)
- [x] Frontend lint passes
- [ ] Manual testing of vote UI updates across components
- [ ] Verify memoization reduces re-renders in React DevTools

## Technical Details

### Backend Changes (`config/graphql/graphene_types.py`)
- Added `user_vote` field to `MessageType` GraphQL type
- Added `resolve_user_vote()` method that queries `MessageVote` for current user
- Returns `'UPVOTE'`, `'DOWNVOTE'`, or `null`

### Frontend Changes

**Mutations (`frontend/src/graphql/mutations.ts`):**
- Fixed mutation names to match backend (`voteMessage` instead of non-existent `upvoteMessage`)
- Added `userVote` field to mutation responses
- Created shared `VoteMessageResponse` interface

**VoteButtons (`frontend/src/components/threads/VoteButtons.tsx`):**
- Added `update` option to all vote mutations with `cache.modify()` calls
- Wrapped component with `React.memo()` for performance
- Added `useCallback` for event handlers

**Thread Components:**
- `MessageItem.tsx` - Wrapped with `React.memo()`
- `MessageTree.tsx` - Wrapped with `React.memo()`
- `ThreadListItem.tsx` - Wrapped with `React.memo()`

### New Tests (`opencontractserver/tests/test_voting_mutations_graphql.py`)
- `test_user_vote_field_returns_current_user_vote` - Verifies userVote returns 'UPVOTE' after upvoting
- `test_user_vote_field_returns_null_for_no_vote` - Verifies userVote is null when user hasn't voted
- `test_user_vote_field_updates_after_vote_change` - Verifies userVote updates to 'DOWNVOTE' after changing vote
- `test_user_vote_field_null_after_remove_vote` - Verifies userVote returns null after removing vote

## Related Issues

Addresses high-priority items from PR #666 code review.