### PR TITLE
fix: Mobile UI/UX improvements for corpus navigation and discussions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,33 @@ All notable changes to OpenContracts will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2025-11-27
+## [Unreleased] - 2025-12-11
+
+### Added
+
+#### Mobile UI/UX Improvements for Corpus Navigation
+- **Mobile-first folder sidebar defaults**: Sidebar now collapses by default on mobile/tablet devices (≤768px) to maximize document viewing area
+- **Mobile bottom-sheet mention pickers**: User, resource, and unified mention pickers now display as bottom sheets on mobile (≤600px) for thumb-friendly interaction
+- **Discussions and Analytics quick access**: Added icon buttons to CorpusHome stat cards for direct navigation to Discussions and Analytics tabs
+- **Sidebar auto-close behavior**: Folder sidebar automatically closes on mobile/tablet after folder selection for seamless navigation
+- **Mobile sidebar backdrop overlay**: Semi-transparent backdrop behind mobile sidebar for visual focus and easy dismissal
+- **Escape key accessibility**: Mobile sidebar can now be dismissed with Escape key for keyboard accessibility
+- **TABLET_BREAKPOINT constant**: Added to `constants.ts` for consistent responsive breakpoint management across components
+
+### Fixed
+
+#### Mobile UI/UX Fixes
+- **Settings button variable name bug** (`frontend/src/components/corpuses/CorpusHome.tsx:780`): Fixed `canUpdate` → `canEdit` reference error that prevented Settings button from displaying for users with update permissions
+- **FAB z-index layering** (`frontend/src/views/Corpuses.tsx:1320`): Raised FAB z-index from 100 to 150 to ensure visibility above folder sidebar toggle (z-index: 101)
+- **Explicit z-index layering**: Made mobile sidebar z-index layering explicit (backdrop: 98, toggle button: 99) to prevent fragile DOM-order-dependent behavior
+
+### Changed
+
+#### Mobile UI/UX Refactoring
+- **Hardcoded breakpoints replaced with constants**: Updated all hardcoded `768px` references in `FolderDocumentBrowser.tsx` and `folderAtoms.ts` to use `TABLET_BREAKPOINT` constant for maintainability
+- **Improved breakpoint documentation**: Added detailed JSDoc comment in `folderAtoms.ts` explaining why `TABLET_BREAKPOINT` (768px) is used for sidebar collapse rather than `MOBILE_VIEW_BREAKPOINT` (600px)
+
+---
 
 ### Added
 

--- a/frontend/src/assets/configurations/constants.ts
+++ b/frontend/src/assets/configurations/constants.ts
@@ -1,2 +1,4 @@
 export const VERSION_TAG = "v3.0.0.b3";
 export const MOBILE_VIEW_BREAKPOINT = 600;
+// Tablet breakpoint - used for sidebar collapse behavior (larger than mobile)
+export const TABLET_BREAKPOINT = 768;

--- a/frontend/src/atoms/folderAtoms.ts
+++ b/frontend/src/atoms/folderAtoms.ts
@@ -128,10 +128,18 @@ export const expandedFolderIdsAtom = atomWithStorage<Set<string>>(
 
 /**
  * Sidebar collapsed state (persisted to localStorage)
+ * Default: collapsed on mobile (< 768px), expanded on desktop
  */
+const getDefaultSidebarCollapsed = (): boolean => {
+  // SSR safety check
+  if (typeof window === "undefined") return false;
+  // Default to collapsed on mobile for better UX
+  return window.innerWidth < 768;
+};
+
 export const sidebarCollapsedAtom = atomWithStorage<boolean>(
   "opencontracts:folderSidebarCollapsed",
-  false
+  getDefaultSidebarCollapsed()
 );
 
 /**

--- a/frontend/src/atoms/folderAtoms.ts
+++ b/frontend/src/atoms/folderAtoms.ts
@@ -7,6 +7,7 @@ import {
   buildFolderBreadcrumb,
   ParsedCorpusFolderType,
 } from "../graphql/queries/folders";
+import { TABLET_BREAKPOINT } from "../assets/configurations/constants";
 
 /**
  * Corpus Folder State Management with Jotai
@@ -128,13 +129,19 @@ export const expandedFolderIdsAtom = atomWithStorage<Set<string>>(
 
 /**
  * Sidebar collapsed state (persisted to localStorage)
- * Default: collapsed on mobile (< 768px), expanded on desktop
+ * Default: collapsed on mobile/tablet (<= TABLET_BREAKPOINT), expanded on desktop
+ *
+ * Uses TABLET_BREAKPOINT (768px) rather than MOBILE_VIEW_BREAKPOINT (600px) because
+ * the folder sidebar takes significant screen real estate. On tablets (600-768px),
+ * users benefit from having the sidebar collapsed by default while still having
+ * easy access via the toggle button. This improves the document browsing experience
+ * on medium-sized screens.
  */
 const getDefaultSidebarCollapsed = (): boolean => {
   // SSR safety check
   if (typeof window === "undefined") return false;
-  // Default to collapsed on mobile for better UX
-  return window.innerWidth < 768;
+  // Default to collapsed on mobile/tablet for better UX
+  return window.innerWidth <= TABLET_BREAKPOINT;
 };
 
 export const sidebarCollapsedAtom = atomWithStorage<boolean>(

--- a/frontend/src/components/corpuses/CorpusHome.tsx
+++ b/frontend/src/components/corpuses/CorpusHome.tsx
@@ -758,18 +758,32 @@ export const CorpusHome: React.FC<CorpusHomeProps> = ({
     PermissionTypes.CAN_UPDATE
   );
 
+  // TAB_IDS in Corpuses.tsx: home(0), documents(1), annotations(2), analyses(3),
+  // extracts(4), discussions(5), analytics(6), settings(7), badges(8)
   const statItems = [
     { label: "Docs", value: stats.totalDocs, navIndex: 1 }, // documents tab
     { label: "Notes", value: stats.totalAnnotations, navIndex: 2 }, // annotations tab
     { label: "Analyses", value: stats.totalAnalyses, navIndex: 3 }, // analyses tab
     { label: "Extracts", value: stats.totalExtracts, navIndex: 4 }, // extracts tab
+    {
+      label: "Discuss",
+      value: null,
+      navIndex: 5,
+      icon: <MessageCircle size={18} />,
+    }, // discussions tab
+    {
+      label: "Analytics",
+      value: null,
+      navIndex: 6,
+      icon: <BarChart3 size={18} />,
+    }, // analytics tab
     ...(canUpdate
       ? [
           {
             label: "Settings",
             value: null,
-            navIndex: 5,
-            icon: <Settings size={20} />,
+            navIndex: 7, // Fixed: was 5, should be 7 (settings tab)
+            icon: <Settings size={18} />,
           },
         ]
       : []),

--- a/frontend/src/components/corpuses/CorpusHome.tsx
+++ b/frontend/src/components/corpuses/CorpusHome.tsx
@@ -777,7 +777,7 @@ export const CorpusHome: React.FC<CorpusHomeProps> = ({
       navIndex: 6,
       icon: <BarChart3 size={18} />,
     }, // analytics tab
-    ...(canUpdate
+    ...(canEdit
       ? [
           {
             label: "Settings",

--- a/frontend/src/components/corpuses/folders/FolderDocumentBrowser.tsx
+++ b/frontend/src/components/corpuses/folders/FolderDocumentBrowser.tsx
@@ -40,6 +40,7 @@ import {
   GET_CORPUS_FOLDERS,
 } from "../../../graphql/queries/folders";
 import { GET_DOCUMENTS } from "../../../graphql/queries";
+import { TABLET_BREAKPOINT } from "../../../assets/configurations/constants";
 
 /**
  * FolderDocumentBrowser - Main container for folder-based document browsing
@@ -89,7 +90,7 @@ const Sidebar = styled.aside<{ $visible: boolean; $collapsed: boolean }>`
   overflow: hidden;
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 
-  @media (max-width: 768px) {
+  @media (max-width: ${TABLET_BREAKPOINT}px) {
     position: absolute;
     left: ${(props) => (props.$visible && !props.$collapsed ? "0" : "-320px")};
     z-index: 100;
@@ -110,7 +111,7 @@ const MainContent = styled.main<{ $hasSidebar: boolean }>`
   overflow: hidden;
   margin-left: ${(props) => (props.$hasSidebar ? "0" : "0")};
 
-  @media (max-width: 768px) {
+  @media (max-width: ${TABLET_BREAKPOINT}px) {
     margin-left: 0;
   }
 `;
@@ -193,7 +194,7 @@ const ToggleButton = styled.button<{ $collapsed: boolean }>`
     transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   }
 
-  @media (max-width: 768px) {
+  @media (max-width: ${TABLET_BREAKPOINT}px) {
     display: none;
   }
 `;
@@ -211,13 +212,13 @@ const MobileToggleButton = styled.button<{ $visible: boolean }>`
   border-radius: 12px;
   color: white;
   cursor: pointer;
-  z-index: 99;
+  z-index: 99; /* Above backdrop (98) */
   box-shadow: 0 4px 12px rgba(59, 130, 246, 0.4);
   transition: all 0.3s ease;
   align-items: center;
   justify-content: center;
 
-  @media (max-width: 768px) {
+  @media (max-width: ${TABLET_BREAKPOINT}px) {
     display: ${(props) => (props.$visible ? "flex" : "none")};
   }
 
@@ -254,7 +255,7 @@ const MobileSidebarCloseButton = styled.button`
   justify-content: center;
   transition: all 0.2s ease;
 
-  @media (max-width: 768px) {
+  @media (max-width: ${TABLET_BREAKPOINT}px) {
     display: flex;
   }
 
@@ -269,7 +270,7 @@ const MobileSidebarCloseButton = styled.button`
   }
 `;
 
-// Mobile backdrop for sidebar
+// Mobile backdrop for sidebar - dismissible via click or Escape key
 const MobileSidebarBackdrop = styled.div<{ $visible: boolean }>`
   display: none;
   position: fixed;
@@ -278,12 +279,12 @@ const MobileSidebarBackdrop = styled.div<{ $visible: boolean }>`
   right: 0;
   bottom: 0;
   background: rgba(0, 0, 0, 0.4);
-  z-index: 99;
+  z-index: 98; /* Below toggle button (99) */
   opacity: ${(props) => (props.$visible ? "1" : "0")};
   pointer-events: ${(props) => (props.$visible ? "auto" : "none")};
   transition: opacity 0.3s ease;
 
-  @media (max-width: 768px) {
+  @media (max-width: ${TABLET_BREAKPOINT}px) {
     display: block;
   }
 `;
@@ -572,6 +573,18 @@ export const FolderDocumentBrowser: React.FC<FolderDocumentBrowserProps> = ({
     setContextMenu(null);
   }, []);
 
+  // Escape key handler for accessibility - closes mobile sidebar
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && showSidebar && !sidebarCollapsed) {
+        setSidebarCollapsed(true);
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [showSidebar, sidebarCollapsed, setSidebarCollapsed]);
+
   const handleCreateFolderInCurrentDir = React.useCallback(() => {
     // Pass the current folder ID - creates subfolder of current directory
     // If selectedFolderId is null, creates folder at root level
@@ -607,8 +620,8 @@ export const FolderDocumentBrowser: React.FC<FolderDocumentBrowserProps> = ({
             corpusId={corpusId}
             onFolderSelect={(folderId) => {
               handleFolderSelect(folderId);
-              // Auto-close sidebar on mobile after selection
-              if (window.innerWidth < 768) {
+              // Auto-close sidebar on mobile/tablet after selection
+              if (window.innerWidth <= TABLET_BREAKPOINT) {
                 setSidebarCollapsed(true);
               }
             }}

--- a/frontend/src/components/corpuses/folders/FolderDocumentBrowser.tsx
+++ b/frontend/src/components/corpuses/folders/FolderDocumentBrowser.tsx
@@ -3,7 +3,7 @@ import { useSetAtom, useAtom, useAtomValue } from "jotai";
 import { useReactiveVar, useMutation, useQuery } from "@apollo/client";
 import { useLocation, useNavigate } from "react-router-dom";
 import styled from "styled-components";
-import { Folder, FolderOpen } from "lucide-react";
+import { Folder, FolderOpen, PanelLeftOpen, X } from "lucide-react";
 import { toast } from "react-toastify";
 import {
   DndContext,
@@ -195,6 +195,96 @@ const ToggleButton = styled.button<{ $collapsed: boolean }>`
 
   @media (max-width: 768px) {
     display: none;
+  }
+`;
+
+// Mobile toggle button - shows on mobile when sidebar is hidden
+const MobileToggleButton = styled.button<{ $visible: boolean }>`
+  display: none;
+  position: fixed;
+  left: 12px;
+  bottom: 80px;
+  width: 48px;
+  height: 48px;
+  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
+  border: none;
+  border-radius: 12px;
+  color: white;
+  cursor: pointer;
+  z-index: 99;
+  box-shadow: 0 4px 12px rgba(59, 130, 246, 0.4);
+  transition: all 0.3s ease;
+  align-items: center;
+  justify-content: center;
+
+  @media (max-width: 768px) {
+    display: ${(props) => (props.$visible ? "flex" : "none")};
+  }
+
+  &:hover {
+    transform: scale(1.05);
+    box-shadow: 0 6px 16px rgba(59, 130, 246, 0.5);
+  }
+
+  &:active {
+    transform: scale(0.95);
+  }
+
+  svg {
+    width: 24px;
+    height: 24px;
+  }
+`;
+
+// Mobile close button for sidebar
+const MobileSidebarCloseButton = styled.button`
+  display: none;
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  width: 36px;
+  height: 36px;
+  background: #f1f5f9;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  color: #64748b;
+  cursor: pointer;
+  z-index: 10;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s ease;
+
+  @media (max-width: 768px) {
+    display: flex;
+  }
+
+  &:hover {
+    background: #e2e8f0;
+    color: #475569;
+  }
+
+  svg {
+    width: 20px;
+    height: 20px;
+  }
+`;
+
+// Mobile backdrop for sidebar
+const MobileSidebarBackdrop = styled.div<{ $visible: boolean }>`
+  display: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 99;
+  opacity: ${(props) => (props.$visible ? "1" : "0")};
+  pointer-events: ${(props) => (props.$visible ? "auto" : "none")};
+  transition: opacity 0.3s ease;
+
+  @media (max-width: 768px) {
+    display: block;
   }
 `;
 
@@ -497,15 +587,35 @@ export const FolderDocumentBrowser: React.FC<FolderDocumentBrowserProps> = ({
       onDragEnd={handleDragEnd}
     >
       <BrowserContainer>
+        {/* Mobile backdrop for sidebar */}
+        <MobileSidebarBackdrop
+          $visible={showSidebar && !sidebarCollapsed}
+          onClick={() => setSidebarCollapsed(true)}
+        />
+
         {/* Folder Tree Sidebar */}
         <Sidebar $visible={showSidebar} $collapsed={sidebarCollapsed}>
+          {/* Mobile close button */}
+          <MobileSidebarCloseButton
+            onClick={() => setSidebarCollapsed(true)}
+            aria-label="Close folders"
+            title="Close folders"
+          >
+            <X />
+          </MobileSidebarCloseButton>
           <FolderTreeSidebar
             corpusId={corpusId}
-            onFolderSelect={handleFolderSelect}
+            onFolderSelect={(folderId) => {
+              handleFolderSelect(folderId);
+              // Auto-close sidebar on mobile after selection
+              if (window.innerWidth < 768) {
+                setSidebarCollapsed(true);
+              }
+            }}
           />
         </Sidebar>
 
-        {/* Toggle Button */}
+        {/* Desktop Toggle Button */}
         {showSidebar && (
           <ToggleButton
             $collapsed={sidebarCollapsed}
@@ -515,6 +625,18 @@ export const FolderDocumentBrowser: React.FC<FolderDocumentBrowserProps> = ({
           >
             {sidebarCollapsed ? <Folder /> : <FolderOpen />}
           </ToggleButton>
+        )}
+
+        {/* Mobile Toggle Button - shows when sidebar is hidden */}
+        {showSidebar && (
+          <MobileToggleButton
+            $visible={sidebarCollapsed}
+            onClick={() => setSidebarCollapsed(false)}
+            aria-label="Open folders"
+            title="Open folders"
+          >
+            <PanelLeftOpen />
+          </MobileToggleButton>
         )}
 
         {/* Main Content Area */}

--- a/frontend/src/components/threads/MentionPicker.tsx
+++ b/frontend/src/components/threads/MentionPicker.tsx
@@ -18,6 +18,21 @@ const Container = styled.div`
   overflow-y: auto;
   z-index: 1000;
   min-width: 200px;
+
+  /* Mobile responsive adjustments */
+  @media (max-width: 600px) {
+    position: fixed;
+    left: 8px !important;
+    right: 8px !important;
+    bottom: 80px !important;
+    top: auto !important;
+    min-width: unset;
+    max-width: unset;
+    width: calc(100% - 16px);
+    max-height: 40vh;
+    border-radius: 12px;
+    box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.25);
+  }
 `;
 
 const MenuItem = styled.button<{ $isSelected: boolean }>`
@@ -44,6 +59,16 @@ const MenuItem = styled.button<{ $isSelected: boolean }>`
 
   &:last-child {
     border-radius: 0 0 6px 6px;
+  }
+
+  /* Mobile touch-friendly adjustments */
+  @media (max-width: 600px) {
+    padding: 12px 16px;
+    min-height: 48px;
+
+    &:active {
+      background: ${color.B1};
+    }
   }
 `;
 

--- a/frontend/src/components/threads/ResourceMentionPicker.tsx
+++ b/frontend/src/components/threads/ResourceMentionPicker.tsx
@@ -19,6 +19,21 @@ const Container = styled.div`
   overflow-y: auto;
   z-index: 1000;
   min-width: 300px;
+
+  /* Mobile responsive adjustments */
+  @media (max-width: 600px) {
+    position: fixed;
+    left: 8px !important;
+    right: 8px !important;
+    bottom: 80px !important;
+    top: auto !important;
+    min-width: unset;
+    max-width: unset;
+    width: calc(100% - 16px);
+    max-height: 45vh;
+    border-radius: 12px;
+    box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.25);
+  }
 `;
 
 const MenuItem = styled.button<{ $isSelected: boolean }>`
@@ -45,6 +60,16 @@ const MenuItem = styled.button<{ $isSelected: boolean }>`
 
   &:last-child {
     border-radius: 0 0 8px 8px;
+  }
+
+  /* Mobile touch-friendly adjustments */
+  @media (max-width: 600px) {
+    padding: 12px 16px;
+    min-height: 56px;
+
+    &:active {
+      background: ${color.B1};
+    }
   }
 `;
 

--- a/frontend/src/components/threads/UnifiedMentionPicker.tsx
+++ b/frontend/src/components/threads/UnifiedMentionPicker.tsx
@@ -21,6 +21,21 @@ const Container = styled.div`
   z-index: 1000;
   min-width: 350px;
   max-width: 500px;
+
+  /* Mobile responsive adjustments */
+  @media (max-width: 600px) {
+    position: fixed;
+    left: 8px !important;
+    right: 8px !important;
+    bottom: 80px !important;
+    top: auto !important;
+    min-width: unset;
+    max-width: unset;
+    width: calc(100% - 16px);
+    max-height: 50vh;
+    border-radius: 12px;
+    box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.25);
+  }
 `;
 
 const CategoryHeader = styled.div`
@@ -57,6 +72,16 @@ const MenuItem = styled.button<{ $isSelected: boolean }>`
 
   &:last-child {
     border-radius: 0 0 8px 8px;
+  }
+
+  /* Mobile touch-friendly adjustments */
+  @media (max-width: 600px) {
+    padding: 12px 16px;
+    min-height: 56px;
+
+    &:active {
+      background: ${color.B1};
+    }
   }
 `;
 

--- a/frontend/src/views/Corpuses.tsx
+++ b/frontend/src/views/Corpuses.tsx
@@ -1304,19 +1304,20 @@ const MobileBackButton = styled.button`
   }
 `;
 
-// Mobile bottom navigation FAB - ultra sleek and compact
+// Mobile bottom navigation FAB - opens corpus sidebar navigation
+// z-index: 150 ensures it appears above folder sidebar toggle (101) and other UI elements
 const BottomNavigationHandle = styled(motion.button)<{ isOpen?: boolean }>`
   display: none;
   position: fixed;
   bottom: 16px;
-  right: 16px; /* Moved to bottom-right */
+  right: 16px;
   width: 56px;
   height: 56px;
   background: linear-gradient(135deg, #4a90e2 0%, #357abd 100%);
   border: none;
   border-radius: 16px;
   cursor: pointer;
-  z-index: 100;
+  z-index: 150; /* Raised from 100 to ensure visibility above folder toggle (101) */
   box-shadow: 0 8px 24px rgba(74, 144, 226, 0.4), 0 2px 8px rgba(0, 0, 0, 0.12);
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   padding: 0;


### PR DESCRIPTION
## Summary

- Fix settings navigation in mobile stats row (was navigating to Discussions tab instead of Settings)
- Add missing Discussions and Analytics tabs to mobile corpus home stats row
- Fix floating menu button (FAB) z-index to ensure visibility on all non-home tabs
- Make mention pickers mobile-responsive with bottom-sheet style positioning
- Default folder sidebar to collapsed on mobile with manual toggle controls

## Test plan

- [ ] On mobile, tap Settings in corpus home stats row → should navigate to Settings tab (not Discussions)
- [ ] On mobile, verify Discussions and Analytics tabs appear in corpus home stats row
- [ ] On mobile, verify floating navigation FAB appears on Documents, Annotations, and other non-home tabs
- [ ] On mobile, type @ in message composer → mention picker should appear as bottom sheet
- [ ] On mobile, navigate to Documents tab → folder sidebar should be collapsed by default
- [ ] On mobile, tap folder toggle button (bottom-left) → sidebar should open with backdrop
- [ ] On mobile, tap backdrop or X button → sidebar should close
- [ ] On mobile, select a folder → sidebar should auto-close