### PR TITLE
fix: Resolve GCS collectstatic failures in production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to OpenContracts will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2025-12-11
+## [Unreleased] - 2025-12-12
+
+### Fixed
+
+#### Production Deployment
+- **Missing COLLECTFAST_STRATEGY for GCP storage backend** (`config/settings/base.py:436`): Added `collectfast.strategies.gcloud.GoogleCloudStrategy` for GCP deployments. Previously, `collectfast` was installed in production but `COLLECTFAST_STRATEGY` was only configured for AWS, causing `collectstatic` to fail with `ImproperlyConfigured: No strategy configured` error when using `STORAGE_BACKEND=GCP`.
+- **GCS static files ACL incompatible with uniform bucket-level access** (`opencontractserver/utils/storages.py:38`): Changed `StaticRootGoogleCloudStorage.default_acl` from `"publicRead"` to `None`. GCS buckets with uniform bucket-level access enabled cannot use per-object ACLs; access must be controlled via IAM policies at the bucket level instead.
 
 ### Added
 

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -433,6 +433,7 @@ elif STORAGE_BACKEND == "GCP":
     STATICFILES_STORAGE = (
         "opencontractserver.utils.storages.StaticRootGoogleCloudStorage"
     )
+    COLLECTFAST_STRATEGY = "collectfast.strategies.gcloud.GoogleCloudStrategy"
     STATIC_URL = f"https://{gcs_domain}/static/"
 
     # MEDIA

--- a/opencontractserver/utils/storages.py
+++ b/opencontractserver/utils/storages.py
@@ -28,10 +28,14 @@ class StaticRootGoogleCloudStorage(GoogleCloudStorage):
     """
     Google Cloud Storage backend for static files.
     Static files are typically public and cached.
+
+    Note: default_acl is set to None to support GCS buckets with uniform
+    bucket-level access enabled. Public access should be configured at the
+    bucket level via IAM policies instead of per-object ACLs.
     """
 
     location = "static"
-    default_acl = "publicRead"  # GCS uses camelCase for ACLs
+    default_acl = None  # Required for uniform bucket-level access
 
     def get_object_parameters(self, name):
         """


### PR DESCRIPTION
## Summary

- Add `COLLECTFAST_STRATEGY` for GCP storage backend - previously only AWS had a strategy configured
- Set `StaticRootGoogleCloudStorage.default_acl` to `None` for compatibility with uniform bucket-level access

## Problem

Production deployments using `STORAGE_BACKEND=GCP` were failing during `collectstatic` with two errors:

1. `ImproperlyConfigured: No strategy configured, please make sure COLLECTFAST_STRATEGY is set`
2. `BadRequest: Cannot insert legacy ACL for an object when uniform bucket-level access is enabled`

## Solution

1. **Added GCS collectfast strategy** (`config/settings/base.py:436`): Configure `collectfast.strategies.gcloud.GoogleCloudStrategy` for GCP deployments

2. **Removed per-object ACL** (`opencontractserver/utils/storages.py:38`): Changed `default_acl` from `"publicRead"` to `None`. GCS buckets with uniform bucket-level access must manage permissions at the bucket level via IAM, not per-object ACLs.

## Test plan

- [x] Deploy to GCP production environment
- [x] Verify `collectstatic` completes successfully
- [x] Verify static files are accessible via the configured GCS bucket