### PR TITLE
feat: Replace CRUDModal with mobile-friendly CorpusModal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,28 @@ All notable changes to OpenContracts will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2025-12-13
+## [Unreleased] - 2025-12-14
 
 ### Added
+
+#### Mobile-Friendly Corpus Modal
+- **New CorpusModal component** (`frontend/src/components/corpuses/CorpusModal.tsx`): Purpose-built modal replacing CRUDModal for corpus create/edit/view operations with mobile-first design
+- **13 comprehensive component tests** (`frontend/tests/CorpusModal.spec.tsx`): Full test coverage for all modal modes and interactions
+- **Smart change detection for EDIT mode**: Only sends changed fields to backend using original value comparison (`CorpusModal.tsx:498-519`)
+- **ARIA accessibility**: CloseButton includes `aria-label="Close modal"` for screen reader users
+
+### Changed
+
+#### Corpus Modal Architecture
+- **Replaced CRUDModal with CorpusModal**: Simplified form handling with controlled inputs instead of complex JSON Schema Form library
+- **Removed debug console.log statements** (`Corpuses.tsx`): Cleaned up 4 debug logging statements
+
+### Technical Details
+
+#### Corpus Modal Implementation
+- Mobile-first responsive design: 16px input font prevents iOS auto-zoom, 48px min touch targets
+- Proper TypeScript types: Icon type is `string | null` (not ArrayBuffer), slug field uses existing type from RawCorpusType
+- isDirty computed by comparing current values against stored original values (not just tracking changes)
 
 #### Social Media Preview (OG Metadata) System (PR #701)
 - **Cloudflare Worker for social media previews** (`cloudflare-og-worker/`): Intercepts requests from social media crawlers (Facebook, Twitter, LinkedIn, Discord, Slack, etc.) and returns HTML with Open Graph meta tags for rich link previews

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Mobile-Friendly Corpus Modal
 - **New CorpusModal component** (`frontend/src/components/corpuses/CorpusModal.tsx`): Purpose-built modal replacing CRUDModal for corpus create/edit/view operations with mobile-first design
-- **13 comprehensive component tests** (`frontend/tests/CorpusModal.spec.tsx`): Full test coverage for all modal modes and interactions
+- **13 comprehensive component tests** (`frontend/tests/corpus-modal.ct.tsx`): Full test coverage for all modal modes and interactions
 - **Smart change detection for EDIT mode**: Only sends changed fields to backend using original value comparison (`CorpusModal.tsx:498-519`)
 - **ARIA accessibility**: CloseButton includes `aria-label="Close modal"` for screen reader users
 

--- a/frontend/src/components/corpuses/CorpusModal.tsx
+++ b/frontend/src/components/corpuses/CorpusModal.tsx
@@ -460,8 +460,12 @@ export const CorpusModal: React.FC<CorpusModalProps> = ({
   );
 
   const handleIconChange = useCallback(
-    ({ data }: { data: string; filename: string }) => {
-      setIcon(data);
+    ({ data }: { data: string | ArrayBuffer; filename: string }) => {
+      // FilePreviewAndUpload uses readAsDataURL which returns a string (base64)
+      // but the type allows ArrayBuffer for flexibility
+      if (typeof data === "string") {
+        setIcon(data);
+      }
     },
     []
   );
@@ -474,9 +478,14 @@ export const CorpusModal: React.FC<CorpusModalProps> = ({
     setPreferredEmbedder(values.preferredEmbedder || null);
   }, []);
 
+  // Form validation - both title and description are required
+  const isFormValid = title.trim().length > 0 && description.trim().length > 0;
+
   // Compute isDirty by comparing current values against original values
+  // For CREATE mode, form is "dirty" (has submittable content) when valid
+  // For EDIT mode, compare each field against original values
   const isDirty = isCreate
-    ? title.trim().length > 0 || description.trim().length > 0
+    ? isFormValid
     : originalValues !== null &&
       (title !== originalValues.title ||
         slug !== originalValues.slug ||
@@ -485,8 +494,6 @@ export const CorpusModal: React.FC<CorpusModalProps> = ({
         labelSetId !== originalValues.labelSetId ||
         preferredEmbedder !== originalValues.preferredEmbedder);
 
-  // Form validation
-  const isFormValid = title.trim().length > 0 && description.trim().length > 0;
   const canSubmit = isFormValid && isDirty && !loading;
 
   // Handle submit

--- a/frontend/src/components/corpuses/CorpusModal.tsx
+++ b/frontend/src/components/corpuses/CorpusModal.tsx
@@ -98,7 +98,8 @@ const ModalBody = styled.div`
     -webkit-overflow-scrolling: touch;
   }
 
-  /* Ensure Semantic UI dropdowns appear above the sticky footer */
+  /* Ensure Semantic UI dropdowns appear above the sticky footer (z-index: 10) */
+  /* z-index scale: header/footer=10, dropdowns=20 */
   .ui.dropdown .menu {
     z-index: 20;
   }
@@ -532,7 +533,7 @@ export const CorpusModal: React.FC<CorpusModalProps> = ({
     } else {
       // Include all for create mode
       formData.title = title.trim();
-      formData.slug = slug.trim();
+      formData.slug = slug.trim() || undefined;
       formData.description = description.trim();
       formData.icon = icon;
       formData.labelSet = labelSetId;

--- a/frontend/src/components/corpuses/CorpusModal.tsx
+++ b/frontend/src/components/corpuses/CorpusModal.tsx
@@ -11,10 +11,10 @@ export type CorpusModalMode = "CREATE" | "EDIT" | "VIEW";
 
 export interface CorpusFormData {
   id?: string;
-  title: string;
-  slug: string;
-  description: string;
-  icon?: string | ArrayBuffer | null;
+  title?: string;
+  slug?: string;
+  description?: string;
+  icon?: string | null;
   labelSet?: string | null;
   preferredEmbedder?: string | null;
 }
@@ -378,7 +378,7 @@ export const CorpusModal: React.FC<CorpusModalProps> = ({
   const [title, setTitle] = useState("");
   const [slug, setSlug] = useState("");
   const [description, setDescription] = useState("");
-  const [icon, setIcon] = useState<string | ArrayBuffer | null>(null);
+  const [icon, setIcon] = useState<string | null>(null);
   const [labelSetId, setLabelSetId] = useState<string | null>(null);
   const [labelSetObj, setLabelSetObj] = useState<LabelSetType | undefined>(
     undefined
@@ -387,19 +387,43 @@ export const CorpusModal: React.FC<CorpusModalProps> = ({
     null
   );
 
-  // Track if form has been modified
-  const [isDirty, setIsDirty] = useState(false);
+  // Track original values for change detection in EDIT mode
+  const [originalValues, setOriginalValues] = useState<{
+    title: string;
+    slug: string;
+    description: string;
+    icon: string | null;
+    labelSetId: string | null;
+    preferredEmbedder: string | null;
+  } | null>(null);
 
   // Initialize form from corpus data
   useEffect(() => {
     if (corpus) {
-      setTitle(corpus.title || "");
-      setSlug((corpus as any).slug || "");
-      setDescription(corpus.description || "");
-      setIcon(corpus.icon || null);
-      setLabelSetId(corpus.labelSet?.id || null);
+      const corpusTitle = corpus.title || "";
+      const corpusSlug = corpus.slug || "";
+      const corpusDescription = corpus.description || "";
+      const corpusIcon = corpus.icon || null;
+      const corpusLabelSetId = corpus.labelSet?.id || null;
+      const corpusPreferredEmbedder = corpus.preferredEmbedder || null;
+
+      setTitle(corpusTitle);
+      setSlug(corpusSlug);
+      setDescription(corpusDescription);
+      setIcon(corpusIcon);
+      setLabelSetId(corpusLabelSetId);
       setLabelSetObj(corpus.labelSet || undefined);
-      setPreferredEmbedder(corpus.preferredEmbedder || null);
+      setPreferredEmbedder(corpusPreferredEmbedder);
+
+      // Store original values for change detection
+      setOriginalValues({
+        title: corpusTitle,
+        slug: corpusSlug,
+        description: corpusDescription,
+        icon: corpusIcon,
+        labelSetId: corpusLabelSetId,
+        preferredEmbedder: corpusPreferredEmbedder,
+      });
     } else {
       // Reset for create mode
       setTitle("");
@@ -409,15 +433,14 @@ export const CorpusModal: React.FC<CorpusModalProps> = ({
       setLabelSetId(null);
       setLabelSetObj(undefined);
       setPreferredEmbedder(null);
+      setOriginalValues(null);
     }
-    setIsDirty(false);
   }, [corpus, open]);
 
   // Handle form field changes
   const handleTitleChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       setTitle(e.target.value);
-      setIsDirty(true);
     },
     []
   );
@@ -425,7 +448,6 @@ export const CorpusModal: React.FC<CorpusModalProps> = ({
   const handleSlugChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       setSlug(e.target.value);
-      setIsDirty(true);
     },
     []
   );
@@ -433,28 +455,35 @@ export const CorpusModal: React.FC<CorpusModalProps> = ({
   const handleDescriptionChange = useCallback(
     (e: React.ChangeEvent<HTMLTextAreaElement>) => {
       setDescription(e.target.value);
-      setIsDirty(true);
     },
     []
   );
 
   const handleIconChange = useCallback(
-    ({ data }: { data: string | ArrayBuffer; filename: string }) => {
+    ({ data }: { data: string; filename: string }) => {
       setIcon(data);
-      setIsDirty(true);
     },
     []
   );
 
   const handleLabelSetChange = useCallback((values: any) => {
     setLabelSetId(values.labelSet || null);
-    setIsDirty(true);
   }, []);
 
   const handleEmbedderChange = useCallback((values: any) => {
     setPreferredEmbedder(values.preferredEmbedder || null);
-    setIsDirty(true);
   }, []);
+
+  // Compute isDirty by comparing current values against original values
+  const isDirty = isCreate
+    ? title.trim().length > 0 || description.trim().length > 0
+    : originalValues !== null &&
+      (title !== originalValues.title ||
+        slug !== originalValues.slug ||
+        description !== originalValues.description ||
+        icon !== originalValues.icon ||
+        labelSetId !== originalValues.labelSetId ||
+        preferredEmbedder !== originalValues.preferredEmbedder);
 
   // Form validation
   const isFormValid = title.trim().length > 0 && description.trim().length > 0;
@@ -464,26 +493,35 @@ export const CorpusModal: React.FC<CorpusModalProps> = ({
   const handleSubmit = useCallback(() => {
     if (!canSubmit || !onSubmit) return;
 
-    const formData: CorpusFormData = {
-      title: title.trim(),
-      slug: slug.trim(),
-      description: description.trim(),
-    };
+    const formData: CorpusFormData = {};
 
-    // Only include changed fields for edit mode
-    if (mode === "EDIT" && corpus) {
+    if (mode === "EDIT" && corpus && originalValues) {
+      // Only include changed fields for edit mode
       formData.id = corpus.id;
-      if (icon !== corpus.icon) {
+
+      if (title.trim() !== originalValues.title) {
+        formData.title = title.trim();
+      }
+      if (slug.trim() !== originalValues.slug) {
+        formData.slug = slug.trim();
+      }
+      if (description.trim() !== originalValues.description) {
+        formData.description = description.trim();
+      }
+      if (icon !== originalValues.icon) {
         formData.icon = icon;
       }
-      if (labelSetId !== corpus.labelSet?.id) {
+      if (labelSetId !== originalValues.labelSetId) {
         formData.labelSet = labelSetId;
       }
-      if (preferredEmbedder !== corpus.preferredEmbedder) {
+      if (preferredEmbedder !== originalValues.preferredEmbedder) {
         formData.preferredEmbedder = preferredEmbedder;
       }
     } else {
       // Include all for create mode
+      formData.title = title.trim();
+      formData.slug = slug.trim();
+      formData.description = description.trim();
       formData.icon = icon;
       formData.labelSet = labelSetId;
       formData.preferredEmbedder = preferredEmbedder;
@@ -495,6 +533,7 @@ export const CorpusModal: React.FC<CorpusModalProps> = ({
     onSubmit,
     mode,
     corpus,
+    originalValues,
     title,
     slug,
     description,
@@ -538,7 +577,11 @@ export const CorpusModal: React.FC<CorpusModalProps> = ({
           {getHeaderText()}
         </HeaderTitle>
         <HeaderSubtitle>{getSubtitle()}</HeaderSubtitle>
-        <CloseButton onClick={onClose} disabled={loading}>
+        <CloseButton
+          onClick={onClose}
+          disabled={loading}
+          aria-label="Close modal"
+        >
           <Icon name="close" />
         </CloseButton>
       </ModalHeader>

--- a/frontend/src/components/corpuses/CorpusModal.tsx
+++ b/frontend/src/components/corpuses/CorpusModal.tsx
@@ -1,0 +1,658 @@
+import React, { useState, useEffect, useCallback } from "react";
+import { Modal, Button, Icon } from "semantic-ui-react";
+import styled from "styled-components";
+import { LabelSetSelector } from "../widgets/CRUD/LabelSetSelector";
+import { EmbedderSelector } from "../widgets/CRUD/EmbedderSelector";
+import { FilePreviewAndUpload } from "../widgets/file-controls/FilePreviewAndUpload";
+import { CorpusType, LabelSetType } from "../../types/graphql-api";
+
+// Types
+export type CorpusModalMode = "CREATE" | "EDIT" | "VIEW";
+
+export interface CorpusFormData {
+  id?: string;
+  title: string;
+  slug: string;
+  description: string;
+  icon?: string | ArrayBuffer | null;
+  labelSet?: string | null;
+  preferredEmbedder?: string | null;
+}
+
+export interface CorpusModalProps {
+  open: boolean;
+  mode: CorpusModalMode;
+  corpus?: CorpusType | null;
+  loading?: boolean;
+  onSubmit?: (data: CorpusFormData) => void;
+  onClose: () => void;
+}
+
+// Styled Components
+const StyledModal = styled(Modal)`
+  &&& {
+    border-radius: 16px;
+    overflow: hidden;
+    max-width: 600px;
+    margin: 1rem auto;
+
+    @media (max-width: 768px) {
+      margin: 0;
+      border-radius: 0;
+      max-height: 100vh;
+      height: 100%;
+      max-width: 100%;
+    }
+  }
+`;
+
+const ModalHeader = styled.div`
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  padding: 1.5rem 2rem;
+  color: white;
+
+  @media (max-width: 768px) {
+    padding: 1rem 1.25rem;
+    position: sticky;
+    top: 0;
+    z-index: 10;
+  }
+`;
+
+const HeaderTitle = styled.h2`
+  margin: 0 0 0.25rem 0;
+  font-size: 1.5rem;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+
+  @media (max-width: 768px) {
+    font-size: 1.25rem;
+  }
+`;
+
+const HeaderSubtitle = styled.p`
+  margin: 0;
+  opacity: 0.9;
+  font-size: 0.9rem;
+
+  @media (max-width: 768px) {
+    font-size: 0.85rem;
+  }
+`;
+
+const ModalBody = styled.div`
+  padding: 2rem;
+  background: #f8fafc;
+  max-height: calc(100vh - 200px);
+  overflow-y: auto;
+
+  @media (max-width: 768px) {
+    padding: 1.25rem;
+    max-height: calc(100vh - 140px);
+    /* Smooth scrolling on iOS */
+    -webkit-overflow-scrolling: touch;
+  }
+`;
+
+const FormSection = styled.div`
+  background: white;
+  border-radius: 12px;
+  padding: 1.5rem;
+  margin-bottom: 1.25rem;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+  border: 1px solid #e2e8f0;
+
+  @media (max-width: 768px) {
+    padding: 1rem;
+    margin-bottom: 1rem;
+    border-radius: 10px;
+  }
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+`;
+
+const SectionTitle = styled.h3`
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #64748b;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin: 0 0 1rem 0;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+
+  @media (max-width: 768px) {
+    font-size: 0.8rem;
+    margin-bottom: 0.75rem;
+  }
+`;
+
+const FormField = styled.div`
+  margin-bottom: 1.25rem;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+
+  @media (max-width: 768px) {
+    margin-bottom: 1rem;
+  }
+`;
+
+const Label = styled.label`
+  display: block;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #1e293b;
+  margin-bottom: 0.5rem;
+
+  @media (max-width: 768px) {
+    font-size: 0.875rem;
+  }
+`;
+
+const HelpText = styled.span`
+  display: block;
+  font-size: 0.8rem;
+  color: #94a3b8;
+  margin-top: 0.25rem;
+
+  @media (max-width: 768px) {
+    font-size: 0.75rem;
+  }
+`;
+
+const TextInput = styled.input<{ $readOnly?: boolean }>`
+  width: 100%;
+  padding: 0.875rem 1rem;
+  border: 2px solid #e2e8f0;
+  border-radius: 10px;
+  font-size: 1rem;
+  color: #1e293b;
+  background: ${(props) => (props.$readOnly ? "#f8fafc" : "white")};
+  transition: all 0.2s ease;
+  outline: none;
+
+  &:focus {
+    border-color: #667eea;
+    box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.15);
+  }
+
+  &:disabled {
+    background: #f1f5f9;
+    color: #94a3b8;
+    cursor: not-allowed;
+  }
+
+  &::placeholder {
+    color: #94a3b8;
+  }
+
+  @media (max-width: 768px) {
+    padding: 1rem;
+    /* Prevent iOS zoom on focus */
+    font-size: 16px;
+    border-radius: 8px;
+    /* Larger touch target */
+    min-height: 48px;
+  }
+`;
+
+const TextArea = styled.textarea<{ $readOnly?: boolean }>`
+  width: 100%;
+  padding: 0.875rem 1rem;
+  border: 2px solid #e2e8f0;
+  border-radius: 10px;
+  font-size: 1rem;
+  color: #1e293b;
+  background: ${(props) => (props.$readOnly ? "#f8fafc" : "white")};
+  transition: all 0.2s ease;
+  outline: none;
+  resize: vertical;
+  min-height: 100px;
+  font-family: inherit;
+  line-height: 1.5;
+
+  &:focus {
+    border-color: #667eea;
+    box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.15);
+  }
+
+  &:disabled {
+    background: #f1f5f9;
+    color: #94a3b8;
+    cursor: not-allowed;
+  }
+
+  &::placeholder {
+    color: #94a3b8;
+  }
+
+  @media (max-width: 768px) {
+    padding: 1rem;
+    /* Prevent iOS zoom on focus */
+    font-size: 16px;
+    border-radius: 8px;
+    min-height: 120px;
+  }
+`;
+
+const ModalFooter = styled.div`
+  padding: 1.25rem 2rem;
+  background: white;
+  border-top: 1px solid #e2e8f0;
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+
+  @media (max-width: 768px) {
+    padding: 1rem 1.25rem;
+    flex-direction: column-reverse;
+    gap: 0.5rem;
+    position: sticky;
+    bottom: 0;
+    z-index: 10;
+
+    button {
+      width: 100%;
+      margin: 0 !important;
+      justify-content: center;
+      min-height: 48px;
+    }
+  }
+`;
+
+const CancelButton = styled(Button)`
+  &&& {
+    background: #f1f5f9;
+    color: #475569;
+    border: none;
+    padding: 0.875rem 1.5rem;
+    font-weight: 600;
+    border-radius: 10px;
+    transition: all 0.2s ease;
+
+    &:hover:not(:disabled) {
+      background: #e2e8f0;
+      color: #1e293b;
+    }
+
+    &:disabled {
+      opacity: 0.6;
+    }
+  }
+`;
+
+const SubmitButton = styled(Button)`
+  &&& {
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: white;
+    border: none;
+    padding: 0.875rem 1.5rem;
+    font-weight: 600;
+    border-radius: 10px;
+    transition: all 0.2s ease;
+    box-shadow: 0 4px 14px rgba(102, 126, 234, 0.35);
+
+    &:hover:not(:disabled) {
+      transform: translateY(-1px);
+      box-shadow: 0 6px 20px rgba(102, 126, 234, 0.45);
+    }
+
+    &:active:not(:disabled) {
+      transform: translateY(0);
+    }
+
+    &:disabled {
+      opacity: 0.6;
+      transform: none;
+    }
+  }
+`;
+
+const IconUploadWrapper = styled.div`
+  max-width: 300px;
+  margin: 0 auto;
+
+  @media (max-width: 768px) {
+    max-width: 200px;
+  }
+`;
+
+const CloseButton = styled.button`
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  background: rgba(255, 255, 255, 0.2);
+  border: none;
+  border-radius: 50%;
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  color: white;
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.3);
+  }
+
+  @media (max-width: 768px) {
+    width: 40px;
+    height: 40px;
+  }
+`;
+
+/**
+ * CorpusModal - A modern, mobile-friendly modal for creating and editing corpuses.
+ *
+ * Features:
+ * - Clean, responsive design that works well on mobile
+ * - Simple controlled inputs (no complex form libraries)
+ * - Supports Create, Edit, and View modes
+ * - Integrates with LabelSetSelector, EmbedderSelector, and icon upload
+ */
+export const CorpusModal: React.FC<CorpusModalProps> = ({
+  open,
+  mode,
+  corpus,
+  loading = false,
+  onSubmit,
+  onClose,
+}) => {
+  const isReadOnly = mode === "VIEW";
+  const isCreate = mode === "CREATE";
+
+  // Form state
+  const [title, setTitle] = useState("");
+  const [slug, setSlug] = useState("");
+  const [description, setDescription] = useState("");
+  const [icon, setIcon] = useState<string | ArrayBuffer | null>(null);
+  const [labelSetId, setLabelSetId] = useState<string | null>(null);
+  const [labelSetObj, setLabelSetObj] = useState<LabelSetType | undefined>(
+    undefined
+  );
+  const [preferredEmbedder, setPreferredEmbedder] = useState<string | null>(
+    null
+  );
+
+  // Track if form has been modified
+  const [isDirty, setIsDirty] = useState(false);
+
+  // Initialize form from corpus data
+  useEffect(() => {
+    if (corpus) {
+      setTitle(corpus.title || "");
+      setSlug((corpus as any).slug || "");
+      setDescription(corpus.description || "");
+      setIcon(corpus.icon || null);
+      setLabelSetId(corpus.labelSet?.id || null);
+      setLabelSetObj(corpus.labelSet || undefined);
+      setPreferredEmbedder(corpus.preferredEmbedder || null);
+    } else {
+      // Reset for create mode
+      setTitle("");
+      setSlug("");
+      setDescription("");
+      setIcon(null);
+      setLabelSetId(null);
+      setLabelSetObj(undefined);
+      setPreferredEmbedder(null);
+    }
+    setIsDirty(false);
+  }, [corpus, open]);
+
+  // Handle form field changes
+  const handleTitleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setTitle(e.target.value);
+      setIsDirty(true);
+    },
+    []
+  );
+
+  const handleSlugChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setSlug(e.target.value);
+      setIsDirty(true);
+    },
+    []
+  );
+
+  const handleDescriptionChange = useCallback(
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      setDescription(e.target.value);
+      setIsDirty(true);
+    },
+    []
+  );
+
+  const handleIconChange = useCallback(
+    ({ data }: { data: string | ArrayBuffer; filename: string }) => {
+      setIcon(data);
+      setIsDirty(true);
+    },
+    []
+  );
+
+  const handleLabelSetChange = useCallback((values: any) => {
+    setLabelSetId(values.labelSet || null);
+    setIsDirty(true);
+  }, []);
+
+  const handleEmbedderChange = useCallback((values: any) => {
+    setPreferredEmbedder(values.preferredEmbedder || null);
+    setIsDirty(true);
+  }, []);
+
+  // Form validation
+  const isFormValid = title.trim().length > 0 && description.trim().length > 0;
+  const canSubmit = isFormValid && isDirty && !loading;
+
+  // Handle submit
+  const handleSubmit = useCallback(() => {
+    if (!canSubmit || !onSubmit) return;
+
+    const formData: CorpusFormData = {
+      title: title.trim(),
+      slug: slug.trim(),
+      description: description.trim(),
+    };
+
+    // Only include changed fields for edit mode
+    if (mode === "EDIT" && corpus) {
+      formData.id = corpus.id;
+      if (icon !== corpus.icon) {
+        formData.icon = icon;
+      }
+      if (labelSetId !== corpus.labelSet?.id) {
+        formData.labelSet = labelSetId;
+      }
+      if (preferredEmbedder !== corpus.preferredEmbedder) {
+        formData.preferredEmbedder = preferredEmbedder;
+      }
+    } else {
+      // Include all for create mode
+      formData.icon = icon;
+      formData.labelSet = labelSetId;
+      formData.preferredEmbedder = preferredEmbedder;
+    }
+
+    onSubmit(formData);
+  }, [
+    canSubmit,
+    onSubmit,
+    mode,
+    corpus,
+    title,
+    slug,
+    description,
+    icon,
+    labelSetId,
+    preferredEmbedder,
+  ]);
+
+  // Get header text based on mode
+  const getHeaderText = () => {
+    switch (mode) {
+      case "CREATE":
+        return "Create New Corpus";
+      case "EDIT":
+        return `Edit Corpus`;
+      case "VIEW":
+        return "View Corpus";
+      default:
+        return "Corpus";
+    }
+  };
+
+  const getSubtitle = () => {
+    switch (mode) {
+      case "CREATE":
+        return "Set up a new corpus to organize your documents";
+      case "EDIT":
+        return title || "Update corpus details";
+      case "VIEW":
+        return title || "Viewing corpus details";
+      default:
+        return "";
+    }
+  };
+
+  return (
+    <StyledModal open={open} onClose={onClose} size="small">
+      <ModalHeader>
+        <HeaderTitle>
+          <Icon name={isCreate ? "plus circle" : "edit"} />
+          {getHeaderText()}
+        </HeaderTitle>
+        <HeaderSubtitle>{getSubtitle()}</HeaderSubtitle>
+        <CloseButton onClick={onClose} disabled={loading}>
+          <Icon name="close" />
+        </CloseButton>
+      </ModalHeader>
+
+      <ModalBody>
+        {/* Basic Info Section */}
+        <FormSection>
+          <SectionTitle>
+            <Icon name="info circle" />
+            Basic Information
+          </SectionTitle>
+
+          <FormField>
+            <Label htmlFor="corpus-title">Title *</Label>
+            <TextInput
+              id="corpus-title"
+              type="text"
+              placeholder="Enter corpus title"
+              value={title}
+              onChange={handleTitleChange}
+              disabled={loading || isReadOnly}
+              $readOnly={isReadOnly}
+              autoComplete="off"
+            />
+          </FormField>
+
+          <FormField>
+            <Label htmlFor="corpus-slug">Slug</Label>
+            <TextInput
+              id="corpus-slug"
+              type="text"
+              placeholder="my-corpus-slug (auto-generated if blank)"
+              value={slug}
+              onChange={handleSlugChange}
+              disabled={loading || isReadOnly}
+              $readOnly={isReadOnly}
+              autoComplete="off"
+            />
+            <HelpText>
+              Case-sensitive. Allowed: A-Z, a-z, 0-9, hyphen (-). Leave blank to
+              auto-generate.
+            </HelpText>
+          </FormField>
+
+          <FormField>
+            <Label htmlFor="corpus-description">Description *</Label>
+            <TextArea
+              id="corpus-description"
+              placeholder="Describe what this corpus is about..."
+              value={description}
+              onChange={handleDescriptionChange}
+              disabled={loading || isReadOnly}
+              $readOnly={isReadOnly}
+            />
+          </FormField>
+        </FormSection>
+
+        {/* Icon Section */}
+        <FormSection>
+          <SectionTitle>
+            <Icon name="image" />
+            Corpus Icon
+          </SectionTitle>
+          <IconUploadWrapper>
+            <FilePreviewAndUpload
+              isImage={true}
+              acceptedTypes="image/*"
+              file={icon || ""}
+              readOnly={isReadOnly}
+              disabled={loading}
+              onChange={handleIconChange}
+            />
+          </IconUploadWrapper>
+        </FormSection>
+
+        {/* Settings Section */}
+        <FormSection>
+          <SectionTitle>
+            <Icon name="cog" />
+            Settings
+          </SectionTitle>
+
+          <FormField>
+            <LabelSetSelector
+              read_only={isReadOnly || loading}
+              labelSet={labelSetObj}
+              onChange={handleLabelSetChange}
+            />
+          </FormField>
+
+          <FormField>
+            <EmbedderSelector
+              read_only={isReadOnly || loading}
+              preferredEmbedder={preferredEmbedder || undefined}
+              onChange={handleEmbedderChange}
+            />
+          </FormField>
+        </FormSection>
+      </ModalBody>
+
+      <ModalFooter>
+        <CancelButton onClick={onClose} disabled={loading}>
+          <Icon name="close" />
+          {isReadOnly ? "Close" : "Cancel"}
+        </CancelButton>
+        {!isReadOnly && onSubmit && (
+          <SubmitButton
+            onClick={handleSubmit}
+            disabled={!canSubmit}
+            loading={loading}
+          >
+            <Icon name="check" />
+            {isCreate ? "Create Corpus" : "Save Changes"}
+          </SubmitButton>
+        )}
+      </ModalFooter>
+    </StyledModal>
+  );
+};
+
+export default CorpusModal;

--- a/frontend/src/components/corpuses/CorpusModal.tsx
+++ b/frontend/src/components/corpuses/CorpusModal.tsx
@@ -47,9 +47,10 @@ const StyledModal = styled(Modal)`
 `;
 
 const ModalHeader = styled.div`
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  background: #ffffff;
   padding: 1.5rem 2rem;
-  color: white;
+  color: #1a1a1a;
+  border-bottom: 1px solid #e5e5e5;
 
   @media (max-width: 768px) {
     padding: 1rem 1.25rem;
@@ -74,7 +75,7 @@ const HeaderTitle = styled.h2`
 
 const HeaderSubtitle = styled.p`
   margin: 0;
-  opacity: 0.9;
+  color: #666666;
   font-size: 0.9rem;
 
   @media (max-width: 768px) {
@@ -84,13 +85,15 @@ const HeaderSubtitle = styled.p`
 
 const ModalBody = styled.div`
   padding: 2rem;
-  background: #f8fafc;
+  background: #fafafa;
   max-height: calc(100vh - 200px);
   overflow-y: auto;
 
   @media (max-width: 768px) {
     padding: 1.25rem;
-    max-height: calc(100vh - 140px);
+    /* Add extra bottom padding so content can scroll above sticky footer */
+    padding-bottom: 120px;
+    max-height: calc(100vh - 80px);
     /* Smooth scrolling on iOS */
     -webkit-overflow-scrolling: touch;
   }
@@ -101,8 +104,8 @@ const FormSection = styled.div`
   border-radius: 12px;
   padding: 1.5rem;
   margin-bottom: 1.25rem;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
-  border: 1px solid #e2e8f0;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+  border: 1px solid #e5e5e5;
 
   @media (max-width: 768px) {
     padding: 1rem;
@@ -118,7 +121,7 @@ const FormSection = styled.div`
 const SectionTitle = styled.h3`
   font-size: 0.875rem;
   font-weight: 600;
-  color: #64748b;
+  color: #888888;
   text-transform: uppercase;
   letter-spacing: 0.05em;
   margin: 0 0 1rem 0;
@@ -148,7 +151,7 @@ const Label = styled.label`
   display: block;
   font-size: 0.9rem;
   font-weight: 600;
-  color: #1e293b;
+  color: #1a1a1a;
   margin-bottom: 0.5rem;
 
   @media (max-width: 768px) {
@@ -159,7 +162,7 @@ const Label = styled.label`
 const HelpText = styled.span`
   display: block;
   font-size: 0.8rem;
-  color: #94a3b8;
+  color: #888888;
   margin-top: 0.25rem;
 
   @media (max-width: 768px) {
@@ -170,27 +173,27 @@ const HelpText = styled.span`
 const TextInput = styled.input<{ $readOnly?: boolean }>`
   width: 100%;
   padding: 0.875rem 1rem;
-  border: 2px solid #e2e8f0;
+  border: 2px solid #e5e5e5;
   border-radius: 10px;
   font-size: 1rem;
-  color: #1e293b;
-  background: ${(props) => (props.$readOnly ? "#f8fafc" : "white")};
+  color: #1a1a1a;
+  background: ${(props) => (props.$readOnly ? "#fafafa" : "white")};
   transition: all 0.2s ease;
   outline: none;
 
   &:focus {
-    border-color: #667eea;
-    box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.15);
+    border-color: #1a1a1a;
+    box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.08);
   }
 
   &:disabled {
-    background: #f1f5f9;
-    color: #94a3b8;
+    background: #f5f5f5;
+    color: #999999;
     cursor: not-allowed;
   }
 
   &::placeholder {
-    color: #94a3b8;
+    color: #999999;
   }
 
   @media (max-width: 768px) {
@@ -206,11 +209,11 @@ const TextInput = styled.input<{ $readOnly?: boolean }>`
 const TextArea = styled.textarea<{ $readOnly?: boolean }>`
   width: 100%;
   padding: 0.875rem 1rem;
-  border: 2px solid #e2e8f0;
+  border: 2px solid #e5e5e5;
   border-radius: 10px;
   font-size: 1rem;
-  color: #1e293b;
-  background: ${(props) => (props.$readOnly ? "#f8fafc" : "white")};
+  color: #1a1a1a;
+  background: ${(props) => (props.$readOnly ? "#fafafa" : "white")};
   transition: all 0.2s ease;
   outline: none;
   resize: vertical;
@@ -219,18 +222,18 @@ const TextArea = styled.textarea<{ $readOnly?: boolean }>`
   line-height: 1.5;
 
   &:focus {
-    border-color: #667eea;
-    box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.15);
+    border-color: #1a1a1a;
+    box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.08);
   }
 
   &:disabled {
-    background: #f1f5f9;
-    color: #94a3b8;
+    background: #f5f5f5;
+    color: #999999;
     cursor: not-allowed;
   }
 
   &::placeholder {
-    color: #94a3b8;
+    color: #999999;
   }
 
   @media (max-width: 768px) {
@@ -245,7 +248,7 @@ const TextArea = styled.textarea<{ $readOnly?: boolean }>`
 const ModalFooter = styled.div`
   padding: 1.25rem 2rem;
   background: white;
-  border-top: 1px solid #e2e8f0;
+  border-top: 1px solid #e5e5e5;
   display: flex;
   justify-content: flex-end;
   gap: 0.75rem;
@@ -269,8 +272,8 @@ const ModalFooter = styled.div`
 
 const CancelButton = styled(Button)`
   &&& {
-    background: #f1f5f9;
-    color: #475569;
+    background: #f5f5f5;
+    color: #666666;
     border: none;
     padding: 0.875rem 1.5rem;
     font-weight: 600;
@@ -278,8 +281,8 @@ const CancelButton = styled(Button)`
     transition: all 0.2s ease;
 
     &:hover:not(:disabled) {
-      background: #e2e8f0;
-      color: #1e293b;
+      background: #e5e5e5;
+      color: #1a1a1a;
     }
 
     &:disabled {
@@ -290,27 +293,27 @@ const CancelButton = styled(Button)`
 
 const SubmitButton = styled(Button)`
   &&& {
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    background: #1a1a1a;
     color: white;
     border: none;
     padding: 0.875rem 1.5rem;
     font-weight: 600;
     border-radius: 10px;
     transition: all 0.2s ease;
-    box-shadow: 0 4px 14px rgba(102, 126, 234, 0.35);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
 
     &:hover:not(:disabled) {
-      transform: translateY(-1px);
-      box-shadow: 0 6px 20px rgba(102, 126, 234, 0.45);
+      background: #333333;
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
     }
 
     &:active:not(:disabled) {
-      transform: translateY(0);
+      background: #000000;
     }
 
     &:disabled {
-      opacity: 0.6;
-      transform: none;
+      background: #cccccc;
+      box-shadow: none;
     }
   }
 `;
@@ -328,7 +331,7 @@ const CloseButton = styled.button`
   position: absolute;
   top: 1rem;
   right: 1rem;
-  background: rgba(255, 255, 255, 0.2);
+  background: #f5f5f5;
   border: none;
   border-radius: 50%;
   width: 36px;
@@ -338,10 +341,11 @@ const CloseButton = styled.button`
   justify-content: center;
   cursor: pointer;
   transition: all 0.2s ease;
-  color: white;
+  color: #666666;
 
   &:hover {
-    background: rgba(255, 255, 255, 0.3);
+    background: #e5e5e5;
+    color: #1a1a1a;
   }
 
   @media (max-width: 768px) {

--- a/frontend/src/components/corpuses/CorpusModal.tsx
+++ b/frontend/src/components/corpuses/CorpusModal.tsx
@@ -91,11 +91,16 @@ const ModalBody = styled.div`
 
   @media (max-width: 768px) {
     padding: 1.25rem;
-    /* Add extra bottom padding so content can scroll above sticky footer */
-    padding-bottom: 120px;
+    /* Add extra bottom padding so content (including dropdowns) can scroll above sticky footer */
+    padding-bottom: 200px;
     max-height: calc(100vh - 80px);
     /* Smooth scrolling on iOS */
     -webkit-overflow-scrolling: touch;
+  }
+
+  /* Ensure Semantic UI dropdowns appear above the sticky footer */
+  .ui.dropdown .menu {
+    z-index: 20;
   }
 `;
 

--- a/frontend/src/components/corpuses/CorpusSettings.tsx
+++ b/frontend/src/components/corpuses/CorpusSettings.tsx
@@ -647,7 +647,7 @@ export const CorpusSettings: React.FC<CorpusSettingsProps> = ({ corpus }) => {
     setPublicDraft(Boolean(corpus.isPublic));
   }, [corpus]);
 
-  const [updateCorpusMutation, { loading: updatingSlug }] = useMutation<
+  const [updateCorpusMutation, { loading: updatingCorpus }] = useMutation<
     UpdateCorpusOutputs,
     UpdateCorpusInputs
   >(UPDATE_CORPUS, {
@@ -675,14 +675,20 @@ export const CorpusSettings: React.FC<CorpusSettingsProps> = ({ corpus }) => {
       toast.error(err.message);
     },
     update: (cache, { data }) => {
-      if (data?.updateCorpus?.ok) {
+      if (data?.updateCorpus?.ok && corpus.id) {
         // Update the corpus in cache with the new slug
-        cache.modify({
-          id: cache.identify({ __typename: "CorpusType", id: corpus.id }),
-          fields: {
-            slug: () => slugDraft || null,
-          },
+        const cacheId = cache.identify({
+          __typename: "CorpusType",
+          id: corpus.id,
         });
+        if (cacheId) {
+          cache.modify({
+            id: cacheId,
+            fields: {
+              slug: () => slugDraft || null,
+            },
+          });
+        }
       }
     },
   });
@@ -710,14 +716,20 @@ export const CorpusSettings: React.FC<CorpusSettingsProps> = ({ corpus }) => {
       toast.error(err.message);
     },
     update: (cache, { data }) => {
-      if (data?.setCorpusVisibility?.ok) {
+      if (data?.setCorpusVisibility?.ok && corpus.id) {
         // Update the corpus in cache with the new visibility
-        cache.modify({
-          id: cache.identify({ __typename: "CorpusType", id: corpus.id }),
-          fields: {
-            isPublic: () => publicDraft,
-          },
+        const cacheId = cache.identify({
+          __typename: "CorpusType",
+          id: corpus.id,
         });
+        if (cacheId) {
+          cache.modify({
+            id: cacheId,
+            fields: {
+              isPublic: () => publicDraft,
+            },
+          });
+        }
       }
     },
   });
@@ -1053,7 +1065,7 @@ export const CorpusSettings: React.FC<CorpusSettingsProps> = ({ corpus }) => {
               <div style={{ gridColumn: "1 / span 2", marginTop: "1rem" }}>
                 <Button
                   primary
-                  loading={updatingSlug || settingVisibility}
+                  loading={updatingCorpus || settingVisibility}
                   disabled={!canUpdate && !canPermission}
                   onClick={() => {
                     // Use separate mutations for visibility vs other settings

--- a/frontend/src/components/corpuses/CorpusSettings.tsx
+++ b/frontend/src/components/corpuses/CorpusSettings.tsx
@@ -647,7 +647,7 @@ export const CorpusSettings: React.FC<CorpusSettingsProps> = ({ corpus }) => {
     setPublicDraft(Boolean(corpus.isPublic));
   }, [corpus]);
 
-  const [updateCorpusMutation, { loading: updatingVisibility }] = useMutation<
+  const [updateCorpusMutation, { loading: updatingSlug }] = useMutation<
     UpdateCorpusOutputs,
     UpdateCorpusInputs
   >(UPDATE_CORPUS, {
@@ -655,16 +655,36 @@ export const CorpusSettings: React.FC<CorpusSettingsProps> = ({ corpus }) => {
       if (data.updateCorpus?.ok) {
         toast.success("Updated corpus settings");
 
+        // Update local state to reflect the saved value
+        setOriginalSlug(slugDraft);
+
         // If slug was updated, navigate to the new URL
         if (slugDraft && slugDraft !== originalSlug && corpus.creator?.slug) {
           const newUrl = `/c/${corpus.creator.slug}/${slugDraft}`;
           navigate(newUrl, { replace: true });
         }
       } else {
+        // Revert local state on failure
+        setSlugDraft(originalSlug);
         toast.error(data.updateCorpus?.message || "Failed to update corpus");
       }
     },
-    onError: (err) => toast.error(err.message),
+    onError: (err) => {
+      // Revert local state on error
+      setSlugDraft(originalSlug);
+      toast.error(err.message);
+    },
+    update: (cache, { data }) => {
+      if (data?.updateCorpus?.ok) {
+        // Update the corpus in cache with the new slug
+        cache.modify({
+          id: cache.identify({ __typename: "CorpusType", id: corpus.id }),
+          fields: {
+            slug: () => slugDraft || null,
+          },
+        });
+      }
+    },
   });
 
   // Separate mutation for visibility changes (uses proper permission checks)
@@ -675,13 +695,31 @@ export const CorpusSettings: React.FC<CorpusSettingsProps> = ({ corpus }) => {
     onCompleted: (data) => {
       if (data.setCorpusVisibility?.ok) {
         toast.success(data.setCorpusVisibility.message);
+        // Local state already updated optimistically, no need to change
       } else {
+        // Revert local state on failure
+        setPublicDraft(Boolean(corpus.isPublic));
         toast.error(
           data.setCorpusVisibility?.message || "Failed to update visibility"
         );
       }
     },
-    onError: (err) => toast.error(err.message),
+    onError: (err) => {
+      // Revert local state on error
+      setPublicDraft(Boolean(corpus.isPublic));
+      toast.error(err.message);
+    },
+    update: (cache, { data }) => {
+      if (data?.setCorpusVisibility?.ok) {
+        // Update the corpus in cache with the new visibility
+        cache.modify({
+          id: cache.identify({ __typename: "CorpusType", id: corpus.id }),
+          fields: {
+            isPublic: () => publicDraft,
+          },
+        });
+      }
+    },
   });
 
   const [isModalOpen, setIsModalOpen] = React.useState(false);
@@ -1015,7 +1053,7 @@ export const CorpusSettings: React.FC<CorpusSettingsProps> = ({ corpus }) => {
               <div style={{ gridColumn: "1 / span 2", marginTop: "1rem" }}>
                 <Button
                   primary
-                  loading={updatingVisibility || settingVisibility}
+                  loading={updatingSlug || settingVisibility}
                   disabled={!canUpdate && !canPermission}
                   onClick={() => {
                     // Use separate mutations for visibility vs other settings

--- a/frontend/src/components/widgets/file-controls/FilePreviewAndUpload.tsx
+++ b/frontend/src/components/widgets/file-controls/FilePreviewAndUpload.tsx
@@ -44,11 +44,11 @@ const UploadContainer = styled(Segment)<{ $isReadOnly: boolean }>`
 
 const ImagePreview = styled.img`
   width: 100%;
-  height: 300px;
+  height: 150px;
   object-fit: contain;
   background: #fff;
   margin: 0;
-  padding: 1rem;
+  padding: 0.75rem;
   display: block;
 `;
 
@@ -180,7 +180,9 @@ export const FilePreviewAndUpload = ({
         <>
           <ImagePreview
             src={
-              typeof displayedFile === "string" ? displayedFile : default_image
+              typeof displayedFile === "string" && displayedFile
+                ? displayedFile
+                : default_image
             }
             alt="Preview"
           />

--- a/frontend/src/views/Corpuses.tsx
+++ b/frontend/src/views/Corpuses.tsx
@@ -38,17 +38,12 @@ import {
   CreateAndSearchBar,
   DropdownActionProps,
 } from "../components/layout/CreateAndSearchBar";
-import { CRUDModal } from "../components/widgets/CRUD/CRUDModal";
 import { CardLayout } from "../components/layout/CardLayout";
 import { CorpusBreadcrumbs } from "../components/corpuses/CorpusBreadcrumbs";
-import { LabelSetSelector } from "../components/widgets/CRUD/LabelSetSelector";
-import { EmbedderSelector } from "../components/widgets/CRUD/EmbedderSelector";
 import {
-  newCorpusForm_Ui_Schema,
-  newCorpusForm_Schema,
-  editCorpusForm_Schema,
-  editCorpusForm_Ui_Schema,
-} from "../components/forms/schemas";
+  CorpusModal,
+  CorpusFormData,
+} from "../components/corpuses/CorpusModal";
 
 import {
   openedCorpus,
@@ -1962,9 +1957,26 @@ export const Corpuses = () => {
     }
   };
 
-  // TODO - Improve typing.
-  const handleUpdateCorpus = (corpus_obj: any) => {
-    tryMutateCorpus({ variables: corpus_obj });
+  // Handle corpus update with properly typed form data
+  const handleUpdateCorpus = (formData: CorpusFormData) => {
+    const variables: UpdateCorpusInputs = {
+      id: formData.id!,
+    };
+
+    // Only include changed fields
+    if (formData.title !== undefined) variables.title = formData.title;
+    if (formData.description !== undefined)
+      variables.description = formData.description;
+    if (formData.slug !== undefined) variables.slug = formData.slug;
+    if (formData.labelSet !== undefined)
+      variables.labelSet = formData.labelSet ?? undefined;
+    if (formData.preferredEmbedder !== undefined)
+      variables.preferredEmbedder = formData.preferredEmbedder ?? undefined;
+    if (formData.icon !== undefined && formData.icon !== null) {
+      variables.icon = formData.icon as string;
+    }
+
+    tryMutateCorpus({ variables });
   };
 
   // TODO - Improve typing.
@@ -1999,9 +2011,22 @@ export const Corpuses = () => {
       });
   };
 
-  // TODO - Improve typing.
-  const handleCreateNewCorpus = (corpus_json: Record<string, any>) => {
-    tryCreateCorpus({ variables: corpus_json })
+  // Handle corpus creation with properly typed form data
+  const handleCreateNewCorpus = (formData: CorpusFormData) => {
+    const variables: CreateCorpusInputs = {
+      title: formData.title,
+      description: formData.description,
+    };
+
+    // Include optional fields if provided
+    if (formData.labelSet) variables.labelSet = formData.labelSet;
+    if (formData.preferredEmbedder)
+      variables.preferredEmbedder = formData.preferredEmbedder;
+    if (formData.icon) {
+      variables.icon = formData.icon as string;
+    }
+
+    tryCreateCorpus({ variables })
       .then((data) => {
         console.log("Data", data);
         if (data.data?.createCorpus.ok) {
@@ -2624,24 +2649,12 @@ export const Corpuses = () => {
             }
             visible={show_remove_docs_from_corpus_modal}
           />
-          <CRUDModal
+          <CorpusModal
             open={corpus_to_edit !== null}
             mode="EDIT"
-            oldInstance={corpus_to_edit ?? {}}
-            modelName="corpus"
-            uiSchema={editCorpusForm_Ui_Schema}
-            dataSchema={editCorpusForm_Schema}
+            corpus={corpus_to_edit}
             onSubmit={handleUpdateCorpus}
             onClose={() => editingCorpus(null)}
-            hasFile={true}
-            fileField={"icon"}
-            fileLabel="Corpus Icon"
-            fileIsImage={true}
-            acceptedFileTypes="image/*"
-            propertyWidgets={{
-              labelSet: <LabelSetSelector />,
-              preferredEmbedder: <EmbedderSelector />,
-            }}
             loading={update_corpus_loading}
           />
           {exporting_corpus ? (
@@ -2659,47 +2672,22 @@ export const Corpuses = () => {
             <></>
           )}
           {corpus_to_view !== null ? (
-            <CRUDModal
+            <CorpusModal
               open={corpus_to_view !== null}
               mode="VIEW"
-              oldInstance={corpus_to_view ? corpus_to_view : {}}
-              modelName="corpus"
-              uiSchema={editCorpusForm_Ui_Schema}
-              dataSchema={editCorpusForm_Schema}
+              corpus={corpus_to_view}
               onClose={() => viewingCorpus(null)}
-              hasFile={true}
-              fileField={"icon"}
-              fileLabel="Corpus Icon"
-              fileIsImage={true}
-              acceptedFileTypes="image/*"
-              propertyWidgets={{
-                labelSet: <LabelSetSelector read_only={true} />,
-                preferredEmbedder: <EmbedderSelector read_only={true} />,
-              }}
             />
           ) : (
             <></>
           )}
 
           {show_new_corpus_modal ? (
-            <CRUDModal
+            <CorpusModal
               open={show_new_corpus_modal}
               mode="CREATE"
-              oldInstance={{ shared_with: [], is_public: false }}
-              modelName="corpus"
-              uiSchema={newCorpusForm_Ui_Schema}
-              dataSchema={newCorpusForm_Schema}
               onSubmit={handleCreateNewCorpus}
-              onClose={() => setShowNewCorpusModal(!show_new_corpus_modal)}
-              hasFile={true}
-              fileField={"icon"}
-              fileLabel="Corpus Icon"
-              fileIsImage={true}
-              acceptedFileTypes="image/*"
-              propertyWidgets={{
-                labelSet: <LabelSetSelector />,
-                preferredEmbedder: <EmbedderSelector />,
-              }}
+              onClose={() => setShowNewCorpusModal(false)}
               loading={create_corpus_loading}
             />
           ) : (

--- a/frontend/src/views/Corpuses.tsx
+++ b/frontend/src/views/Corpuses.tsx
@@ -1951,7 +1951,7 @@ export const Corpuses = () => {
     if (formData.preferredEmbedder !== undefined)
       variables.preferredEmbedder = formData.preferredEmbedder ?? undefined;
     if (formData.icon !== undefined && formData.icon !== null) {
-      variables.icon = formData.icon as string;
+      variables.icon = formData.icon;
     }
 
     tryMutateCorpus({ variables });
@@ -2001,7 +2001,7 @@ export const Corpuses = () => {
     if (formData.preferredEmbedder)
       variables.preferredEmbedder = formData.preferredEmbedder;
     if (formData.icon) {
-      variables.icon = formData.icon as string;
+      variables.icon = formData.icon;
     }
 
     tryCreateCorpus({ variables })

--- a/frontend/src/views/Corpuses.tsx
+++ b/frontend/src/views/Corpuses.tsx
@@ -1651,7 +1651,6 @@ export const Corpuses = () => {
    * -------------------------------------------------------------------------------------------------- */
 
   if (corpus_load_error) {
-    console.log("Corpuses.tsx - corpus_load_error", corpus_load_error);
     toast.error("ERROR\nUnable to fetch corpuses.");
   }
 
@@ -1842,27 +1841,6 @@ export const Corpuses = () => {
   // When query is skipped (no valid corpus ID), treat as not loading
   const effectiveStatsLoading = validCorpusId ? statsLoading : false;
 
-  // Debug logging for stats issues
-  useEffect(() => {
-    if (opened_corpus) {
-      console.log("Corpus Stats Debug:", {
-        corpusId: opened_corpus.id,
-        validCorpusId,
-        statsLoading,
-        effectiveStatsLoading,
-        hasStatsData: !!statsData?.corpusStats,
-        stats,
-      });
-    }
-  }, [
-    opened_corpus?.id,
-    validCorpusId,
-    statsLoading,
-    effectiveStatsLoading,
-    statsData,
-    stats,
-  ]);
-
   ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   // Query to shape item data
   ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -2028,7 +2006,6 @@ export const Corpuses = () => {
 
     tryCreateCorpus({ variables })
       .then((data) => {
-        console.log("Data", data);
         if (data.data?.createCorpus.ok) {
           toast.success("SUCCESS. Created corpus.");
         } else {
@@ -2585,7 +2562,6 @@ export const Corpuses = () => {
     opened_document !== null &&
     opened_document !== undefined
   ) {
-    console.log("Show annotator");
     content = <></>;
   }
 

--- a/frontend/src/views/Corpuses.tsx
+++ b/frontend/src/views/Corpuses.tsx
@@ -1991,6 +1991,12 @@ export const Corpuses = () => {
 
   // Handle corpus creation with properly typed form data
   const handleCreateNewCorpus = (formData: CorpusFormData) => {
+    // Runtime validation for required fields
+    if (!formData.title || !formData.description) {
+      toast.error("Title and description are required");
+      return;
+    }
+
     const variables: CreateCorpusInputs = {
       title: formData.title,
       description: formData.description,

--- a/frontend/tests/corpus-modal.ct.tsx
+++ b/frontend/tests/corpus-modal.ct.tsx
@@ -1,0 +1,504 @@
+// Playwright Component Test for CorpusModal
+import React from "react";
+import { test, expect } from "@playwright/experimental-ct-react";
+import { MockedProvider } from "@apollo/client/testing";
+import { CorpusModal } from "../src/components/corpuses/CorpusModal";
+import { GET_LABELSETS, GET_EMBEDDERS } from "../src/graphql/queries";
+import { CorpusType } from "../src/types/graphql-api";
+
+// Mock data
+const mockLabelSet = {
+  id: "TGFiZWxTZXRUeXBlOjE=",
+  title: "Legal Labels",
+  description: "Labels for legal documents",
+  icon: null,
+};
+
+const mockEmbedder = {
+  className:
+    "opencontractserver.pipeline.embedders.SentenceTransformerEmbedder",
+  name: "SentenceTransformer",
+  title: "Sentence Transformer",
+  description: "Default text embedder",
+  author: "OpenContracts",
+  vectorSize: 768,
+};
+
+const mockCorpus: CorpusType = {
+  id: "Q29ycHVzVHlwZTox",
+  title: "Test Corpus",
+  description: "A test corpus for unit testing",
+  icon: null,
+  isPublic: false,
+  labelSet: mockLabelSet as any,
+  preferredEmbedder: mockEmbedder.className,
+  creator: {
+    id: "VXNlclR5cGU6MQ==",
+    email: "test@example.com",
+  },
+  myPermissions: ["update_corpus", "read_corpus"],
+  documents: { totalCount: 0 },
+  annotations: { totalCount: 0 },
+} as CorpusType;
+
+// GraphQL mocks for selectors
+const labelSetsMock = {
+  request: {
+    query: GET_LABELSETS,
+    variables: { description: "" },
+  },
+  result: {
+    data: {
+      labelsets: {
+        edges: [{ node: mockLabelSet }],
+      },
+    },
+  },
+};
+
+const embeddersMock = {
+  request: {
+    query: GET_EMBEDDERS,
+    variables: {},
+  },
+  result: {
+    data: {
+      pipelineComponents: {
+        embedders: [mockEmbedder],
+      },
+    },
+  },
+};
+
+test.describe("CorpusModal - CREATE Mode", () => {
+  test("should render create modal with empty form", async ({
+    mount,
+    page,
+  }) => {
+    const component = await mount(
+      <MockedProvider
+        mocks={[labelSetsMock, embeddersMock]}
+        addTypename={false}
+      >
+        <CorpusModal
+          open={true}
+          mode="CREATE"
+          onSubmit={() => {}}
+          onClose={() => {}}
+        />
+      </MockedProvider>
+    );
+
+    // Check header
+    await expect(page.locator("text=Create New Corpus")).toBeVisible();
+
+    // Check form fields are present
+    await expect(page.locator("#corpus-title")).toBeVisible();
+    await expect(page.locator("#corpus-slug")).toBeVisible();
+    await expect(page.locator("#corpus-description")).toBeVisible();
+
+    // Form should be empty
+    await expect(page.locator("#corpus-title")).toHaveValue("");
+    await expect(page.locator("#corpus-description")).toHaveValue("");
+
+    // Submit button should be present but disabled (no content yet)
+    await expect(
+      page.locator('button:has-text("Create Corpus")')
+    ).toBeVisible();
+
+    await component.unmount();
+  });
+
+  test("should enable submit when required fields are filled", async ({
+    mount,
+    page,
+  }) => {
+    const component = await mount(
+      <MockedProvider
+        mocks={[labelSetsMock, embeddersMock]}
+        addTypename={false}
+      >
+        <CorpusModal
+          open={true}
+          mode="CREATE"
+          onSubmit={() => {}}
+          onClose={() => {}}
+        />
+      </MockedProvider>
+    );
+
+    // Fill required fields
+    await page.locator("#corpus-title").fill("My New Corpus");
+    await page
+      .locator("#corpus-description")
+      .fill("A description for my corpus");
+
+    // Submit button should now be enabled
+    const submitButton = page.locator('button:has-text("Create Corpus")');
+    await expect(submitButton).toBeEnabled();
+
+    await component.unmount();
+  });
+
+  test("should call onSubmit with form data", async ({ mount, page }) => {
+    let submittedData: any = null;
+
+    const component = await mount(
+      <MockedProvider
+        mocks={[labelSetsMock, embeddersMock]}
+        addTypename={false}
+      >
+        <CorpusModal
+          open={true}
+          mode="CREATE"
+          onSubmit={(data) => {
+            submittedData = data;
+          }}
+          onClose={() => {}}
+        />
+      </MockedProvider>
+    );
+
+    // Fill form
+    await page.locator("#corpus-title").fill("My New Corpus");
+    await page.locator("#corpus-slug").fill("my-new-corpus");
+    await page.locator("#corpus-description").fill("A test description");
+
+    // Submit
+    await page.locator('button:has-text("Create Corpus")').click();
+
+    // Verify data was submitted
+    expect(submittedData).not.toBeNull();
+    expect(submittedData.title).toBe("My New Corpus");
+    expect(submittedData.slug).toBe("my-new-corpus");
+    expect(submittedData.description).toBe("A test description");
+
+    await component.unmount();
+  });
+
+  test("should call onClose when cancel clicked", async ({ mount, page }) => {
+    let closed = false;
+
+    const component = await mount(
+      <MockedProvider
+        mocks={[labelSetsMock, embeddersMock]}
+        addTypename={false}
+      >
+        <CorpusModal
+          open={true}
+          mode="CREATE"
+          onSubmit={() => {}}
+          onClose={() => {
+            closed = true;
+          }}
+        />
+      </MockedProvider>
+    );
+
+    // Click cancel
+    await page.locator('button:has-text("Cancel")').click();
+
+    expect(closed).toBe(true);
+
+    await component.unmount();
+  });
+});
+
+test.describe("CorpusModal - EDIT Mode", () => {
+  test("should populate form with existing corpus data", async ({
+    mount,
+    page,
+  }) => {
+    const component = await mount(
+      <MockedProvider
+        mocks={[labelSetsMock, embeddersMock]}
+        addTypename={false}
+      >
+        <CorpusModal
+          open={true}
+          mode="EDIT"
+          corpus={mockCorpus}
+          onSubmit={() => {}}
+          onClose={() => {}}
+        />
+      </MockedProvider>
+    );
+
+    // Check header
+    await expect(page.locator("text=Edit Corpus")).toBeVisible();
+
+    // Form should be populated with corpus data
+    await expect(page.locator("#corpus-title")).toHaveValue("Test Corpus");
+    await expect(page.locator("#corpus-description")).toHaveValue(
+      "A test corpus for unit testing"
+    );
+
+    // Save button should be visible
+    await expect(page.locator('button:has-text("Save Changes")')).toBeVisible();
+
+    await component.unmount();
+  });
+
+  test("should only submit changed fields", async ({ mount, page }) => {
+    let submittedData: any = null;
+
+    const component = await mount(
+      <MockedProvider
+        mocks={[labelSetsMock, embeddersMock]}
+        addTypename={false}
+      >
+        <CorpusModal
+          open={true}
+          mode="EDIT"
+          corpus={mockCorpus}
+          onSubmit={(data) => {
+            submittedData = data;
+          }}
+          onClose={() => {}}
+        />
+      </MockedProvider>
+    );
+
+    // Only change the title
+    await page.locator("#corpus-title").clear();
+    await page.locator("#corpus-title").fill("Updated Corpus Title");
+
+    // Submit
+    await page.locator('button:has-text("Save Changes")').click();
+
+    // Verify only changed field is included
+    expect(submittedData).not.toBeNull();
+    expect(submittedData.id).toBe("Q29ycHVzVHlwZTox");
+    expect(submittedData.title).toBe("Updated Corpus Title");
+
+    await component.unmount();
+  });
+
+  test("should show loading state", async ({ mount, page }) => {
+    const component = await mount(
+      <MockedProvider
+        mocks={[labelSetsMock, embeddersMock]}
+        addTypename={false}
+      >
+        <CorpusModal
+          open={true}
+          mode="EDIT"
+          corpus={mockCorpus}
+          onSubmit={() => {}}
+          onClose={() => {}}
+          loading={true}
+        />
+      </MockedProvider>
+    );
+
+    // Form inputs should be disabled during loading
+    await expect(page.locator("#corpus-title")).toBeDisabled();
+    await expect(page.locator("#corpus-description")).toBeDisabled();
+
+    await component.unmount();
+  });
+});
+
+test.describe("CorpusModal - VIEW Mode", () => {
+  test("should display corpus data in read-only mode", async ({
+    mount,
+    page,
+  }) => {
+    const component = await mount(
+      <MockedProvider
+        mocks={[labelSetsMock, embeddersMock]}
+        addTypename={false}
+      >
+        <CorpusModal
+          open={true}
+          mode="VIEW"
+          corpus={mockCorpus}
+          onClose={() => {}}
+        />
+      </MockedProvider>
+    );
+
+    // Check header
+    await expect(page.locator("text=View Corpus")).toBeVisible();
+
+    // Form fields should be disabled
+    await expect(page.locator("#corpus-title")).toBeDisabled();
+    await expect(page.locator("#corpus-description")).toBeDisabled();
+
+    // No submit button in view mode
+    await expect(
+      page.locator('button:has-text("Save Changes")')
+    ).not.toBeVisible();
+    await expect(
+      page.locator('button:has-text("Create Corpus")')
+    ).not.toBeVisible();
+
+    // Close button should say "Close" not "Cancel"
+    await expect(page.locator('button:has-text("Close")')).toBeVisible();
+
+    await component.unmount();
+  });
+});
+
+test.describe("CorpusModal - Mobile Responsiveness", () => {
+  test.use({ viewport: { width: 375, height: 667 } }); // iPhone SE size
+
+  test("should display correctly on mobile viewport", async ({
+    mount,
+    page,
+  }) => {
+    const component = await mount(
+      <MockedProvider
+        mocks={[labelSetsMock, embeddersMock]}
+        addTypename={false}
+      >
+        <CorpusModal
+          open={true}
+          mode="CREATE"
+          onSubmit={() => {}}
+          onClose={() => {}}
+        />
+      </MockedProvider>
+    );
+
+    // Modal should be visible
+    await expect(page.locator("text=Create New Corpus")).toBeVisible();
+
+    // Form elements should still be accessible
+    await expect(page.locator("#corpus-title")).toBeVisible();
+    await expect(page.locator("#corpus-description")).toBeVisible();
+
+    // Footer buttons should be stacked on mobile
+    const footer = page.locator('button:has-text("Cancel")').locator("..");
+    await expect(footer).toBeVisible();
+
+    await component.unmount();
+  });
+
+  test("should not lose focus or clear fields when switching inputs on mobile", async ({
+    mount,
+    page,
+  }) => {
+    const component = await mount(
+      <MockedProvider
+        mocks={[labelSetsMock, embeddersMock]}
+        addTypename={false}
+      >
+        <CorpusModal
+          open={true}
+          mode="CREATE"
+          onSubmit={() => {}}
+          onClose={() => {}}
+        />
+      </MockedProvider>
+    );
+
+    // Type in title field
+    await page.locator("#corpus-title").fill("Test Title");
+
+    // Move to slug field
+    await page.locator("#corpus-slug").focus();
+    await page.locator("#corpus-slug").fill("test-slug");
+
+    // Move to description field
+    await page.locator("#corpus-description").focus();
+    await page.locator("#corpus-description").fill("Test description");
+
+    // Go back and verify title is still there (this was the bug)
+    await page.locator("#corpus-title").focus();
+    await expect(page.locator("#corpus-title")).toHaveValue("Test Title");
+
+    // Verify all fields retained their values
+    await expect(page.locator("#corpus-slug")).toHaveValue("test-slug");
+    await expect(page.locator("#corpus-description")).toHaveValue(
+      "Test description"
+    );
+
+    await component.unmount();
+  });
+});
+
+test.describe("CorpusModal - Form Validation", () => {
+  test("should require title field", async ({ mount, page }) => {
+    const component = await mount(
+      <MockedProvider
+        mocks={[labelSetsMock, embeddersMock]}
+        addTypename={false}
+      >
+        <CorpusModal
+          open={true}
+          mode="CREATE"
+          onSubmit={() => {}}
+          onClose={() => {}}
+        />
+      </MockedProvider>
+    );
+
+    // Only fill description, leave title empty
+    await page.locator("#corpus-description").fill("A description");
+
+    // Submit should still be disabled
+    const submitButton = page.locator('button:has-text("Create Corpus")');
+    await expect(submitButton).toBeDisabled();
+
+    await component.unmount();
+  });
+
+  test("should require description field", async ({ mount, page }) => {
+    const component = await mount(
+      <MockedProvider
+        mocks={[labelSetsMock, embeddersMock]}
+        addTypename={false}
+      >
+        <CorpusModal
+          open={true}
+          mode="CREATE"
+          onSubmit={() => {}}
+          onClose={() => {}}
+        />
+      </MockedProvider>
+    );
+
+    // Only fill title, leave description empty
+    await page.locator("#corpus-title").fill("A title");
+
+    // Submit should still be disabled
+    const submitButton = page.locator('button:has-text("Create Corpus")');
+    await expect(submitButton).toBeDisabled();
+
+    await component.unmount();
+  });
+
+  test("slug field should be optional", async ({ mount, page }) => {
+    let submittedData: any = null;
+
+    const component = await mount(
+      <MockedProvider
+        mocks={[labelSetsMock, embeddersMock]}
+        addTypename={false}
+      >
+        <CorpusModal
+          open={true}
+          mode="CREATE"
+          onSubmit={(data) => {
+            submittedData = data;
+          }}
+          onClose={() => {}}
+        />
+      </MockedProvider>
+    );
+
+    // Fill only required fields, leave slug empty
+    await page.locator("#corpus-title").fill("My Corpus");
+    await page.locator("#corpus-description").fill("A description");
+
+    // Submit should be enabled
+    await page.locator('button:has-text("Create Corpus")').click();
+
+    // Data should be submitted with empty slug
+    expect(submittedData).not.toBeNull();
+    expect(submittedData.slug).toBe("");
+
+    await component.unmount();
+  });
+});

--- a/frontend/tests/corpus-modal.ct.tsx
+++ b/frontend/tests/corpus-modal.ct.tsx
@@ -495,9 +495,10 @@ test.describe("CorpusModal - Form Validation", () => {
     // Submit should be enabled
     await page.locator('button:has-text("Create Corpus")').click();
 
-    // Data should be submitted with empty slug
+    // Data should be submitted with undefined slug (converted from empty string)
+    // Empty slug becomes undefined so backend auto-generates one
     expect(submittedData).not.toBeNull();
-    expect(submittedData.slug).toBe("");
+    expect(submittedData.slug).toBeUndefined();
 
     await component.unmount();
   });


### PR DESCRIPTION
## Summary

- Replace the generic `CRUDModal`/`CRUDWidget` system with a purpose-built `CorpusModal` component for corpus create/edit/view operations
- Fix fields clearing when switching between inputs on mobile (caused by JSON Schema Form library state management)
- Fix poor mobile styling (modal too wide, inputs too small, no responsive adjustments)

## Changes

### New CorpusModal Component
- Modern, mobile-first design with clean styling
- Simple controlled inputs instead of `@rjsf/semantic-ui` (fixes the field clearing issue)
- Responsive layout that works well on desktop and mobile:
  - Full-screen modal on mobile devices
  - Stacked footer buttons on mobile
  - Touch-friendly input sizes (48px min height, 16px font to prevent iOS zoom)
  - Smooth scrolling with `-webkit-overflow-scrolling: touch`
- Supports CREATE, EDIT, and VIEW modes
- Integrates with existing `LabelSetSelector`, `EmbedderSelector`, and `FilePreviewAndUpload`

### Files Changed
- `frontend/src/components/corpuses/CorpusModal.tsx` - New component
- `frontend/src/views/Corpuses.tsx` - Updated to use `CorpusModal` instead of `CRUDModal`
- `frontend/tests/corpus-modal.ct.tsx` - 13 component tests

## Test plan

- [x] All 13 new component tests pass
- [ ] Manual test: Create new corpus on desktop
- [ ] Manual test: Edit corpus on desktop
- [ ] Manual test: View corpus on desktop
- [ ] Manual test: Create/edit corpus on mobile - verify fields don't clear when switching inputs
- [ ] Manual test: Verify modal looks good on mobile viewport