### PR TITLE
fix: Add trailing slash to GraphQL endpoint in OG worker

### DIFF
--- a/cloudflare-og-worker/src/metadata.ts
+++ b/cloudflare-og-worker/src/metadata.ts
@@ -124,7 +124,7 @@ export async function fetchOGMetadata(
   const variables = buildVariables(route);
 
   try {
-    const response = await fetch(`${env.API_URL}/graphql`, {
+    const response = await fetch(`${env.API_URL}/graphql/`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",


### PR DESCRIPTION
## Summary

- Fixed OG worker not returning entity-specific metadata for social media previews
- Added trailing slash to GraphQL endpoint (`/graphql` → `/graphql/`)

## Problem

The Django/nginx backend requires a trailing slash on the `/graphql/` endpoint. Without it, requests returned `405 Not Allowed`, causing the Cloudflare Worker to fall back to generic OG metadata instead of entity-specific metadata (title, description, image).

This meant LinkedIn, Twitter, and other social media crawlers were seeing generic "OpenContracts" previews instead of the actual corpus/document titles and descriptions.

## Fix

Single character change in `cloudflare-og-worker/src/metadata.ts:127`:
```diff
- const response = await fetch(`${env.API_URL}/graphql`, {
+ const response = await fetch(`${env.API_URL}/graphql/`, {
```

## Test plan

- [x] Verified fix locally with curl simulating LinkedInBot user agent
- [x] Deployed to production and confirmed entity-specific OG tags returned
- [x] Tested in LinkedIn Post Inspector - now shows correct title/description/image