### PR TITLE
Implement issue 696

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,35 @@ All notable changes to OpenContracts will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2025-12-14
+## [Unreleased] - 2025-12-23
+
+### Added
+
+#### Upload Modal Styling Improvements (Issue #696)
+- **New styled components for upload modals** (`frontend/src/components/widgets/modals/UploadModalStyles.ts`): Comprehensive styled-components library with 25+ responsive components including `StyledUploadModal`, `DropZone`, `StepIndicator`, `FileListItem`, and more
+- **Step indicator UI** for DocumentUploadModal showing progress through upload workflow (Select → Details → Corpus)
+- **Modern gradient header** with icon and subtitle for both upload modals
+- **Progress bar integration** showing real-time upload progress with success/error states
+
+### Changed
+
+#### Upload Modal Mobile Responsiveness (Issue #696)
+- **DocumentUploadModal** (`frontend/src/components/widgets/modals/DocumentUploadModal.tsx`): Refactored to use new styled components with responsive grid layout for edit step
+- **BulkUploadModal** (`frontend/src/components/widgets/modals/BulkUploadModal.tsx`): Complete visual overhaul with styled drop zone, file size display, and responsive layout
+- **DocumentUploadList** (`frontend/src/components/documents/DocumentUploadList.tsx`): New drop zone styling with drag-active feedback and pulse animation
+- **DocumentListItem** (`frontend/src/components/documents/DocumentListItem.tsx`): Improved file list items with proper touch targets (56px min-height, 64px on mobile), status icons, and delete button styling
+- **Mobile-first breakpoints**: All upload modal components now have explicit breakpoints at 480px (mobile) and 768px (tablet)
+- **Touch target compliance**: All interactive elements meet 44px minimum touch target size for mobile accessibility
+- **Responsive action buttons**: Modal actions stack vertically on mobile for full-width tappable buttons
+- **Custom scrollbar styling**: File list has styled scrollbars for visual polish
+
+### Technical Details
+
+#### Upload Modal Architecture
+- Styled-components with transient props (`$active`, `$selected`, `$status`) to prevent DOM attribute warnings
+- CSS keyframe animations for drag-active pulse effect and fade-in modal transitions
+- Gradient backgrounds using `linear-gradient(135deg, #667eea 0%, #764ba2 100%)` for visual consistency
+- Semantic UI React components wrapped with styled-components for enhanced styling while preserving functionality
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to OpenContracts will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2025-12-23
+## [Unreleased] - 2025-12-25
 
 ### Added
 

--- a/frontend/src/components/documents/DocumentListItem.tsx
+++ b/frontend/src/components/documents/DocumentListItem.tsx
@@ -1,5 +1,4 @@
-import { Icon, List, Message } from "semantic-ui-react";
-import { SemanticCOLORS } from "semantic-ui-react/dist/commonjs/generic";
+import { Icon } from "semantic-ui-react";
 import { LoadingOverlay } from "../common/LoadingOverlay";
 
 import {
@@ -9,6 +8,14 @@ import {
   FAILED,
   FileDetailsProps,
 } from "../widgets/modals/DocumentUploadModal";
+import {
+  FileListItem,
+  FileItemContent,
+  FileItemIcon,
+  FileItemDetails,
+  FileItemActions,
+  DeleteButton,
+} from "../widgets/modals/UploadModalStyles";
 
 interface ContractListItemProps {
   document: FileDetailsProps;
@@ -25,54 +32,72 @@ export const ContractListItem = ({
   onRemove,
   onSelect,
 }: ContractListItemProps) => {
-  let icon_color = "gray";
-  if (status === SUCCESS) {
-    icon_color = "green";
-  } else if (status === FAILED) {
-    icon_color = "red";
-  }
+  const getStatusIcon = () => {
+    switch (status) {
+      case SUCCESS:
+        return "check circle";
+      case FAILED:
+        return "times circle";
+      case UPLOADING:
+        return "spinner";
+      default:
+        return "file pdf outline";
+    }
+  };
+
+  const getStatusText = () => {
+    switch (status) {
+      case SUCCESS:
+        return "Uploaded successfully";
+      case FAILED:
+        return "Upload failed";
+      case UPLOADING:
+        return "Uploading...";
+      default:
+        return "Ready to upload";
+    }
+  };
+
+  const handleRemoveClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onRemove();
+  };
 
   return (
-    <List.Item
-      style={
-        selected
-          ? { backgroundColor: "#e2ffdb", position: "relative" }
-          : { position: "relative" }
-      }
-      onClick={onSelect}
-    >
+    <FileListItem $selected={selected} $status={status} onClick={onSelect}>
       <LoadingOverlay
         active={status === UPLOADING}
         inverted
-        content="Loading"
+        content="Uploading..."
       />
-      {status === NOT_STARTED ? (
-        <div style={{ float: "right", cursor: "pointer" }}>
-          <Icon name="trash" color="red" onClick={onRemove} />
-        </div>
-      ) : (
-        <></>
+      <FileItemContent>
+        <FileItemIcon $status={status}>
+          <Icon name={getStatusIcon()} loading={status === UPLOADING} />
+        </FileItemIcon>
+        <FileItemDetails>
+          <div className="file-name">
+            {document?.title || "Untitled Document"}
+          </div>
+          <div
+            className={`file-status ${
+              status === FAILED ? "error" : status === SUCCESS ? "success" : ""
+            }`}
+          >
+            {getStatusText()}
+          </div>
+        </FileItemDetails>
+      </FileItemContent>
+      {status === NOT_STARTED && (
+        <FileItemActions>
+          <DeleteButton
+            icon
+            onClick={handleRemoveClick}
+            aria-label="Remove file"
+          >
+            <Icon name="trash alternate outline" />
+          </DeleteButton>
+        </FileItemActions>
       )}
-      <List.Icon
-        name="file alternate"
-        size="large"
-        color={icon_color as SemanticCOLORS}
-        verticalAlign="middle"
-      />
-      <List.Content>
-        <List.Header>
-          {status === FAILED ? (
-            <Message negative>
-              <Message.Header>
-                ERROR UPLOADING:{" "}
-                {document?.title ? document.title : "No contracts"}{" "}
-              </Message.Header>
-            </Message>
-          ) : (
-            <p>{document?.title ? document.title : "No contracts"}</p>
-          )}
-        </List.Header>
-      </List.Content>
-    </List.Item>
+    </FileListItem>
   );
 };

--- a/frontend/src/components/documents/DocumentUploadList.tsx
+++ b/frontend/src/components/documents/DocumentUploadList.tsx
@@ -49,7 +49,7 @@ export function DocumentUploadList(props: DocumentUploadListProps) {
     [props]
   );
 
-  const { getRootProps, getInputProps } = useDropzone({
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({
     disabled: documents && Object.keys(documents).length > 0,
     onDrop,
   });
@@ -85,13 +85,6 @@ export function DocumentUploadList(props: DocumentUploadListProps) {
       onDrop(files, [], event);
     }
   }
-
-  const { isDragActive } = useDropzone({
-    disabled: documents && Object.keys(documents).length > 0,
-    onDrop,
-    noClick: true,
-    noKeyboard: true,
-  });
 
   return (
     <div style={{ height: "100%" }}>

--- a/frontend/src/components/documents/DocumentUploadList.tsx
+++ b/frontend/src/components/documents/DocumentUploadList.tsx
@@ -1,8 +1,15 @@
 import React, { useCallback, useRef } from "react";
-import { Icon, Button, List, Segment, Header } from "semantic-ui-react";
+import { Icon, List } from "semantic-ui-react";
 import { DropEvent, FileRejection, useDropzone } from "react-dropzone";
 import { ContractListItem } from "./DocumentListItem";
 import { FileUploadPackageProps } from "../widgets/modals/DocumentUploadModal";
+import {
+  DropZone,
+  DropZoneIcon,
+  DropZoneText,
+  DropZoneButton,
+  FileListContainer,
+} from "../widgets/modals/UploadModalStyles";
 
 interface DocumentUploadListProps {
   documents: FileUploadPackageProps[];
@@ -79,37 +86,41 @@ export function DocumentUploadList(props: DocumentUploadListProps) {
     }
   }
 
+  const { isDragActive } = useDropzone({
+    disabled: documents && Object.keys(documents).length > 0,
+    onDrop,
+    noClick: true,
+    noKeyboard: true,
+  });
+
   return (
     <div style={{ height: "100%" }}>
-      <div
-        {...getRootProps()}
-        style={{
-          height: "40vh",
-          width: "100%",
-          padding: "1rem",
-        }}
-      >
+      <div {...getRootProps()}>
         {documents && documents.length > 0 ? (
-          <Segment
-            style={{ height: "100%", width: "100%", overflowY: "scroll" }}
-          >
-            <List celled>{grid}</List>
-          </Segment>
+          <FileListContainer>
+            <List divided relaxed>
+              {grid}
+            </List>
+          </FileListContainer>
         ) : (
-          <Segment
-            placeholder
-            style={{ height: "100%", width: "100%", overflowY: "scroll" }}
-          >
-            <Header icon>
+          <DropZone $isDragActive={isDragActive} $hasFiles={false}>
+            <DropZoneIcon>
               <Icon name="file pdf outline" />
-              Drag Documents Here or Click "Add Document(s)" to Upload
-              <br />
-              <em>(Only *.pdf files supported for now)</em>
-            </Header>
-            <Button primary onClick={() => fileInputRef.current.click()}>
-              Add Document(s)
-            </Button>
-          </Segment>
+            </DropZoneIcon>
+            <DropZoneText>
+              <div className="primary-text">
+                {isDragActive
+                  ? "Drop your PDFs here..."
+                  : "Drag & drop PDF files here"}
+              </div>
+              <div className="secondary-text">
+                or click the button below to browse
+              </div>
+            </DropZoneText>
+            <DropZoneButton onClick={() => fileInputRef.current.click()}>
+              <Icon name="folder open" /> Browse Files
+            </DropZoneButton>
+          </DropZone>
         )}
         <input
           accept="application/pdf"

--- a/frontend/src/components/documents/DocumentUploadList.tsx
+++ b/frontend/src/components/documents/DocumentUploadList.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef } from "react";
+import React, { useCallback, useMemo, useRef } from "react";
 import { Icon, List } from "semantic-ui-react";
 import { DropEvent, FileRejection, useDropzone } from "react-dropzone";
 import { ContractListItem } from "./DocumentListItem";
@@ -49,8 +49,14 @@ export function DocumentUploadList(props: DocumentUploadListProps) {
     [props]
   );
 
+  // Memoize disabled state to prevent unnecessary dropzone re-initialization
+  const isDisabled = useMemo(
+    () => documents && documents.length > 0,
+    [documents]
+  );
+
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
-    disabled: documents && Object.keys(documents).length > 0,
+    disabled: isDisabled,
     onDrop,
   });
 

--- a/frontend/src/components/widgets/modals/BulkUploadModal.tsx
+++ b/frontend/src/components/widgets/modals/BulkUploadModal.tsx
@@ -172,8 +172,11 @@ export const BulkUploadModal = () => {
       }
     } catch (err: any) {
       console.error("Upload error:", err);
+      // Extract GraphQL errors explicitly, falling back to general message
       const errorMessage =
-        err.message || "An unexpected error occurred during upload.";
+        err.graphQLErrors?.[0]?.message ||
+        err.message ||
+        "An unexpected error occurred during upload.";
       setError(errorMessage);
       toast.error(`Upload failed: ${errorMessage}`);
       setUploadProgress(0); // Reset progress on error
@@ -231,11 +234,13 @@ export const BulkUploadModal = () => {
             style={{ marginBottom: "1.5rem" }}
           >
             <input
+              id="bulk-upload-file-input"
               ref={fileInputRef}
               type="file"
               accept=".zip,application/zip"
               onChange={handleFileChange}
               disabled={loading}
+              aria-label="Select ZIP file for bulk upload"
               style={{ display: "none" }}
             />
             {selectedFile ? (

--- a/frontend/src/components/widgets/modals/BulkUploadModal.tsx
+++ b/frontend/src/components/widgets/modals/BulkUploadModal.tsx
@@ -178,10 +178,7 @@ export const BulkUploadModal = () => {
       toast.error(`Upload failed: ${errorMessage}`);
       setUploadProgress(0); // Reset progress on error
     } finally {
-      // Don't set loading to false immediately if progress is 100,
-      // let the success/error handling manage it or add a slight delay.
-      // setLoading(false); // Moved setting loading false to handleClose or error block
-      if (!loading) setLoading(false); // Ensure loading is false if an error occurred before finally
+      setLoading(false);
     }
   };
 
@@ -255,7 +252,9 @@ export const BulkUploadModal = () => {
                 <DropZoneButton
                   onClick={(e: React.MouseEvent) => {
                     e.stopPropagation();
-                    handleDropZoneClick();
+                    if (!loading && fileInputRef.current) {
+                      fileInputRef.current.click();
+                    }
                   }}
                 >
                   <Icon name="exchange" /> Change File

--- a/frontend/src/components/widgets/modals/BulkUploadModal.tsx
+++ b/frontend/src/components/widgets/modals/BulkUploadModal.tsx
@@ -1,20 +1,26 @@
 // frontend/src/components/widgets/modals/BulkUploadModal.tsx
-import React, { useState } from "react";
+import React, { useState, useRef } from "react";
 import { useMutation, useReactiveVar } from "@apollo/client";
-import {
-  Modal,
-  Button,
-  Form,
-  Message,
-  Progress,
-  FormField, // Import FormField
-} from "semantic-ui-react";
+import { Button, Form, Message, FormField, Icon } from "semantic-ui-react";
 import { toast } from "react-toastify";
-import { gql } from "@apollo/client"; // Import gql
+import { gql } from "@apollo/client";
 
-import { showBulkUploadModal } from "../../../graphql/cache"; // Removed filterToCorpus import as it's unused
-import { CorpusType } from "../../../types/graphql-api"; // Import CorpusType
-import { CorpusDropdown } from "../selectors/CorpusDropdown"; // Import CorpusDropdown
+import { showBulkUploadModal } from "../../../graphql/cache";
+import { CorpusType } from "../../../types/graphql-api";
+import { CorpusDropdown } from "../selectors/CorpusDropdown";
+import {
+  StyledUploadModal,
+  ModalHeader,
+  ModalHeaderContent,
+  DropZone,
+  DropZoneIcon,
+  DropZoneText,
+  DropZoneButton,
+  UploadProgress,
+  ActionButton,
+  FieldLabel,
+  ErrorMessage,
+} from "./UploadModalStyles";
 
 // Define the mutation GraphQL string (Renamed back)
 const UPLOAD_DOCUMENTS_ZIP = gql`
@@ -179,89 +185,151 @@ export const BulkUploadModal = () => {
     }
   };
 
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleDropZoneClick = () => {
+    if (!loading && fileInputRef.current) {
+      fileInputRef.current.click();
+    }
+  };
+
+  const formatFileSize = (bytes: number): string => {
+    if (bytes === 0) return "0 Bytes";
+    const k = 1024;
+    const sizes = ["Bytes", "KB", "MB", "GB"];
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + " " + sizes[i];
+  };
+
   return (
-    <Modal open={visible} onClose={handleClose} size="tiny">
-      <Modal.Header>Bulk Upload Documents (.zip)</Modal.Header>
-      <Modal.Content>
+    <StyledUploadModal open={visible} onClose={handleClose} size="small">
+      <StyledUploadModal.Header>
+        <ModalHeader>
+          <Icon name="file archive" size="large" />
+          <ModalHeaderContent>
+            <span className="title">Bulk Upload Documents</span>
+            <span className="subtitle">
+              Upload multiple PDFs from a ZIP file
+            </span>
+          </ModalHeaderContent>
+        </ModalHeader>
+      </StyledUploadModal.Header>
+      <StyledUploadModal.Content>
         <Form loading={loading} error={!!error}>
           {/* Error Message Display */}
-          <Message
-            error
-            header="Upload Error"
-            content={error}
-            visible={!!error} // Control visibility directly
-            onDismiss={() => setError(null)}
-          />
+          {error && (
+            <ErrorMessage>
+              <Icon name="exclamation circle" size="large" className="icon" />
+              <div className="content">
+                <div className="header">Upload Error</div>
+                <div className="message">{error}</div>
+              </div>
+            </ErrorMessage>
+          )}
 
-          {/* File Input Field */}
-          <Form.Field required>
-            {" "}
-            {/* Mark as required */}
-            <label>Select Zip File</label>
+          {/* File Drop Zone */}
+          <DropZone
+            $hasFiles={!!selectedFile}
+            onClick={handleDropZoneClick}
+            style={{ marginBottom: "1.5rem" }}
+          >
             <input
+              ref={fileInputRef}
               type="file"
               accept=".zip,application/zip"
               onChange={handleFileChange}
               disabled={loading}
-              // Add required attribute for browser validation (optional)
-              // required
+              style={{ display: "none" }}
             />
-            {selectedFile && (
-              <p style={{ marginTop: "5px", color: "#666" }}>
-                Selected: {selectedFile.name}
-              </p>
+            {selectedFile ? (
+              <>
+                <DropZoneIcon>
+                  <Icon name="file archive" />
+                </DropZoneIcon>
+                <DropZoneText>
+                  <div className="primary-text">{selectedFile.name}</div>
+                  <div className="secondary-text">
+                    {formatFileSize(selectedFile.size)}
+                  </div>
+                </DropZoneText>
+                <DropZoneButton
+                  onClick={(e: React.MouseEvent) => {
+                    e.stopPropagation();
+                    handleDropZoneClick();
+                  }}
+                >
+                  <Icon name="exchange" /> Change File
+                </DropZoneButton>
+              </>
+            ) : (
+              <>
+                <DropZoneIcon>
+                  <Icon name="cloud upload" />
+                </DropZoneIcon>
+                <DropZoneText>
+                  <div className="primary-text">Click to select a ZIP file</div>
+                  <div className="secondary-text">
+                    The ZIP should contain PDF documents
+                  </div>
+                </DropZoneText>
+                <DropZoneButton>
+                  <Icon name="folder open" /> Browse Files
+                </DropZoneButton>
+              </>
             )}
-          </Form.Field>
+          </DropZone>
 
           {/* Corpus Selection Field */}
           <FormField>
-            {" "}
-            {/* Wrap Dropdown in FormField for consistent styling */}
-            <label>Add to Corpus (Optional)</label>
+            <FieldLabel>
+              Add to Corpus{" "}
+              <span style={{ color: "#868e96", fontWeight: 400 }}>
+                (Optional)
+              </span>
+            </FieldLabel>
             <CorpusDropdown
-              value={targetCorpus?.id ?? null} // Pass controlled value (will be handled in CorpusDropdown)
-              onChange={setTargetCorpus} // Pass state setter
+              value={targetCorpus?.id ?? null}
+              onChange={setTargetCorpus}
               clearable={true}
               placeholder="Select a corpus..."
             />
           </FormField>
 
-          {/* Optional: Add fields for title prefix, description, make public checkbox */}
-          {/* Example:
-          <Form.Input label="Title Prefix (Optional)" placeholder="e.g., ProjectX-" />
-          <Form.Checkbox label="Make documents public" defaultChecked />
-          */}
-
-          {/* Remove the message about the currently selected corpus */}
-          {/* {currentCorpus && ( ... )} */}
-
           {/* Loading Progress */}
-          {loading &&
-            uploadProgress > 0 && ( // Show progress only when loading and progress > 0
-              <Progress
-                percent={uploadProgress}
-                indicating={uploadProgress < 100} // Only indicating while in progress
-                success={uploadProgress === 100} // Show success state at 100%
-                progress
-                size="small"
-                style={{ marginTop: "1em" }} // Add some margin
-              />
-            )}
+          {loading && uploadProgress > 0 && (
+            <UploadProgress
+              percent={uploadProgress}
+              indicating={uploadProgress < 100}
+              success={uploadProgress === 100}
+              progress
+            />
+          )}
         </Form>
-      </Modal.Content>
-      <Modal.Actions>
-        <Button onClick={handleClose} disabled={loading}>
+      </StyledUploadModal.Content>
+      <StyledUploadModal.Actions>
+        <ActionButton
+          $variant="secondary"
+          onClick={handleClose}
+          disabled={loading}
+        >
           Cancel
-        </Button>
-        <Button
-          primary
+        </ActionButton>
+        <ActionButton
+          $variant="primary"
           onClick={handleSubmit}
           disabled={!selectedFile || !base64File || loading}
-          loading={loading && uploadProgress < 100} // Show loading spinner only during active upload
         >
-          {loading && uploadProgress < 100 ? "Uploading..." : "Upload"}
-        </Button>
-      </Modal.Actions>
-    </Modal>
+          {loading && uploadProgress < 100 ? (
+            <>
+              <Icon name="spinner" loading /> Uploading...
+            </>
+          ) : (
+            <>
+              <Icon name="cloud upload" /> Upload ZIP
+            </>
+          )}
+        </ActionButton>
+      </StyledUploadModal.Actions>
+    </StyledUploadModal>
   );
 };

--- a/frontend/src/components/widgets/modals/DocumentUploadModal.tsx
+++ b/frontend/src/components/widgets/modals/DocumentUploadModal.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState, useMemo } from "react";
 import { gql, useReactiveVar } from "@apollo/client";
-import { Button, Icon, Segment, Header } from "semantic-ui-react";
+import { Icon, Header } from "semantic-ui-react";
 import _ from "lodash";
 
 import Form from "@rjsf/semantic-ui";
@@ -510,9 +510,12 @@ export function DocumentUploadModal(props: DocumentUploadModalProps) {
               </ActionButton>
             ) : (
               <>
-                <Button basic onClick={() => uploadFiles()}>
+                <ActionButton
+                  $variant="secondary"
+                  onClick={() => uploadFiles()}
+                >
                   Skip Corpus
-                </Button>
+                </ActionButton>
                 <ActionButton
                   $variant="primary"
                   onClick={() => setStep("corpus")}
@@ -528,9 +531,9 @@ export function DocumentUploadModal(props: DocumentUploadModalProps) {
             <ActionButton $variant="secondary" onClick={() => setStep("edit")}>
               <Icon name="arrow left" /> Back
             </ActionButton>
-            <Button basic onClick={() => uploadFiles()}>
+            <ActionButton $variant="secondary" onClick={() => uploadFiles()}>
               Skip
-            </Button>
+            </ActionButton>
             <ActionButton $variant="primary" onClick={() => uploadFiles()}>
               <Icon name="cloud upload" /> Upload
             </ActionButton>

--- a/frontend/src/components/widgets/modals/DocumentUploadModal.tsx
+++ b/frontend/src/components/widgets/modals/DocumentUploadModal.tsx
@@ -1,20 +1,11 @@
 import { useCallback, useEffect, useState, useMemo } from "react";
 import { gql, useReactiveVar } from "@apollo/client";
-import {
-  Button,
-  Modal,
-  Grid,
-  Divider,
-  Segment,
-  Header,
-  Icon,
-} from "semantic-ui-react";
+import { Button, Icon, Segment, Header } from "semantic-ui-react";
 import _ from "lodash";
 
 import Form from "@rjsf/semantic-ui";
 import validator from "@rjsf/validator-ajv8";
 import { DocumentUploadList } from "../../documents/DocumentUploadList";
-import { HorizontallyCenteredDiv } from "../../layout/Wrappers";
 import { newDocForm_Schema, newDocForm_Ui_Schema } from "../../forms/schemas";
 import {
   ApolloError,
@@ -39,6 +30,20 @@ import { CorpusSelector } from "../../corpuses/CorpusSelector";
 import { uploadModalPreloadedFiles } from "../../../graphql/cache";
 import { GET_DOCUMENTS } from "../../../graphql/queries";
 import { GET_CORPUS_FOLDERS } from "../../../graphql/queries/folders";
+import {
+  StyledUploadModal,
+  ModalHeader,
+  ModalHeaderContent,
+  StepIndicator,
+  Step,
+  StepConnector,
+  EditSection,
+  EditPanel,
+  EditPanelHeader,
+  FormContainer,
+  UploadProgress,
+  ActionButton,
+} from "./UploadModalStyles";
 
 export const NOT_STARTED = "NOT_STARTED";
 export const SUCCESS = "SUCCESS";
@@ -65,7 +70,7 @@ interface RightColProps {
 function RightCol({ files, selected_file_num, handleChange }: RightColProps) {
   if (files && files.length > 0 && selected_file_num >= 0) {
     return (
-      <Segment style={{ height: "100%", width: "100%", padding: "2rem" }}>
+      <FormContainer>
         <Form
           schema={newDocForm_Schema}
           uiSchema={newDocForm_Ui_Schema}
@@ -75,19 +80,18 @@ function RightCol({ files, selected_file_num, handleChange }: RightColProps) {
         >
           <></>
         </Form>
-      </Segment>
+      </FormContainer>
     );
   }
   return (
-    <Segment
-      placeholder
-      style={{ height: "100%", width: "100%", padding: "2rem" }}
-    >
+    <FormContainer placeholder>
       <Header icon>
-        <Icon name="settings" />
-        Click on a document to update default title and descriptions.
+        <Icon name="edit outline" style={{ color: "#667eea" }} />
+        <Header.Content style={{ color: "#495057", fontSize: "1rem" }}>
+          Click on a document to edit its details
+        </Header.Content>
       </Header>
-    </Segment>
+    </FormContainer>
   );
 }
 
@@ -356,38 +360,27 @@ export function DocumentUploadModal(props: DocumentUploadModalProps) {
   );
 
   const renderEditStep = () => (
-    <Grid columns={2} stackable textAlign="center">
-      <Divider vertical>Details:</Divider>
-      <Grid.Row verticalAlign="middle">
-        <Grid.Column style={{ paddingRight: "2rem" }}>
-          <DocumentUploadList
-            selected_file_num={selected_file_num}
-            documents={files}
-            statuses={upload_state}
-            onAddFile={addFile}
-            onRemove={removeFile}
-            onSelect={toggleSelectedDoc}
-          />
-        </Grid.Column>
-        <Grid.Column style={{ paddingLeft: "2rem" }}>
-          <div style={{ height: "100%", width: "100%" }}>
-            <div
-              style={{
-                height: "40vh",
-                width: "100%",
-                padding: "1rem",
-              }}
-            >
-              <RightCol
-                files={files}
-                selected_file_num={selected_file_num}
-                handleChange={handleChange}
-              />
-            </div>
-          </div>
-        </Grid.Column>
-      </Grid.Row>
-    </Grid>
+    <EditSection>
+      <EditPanel>
+        <EditPanelHeader>Selected Files</EditPanelHeader>
+        <DocumentUploadList
+          selected_file_num={selected_file_num}
+          documents={files}
+          statuses={upload_state}
+          onAddFile={addFile}
+          onRemove={removeFile}
+          onSelect={toggleSelectedDoc}
+        />
+      </EditPanel>
+      <EditPanel>
+        <EditPanelHeader>Document Details</EditPanelHeader>
+        <RightCol
+          files={files}
+          selected_file_num={selected_file_num}
+          handleChange={handleChange}
+        />
+      </EditPanel>
+    </EditSection>
   );
 
   const renderCorpusStep = () => (
@@ -415,78 +408,135 @@ export function DocumentUploadModal(props: DocumentUploadModalProps) {
     </div>
   );
 
+  const getStepNumber = () => {
+    switch (step) {
+      case "upload":
+        return 1;
+      case "edit":
+        return 2;
+      case "corpus":
+        return 3;
+      case "uploading":
+        return 4;
+      default:
+        return 1;
+    }
+  };
+
+  const currentStep = getStepNumber();
+
   return (
-    <Modal open={open} onClose={() => onClose()}>
-      <HorizontallyCenteredDiv>
-        <div style={{ marginTop: "1rem", textAlign: "left" }}>
-          <Header as="h2">
-            <Icon name="file pdf outline" />
-            <Header.Content>
-              Upload Your Documents
-              <Header.Subheader>
-                {step === "upload" && "Select New Document Files to Upload"}
-                {step === "edit" && "Edit Document Details"}
-                {step === "corpus" && "Select a Corpus (Optional)"}
-                {step === "uploading" && "Uploading Documents"}
-              </Header.Subheader>
-            </Header.Content>
-          </Header>
-        </div>
-      </HorizontallyCenteredDiv>
-      <Modal.Content>
+    <StyledUploadModal open={open} onClose={() => onClose()}>
+      <StyledUploadModal.Header>
+        <ModalHeader>
+          <Icon name="cloud upload" size="large" />
+          <ModalHeaderContent>
+            <span className="title">Upload Documents</span>
+            <span className="subtitle">
+              {step === "upload" && "Select PDF files to upload"}
+              {step === "edit" && "Review and edit document details"}
+              {step === "corpus" && "Optionally add to a corpus"}
+              {step === "uploading" && "Processing your uploads..."}
+            </span>
+          </ModalHeaderContent>
+        </ModalHeader>
+      </StyledUploadModal.Header>
+      <StyledUploadModal.Content>
+        {!corpusId && step !== "uploading" && (
+          <StepIndicator>
+            <Step $active={currentStep === 1} $completed={currentStep > 1}>
+              <Icon name="file" /> Select
+            </Step>
+            <StepConnector $completed={currentStep > 1} />
+            <Step $active={currentStep === 2} $completed={currentStep > 2}>
+              <Icon name="edit" /> Details
+            </Step>
+            <StepConnector $completed={currentStep > 2} />
+            <Step $active={currentStep === 3} $completed={currentStep > 3}>
+              <Icon name="folder open" /> Corpus
+            </Step>
+          </StepIndicator>
+        )}
+        {corpusId && step !== "uploading" && (
+          <StepIndicator>
+            <Step $active={currentStep === 1} $completed={currentStep > 1}>
+              <Icon name="file" /> Select
+            </Step>
+            <StepConnector $completed={currentStep > 1} />
+            <Step $active={currentStep === 2} $completed={currentStep > 2}>
+              <Icon name="edit" /> Details
+            </Step>
+          </StepIndicator>
+        )}
+        {step === "uploading" && (
+          <UploadProgress
+            percent={
+              (upload_state.filter((s) => s === SUCCESS || s === FAILED)
+                .length /
+                upload_state.length) *
+              100
+            }
+            indicating={upload_status === UPLOADING}
+            success={upload_status === SUCCESS}
+            error={upload_status === FAILED}
+            progress
+          />
+        )}
         {step === "upload" && renderUploadStep()}
         {step === "edit" && renderEditStep()}
         {step === "corpus" && !corpusId && renderCorpusStep()}
         {step === "uploading" && renderUploadingStep()}
-      </Modal.Content>
-      <Modal.Actions>
-        <Button basic color="grey" onClick={() => onClose()}>
+      </StyledUploadModal.Content>
+      <StyledUploadModal.Actions>
+        <ActionButton $variant="secondary" onClick={() => onClose()}>
           <Icon name="remove" /> Close
-        </Button>
+        </ActionButton>
         {step === "upload" && files.length > 0 && (
-          <Button color="green" inverted onClick={() => setStep("edit")}>
-            <Icon name="checkmark" /> Next
-          </Button>
+          <ActionButton $variant="primary" onClick={() => setStep("edit")}>
+            Continue <Icon name="arrow right" />
+          </ActionButton>
         )}
         {step === "edit" && (
           <>
-            <Button color="grey" inverted onClick={() => setStep("upload")}>
+            <ActionButton
+              $variant="secondary"
+              onClick={() => setStep("upload")}
+            >
               <Icon name="arrow left" /> Back
-            </Button>
+            </ActionButton>
             {corpusId ? (
-              <Button color="green" inverted onClick={() => uploadFiles()}>
-                <Icon name="checkmark" /> Upload
-              </Button>
+              <ActionButton $variant="primary" onClick={() => uploadFiles()}>
+                <Icon name="cloud upload" /> Upload
+              </ActionButton>
             ) : (
               <>
-                <Button color="blue" inverted onClick={() => uploadFiles()}>
-                  <Icon name="arrow right" /> Skip
+                <Button basic onClick={() => uploadFiles()}>
+                  Skip Corpus
                 </Button>
-                <Button
-                  color="green"
-                  inverted
+                <ActionButton
+                  $variant="primary"
                   onClick={() => setStep("corpus")}
                 >
-                  <Icon name="checkmark" /> Next
-                </Button>
+                  Continue <Icon name="arrow right" />
+                </ActionButton>
               </>
             )}
           </>
         )}
         {step === "corpus" && !corpusId && (
           <>
-            <Button color="grey" inverted onClick={() => setStep("edit")}>
+            <ActionButton $variant="secondary" onClick={() => setStep("edit")}>
               <Icon name="arrow left" /> Back
+            </ActionButton>
+            <Button basic onClick={() => uploadFiles()}>
+              Skip
             </Button>
-            <Button color="blue" inverted onClick={() => uploadFiles()}>
-              <Icon name="arrow right" /> Skip
-            </Button>
-            <Button color="green" inverted onClick={() => uploadFiles()}>
-              <Icon name="checkmark" /> Upload
-            </Button>
+            <ActionButton $variant="primary" onClick={() => uploadFiles()}>
+              <Icon name="cloud upload" /> Upload
+            </ActionButton>
           </>
         )}
-      </Modal.Actions>
-    </Modal>
+      </StyledUploadModal.Actions>
+    </StyledUploadModal>
   );
 }

--- a/frontend/src/components/widgets/modals/UploadModalStyles.ts
+++ b/frontend/src/components/widgets/modals/UploadModalStyles.ts
@@ -589,49 +589,6 @@ export const ActionButton = styled(Button)<{
   }
 `;
 
-// Bulk upload specific styles
-export const BulkUploadContent = styled.div`
-  .file-input-wrapper {
-    position: relative;
-    margin-bottom: 1.5rem;
-
-    input[type="file"] {
-      position: absolute;
-      left: 0;
-      top: 0;
-      opacity: 0;
-      width: 100%;
-      height: 100%;
-      cursor: pointer;
-    }
-  }
-
-  .selected-file-info {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    padding: 1rem;
-    background: #f8f9fa;
-    border-radius: 8px;
-    margin-top: 0.75rem;
-
-    .icon {
-      color: #667eea;
-    }
-
-    .file-name {
-      flex: 1;
-      font-weight: 500;
-      color: #495057;
-    }
-
-    .file-size {
-      font-size: 0.875rem;
-      color: #868e96;
-    }
-  }
-`;
-
 export const FieldLabel = styled.label`
   display: block;
   font-weight: 500;

--- a/frontend/src/components/widgets/modals/UploadModalStyles.ts
+++ b/frontend/src/components/widgets/modals/UploadModalStyles.ts
@@ -1,0 +1,692 @@
+import styled, { css, keyframes } from "styled-components";
+import { Modal, Button, Segment, List, Progress } from "semantic-ui-react";
+
+// Breakpoints for responsive design
+const breakpoints = {
+  mobile: "480px",
+  tablet: "768px",
+  desktop: "1024px",
+};
+
+// Animation keyframes
+const fadeIn = keyframes`
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+`;
+
+const pulse = keyframes`
+  0% {
+    box-shadow: 0 0 0 0 rgba(33, 133, 208, 0.4);
+  }
+  70% {
+    box-shadow: 0 0 0 10px rgba(33, 133, 208, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(33, 133, 208, 0);
+  }
+`;
+
+// Styled Modal with responsive sizing
+export const StyledUploadModal = styled(Modal)`
+  &.ui.modal {
+    width: 90% !important;
+    max-width: 700px !important;
+    margin: 1rem auto !important;
+    border-radius: 12px !important;
+    overflow: hidden;
+    animation: ${fadeIn} 0.3s ease-out;
+
+    @media (max-width: ${breakpoints.mobile}) {
+      width: 95% !important;
+      margin: 0.5rem auto !important;
+      max-height: 95vh;
+    }
+
+    @media (max-width: ${breakpoints.tablet}) {
+      width: 95% !important;
+    }
+
+    > .header {
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      color: white !important;
+      padding: 1.25rem 1.5rem !important;
+      font-size: 1.25rem !important;
+      border-bottom: none !important;
+
+      @media (max-width: ${breakpoints.mobile}) {
+        padding: 1rem !important;
+        font-size: 1.1rem !important;
+      }
+    }
+
+    > .content {
+      padding: 1.5rem !important;
+
+      @media (max-width: ${breakpoints.mobile}) {
+        padding: 1rem !important;
+      }
+    }
+
+    > .actions {
+      padding: 1rem 1.5rem !important;
+      background: #f8f9fa !important;
+      border-top: 1px solid #e9ecef !important;
+
+      @media (max-width: ${breakpoints.mobile}) {
+        padding: 0.75rem 1rem !important;
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+
+        .button {
+          width: 100% !important;
+          margin: 0 !important;
+        }
+      }
+    }
+  }
+`;
+
+// Modal header with icon
+export const ModalHeader = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+
+  .icon {
+    font-size: 1.5rem;
+
+    @media (max-width: ${breakpoints.mobile}) {
+      font-size: 1.25rem;
+    }
+  }
+`;
+
+export const ModalHeaderContent = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  .title {
+    font-weight: 600;
+    font-size: 1.25rem;
+    margin-bottom: 0.25rem;
+
+    @media (max-width: ${breakpoints.mobile}) {
+      font-size: 1.1rem;
+    }
+  }
+
+  .subtitle {
+    font-size: 0.875rem;
+    opacity: 0.9;
+    font-weight: 400;
+
+    @media (max-width: ${breakpoints.mobile}) {
+      font-size: 0.8rem;
+    }
+  }
+`;
+
+// Step indicator for multi-step upload
+export const StepIndicator = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 1.5rem;
+  padding: 0 1rem;
+
+  @media (max-width: ${breakpoints.mobile}) {
+    gap: 0.25rem;
+    margin-bottom: 1rem;
+  }
+`;
+
+export const Step = styled.div<{ $active?: boolean; $completed?: boolean }>`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  border-radius: 20px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  transition: all 0.2s ease;
+
+  @media (max-width: ${breakpoints.mobile}) {
+    padding: 0.375rem 0.75rem;
+    font-size: 0.75rem;
+    gap: 0.25rem;
+  }
+
+  ${({ $active, $completed }) =>
+    $active
+      ? css`
+          background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+          color: white;
+        `
+      : $completed
+      ? css`
+          background: #e8f5e9;
+          color: #2e7d32;
+        `
+      : css`
+          background: #f1f3f5;
+          color: #868e96;
+        `}
+`;
+
+export const StepConnector = styled.div<{ $completed?: boolean }>`
+  width: 30px;
+  height: 2px;
+  background: ${({ $completed }) => ($completed ? "#2e7d32" : "#dee2e6")};
+  transition: background 0.2s ease;
+
+  @media (max-width: ${breakpoints.mobile}) {
+    width: 15px;
+  }
+`;
+
+// Drag and drop zone
+export const DropZone = styled.div<{
+  $isDragActive?: boolean;
+  $hasFiles?: boolean;
+}>`
+  border: 2px dashed
+    ${({ $isDragActive }) => ($isDragActive ? "#667eea" : "#dee2e6")};
+  border-radius: 12px;
+  background: ${({ $isDragActive }) =>
+    $isDragActive
+      ? "linear-gradient(135deg, rgba(102, 126, 234, 0.1) 0%, rgba(118, 75, 162, 0.1) 100%)"
+      : "#fafbfc"};
+  min-height: 250px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  cursor: ${({ $hasFiles }) => ($hasFiles ? "default" : "pointer")};
+  transition: all 0.2s ease;
+  position: relative;
+  overflow: hidden;
+
+  @media (max-width: ${breakpoints.mobile}) {
+    min-height: 200px;
+    padding: 1.5rem 1rem;
+  }
+
+  &:hover {
+    border-color: ${({ $hasFiles }) => ($hasFiles ? "#dee2e6" : "#667eea")};
+    background: ${({ $hasFiles }) =>
+      $hasFiles
+        ? "#fafbfc"
+        : "linear-gradient(135deg, rgba(102, 126, 234, 0.05) 0%, rgba(118, 75, 162, 0.05) 100%)"};
+  }
+
+  ${({ $isDragActive }) =>
+    $isDragActive &&
+    css`
+      animation: ${pulse} 1.5s infinite;
+    `}
+`;
+
+export const DropZoneIcon = styled.div`
+  font-size: 3rem;
+  color: #667eea;
+  margin-bottom: 1rem;
+  opacity: 0.8;
+
+  @media (max-width: ${breakpoints.mobile}) {
+    font-size: 2.5rem;
+    margin-bottom: 0.75rem;
+  }
+`;
+
+export const DropZoneText = styled.div`
+  text-align: center;
+
+  .primary-text {
+    font-size: 1.1rem;
+    font-weight: 500;
+    color: #495057;
+    margin-bottom: 0.5rem;
+
+    @media (max-width: ${breakpoints.mobile}) {
+      font-size: 1rem;
+    }
+  }
+
+  .secondary-text {
+    font-size: 0.875rem;
+    color: #868e96;
+
+    @media (max-width: ${breakpoints.mobile}) {
+      font-size: 0.8rem;
+    }
+  }
+`;
+
+export const DropZoneButton = styled(Button)`
+  &.ui.button {
+    margin-top: 1rem;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%) !important;
+    color: white !important;
+    border-radius: 8px !important;
+    padding: 0.875rem 1.5rem !important;
+    font-weight: 500 !important;
+    transition: all 0.2s ease !important;
+    min-height: 44px; /* Touch target size */
+
+    @media (max-width: ${breakpoints.mobile}) {
+      width: 100%;
+      padding: 1rem !important;
+    }
+
+    &:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 4px 12px rgba(102, 126, 234, 0.4);
+    }
+
+    &:active {
+      transform: translateY(0);
+    }
+  }
+`;
+
+// File list container
+export const FileListContainer = styled(Segment)`
+  &.ui.segment {
+    border-radius: 12px !important;
+    border: 1px solid #e9ecef !important;
+    box-shadow: none !important;
+    max-height: 300px;
+    overflow-y: auto;
+    padding: 0.5rem !important;
+    margin: 0 !important;
+
+    @media (max-width: ${breakpoints.mobile}) {
+      max-height: 250px;
+    }
+
+    /* Custom scrollbar */
+    &::-webkit-scrollbar {
+      width: 6px;
+    }
+
+    &::-webkit-scrollbar-track {
+      background: #f1f3f5;
+      border-radius: 3px;
+    }
+
+    &::-webkit-scrollbar-thumb {
+      background: #ced4da;
+      border-radius: 3px;
+    }
+
+    &::-webkit-scrollbar-thumb:hover {
+      background: #adb5bd;
+    }
+  }
+`;
+
+// File list item
+export const FileListItem = styled(List.Item)<{
+  $selected?: boolean;
+  $status?: string;
+}>`
+  &.item {
+    padding: 0.875rem 1rem !important;
+    margin: 0.25rem 0 !important;
+    border-radius: 8px !important;
+    cursor: pointer;
+    transition: all 0.15s ease;
+    position: relative;
+    display: flex !important;
+    align-items: center !important;
+    min-height: 56px; /* Touch target size */
+
+    @media (max-width: ${breakpoints.mobile}) {
+      padding: 1rem !important;
+      min-height: 64px;
+    }
+
+    ${({ $selected }) =>
+      $selected &&
+      css`
+        background: linear-gradient(
+          135deg,
+          rgba(102, 126, 234, 0.1) 0%,
+          rgba(118, 75, 162, 0.1) 100%
+        ) !important;
+        border: 1px solid rgba(102, 126, 234, 0.3);
+      `}
+
+    ${({ $status }) =>
+      $status === "SUCCESS" &&
+      css`
+        background: #e8f5e9 !important;
+        border: 1px solid #c8e6c9;
+      `}
+
+    ${({ $status }) =>
+      $status === "FAILED" &&
+      css`
+        background: #ffebee !important;
+        border: 1px solid #ffcdd2;
+      `}
+
+    &:hover {
+      background: ${({ $selected }) =>
+        $selected ? "rgba(102, 126, 234, 0.15)" : "#f8f9fa"};
+    }
+  }
+`;
+
+export const FileItemContent = styled.div`
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+`;
+
+export const FileItemIcon = styled.div<{ $status?: string }>`
+  font-size: 1.5rem;
+  color: ${({ $status }) =>
+    $status === "SUCCESS"
+      ? "#2e7d32"
+      : $status === "FAILED"
+      ? "#c62828"
+      : "#667eea"};
+  flex-shrink: 0;
+`;
+
+export const FileItemDetails = styled.div`
+  flex: 1;
+  min-width: 0;
+
+  .file-name {
+    font-weight: 500;
+    color: #212529;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+
+    @media (max-width: ${breakpoints.mobile}) {
+      font-size: 0.9rem;
+    }
+  }
+
+  .file-status {
+    font-size: 0.75rem;
+    color: #868e96;
+    margin-top: 0.25rem;
+
+    &.error {
+      color: #c62828;
+    }
+
+    &.success {
+      color: #2e7d32;
+    }
+  }
+`;
+
+export const FileItemActions = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+`;
+
+export const DeleteButton = styled(Button)`
+  &.ui.button {
+    padding: 0.5rem !important;
+    margin: 0 !important;
+    background: transparent !important;
+    color: #868e96 !important;
+    border-radius: 6px !important;
+    min-width: 36px;
+    min-height: 36px;
+    display: flex !important;
+    align-items: center;
+    justify-content: center;
+
+    @media (max-width: ${breakpoints.mobile}) {
+      min-width: 44px;
+      min-height: 44px;
+    }
+
+    &:hover {
+      background: #ffebee !important;
+      color: #c62828 !important;
+    }
+
+    i.icon {
+      margin: 0 !important;
+    }
+  }
+`;
+
+// Form edit section (two-column on desktop)
+export const EditSection = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+
+  @media (max-width: ${breakpoints.tablet}) {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+`;
+
+export const EditPanel = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+export const EditPanelHeader = styled.h4`
+  font-size: 1rem;
+  font-weight: 600;
+  color: #495057;
+  margin-bottom: 1rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 2px solid #667eea;
+`;
+
+export const FormContainer = styled(Segment)`
+  &.ui.segment {
+    border-radius: 12px !important;
+    border: 1px solid #e9ecef !important;
+    box-shadow: none !important;
+    padding: 1.5rem !important;
+    height: 100%;
+
+    @media (max-width: ${breakpoints.mobile}) {
+      padding: 1rem !important;
+    }
+  }
+`;
+
+// Progress indicator
+export const UploadProgress = styled(Progress)`
+  &.ui.progress {
+    margin: 1rem 0 !important;
+    border-radius: 8px !important;
+    overflow: hidden;
+
+    .bar {
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%) !important;
+      border-radius: 8px !important;
+      min-width: 0 !important;
+    }
+
+    .label {
+      font-size: 0.875rem !important;
+      color: #495057 !important;
+    }
+  }
+`;
+
+// Action buttons
+export const ActionButton = styled(Button)<{
+  $variant?: "primary" | "secondary" | "danger";
+}>`
+  &.ui.button {
+    border-radius: 8px !important;
+    font-weight: 500 !important;
+    min-height: 44px;
+    padding: 0.875rem 1.5rem !important;
+    transition: all 0.2s ease !important;
+
+    @media (max-width: ${breakpoints.mobile}) {
+      width: 100%;
+      padding: 1rem !important;
+    }
+
+    ${({ $variant }) =>
+      $variant === "primary" &&
+      css`
+        background: linear-gradient(
+          135deg,
+          #667eea 0%,
+          #764ba2 100%
+        ) !important;
+        color: white !important;
+
+        &:hover {
+          transform: translateY(-1px);
+          box-shadow: 0 4px 12px rgba(102, 126, 234, 0.4);
+        }
+      `}
+
+    ${({ $variant }) =>
+      $variant === "secondary" &&
+      css`
+        background: #f1f3f5 !important;
+        color: #495057 !important;
+
+        &:hover {
+          background: #e9ecef !important;
+        }
+      `}
+
+    ${({ $variant }) =>
+      $variant === "danger" &&
+      css`
+        background: #ffebee !important;
+        color: #c62828 !important;
+
+        &:hover {
+          background: #ffcdd2 !important;
+        }
+      `}
+  }
+`;
+
+// Bulk upload specific styles
+export const BulkUploadContent = styled.div`
+  .file-input-wrapper {
+    position: relative;
+    margin-bottom: 1.5rem;
+
+    input[type="file"] {
+      position: absolute;
+      left: 0;
+      top: 0;
+      opacity: 0;
+      width: 100%;
+      height: 100%;
+      cursor: pointer;
+    }
+  }
+
+  .selected-file-info {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 1rem;
+    background: #f8f9fa;
+    border-radius: 8px;
+    margin-top: 0.75rem;
+
+    .icon {
+      color: #667eea;
+    }
+
+    .file-name {
+      flex: 1;
+      font-weight: 500;
+      color: #495057;
+    }
+
+    .file-size {
+      font-size: 0.875rem;
+      color: #868e96;
+    }
+  }
+`;
+
+export const FieldLabel = styled.label`
+  display: block;
+  font-weight: 500;
+  color: #495057;
+  margin-bottom: 0.5rem;
+  font-size: 0.9375rem;
+
+  .required {
+    color: #e03131;
+    margin-left: 0.25rem;
+  }
+`;
+
+// Error message styling
+export const ErrorMessage = styled.div`
+  background: #ffebee;
+  border: 1px solid #ffcdd2;
+  border-radius: 8px;
+  padding: 1rem;
+  margin-bottom: 1rem;
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+
+  .icon {
+    color: #c62828;
+    flex-shrink: 0;
+  }
+
+  .content {
+    flex: 1;
+
+    .header {
+      font-weight: 600;
+      color: #c62828;
+      margin-bottom: 0.25rem;
+    }
+
+    .message {
+      font-size: 0.875rem;
+      color: #6e0000;
+    }
+  }
+`;
+
+// Mobile-specific action bar
+export const MobileActionBar = styled.div`
+  display: none;
+
+  @media (max-width: ${breakpoints.mobile}) {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    padding: 1rem;
+    background: #f8f9fa;
+    border-top: 1px solid #e9ecef;
+  }
+`;


### PR DESCRIPTION
- Add comprehensive styled components library (UploadModalStyles.ts) with 25+ responsive components for upload modals
- Refactor DocumentUploadModal with step indicator UI, gradient header, and responsive grid layout for edit step
- Overhaul BulkUploadModal with styled drop zone, file size display, and responsive layout
- Improve DocumentUploadList with drag-active feedback and pulse animation
- Enhance DocumentListItem with proper touch targets (56px min-height, 64px on mobile), status icons, and delete button styling
- Add mobile-first breakpoints at 480px (mobile) and 768px (tablet)
- Ensure all interactive elements meet 44px minimum touch target size
- Stack modal action buttons vertically on mobile for full-width tappability
- Add custom scrollbar styling for file lists

Closes #696