### PR TITLE
feat: Add proactive cache refresh for auth state changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - 2025-12-26
 
+### Added
+
+#### Proactive Apollo Cache Management System (PR #725)
+- **New `CacheManager` service** (`frontend/src/services/cacheManager.ts`): Centralized Apollo cache management with debouncing, targeted invalidation, and auth-aware cache operations
+  - `resetOnAuthChange()`: Full cache clear with optional refetch for login/logout transitions
+  - `refreshActiveQueries()`: Soft refresh without clearing cache
+  - `invalidateEntityQueries()`: Targeted invalidation for document/corpus/annotation CRUD operations
+  - Debouncing: 1000ms for full resets, 500ms for entity invalidations
+  - Debug utilities: `logCacheSize()`, `extractCacheForDebug()`
+- **New `useCacheManager` hook** (`frontend/src/hooks/useCacheManager.ts`): React hook with memoized CacheManager instance and stable callback references
+- **Comprehensive test suite** (`frontend/src/services/__tests__/cacheManager.test.ts`, `frontend/src/hooks/__tests__/useCacheManager.test.tsx`): 30+ tests covering debouncing, error handling, lifecycle, singleton management, and auth scenarios
+
+### Fixed
+
+#### Cache Management Race Condition Fix (PR #725)
+- **Auth state now set BEFORE cache clear** (`frontend/src/components/auth/AuthGate.tsx:69-92`, `frontend/src/views/Login.tsx:106-117`, `frontend/src/components/layout/useNavMenu.ts:64-90`):
+  - Previously, cache was cleared before updating auth state, creating a window where queries could fetch with wrong auth context
+  - Fixed by setting auth token/user/status first, then clearing cache
+  - Refetched queries now correctly use the new auth context
+- **AuthGate uses useCacheManager hook** (`frontend/src/components/auth/AuthGate.tsx:7,27`): Replaced direct `new CacheManager()` instantiation with proper hook usage, eliminating `as any` type assertion and ensuring memoization
+- **Fire-and-forget logout cache clear** (`frontend/src/components/layout/useNavMenu.ts:69-79`): Logout no longer blocks on cache clear operation, improving perceived performance
+
+### Technical Details
+
+#### Cache Management Architecture
+- **Race condition prevention**: Auth state updates are synchronous; cache clear is async. By setting auth first, any queries triggered during cache clear use the correct credentials.
+- **Singleton pattern preserved for non-React contexts**: The singleton functions (`initializeCacheManager`, `getCacheManager`, etc.) remain exported for testing and non-React usage, with documentation clarifying when to use hooks vs singleton.
+- **Dependency management**: `useCacheManager` hook returns stable callback references via `useCallback`, safe to include in effect dependencies.
+
 ### Fixed
 
 #### Agent Chat Processing Indicator (PR #687)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -132,6 +132,10 @@ export const App = () => {
   // Track if we've applied mobile display settings to prevent infinite loop
   const mobileSettingsAppliedRef = useRef(false);
 
+  // Track if we've shown the user fetch error toast to prevent duplicates
+  // This can happen on mobile where network is slower and query may fail initially
+  const meErrorShownRef = useRef(false);
+
   const {
     data: meData,
     loading: meLoading,
@@ -141,14 +145,28 @@ export const App = () => {
     fetchPolicy: "network-only",
   });
 
+  // Reset error shown flag when auth_token changes (new login session)
+  useEffect(() => {
+    meErrorShownRef.current = false;
+  }, [auth_token]);
+
   useEffect(() => {
     if (isLoading) return; // wait until Auth0 SDK has decided
 
     if (meData?.me) {
       backendUserObj(meData.me);
-    } else if (!meLoading && auth_token && meError) {
+      // Clear error flag if we successfully got user data
+      meErrorShownRef.current = false;
+    } else if (
+      !meLoading &&
+      auth_token &&
+      meError &&
+      !meErrorShownRef.current
+    ) {
+      // Only show error once per session, and only if we don't already have user data
       console.error("Error fetching backend user:", meError);
       toast.error("Could not get user details from server");
+      meErrorShownRef.current = true;
     } else if (!auth_token) {
       backendUserObj(null);
     }

--- a/frontend/src/components/auth/AuthGate.test.tsx
+++ b/frontend/src/components/auth/AuthGate.test.tsx
@@ -14,6 +14,18 @@ import { authToken, authStatusVar, userObj } from "../../graphql/cache";
 // Mock Auth0
 vi.mock("@auth0/auth0-react");
 
+// Mock useCacheManager - we don't need to test cache behavior here
+vi.mock("../../hooks/useCacheManager", () => ({
+  useCacheManager: () => ({
+    resetOnAuthChange: vi.fn().mockResolvedValue({ success: true }),
+    refreshActiveQueries: vi.fn().mockResolvedValue({ success: true }),
+    invalidateEntityQueries: vi.fn().mockResolvedValue({ success: true }),
+    invalidateDocumentQueries: vi.fn().mockResolvedValue({ success: true }),
+    invalidateCorpusQueries: vi.fn().mockResolvedValue({ success: true }),
+    logCacheSize: vi.fn(),
+  }),
+}));
+
 // Mock toast
 vi.mock("react-toastify", () => ({
   toast: {

--- a/frontend/src/components/auth/AuthGate.test.tsx
+++ b/frontend/src/components/auth/AuthGate.test.tsx
@@ -52,6 +52,9 @@ const baseAuth0Props = {
   isReadOnly: false,
 };
 
+// Key used by AuthGate to track if user has authenticated before
+const HAS_AUTHENTICATED_KEY = "oc_has_authenticated";
+
 describe("AuthGate", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -59,6 +62,8 @@ describe("AuthGate", () => {
     authToken("");
     authStatusVar("LOADING");
     userObj(null);
+    // Clear localStorage before each test
+    localStorage.removeItem(HAS_AUTHENTICATED_KEY);
   });
 
   describe("Auth0 Mode", () => {
@@ -180,13 +185,16 @@ describe("AuthGate", () => {
       expect(userObj()).toBeNull();
     });
 
-    it("preserves current path when redirecting to login on login_required error", async () => {
+    it("redirects returning user to login on login_required error", async () => {
       const mockUser = { email: "test@example.com", sub: "user123" };
       const mockLoginWithRedirect = vi.fn();
       const mockGetAccessTokenSilently = vi.fn().mockRejectedValue({
         error: "login_required",
         message: "Login required",
       });
+
+      // Set flag indicating user has previously authenticated
+      localStorage.setItem(HAS_AUTHENTICATED_KEY, "true");
 
       // Mock window.location
       const originalLocation = window.location;
@@ -233,6 +241,78 @@ describe("AuthGate", () => {
 
       // Restore window.location
       (window as any).location = originalLocation;
+    });
+
+    it("defaults first-time visitor to anonymous on login_required error", async () => {
+      const mockUser = { email: "test@example.com", sub: "user123" };
+      const mockLoginWithRedirect = vi.fn();
+      const mockGetAccessTokenSilently = vi.fn().mockRejectedValue({
+        error: "login_required",
+        message: "Login required",
+      });
+
+      // Ensure no previous auth flag exists (first-time visitor)
+      localStorage.removeItem(HAS_AUTHENTICATED_KEY);
+
+      const mockUseAuth0 = useAuth0 as MockedFunction<typeof useAuth0>;
+      mockUseAuth0.mockReturnValue({
+        ...baseAuth0Props,
+        isLoading: false,
+        isAuthenticated: true,
+        user: mockUser,
+        getAccessTokenSilently: mockGetAccessTokenSilently,
+        loginWithRedirect: mockLoginWithRedirect,
+      });
+
+      render(
+        <AuthGate useAuth0={true} audience="test-audience">
+          <div>Protected Content</div>
+        </AuthGate>
+      );
+
+      // Wait for auth to complete - should render content as anonymous
+      await waitFor(() => {
+        expect(screen.getByText("Protected Content")).toBeInTheDocument();
+      });
+
+      // Verify loginWithRedirect was NOT called for first-time visitor
+      expect(mockLoginWithRedirect).not.toHaveBeenCalled();
+
+      // Verify anonymous state
+      expect(authToken()).toBe("");
+      expect(authStatusVar()).toBe("ANONYMOUS");
+      expect(userObj()).toBeNull();
+    });
+
+    it("sets auth flag on successful authentication", async () => {
+      const mockToken = "test-token-123";
+      const mockUser = { email: "test@example.com", sub: "user123" };
+      const mockGetAccessTokenSilently = vi.fn().mockResolvedValue(mockToken);
+
+      // Ensure no previous auth flag exists
+      localStorage.removeItem(HAS_AUTHENTICATED_KEY);
+
+      const mockUseAuth0 = useAuth0 as MockedFunction<typeof useAuth0>;
+      mockUseAuth0.mockReturnValue({
+        isLoading: false,
+        isAuthenticated: true,
+        user: mockUser,
+        ...baseAuth0Props,
+        getAccessTokenSilently: mockGetAccessTokenSilently,
+      });
+
+      render(
+        <AuthGate useAuth0={true} audience="test-audience">
+          <div>Protected Content</div>
+        </AuthGate>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("Protected Content")).toBeInTheDocument();
+      });
+
+      // Verify auth flag was set
+      expect(localStorage.getItem(HAS_AUTHENTICATED_KEY)).toBe("true");
     });
   });
 

--- a/frontend/src/components/auth/AuthGate.tsx
+++ b/frontend/src/components/auth/AuthGate.tsx
@@ -66,9 +66,12 @@ export const AuthGate: React.FC<AuthGateProps> = ({
           if (token) {
             console.log("[AuthGate] Token obtained successfully");
 
-            // Set auth state FIRST - this ensures any subsequent queries use
-            // the new auth context. Cache clear happens AFTER to prevent race
-            // condition where queries fetch with wrong auth state.
+            // RACE CONDITION PREVENTION: Auth state MUST be set synchronously BEFORE
+            // cache clear. clearStore() is async and may trigger Apollo query refetches.
+            // If auth state isn't set first, those refetches would execute with stale/missing
+            // credentials, causing auth errors or returning anonymous data that gets cached.
+            // By setting token/user/status synchronously here, any subsequent queries
+            // (whether from cache clear or component mounts) will use correct auth context.
             authToken(token);
             userObj(user);
             authStatusVar("AUTHENTICATED");
@@ -80,15 +83,25 @@ export const AuthGate: React.FC<AuthGateProps> = ({
               verifyToken ? "Present" : "Missing"
             );
 
-            // Now clear cache - refetched queries will use new auth context
+            // Clear any stale anonymous/previous-user cache data.
+            // TRADEOFF: We await this to ensure cache is clean before showing authenticated UI.
+            // This may delay render by ~50-100ms, but prevents flash of stale data.
+            // Unlike logout (fire-and-forget), login benefits from clean cache before render
+            // since users expect to see their own data immediately.
+            // refetchActive: false because auth state is already set and component mount
+            // will trigger necessary queries with correct credentials.
             try {
               await resetOnAuthChange({
                 reason: "auth0_login",
                 refetchActive: false,
               });
             } catch (cacheError) {
-              console.warn("[AuthGate] Cache reset warning:", cacheError);
-              // Continue even if cache reset fails
+              // Log with context for debugging but don't block - cache clear is best-effort
+              console.warn("[AuthGate] Cache reset failed on login:", {
+                error:
+                  cacheError instanceof Error ? cacheError.message : cacheError,
+                userId: user?.sub,
+              });
             }
 
             setAuthInitialized(true);

--- a/frontend/src/components/auth/AuthGate.tsx
+++ b/frontend/src/components/auth/AuthGate.tsx
@@ -6,6 +6,10 @@ import { toast } from "react-toastify";
 import { ModernLoadingDisplay } from "../widgets/ModernLoadingDisplay";
 import { useCacheManager } from "../../hooks/useCacheManager";
 
+// LocalStorage key to track if user has ever successfully authenticated.
+// Used to distinguish first-time visitors from returning users with expired sessions.
+const HAS_AUTHENTICATED_KEY = "oc_has_authenticated";
+
 interface AuthGateProps {
   children: React.ReactNode;
   useAuth0: boolean;
@@ -65,6 +69,18 @@ export const AuthGate: React.FC<AuthGateProps> = ({
         .then(async (token) => {
           if (token) {
             console.log("[AuthGate] Token obtained successfully");
+
+            // Mark that user has successfully authenticated at least once.
+            // This flag helps distinguish first-time visitors from returning users
+            // when handling "login_required" errors from Auth0.
+            try {
+              localStorage.setItem(HAS_AUTHENTICATED_KEY, "true");
+            } catch (e) {
+              // localStorage may be unavailable in some contexts
+              console.warn(
+                "[AuthGate] Could not set auth flag in localStorage"
+              );
+            }
 
             // RACE CONDITION PREVENTION: Auth state MUST be set synchronously BEFORE
             // cache clear. clearStore() is async and may trigger Apollo query refetches.
@@ -126,25 +142,46 @@ export const AuthGate: React.FC<AuthGateProps> = ({
             error.message?.toLowerCase().includes("login required");
 
           if (needsInteraction) {
-            // User needs to re-authenticate - redirect to Auth0 login
-            console.log(
-              "[AuthGate] User interaction required, redirecting to login..."
-            );
-            toast.info("Please log in to continue.", {
-              autoClose: 2000,
-            });
+            // Check if user has previously authenticated successfully.
+            // This distinguishes first-time visitors from returning users with expired sessions.
+            let hasAuthenticatedBefore = false;
+            try {
+              hasAuthenticatedBefore =
+                localStorage.getItem(HAS_AUTHENTICATED_KEY) === "true";
+            } catch (e) {
+              // localStorage may be unavailable
+            }
 
-            // Redirect to Auth0 login, preserving current path
-            loginWithRedirect({
-              authorizationParams: {
-                audience: audience || undefined,
-                scope: "openid profile email",
-                redirect_uri: window.location.origin,
-              },
-              appState: {
-                returnTo: window.location.pathname + window.location.search,
-              },
-            });
+            if (hasAuthenticatedBefore) {
+              // Returning user with expired session - redirect to Auth0 login
+              console.log(
+                "[AuthGate] Returning user needs to re-authenticate, redirecting to login..."
+              );
+              toast.info("Please log in to continue.", {
+                autoClose: 2000,
+              });
+
+              // Redirect to Auth0 login, preserving current path
+              loginWithRedirect({
+                authorizationParams: {
+                  audience: audience || undefined,
+                  scope: "openid profile email",
+                  redirect_uri: window.location.origin,
+                },
+                appState: {
+                  returnTo: window.location.pathname + window.location.search,
+                },
+              });
+            } else {
+              // First-time visitor - fall back to anonymous mode instead of prompting login
+              console.log(
+                "[AuthGate] First-time visitor, defaulting to anonymous mode"
+              );
+              authToken("");
+              userObj(null);
+              authStatusVar("ANONYMOUS");
+              setAuthInitialized(true);
+            }
           } else {
             // Other error - fall back to anonymous mode
             console.error("[AuthGate] Auth error, falling back to anonymous");

--- a/frontend/src/components/auth/AuthGate.tsx
+++ b/frontend/src/components/auth/AuthGate.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useState } from "react";
 import { useAuth0 } from "@auth0/auth0-react";
-import { useReactiveVar } from "@apollo/client";
+import { useReactiveVar, useApolloClient } from "@apollo/client";
 import { authToken, authStatusVar, userObj } from "../../graphql/cache";
 import { toast } from "react-toastify";
 import { ModernLoadingDisplay } from "../widgets/ModernLoadingDisplay";
+import { CacheManager } from "../../services/cacheManager";
 
 interface AuthGateProps {
   children: React.ReactNode;
@@ -23,6 +24,7 @@ export const AuthGate: React.FC<AuthGateProps> = ({
 }) => {
   const [authInitialized, setAuthInitialized] = useState(false);
   const authStatus = useReactiveVar(authStatusVar);
+  const apolloClient = useApolloClient();
 
   // Auth0 hooks
   const {
@@ -60,9 +62,23 @@ export const AuthGate: React.FC<AuthGateProps> = ({
           scope: "openid profile email",
         },
       })
-        .then((token) => {
+        .then(async (token) => {
           if (token) {
             console.log("[AuthGate] Token obtained successfully");
+
+            // Clear cache before setting new auth state to ensure fresh data
+            // This prevents stale data from anonymous/previous user session
+            try {
+              const cacheManager = new CacheManager(apolloClient as any);
+              await cacheManager.resetOnAuthChange({
+                reason: "auth0_login",
+                refetchActive: false,
+              });
+            } catch (cacheError) {
+              console.warn("[AuthGate] Cache reset warning:", cacheError);
+              // Continue with auth even if cache reset fails
+            }
+
             // Set token first, then user, then status - all synchronously
             authToken(token);
             userObj(user);

--- a/frontend/src/components/auth/AuthGate.tsx
+++ b/frontend/src/components/auth/AuthGate.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useState } from "react";
 import { useAuth0 } from "@auth0/auth0-react";
-import { useReactiveVar, useApolloClient } from "@apollo/client";
+import { useReactiveVar } from "@apollo/client";
 import { authToken, authStatusVar, userObj } from "../../graphql/cache";
 import { toast } from "react-toastify";
 import { ModernLoadingDisplay } from "../widgets/ModernLoadingDisplay";
-import { CacheManager } from "../../services/cacheManager";
+import { useCacheManager } from "../../hooks/useCacheManager";
 
 interface AuthGateProps {
   children: React.ReactNode;
@@ -24,7 +24,7 @@ export const AuthGate: React.FC<AuthGateProps> = ({
 }) => {
   const [authInitialized, setAuthInitialized] = useState(false);
   const authStatus = useReactiveVar(authStatusVar);
-  const apolloClient = useApolloClient();
+  const { resetOnAuthChange } = useCacheManager();
 
   // Auth0 hooks
   const {
@@ -66,20 +66,9 @@ export const AuthGate: React.FC<AuthGateProps> = ({
           if (token) {
             console.log("[AuthGate] Token obtained successfully");
 
-            // Clear cache before setting new auth state to ensure fresh data
-            // This prevents stale data from anonymous/previous user session
-            try {
-              const cacheManager = new CacheManager(apolloClient as any);
-              await cacheManager.resetOnAuthChange({
-                reason: "auth0_login",
-                refetchActive: false,
-              });
-            } catch (cacheError) {
-              console.warn("[AuthGate] Cache reset warning:", cacheError);
-              // Continue with auth even if cache reset fails
-            }
-
-            // Set token first, then user, then status - all synchronously
+            // Set auth state FIRST - this ensures any subsequent queries use
+            // the new auth context. Cache clear happens AFTER to prevent race
+            // condition where queries fetch with wrong auth state.
             authToken(token);
             userObj(user);
             authStatusVar("AUTHENTICATED");
@@ -90,6 +79,17 @@ export const AuthGate: React.FC<AuthGateProps> = ({
               "[AuthGate] Token verified:",
               verifyToken ? "Present" : "Missing"
             );
+
+            // Now clear cache - refetched queries will use new auth context
+            try {
+              await resetOnAuthChange({
+                reason: "auth0_login",
+                refetchActive: false,
+              });
+            } catch (cacheError) {
+              console.warn("[AuthGate] Cache reset warning:", cacheError);
+              // Continue even if cache reset fails
+            }
 
             setAuthInitialized(true);
           } else {
@@ -156,7 +156,9 @@ export const AuthGate: React.FC<AuthGateProps> = ({
     isAuthenticated,
     user,
     getAccessTokenSilently,
+    loginWithRedirect,
     audience,
+    resetOnAuthChange,
   ]);
 
   // Show loading screen while auth is initializing

--- a/frontend/src/components/layout/useNavMenu.ts
+++ b/frontend/src/components/layout/useNavMenu.ts
@@ -4,6 +4,7 @@ import { useReactiveVar } from "@apollo/client";
 import { authToken, userObj, showExportModal } from "../../graphql/cache";
 import { header_menu_items } from "../../assets/configurations/menus";
 import { useEnv } from "../hooks/UseEnv";
+import { useCacheManager } from "../../hooks/useCacheManager";
 
 /**
  * Shared navigation menu logic for both desktop and mobile nav components.
@@ -21,6 +22,7 @@ export const useNavMenu = () => {
   const cache_user = useReactiveVar(userObj);
   const { pathname } = useLocation();
   const navigate = useNavigate();
+  const { resetOnAuthChange } = useCacheManager();
 
   const user = REACT_APP_USE_AUTH0 ? auth0_user : cache_user;
   const show_export_modal = useReactiveVar(showExportModal);
@@ -50,8 +52,16 @@ export const useNavMenu = () => {
    * Logs out the user. Uses Auth0 logout if Auth0 is enabled, otherwise
    * clears local auth state and redirects to home.
    * CentralRouteManager will automatically clear entity state when navigating to "/".
+   *
+   * IMPORTANT: Clears the Apollo cache on logout to ensure:
+   * 1. Security: Previous user's data is not accessible
+   * 2. Data freshness: Next login starts with clean cache
    */
-  const requestLogout = () => {
+  const requestLogout = async () => {
+    // Clear cache before logout to prevent stale data
+    // For Auth0, this happens before redirect; for non-Auth0, before navigation
+    await resetOnAuthChange({ reason: "user_logout", refetchActive: false });
+
     if (REACT_APP_USE_AUTH0) {
       logout({
         logoutParams: {

--- a/frontend/src/components/layout/useNavMenu.ts
+++ b/frontend/src/components/layout/useNavMenu.ts
@@ -75,7 +75,12 @@ export const useNavMenu = () => {
     // Fire-and-forget cache clear (don't block logout on this)
     // No refetch needed since we're logging out
     resetOnAuthChange({ reason: "user_logout", refetchActive: false }).catch(
-      (error) => console.warn("[useNavMenu] Cache reset warning:", error)
+      (error) =>
+        console.warn("[useNavMenu] Cache reset failed on logout:", {
+          error: error instanceof Error ? error.message : error,
+          userId: user?.sub || cache_user?.id,
+          timestamp: new Date().toISOString(),
+        })
     );
 
     if (REACT_APP_USE_AUTH0) {

--- a/frontend/src/components/layout/useNavMenu.ts
+++ b/frontend/src/components/layout/useNavMenu.ts
@@ -1,7 +1,12 @@
 import { useLocation, useNavigate } from "react-router-dom";
 import { useAuth0 } from "@auth0/auth0-react";
 import { useReactiveVar } from "@apollo/client";
-import { authToken, userObj, showExportModal } from "../../graphql/cache";
+import {
+  authToken,
+  authStatusVar,
+  userObj,
+  showExportModal,
+} from "../../graphql/cache";
 import { header_menu_items } from "../../assets/configurations/menus";
 import { useEnv } from "../hooks/UseEnv";
 import { useCacheManager } from "../../hooks/useCacheManager";
@@ -56,11 +61,22 @@ export const useNavMenu = () => {
    * IMPORTANT: Clears the Apollo cache on logout to ensure:
    * 1. Security: Previous user's data is not accessible
    * 2. Data freshness: Next login starts with clean cache
+   *
+   * Order of operations: Clear auth state FIRST (prevents new authenticated
+   * queries), then fire-and-forget cache clear (removes cached data).
+   * We don't await cache clear since logout shouldn't block on it.
    */
-  const requestLogout = async () => {
-    // Clear cache before logout to prevent stale data
-    // For Auth0, this happens before redirect; for non-Auth0, before navigation
-    await resetOnAuthChange({ reason: "user_logout", refetchActive: false });
+  const requestLogout = () => {
+    // Clear auth state FIRST - prevents any new queries from using old credentials
+    authToken("");
+    userObj(null);
+    authStatusVar("ANONYMOUS");
+
+    // Fire-and-forget cache clear (don't block logout on this)
+    // No refetch needed since we're logging out
+    resetOnAuthChange({ reason: "user_logout", refetchActive: false }).catch(
+      (error) => console.warn("[useNavMenu] Cache reset warning:", error)
+    );
 
     if (REACT_APP_USE_AUTH0) {
       logout({
@@ -69,8 +85,6 @@ export const useNavMenu = () => {
         },
       });
     } else {
-      authToken("");
-      userObj(null);
       navigate("/");
     }
   };

--- a/frontend/src/hooks/__tests__/useCacheManager.test.tsx
+++ b/frontend/src/hooks/__tests__/useCacheManager.test.tsx
@@ -1,0 +1,428 @@
+/**
+ * useCacheManager Hook Tests
+ *
+ * Tests for the React hook that provides access to cache management operations.
+ *
+ * Related to Issue #694 - Apollo Cache Stale Data Problem
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { ApolloClient, InMemoryCache, ApolloProvider } from "@apollo/client";
+import React from "react";
+import { useCacheManager } from "../useCacheManager";
+
+// ============================================================================
+// Test Setup
+// ============================================================================
+
+/**
+ * Creates a mock Apollo Client for testing.
+ */
+function createMockApolloClient() {
+  const cache = new InMemoryCache();
+
+  const client = new ApolloClient({
+    cache,
+    // No link - we're testing cache operations only
+  });
+
+  // Mock the methods we'll be testing
+  vi.spyOn(client, "clearStore").mockResolvedValue([]);
+  vi.spyOn(client, "refetchQueries").mockResolvedValue([]);
+
+  return client;
+}
+
+/**
+ * Wrapper component that provides Apollo Client context.
+ */
+function createWrapper(client: ApolloClient<any>) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <ApolloProvider client={client}>{children}</ApolloProvider>;
+  };
+}
+
+// ============================================================================
+// Hook Tests
+// ============================================================================
+
+describe("useCacheManager", () => {
+  let client: ApolloClient<any>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client = createMockApolloClient();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("Hook Initialization", () => {
+    it("should return all expected methods", () => {
+      // Arrange
+      const wrapper = createWrapper(client);
+
+      // Act
+      const { result } = renderHook(() => useCacheManager(), { wrapper });
+
+      // Assert
+      expect(result.current).toHaveProperty("resetOnAuthChange");
+      expect(result.current).toHaveProperty("refreshActiveQueries");
+      expect(result.current).toHaveProperty("invalidateEntityQueries");
+      expect(result.current).toHaveProperty("invalidateDocumentQueries");
+      expect(result.current).toHaveProperty("invalidateCorpusQueries");
+      expect(result.current).toHaveProperty("logCacheSize");
+    });
+
+    it("should return stable function references", () => {
+      // Arrange
+      const wrapper = createWrapper(client);
+
+      // Act
+      const { result, rerender } = renderHook(() => useCacheManager(), { wrapper });
+      const firstRender = { ...result.current };
+      rerender();
+      const secondRender = result.current;
+
+      // Assert - Functions should be memoized
+      expect(firstRender.resetOnAuthChange).toBe(secondRender.resetOnAuthChange);
+      expect(firstRender.refreshActiveQueries).toBe(secondRender.refreshActiveQueries);
+      expect(firstRender.invalidateEntityQueries).toBe(secondRender.invalidateEntityQueries);
+    });
+  });
+
+  describe("resetOnAuthChange", () => {
+    it("should clear the Apollo cache", async () => {
+      // Arrange
+      const wrapper = createWrapper(client);
+      const { result } = renderHook(() => useCacheManager(), { wrapper });
+
+      // Act
+      await act(async () => {
+        await result.current.resetOnAuthChange({ reason: "test_login" });
+      });
+
+      // Assert
+      expect(client.clearStore).toHaveBeenCalled();
+    });
+
+    it("should refetch active queries by default", async () => {
+      // Arrange
+      const wrapper = createWrapper(client);
+      const { result } = renderHook(() => useCacheManager(), { wrapper });
+
+      // Act
+      await act(async () => {
+        await result.current.resetOnAuthChange({ reason: "test" });
+      });
+
+      // Assert
+      expect(client.refetchQueries).toHaveBeenCalledWith({ include: "active" });
+    });
+
+    it("should skip refetch when refetchActive is false", async () => {
+      // Arrange
+      const wrapper = createWrapper(client);
+      const { result } = renderHook(() => useCacheManager(), { wrapper });
+
+      // Act
+      await act(async () => {
+        await result.current.resetOnAuthChange({
+          reason: "test",
+          refetchActive: false,
+        });
+      });
+
+      // Assert
+      expect(client.clearStore).toHaveBeenCalled();
+      expect(client.refetchQueries).not.toHaveBeenCalled();
+    });
+
+    it("should return success result", async () => {
+      // Arrange
+      const wrapper = createWrapper(client);
+      const { result } = renderHook(() => useCacheManager(), { wrapper });
+
+      // Act
+      let operationResult;
+      await act(async () => {
+        operationResult = await result.current.resetOnAuthChange({ reason: "test" });
+      });
+
+      // Assert
+      expect(operationResult).toHaveProperty("success", true);
+      expect(operationResult).toHaveProperty("message");
+      expect(operationResult).toHaveProperty("duration");
+    });
+  });
+
+  describe("refreshActiveQueries", () => {
+    it("should refetch active queries without clearing cache", async () => {
+      // Arrange
+      const wrapper = createWrapper(client);
+      const { result } = renderHook(() => useCacheManager(), { wrapper });
+
+      // Act
+      await act(async () => {
+        await result.current.refreshActiveQueries("manual_refresh");
+      });
+
+      // Assert
+      expect(client.refetchQueries).toHaveBeenCalledWith({ include: "active" });
+      expect(client.clearStore).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("invalidateEntityQueries", () => {
+    it("should refetch queries for document entity type", async () => {
+      // Arrange
+      const wrapper = createWrapper(client);
+      const { result } = renderHook(() => useCacheManager(), { wrapper });
+
+      // Act
+      await act(async () => {
+        await result.current.invalidateEntityQueries({
+          entityType: "document",
+          corpusId: "corpus-1",
+          reason: "upload",
+        });
+      });
+
+      // Assert
+      expect(client.refetchQueries).toHaveBeenCalled();
+    });
+
+    it("should refetch queries for corpus entity type", async () => {
+      // Arrange
+      const wrapper = createWrapper(client);
+      const { result } = renderHook(() => useCacheManager(), { wrapper });
+
+      // Act
+      await act(async () => {
+        await result.current.invalidateEntityQueries({
+          entityType: "corpus",
+          reason: "create",
+        });
+      });
+
+      // Assert
+      expect(client.refetchQueries).toHaveBeenCalled();
+    });
+  });
+
+  describe("invalidateDocumentQueries", () => {
+    it("should invalidate document-related queries", async () => {
+      // Arrange
+      const wrapper = createWrapper(client);
+      const { result } = renderHook(() => useCacheManager(), { wrapper });
+
+      // Act
+      let operationResult;
+      await act(async () => {
+        operationResult = await result.current.invalidateDocumentQueries(
+          "corpus-1",
+          "document_upload"
+        );
+      });
+
+      // Assert
+      expect(operationResult).toHaveProperty("success", true);
+      expect(client.refetchQueries).toHaveBeenCalled();
+    });
+
+    it("should work without corpusId", async () => {
+      // Arrange
+      const wrapper = createWrapper(client);
+      const { result } = renderHook(() => useCacheManager(), { wrapper });
+
+      // Act
+      let operationResult;
+      await act(async () => {
+        operationResult = await result.current.invalidateDocumentQueries(
+          undefined,
+          "global_document_change"
+        );
+      });
+
+      // Assert
+      expect(operationResult).toHaveProperty("success", true);
+    });
+  });
+
+  describe("invalidateCorpusQueries", () => {
+    it("should invalidate corpus-related queries", async () => {
+      // Arrange
+      const wrapper = createWrapper(client);
+      const { result } = renderHook(() => useCacheManager(), { wrapper });
+
+      // Act
+      let operationResult;
+      await act(async () => {
+        operationResult = await result.current.invalidateCorpusQueries("corpus_delete");
+      });
+
+      // Assert
+      expect(operationResult).toHaveProperty("success", true);
+      expect(client.refetchQueries).toHaveBeenCalled();
+    });
+  });
+
+  describe("logCacheSize", () => {
+    it("should not throw when called", async () => {
+      // Arrange
+      const wrapper = createWrapper(client);
+      const { result } = renderHook(() => useCacheManager(), { wrapper });
+
+      // Act & Assert
+      expect(() => result.current.logCacheSize()).not.toThrow();
+    });
+  });
+});
+
+// ============================================================================
+// Integration Tests with Component Lifecycle
+// ============================================================================
+
+describe("useCacheManager Component Lifecycle", () => {
+  let client: ApolloClient<any>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client = createMockApolloClient();
+  });
+
+  it("should handle component unmount gracefully", async () => {
+    // Arrange
+    const wrapper = createWrapper(client);
+    const { result, unmount } = renderHook(() => useCacheManager(), { wrapper });
+
+    // Act - Start an operation then unmount
+    const operationPromise = act(async () => {
+      return result.current.resetOnAuthChange({ reason: "test" });
+    });
+
+    // Unmount during operation
+    unmount();
+
+    // Assert - Should not throw
+    await expect(operationPromise).resolves.toBeDefined();
+  });
+
+  it("should work with multiple hook instances", async () => {
+    // Arrange
+    const wrapper = createWrapper(client);
+    const { result: result1 } = renderHook(() => useCacheManager(), { wrapper });
+    const { result: result2 } = renderHook(() => useCacheManager(), { wrapper });
+
+    // Act - Use both instances
+    await act(async () => {
+      await result1.current.resetOnAuthChange({ reason: "instance_1" });
+    });
+
+    // Small delay to avoid debounce
+    await new Promise((resolve) => setTimeout(resolve, 1100));
+
+    await act(async () => {
+      await result2.current.resetOnAuthChange({ reason: "instance_2" });
+    });
+
+    // Assert - Both should work independently
+    // Note: Due to debouncing, the second call might be debounced if called too quickly
+    expect(client.clearStore).toHaveBeenCalled();
+  });
+});
+
+// ============================================================================
+// Human-Readable Scenario Tests
+// ============================================================================
+
+describe("useCacheManager Usage Scenarios", () => {
+  let client: ApolloClient<any>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client = createMockApolloClient();
+  });
+
+  it("Logout button component should be able to clear cache before logout", async () => {
+    // Scenario: A logout button component needs to clear the cache
+    // when the user clicks logout
+
+    const wrapper = createWrapper(client);
+    const { result } = renderHook(() => useCacheManager(), { wrapper });
+
+    // Simulate logout button click
+    await act(async () => {
+      const response = await result.current.resetOnAuthChange({
+        reason: "user_logout",
+        refetchActive: false, // No need to refetch - user is logging out
+      });
+      expect(response.success).toBe(true);
+    });
+
+    // Cache should be cleared
+    expect(client.clearStore).toHaveBeenCalled();
+  });
+
+  it("Document upload modal should refresh document list after upload", async () => {
+    // Scenario: After a document is uploaded, the document list
+    // should refresh to show the new document
+
+    const wrapper = createWrapper(client);
+    const { result } = renderHook(() => useCacheManager(), { wrapper });
+
+    // Simulate document upload completion
+    await act(async () => {
+      const response = await result.current.invalidateDocumentQueries(
+        "corpus-123",
+        "document_upload_complete"
+      );
+      expect(response.success).toBe(true);
+    });
+
+    // Document queries should be refetched
+    expect(client.refetchQueries).toHaveBeenCalled();
+  });
+
+  it("Corpus creation form should refresh corpus list after creation", async () => {
+    // Scenario: After a corpus is created, the corpus list
+    // should refresh to show the new corpus
+
+    const wrapper = createWrapper(client);
+    const { result } = renderHook(() => useCacheManager(), { wrapper });
+
+    // Simulate corpus creation completion
+    await act(async () => {
+      const response = await result.current.invalidateCorpusQueries(
+        "corpus_creation_complete"
+      );
+      expect(response.success).toBe(true);
+    });
+
+    // Corpus queries should be refetched
+    expect(client.refetchQueries).toHaveBeenCalled();
+  });
+
+  it("Manual refresh button should refresh all active data", async () => {
+    // Scenario: A user clicks a "Refresh Data" button to manually
+    // refresh all displayed data
+
+    const wrapper = createWrapper(client);
+    const { result } = renderHook(() => useCacheManager(), { wrapper });
+
+    // Simulate refresh button click
+    await act(async () => {
+      const response = await result.current.refreshActiveQueries(
+        "manual_user_refresh"
+      );
+      expect(response.success).toBe(true);
+    });
+
+    // Active queries should be refetched
+    expect(client.refetchQueries).toHaveBeenCalledWith({ include: "active" });
+    // But cache should not be cleared (just refresh, not reset)
+    expect(client.clearStore).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/__tests__/useCacheManager.test.tsx
+++ b/frontend/src/hooks/__tests__/useCacheManager.test.tsx
@@ -7,7 +7,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { renderHook, act } from "@testing-library/react";
+import { renderHook, act } from "@testing-library/react-hooks";
 import { ApolloClient, InMemoryCache, ApolloProvider } from "@apollo/client";
 import React from "react";
 import { useCacheManager } from "../useCacheManager";
@@ -81,15 +81,23 @@ describe("useCacheManager", () => {
       const wrapper = createWrapper(client);
 
       // Act
-      const { result, rerender } = renderHook(() => useCacheManager(), { wrapper });
+      const { result, rerender } = renderHook(() => useCacheManager(), {
+        wrapper,
+      });
       const firstRender = { ...result.current };
       rerender();
       const secondRender = result.current;
 
       // Assert - Functions should be memoized
-      expect(firstRender.resetOnAuthChange).toBe(secondRender.resetOnAuthChange);
-      expect(firstRender.refreshActiveQueries).toBe(secondRender.refreshActiveQueries);
-      expect(firstRender.invalidateEntityQueries).toBe(secondRender.invalidateEntityQueries);
+      expect(firstRender.resetOnAuthChange).toBe(
+        secondRender.resetOnAuthChange
+      );
+      expect(firstRender.refreshActiveQueries).toBe(
+        secondRender.refreshActiveQueries
+      );
+      expect(firstRender.invalidateEntityQueries).toBe(
+        secondRender.invalidateEntityQueries
+      );
     });
   });
 
@@ -148,7 +156,9 @@ describe("useCacheManager", () => {
       // Act
       let operationResult;
       await act(async () => {
-        operationResult = await result.current.resetOnAuthChange({ reason: "test" });
+        operationResult = await result.current.resetOnAuthChange({
+          reason: "test",
+        });
       });
 
       // Assert
@@ -260,7 +270,9 @@ describe("useCacheManager", () => {
       // Act
       let operationResult;
       await act(async () => {
-        operationResult = await result.current.invalidateCorpusQueries("corpus_delete");
+        operationResult = await result.current.invalidateCorpusQueries(
+          "corpus_delete"
+        );
       });
 
       // Assert
@@ -296,25 +308,34 @@ describe("useCacheManager Component Lifecycle", () => {
   it("should handle component unmount gracefully", async () => {
     // Arrange
     const wrapper = createWrapper(client);
-    const { result, unmount } = renderHook(() => useCacheManager(), { wrapper });
+    const { result, unmount } = renderHook(() => useCacheManager(), {
+      wrapper,
+    });
 
     // Act - Start an operation then unmount
-    const operationPromise = act(async () => {
-      return result.current.resetOnAuthChange({ reason: "test" });
+    let operationResult: unknown;
+    await act(async () => {
+      operationResult = await result.current.resetOnAuthChange({
+        reason: "test",
+      });
     });
 
     // Unmount during operation
     unmount();
 
     // Assert - Should not throw
-    await expect(operationPromise).resolves.toBeDefined();
+    expect(operationResult).toBeDefined();
   });
 
   it("should work with multiple hook instances", async () => {
     // Arrange
     const wrapper = createWrapper(client);
-    const { result: result1 } = renderHook(() => useCacheManager(), { wrapper });
-    const { result: result2 } = renderHook(() => useCacheManager(), { wrapper });
+    const { result: result1 } = renderHook(() => useCacheManager(), {
+      wrapper,
+    });
+    const { result: result2 } = renderHook(() => useCacheManager(), {
+      wrapper,
+    });
 
     // Act - Use both instances
     await act(async () => {

--- a/frontend/src/hooks/useCacheManager.ts
+++ b/frontend/src/hooks/useCacheManager.ts
@@ -1,0 +1,137 @@
+/**
+ * useCacheManager - React hook for proactive Apollo cache management
+ *
+ * This hook provides access to the CacheManager for components that need
+ * to trigger cache operations (e.g., on auth changes, entity CRUD).
+ *
+ * Related to Issue #694 - Apollo Cache Stale Data Problem
+ *
+ * @example
+ * ```tsx
+ * function LogoutButton() {
+ *   const { resetOnAuthChange } = useCacheManager();
+ *
+ *   const handleLogout = async () => {
+ *     await resetOnAuthChange({ reason: "user_logout" });
+ *     // ... rest of logout logic
+ *   };
+ *
+ *   return <button onClick={handleLogout}>Logout</button>;
+ * }
+ * ```
+ */
+
+import { useCallback, useMemo } from "react";
+import { useApolloClient, ApolloClient, NormalizedCacheObject } from "@apollo/client";
+import {
+  CacheManager,
+  CacheResetOptions,
+  InvalidationOptions,
+  CacheOperationResult,
+} from "../services/cacheManager";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * Return type of the useCacheManager hook
+ */
+export interface UseCacheManagerReturn {
+  /**
+   * Resets the entire cache and refetches active queries.
+   * Use this on authentication state changes (login/logout).
+   */
+  resetOnAuthChange: (options?: CacheResetOptions) => Promise<CacheOperationResult>;
+
+  /**
+   * Refreshes all active queries without clearing the cache.
+   * Use this for a "soft refresh" of displayed data.
+   */
+  refreshActiveQueries: (reason?: string) => Promise<CacheOperationResult>;
+
+  /**
+   * Invalidates queries related to a specific entity type.
+   * Use this after entity CRUD operations.
+   */
+  invalidateEntityQueries: (options: InvalidationOptions) => Promise<CacheOperationResult>;
+
+  /**
+   * Convenience method to invalidate document-related queries.
+   */
+  invalidateDocumentQueries: (corpusId?: string, reason?: string) => Promise<CacheOperationResult>;
+
+  /**
+   * Convenience method to invalidate corpus-related queries.
+   */
+  invalidateCorpusQueries: (reason?: string) => Promise<CacheOperationResult>;
+
+  /**
+   * Logs the current cache size for debugging.
+   */
+  logCacheSize: () => void;
+}
+
+// ============================================================================
+// Hook Implementation
+// ============================================================================
+
+/**
+ * Hook that provides access to cache management operations.
+ *
+ * This hook creates a CacheManager instance using the current Apollo Client
+ * and exposes its methods in a React-friendly way.
+ *
+ * The CacheManager instance is memoized to prevent unnecessary recreations.
+ */
+export function useCacheManager(): UseCacheManagerReturn {
+  const client = useApolloClient() as ApolloClient<NormalizedCacheObject>;
+
+  // Create a memoized CacheManager instance for this client
+  const cacheManager = useMemo(() => {
+    return new CacheManager(client);
+  }, [client]);
+
+  // Memoize all the callback functions to maintain stable references
+  const resetOnAuthChange = useCallback(
+    (options?: CacheResetOptions) => cacheManager.resetOnAuthChange(options),
+    [cacheManager]
+  );
+
+  const refreshActiveQueries = useCallback(
+    (reason?: string) => cacheManager.refreshActiveQueries(reason),
+    [cacheManager]
+  );
+
+  const invalidateEntityQueries = useCallback(
+    (options: InvalidationOptions) => cacheManager.invalidateEntityQueries(options),
+    [cacheManager]
+  );
+
+  const invalidateDocumentQueries = useCallback(
+    (corpusId?: string, reason?: string) =>
+      cacheManager.invalidateDocumentQueries(corpusId, reason),
+    [cacheManager]
+  );
+
+  const invalidateCorpusQueries = useCallback(
+    (reason?: string) => cacheManager.invalidateCorpusQueries(reason),
+    [cacheManager]
+  );
+
+  const logCacheSize = useCallback(
+    () => cacheManager.logCacheSize(),
+    [cacheManager]
+  );
+
+  return {
+    resetOnAuthChange,
+    refreshActiveQueries,
+    invalidateEntityQueries,
+    invalidateDocumentQueries,
+    invalidateCorpusQueries,
+    logCacheSize,
+  };
+}
+
+export default useCacheManager;

--- a/frontend/src/hooks/useCacheManager.ts
+++ b/frontend/src/hooks/useCacheManager.ts
@@ -22,7 +22,11 @@
  */
 
 import { useCallback, useMemo } from "react";
-import { useApolloClient, ApolloClient, NormalizedCacheObject } from "@apollo/client";
+import {
+  useApolloClient,
+  ApolloClient,
+  NormalizedCacheObject,
+} from "@apollo/client";
 import {
   CacheManager,
   CacheResetOptions,
@@ -42,7 +46,9 @@ export interface UseCacheManagerReturn {
    * Resets the entire cache and refetches active queries.
    * Use this on authentication state changes (login/logout).
    */
-  resetOnAuthChange: (options?: CacheResetOptions) => Promise<CacheOperationResult>;
+  resetOnAuthChange: (
+    options?: CacheResetOptions
+  ) => Promise<CacheOperationResult>;
 
   /**
    * Refreshes all active queries without clearing the cache.
@@ -54,12 +60,17 @@ export interface UseCacheManagerReturn {
    * Invalidates queries related to a specific entity type.
    * Use this after entity CRUD operations.
    */
-  invalidateEntityQueries: (options: InvalidationOptions) => Promise<CacheOperationResult>;
+  invalidateEntityQueries: (
+    options: InvalidationOptions
+  ) => Promise<CacheOperationResult>;
 
   /**
    * Convenience method to invalidate document-related queries.
    */
-  invalidateDocumentQueries: (corpusId?: string, reason?: string) => Promise<CacheOperationResult>;
+  invalidateDocumentQueries: (
+    corpusId?: string,
+    reason?: string
+  ) => Promise<CacheOperationResult>;
 
   /**
    * Convenience method to invalidate corpus-related queries.
@@ -104,7 +115,8 @@ export function useCacheManager(): UseCacheManagerReturn {
   );
 
   const invalidateEntityQueries = useCallback(
-    (options: InvalidationOptions) => cacheManager.invalidateEntityQueries(options),
+    (options: InvalidationOptions) =>
+      cacheManager.invalidateEntityQueries(options),
     [cacheManager]
   );
 

--- a/frontend/src/services/__tests__/cacheManager.test.ts
+++ b/frontend/src/services/__tests__/cacheManager.test.ts
@@ -1,0 +1,658 @@
+/**
+ * CacheManager Tests
+ *
+ * Comprehensive tests for the proactive Apollo cache management system.
+ *
+ * These tests verify:
+ * 1. Full cache reset on authentication changes
+ * 2. Targeted cache invalidation for entity CRUD
+ * 3. Debouncing behavior to prevent rapid repeated operations
+ * 4. Error handling and recovery
+ *
+ * Related to Issue #694 - Apollo Cache Stale Data Problem
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { ApolloClient, InMemoryCache, NormalizedCacheObject } from "@apollo/client";
+import {
+  CacheManager,
+  CacheOperationResult,
+  initializeCacheManager,
+  getCacheManager,
+  isCacheManagerInitialized,
+  resetCacheManagerForTesting,
+} from "../cacheManager";
+
+// ============================================================================
+// Test Setup
+// ============================================================================
+
+/**
+ * Creates a mock Apollo Client for testing.
+ *
+ * We use a real InMemoryCache but mock the network operations.
+ */
+function createMockApolloClient(): ApolloClient<NormalizedCacheObject> {
+  const cache = new InMemoryCache();
+
+  const client = new ApolloClient({
+    cache,
+    // No link - we're testing cache operations only
+  });
+
+  // Mock the network-dependent methods
+  vi.spyOn(client, "clearStore").mockResolvedValue([]);
+  vi.spyOn(client, "refetchQueries").mockResolvedValue([]);
+
+  return client;
+}
+
+// ============================================================================
+// CacheManager Class Tests
+// ============================================================================
+
+describe("CacheManager", () => {
+  let client: ApolloClient<NormalizedCacheObject>;
+  let cacheManager: CacheManager;
+
+  beforeEach(() => {
+    // Reset all mocks and create fresh instances
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    client = createMockApolloClient();
+    cacheManager = new CacheManager(client);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    resetCacheManagerForTesting();
+  });
+
+  // ==========================================================================
+  // Full Cache Reset Tests
+  // ==========================================================================
+
+  describe("resetOnAuthChange", () => {
+    it("should clear the Apollo cache store", async () => {
+      // Act
+      const result = await cacheManager.resetOnAuthChange({
+        reason: "test_reset",
+      });
+
+      // Assert
+      expect(client.clearStore).toHaveBeenCalledTimes(1);
+      expect(result.success).toBe(true);
+      expect(result.message).toContain("test_reset");
+    });
+
+    it("should refetch active queries by default", async () => {
+      // Act
+      await cacheManager.resetOnAuthChange({ reason: "test_reset" });
+
+      // Assert
+      expect(client.refetchQueries).toHaveBeenCalledWith({
+        include: "active",
+      });
+    });
+
+    it("should skip refetch when refetchActive is false", async () => {
+      // Act
+      await cacheManager.resetOnAuthChange({
+        reason: "test_reset",
+        refetchActive: false,
+      });
+
+      // Assert
+      expect(client.clearStore).toHaveBeenCalledTimes(1);
+      expect(client.refetchQueries).not.toHaveBeenCalled();
+    });
+
+    it("should debounce rapid consecutive calls", async () => {
+      // Act - Call twice rapidly
+      await cacheManager.resetOnAuthChange({ reason: "first_call" });
+      const result = await cacheManager.resetOnAuthChange({ reason: "second_call" });
+
+      // Assert - Second call should be debounced
+      expect(client.clearStore).toHaveBeenCalledTimes(1);
+      expect(result.message).toContain("debounced");
+    });
+
+    it("should allow reset after debounce period expires", async () => {
+      // Arrange
+      await cacheManager.resetOnAuthChange({ reason: "first_call" });
+
+      // Act - Advance time past debounce period
+      vi.advanceTimersByTime(1100); // > 1000ms debounce
+      await cacheManager.resetOnAuthChange({ reason: "second_call" });
+
+      // Assert - Both calls should have executed
+      expect(client.clearStore).toHaveBeenCalledTimes(2);
+    });
+
+    it("should return duration in the result", async () => {
+      // Act
+      const result = await cacheManager.resetOnAuthChange({ reason: "test" });
+
+      // Assert
+      expect(result.duration).toBeDefined();
+      expect(typeof result.duration).toBe("number");
+      expect(result.duration).toBeGreaterThanOrEqual(0);
+    });
+
+    it("should handle errors gracefully", async () => {
+      // Arrange
+      const errorMessage = "Network error";
+      vi.spyOn(client, "clearStore").mockRejectedValueOnce(new Error(errorMessage));
+
+      // Act
+      const result = await cacheManager.resetOnAuthChange({ reason: "test" });
+
+      // Assert
+      expect(result.success).toBe(false);
+      expect(result.message).toContain(errorMessage);
+    });
+
+    it("should use default reason when not provided", async () => {
+      // Act
+      const result = await cacheManager.resetOnAuthChange();
+
+      // Assert
+      expect(result.message).toContain("auth_change");
+    });
+  });
+
+  // ==========================================================================
+  // Active Query Refresh Tests
+  // ==========================================================================
+
+  describe("refreshActiveQueries", () => {
+    it("should refetch all active queries", async () => {
+      // Act
+      const result = await cacheManager.refreshActiveQueries("test_refresh");
+
+      // Assert
+      expect(client.refetchQueries).toHaveBeenCalledWith({
+        include: "active",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("should not clear the cache", async () => {
+      // Act
+      await cacheManager.refreshActiveQueries("test_refresh");
+
+      // Assert
+      expect(client.clearStore).not.toHaveBeenCalled();
+    });
+
+    it("should handle errors gracefully", async () => {
+      // Arrange
+      vi.spyOn(client, "refetchQueries").mockRejectedValueOnce(new Error("Network error"));
+
+      // Act
+      const result = await cacheManager.refreshActiveQueries("test");
+
+      // Assert
+      expect(result.success).toBe(false);
+      expect(result.message).toContain("failed");
+    });
+  });
+
+  // ==========================================================================
+  // Targeted Cache Invalidation Tests
+  // ==========================================================================
+
+  describe("invalidateEntityQueries", () => {
+    it("should refetch document-related queries for document entity type", async () => {
+      // Act
+      const result = await cacheManager.invalidateEntityQueries({
+        entityType: "document",
+        reason: "document_upload",
+      });
+
+      // Assert
+      expect(client.refetchQueries).toHaveBeenCalled();
+      expect(result.success).toBe(true);
+      expect(result.message).toContain("document");
+    });
+
+    it("should refetch corpus-related queries for corpus entity type", async () => {
+      // Act
+      const result = await cacheManager.invalidateEntityQueries({
+        entityType: "corpus",
+        reason: "corpus_create",
+      });
+
+      // Assert
+      expect(client.refetchQueries).toHaveBeenCalled();
+      expect(result.success).toBe(true);
+      expect(result.message).toContain("corpus");
+    });
+
+    it("should debounce rapid invalidations for the same entity", async () => {
+      // Act
+      await cacheManager.invalidateEntityQueries({
+        entityType: "document",
+        corpusId: "corpus-1",
+        reason: "first",
+      });
+      const result = await cacheManager.invalidateEntityQueries({
+        entityType: "document",
+        corpusId: "corpus-1",
+        reason: "second",
+      });
+
+      // Assert - Second call should be debounced
+      expect(client.refetchQueries).toHaveBeenCalledTimes(1);
+      expect(result.message).toContain("debounced");
+    });
+
+    it("should not debounce invalidations for different entities", async () => {
+      // Act
+      await cacheManager.invalidateEntityQueries({
+        entityType: "document",
+        corpusId: "corpus-1",
+        reason: "first",
+      });
+      await cacheManager.invalidateEntityQueries({
+        entityType: "document",
+        corpusId: "corpus-2", // Different corpus
+        reason: "second",
+      });
+
+      // Assert - Both calls should execute
+      expect(client.refetchQueries).toHaveBeenCalledTimes(2);
+    });
+
+    it("should handle unknown entity types", async () => {
+      // Act - Force unknown entity type
+      const result = await cacheManager.invalidateEntityQueries({
+        entityType: "unknown" as any,
+        reason: "test",
+      });
+
+      // Assert
+      expect(result.success).toBe(true);
+      expect(result.message).toContain("No queries to refetch");
+    });
+  });
+
+  // ==========================================================================
+  // Convenience Method Tests
+  // ==========================================================================
+
+  describe("invalidateDocumentQueries", () => {
+    it("should call invalidateEntityQueries with document type", async () => {
+      // Act
+      const result = await cacheManager.invalidateDocumentQueries(
+        "corpus-1",
+        "document_upload"
+      );
+
+      // Assert
+      expect(result.success).toBe(true);
+      expect(result.message).toContain("document");
+    });
+  });
+
+  describe("invalidateCorpusQueries", () => {
+    it("should call invalidateEntityQueries with corpus type", async () => {
+      // Act
+      const result = await cacheManager.invalidateCorpusQueries("corpus_create");
+
+      // Assert
+      expect(result.success).toBe(true);
+      expect(result.message).toContain("corpus");
+    });
+  });
+
+  // ==========================================================================
+  // Debug Helper Tests
+  // ==========================================================================
+
+  describe("logCacheSize", () => {
+    it("should not throw when logging cache size", () => {
+      // Act & Assert
+      expect(() => cacheManager.logCacheSize()).not.toThrow();
+    });
+  });
+
+  describe("extractCacheForDebug", () => {
+    it("should return cache contents", () => {
+      // Act
+      const cache = cacheManager.extractCacheForDebug();
+
+      // Assert
+      expect(cache).toBeDefined();
+      expect(typeof cache).toBe("object");
+    });
+  });
+});
+
+// ============================================================================
+// Singleton Management Tests
+// ============================================================================
+
+describe("CacheManager Singleton", () => {
+  let client: ApolloClient<NormalizedCacheObject>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetCacheManagerForTesting();
+    client = createMockApolloClient();
+  });
+
+  afterEach(() => {
+    resetCacheManagerForTesting();
+  });
+
+  describe("initializeCacheManager", () => {
+    it("should create a new CacheManager instance", () => {
+      // Act
+      const manager = initializeCacheManager(client);
+
+      // Assert
+      expect(manager).toBeInstanceOf(CacheManager);
+      expect(isCacheManagerInitialized()).toBe(true);
+    });
+
+    it("should return existing instance if already initialized", () => {
+      // Arrange
+      const first = initializeCacheManager(client);
+
+      // Act
+      const second = initializeCacheManager(client);
+
+      // Assert
+      expect(first).toBe(second);
+    });
+  });
+
+  describe("getCacheManager", () => {
+    it("should throw if not initialized", () => {
+      // Act & Assert
+      expect(() => getCacheManager()).toThrow("Not initialized");
+    });
+
+    it("should return the initialized instance", () => {
+      // Arrange
+      initializeCacheManager(client);
+
+      // Act
+      const manager = getCacheManager();
+
+      // Assert
+      expect(manager).toBeInstanceOf(CacheManager);
+    });
+  });
+
+  describe("isCacheManagerInitialized", () => {
+    it("should return false before initialization", () => {
+      // Act & Assert
+      expect(isCacheManagerInitialized()).toBe(false);
+    });
+
+    it("should return true after initialization", () => {
+      // Arrange
+      initializeCacheManager(client);
+
+      // Act & Assert
+      expect(isCacheManagerInitialized()).toBe(true);
+    });
+
+    it("should return false after reset", () => {
+      // Arrange
+      initializeCacheManager(client);
+
+      // Act
+      resetCacheManagerForTesting();
+
+      // Assert
+      expect(isCacheManagerInitialized()).toBe(false);
+    });
+  });
+});
+
+// ============================================================================
+// Integration Scenario Tests
+// ============================================================================
+
+describe("CacheManager Integration Scenarios", () => {
+  let client: ApolloClient<NormalizedCacheObject>;
+  let cacheManager: CacheManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    client = createMockApolloClient();
+    cacheManager = new CacheManager(client);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("User Login Flow", () => {
+    it("should clear stale anonymous data before login", async () => {
+      // Scenario: User was browsing anonymously, then logs in
+      // Expected: Cache should be cleared to remove anonymous-context data
+
+      // Act
+      const result = await cacheManager.resetOnAuthChange({
+        reason: "user_login",
+        refetchActive: false, // Don't refetch yet - auth not complete
+      });
+
+      // Assert
+      expect(result.success).toBe(true);
+      expect(client.clearStore).toHaveBeenCalled();
+      expect(client.refetchQueries).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("User Logout Flow", () => {
+    it("should clear all user data on logout for security", async () => {
+      // Scenario: Authenticated user logs out
+      // Expected: All cache data should be cleared for security
+
+      // Act
+      const result = await cacheManager.resetOnAuthChange({
+        reason: "user_logout",
+        refetchActive: false, // No point refetching - user is logging out
+      });
+
+      // Assert
+      expect(result.success).toBe(true);
+      expect(client.clearStore).toHaveBeenCalled();
+    });
+  });
+
+  describe("Document Upload Flow", () => {
+    it("should invalidate document lists after upload", async () => {
+      // Scenario: User uploads a new document to a corpus
+      // Expected: Document lists should be refreshed to show the new document
+
+      // Act
+      const result = await cacheManager.invalidateDocumentQueries(
+        "corpus-1",
+        "document_upload"
+      );
+
+      // Assert
+      expect(result.success).toBe(true);
+      expect(client.refetchQueries).toHaveBeenCalled();
+    });
+  });
+
+  describe("Corpus Creation Flow", () => {
+    it("should invalidate corpus lists after creation", async () => {
+      // Scenario: User creates a new corpus
+      // Expected: Corpus lists should be refreshed to show the new corpus
+
+      // Act
+      const result = await cacheManager.invalidateCorpusQueries("corpus_create");
+
+      // Assert
+      expect(result.success).toBe(true);
+      expect(client.refetchQueries).toHaveBeenCalled();
+    });
+  });
+
+  describe("Rapid Operations", () => {
+    it("should handle burst of document operations efficiently", async () => {
+      // Scenario: Multiple documents uploaded in quick succession
+      // Expected: Operations should be debounced to prevent excessive refetches
+
+      // Act - Simulate 5 rapid document uploads
+      const results: CacheOperationResult[] = [];
+      for (let i = 0; i < 5; i++) {
+        results.push(
+          await cacheManager.invalidateDocumentQueries("corpus-1", `upload_${i}`)
+        );
+      }
+
+      // Assert - Only first should actually execute, rest should be debounced
+      expect(results[0].message).not.toContain("debounced");
+      expect(results.slice(1).every((r) => r.message.includes("debounced"))).toBe(true);
+      expect(client.refetchQueries).toHaveBeenCalledTimes(1);
+    });
+
+    it("should allow operations after debounce period", async () => {
+      // Scenario: Document uploads spaced out over time
+      // Expected: Each should execute if outside debounce window
+
+      // Act
+      await cacheManager.invalidateDocumentQueries("corpus-1", "upload_1");
+      vi.advanceTimersByTime(600); // > 500ms debounce
+      await cacheManager.invalidateDocumentQueries("corpus-1", "upload_2");
+
+      // Assert - Both should execute
+      expect(client.refetchQueries).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("Error Recovery", () => {
+    it("should continue operation if cache clear fails but refetch succeeds", async () => {
+      // Scenario: Cache clear fails but we still want to try refetching
+      // Note: Current implementation doesn't do this, but documents the expected behavior
+
+      // Arrange
+      vi.spyOn(client, "clearStore").mockRejectedValueOnce(new Error("Clear failed"));
+
+      // Act
+      const result = await cacheManager.resetOnAuthChange({ reason: "test" });
+
+      // Assert
+      expect(result.success).toBe(false);
+      // Error should be reported but not crash the app
+    });
+  });
+});
+
+// ============================================================================
+// Human-Readable Test Descriptions
+// ============================================================================
+
+describe("Cache Management Behavior (Human Readable)", () => {
+  let client: ApolloClient<NormalizedCacheObject>;
+  let cacheManager: CacheManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    client = createMockApolloClient();
+    cacheManager = new CacheManager(client);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("When a user logs in, their previous session's cached data should be cleared", async () => {
+    // Given: A user who was browsing anonymously
+    // When: They log in with their credentials
+    const result = await cacheManager.resetOnAuthChange({
+      reason: "user_login",
+      refetchActive: false,
+    });
+
+    // Then: The cache should be cleared to prevent showing stale anonymous data
+    expect(result.success).toBe(true);
+    expect(client.clearStore).toHaveBeenCalled();
+  });
+
+  it("When a user logs out, all their cached data should be removed for security", async () => {
+    // Given: An authenticated user with cached data
+    // When: They click the logout button
+    const result = await cacheManager.resetOnAuthChange({
+      reason: "user_logout",
+      refetchActive: false,
+    });
+
+    // Then: All cached data should be cleared so the next user doesn't see it
+    expect(result.success).toBe(true);
+    expect(client.clearStore).toHaveBeenCalled();
+  });
+
+  it("When a document is uploaded, the document list should refresh automatically", async () => {
+    // Given: A user viewing a corpus's document list
+    // When: They upload a new document
+    const result = await cacheManager.invalidateDocumentQueries(
+      "corpus-123",
+      "document_upload"
+    );
+
+    // Then: The document list should refresh to show the newly uploaded document
+    expect(result.success).toBe(true);
+    expect(client.refetchQueries).toHaveBeenCalled();
+  });
+
+  it("When multiple documents are uploaded rapidly, the system should batch refreshes", async () => {
+    // Given: A user uploading multiple documents at once
+    // When: 5 documents are uploaded within 500ms
+    const results = await Promise.all([
+      cacheManager.invalidateDocumentQueries("corpus-123", "upload_1"),
+      cacheManager.invalidateDocumentQueries("corpus-123", "upload_2"),
+      cacheManager.invalidateDocumentQueries("corpus-123", "upload_3"),
+    ]);
+
+    // Then: Only one refresh should occur to avoid overwhelming the server
+    expect(client.refetchQueries).toHaveBeenCalledTimes(1);
+    // And subsequent calls should be debounced
+    expect(results[1].message).toContain("debounced");
+    expect(results[2].message).toContain("debounced");
+  });
+
+  it("When a corpus is created, the corpus list should update to show the new corpus", async () => {
+    // Given: A user viewing their corpus list
+    // When: They create a new corpus
+    const result = await cacheManager.invalidateCorpusQueries("corpus_create");
+
+    // Then: The corpus list should refresh to include the new corpus
+    expect(result.success).toBe(true);
+    expect(client.refetchQueries).toHaveBeenCalled();
+  });
+
+  it("When a network error occurs during cache clear, it should fail gracefully", async () => {
+    // Given: A user logging out
+    // When: A network error occurs during cache clearing
+    vi.spyOn(client, "clearStore").mockRejectedValueOnce(new Error("Network unavailable"));
+
+    const result = await cacheManager.resetOnAuthChange({ reason: "user_logout" });
+
+    // Then: The operation should fail but return a meaningful error message
+    expect(result.success).toBe(false);
+    expect(result.message).toContain("Network unavailable");
+    // And the app should not crash
+  });
+
+  it("When checking cache status, developers should see meaningful debug info", () => {
+    // Given: A developer debugging cache issues
+    // When: They extract cache contents
+    const cacheContents = cacheManager.extractCacheForDebug();
+
+    // Then: They should receive a valid object with cache data
+    expect(cacheContents).toBeDefined();
+    expect(typeof cacheContents).toBe("object");
+  });
+});

--- a/frontend/src/services/__tests__/cacheManager.test.ts
+++ b/frontend/src/services/__tests__/cacheManager.test.ts
@@ -13,7 +13,11 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { ApolloClient, InMemoryCache, NormalizedCacheObject } from "@apollo/client";
+import {
+  ApolloClient,
+  InMemoryCache,
+  NormalizedCacheObject,
+} from "@apollo/client";
 import {
   CacheManager,
   CacheOperationResult,
@@ -110,7 +114,9 @@ describe("CacheManager", () => {
     it("should debounce rapid consecutive calls", async () => {
       // Act - Call twice rapidly
       await cacheManager.resetOnAuthChange({ reason: "first_call" });
-      const result = await cacheManager.resetOnAuthChange({ reason: "second_call" });
+      const result = await cacheManager.resetOnAuthChange({
+        reason: "second_call",
+      });
 
       // Assert - Second call should be debounced
       expect(client.clearStore).toHaveBeenCalledTimes(1);
@@ -142,7 +148,9 @@ describe("CacheManager", () => {
     it("should handle errors gracefully", async () => {
       // Arrange
       const errorMessage = "Network error";
-      vi.spyOn(client, "clearStore").mockRejectedValueOnce(new Error(errorMessage));
+      vi.spyOn(client, "clearStore").mockRejectedValueOnce(
+        new Error(errorMessage)
+      );
 
       // Act
       const result = await cacheManager.resetOnAuthChange({ reason: "test" });
@@ -187,7 +195,9 @@ describe("CacheManager", () => {
 
     it("should handle errors gracefully", async () => {
       // Arrange
-      vi.spyOn(client, "refetchQueries").mockRejectedValueOnce(new Error("Network error"));
+      vi.spyOn(client, "refetchQueries").mockRejectedValueOnce(
+        new Error("Network error")
+      );
 
       // Act
       const result = await cacheManager.refreshActiveQueries("test");
@@ -298,7 +308,9 @@ describe("CacheManager", () => {
   describe("invalidateCorpusQueries", () => {
     it("should call invalidateEntityQueries with corpus type", async () => {
       // Act
-      const result = await cacheManager.invalidateCorpusQueries("corpus_create");
+      const result = await cacheManager.invalidateCorpusQueries(
+        "corpus_create"
+      );
 
       // Assert
       expect(result.success).toBe(true);
@@ -490,7 +502,9 @@ describe("CacheManager Integration Scenarios", () => {
       // Expected: Corpus lists should be refreshed to show the new corpus
 
       // Act
-      const result = await cacheManager.invalidateCorpusQueries("corpus_create");
+      const result = await cacheManager.invalidateCorpusQueries(
+        "corpus_create"
+      );
 
       // Assert
       expect(result.success).toBe(true);
@@ -507,13 +521,18 @@ describe("CacheManager Integration Scenarios", () => {
       const results: CacheOperationResult[] = [];
       for (let i = 0; i < 5; i++) {
         results.push(
-          await cacheManager.invalidateDocumentQueries("corpus-1", `upload_${i}`)
+          await cacheManager.invalidateDocumentQueries(
+            "corpus-1",
+            `upload_${i}`
+          )
         );
       }
 
       // Assert - Only first should actually execute, rest should be debounced
       expect(results[0].message).not.toContain("debounced");
-      expect(results.slice(1).every((r) => r.message.includes("debounced"))).toBe(true);
+      expect(
+        results.slice(1).every((r) => r.message.includes("debounced"))
+      ).toBe(true);
       expect(client.refetchQueries).toHaveBeenCalledTimes(1);
     });
 
@@ -537,7 +556,9 @@ describe("CacheManager Integration Scenarios", () => {
       // Note: Current implementation doesn't do this, but documents the expected behavior
 
       // Arrange
-      vi.spyOn(client, "clearStore").mockRejectedValueOnce(new Error("Clear failed"));
+      vi.spyOn(client, "clearStore").mockRejectedValueOnce(
+        new Error("Clear failed")
+      );
 
       // Act
       const result = await cacheManager.resetOnAuthChange({ reason: "test" });
@@ -636,9 +657,13 @@ describe("Cache Management Behavior (Human Readable)", () => {
   it("When a network error occurs during cache clear, it should fail gracefully", async () => {
     // Given: A user logging out
     // When: A network error occurs during cache clearing
-    vi.spyOn(client, "clearStore").mockRejectedValueOnce(new Error("Network unavailable"));
+    vi.spyOn(client, "clearStore").mockRejectedValueOnce(
+      new Error("Network unavailable")
+    );
 
-    const result = await cacheManager.resetOnAuthChange({ reason: "user_logout" });
+    const result = await cacheManager.resetOnAuthChange({
+      reason: "user_logout",
+    });
 
     // Then: The operation should fail but return a meaningful error message
     expect(result.success).toBe(false);
@@ -654,5 +679,327 @@ describe("Cache Management Behavior (Human Readable)", () => {
     // Then: They should receive a valid object with cache data
     expect(cacheContents).toBeDefined();
     expect(typeof cacheContents).toBe("object");
+  });
+});
+
+// ============================================================================
+// Auth Flow Tests with Cache Inspection (E2E-style)
+// ============================================================================
+
+describe("Auth Flow with Cache Inspection", () => {
+  let client: ApolloClient<NormalizedCacheObject>;
+  let cacheManager: CacheManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    client = createMockApolloClient();
+    cacheManager = new CacheManager(client);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("should clear cache completely on login transition", async () => {
+    // Simulate pre-login state with cached anonymous data
+    const preCacheState = cacheManager.extractCacheForDebug();
+
+    // Perform login cache reset
+    const loginResult = await cacheManager.resetOnAuthChange({
+      reason: "user_login",
+      refetchActive: false,
+    });
+
+    // Verify cache was cleared
+    expect(loginResult.success).toBe(true);
+    expect(client.clearStore).toHaveBeenCalledTimes(1);
+
+    // Extract post-login cache state
+    const postCacheState = cacheManager.extractCacheForDebug();
+    expect(postCacheState).toBeDefined();
+  });
+
+  it("should clear cache completely on logout transition", async () => {
+    // Perform logout cache reset
+    const logoutResult = await cacheManager.resetOnAuthChange({
+      reason: "user_logout",
+      refetchActive: false,
+    });
+
+    // Verify cache was cleared for security
+    expect(logoutResult.success).toBe(true);
+    expect(client.clearStore).toHaveBeenCalledTimes(1);
+  });
+
+  it("should track cache state changes through full auth lifecycle", async () => {
+    // Phase 1: Initial anonymous state
+    const initialCache = cacheManager.extractCacheForDebug();
+    expect(initialCache).toBeDefined();
+
+    // Phase 2: Login
+    const loginResult = await cacheManager.resetOnAuthChange({
+      reason: "user_login",
+      refetchActive: false,
+    });
+    expect(loginResult.success).toBe(true);
+
+    // Advance time to allow next operation
+    vi.advanceTimersByTime(1100);
+
+    // Phase 3: Logout
+    const logoutResult = await cacheManager.resetOnAuthChange({
+      reason: "user_logout",
+      refetchActive: false,
+    });
+    expect(logoutResult.success).toBe(true);
+
+    // Verify both operations executed
+    expect(client.clearStore).toHaveBeenCalledTimes(2);
+  });
+
+  it("should handle rapid login/logout cycles gracefully", async () => {
+    // Simulate rapid auth state changes (e.g., token refresh issues)
+    const result1 = await cacheManager.resetOnAuthChange({ reason: "login" });
+    const result2 = await cacheManager.resetOnAuthChange({ reason: "logout" });
+    const result3 = await cacheManager.resetOnAuthChange({ reason: "login" });
+
+    // First should succeed, rest should be debounced
+    expect(result1.success).toBe(true);
+    expect(result2.message).toContain("debounced");
+    expect(result3.message).toContain("debounced");
+    expect(client.clearStore).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ============================================================================
+// Race Condition Verification Tests
+// ============================================================================
+
+describe("Race Condition Prevention", () => {
+  let client: ApolloClient<NormalizedCacheObject>;
+  let cacheManager: CacheManager;
+  let operationOrder: string[];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    client = createMockApolloClient();
+    cacheManager = new CacheManager(client);
+    operationOrder = [];
+
+    // Track operation order
+    vi.spyOn(client, "clearStore").mockImplementation(async () => {
+      operationOrder.push("clearStore");
+      return [];
+    });
+    vi.spyOn(client, "refetchQueries").mockImplementation((async () => {
+      operationOrder.push("refetchQueries");
+      return [];
+    }) as any);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("should execute cache operations in deterministic order", async () => {
+    // When reset is called with refetch
+    await cacheManager.resetOnAuthChange({
+      reason: "auth_change",
+      refetchActive: true,
+    });
+
+    // Then clearStore should happen before refetchQueries
+    expect(operationOrder).toEqual(["clearStore", "refetchQueries"]);
+  });
+
+  it("should not trigger refetch when refetchActive is false", async () => {
+    // When reset is called without refetch
+    await cacheManager.resetOnAuthChange({
+      reason: "auth_change",
+      refetchActive: false,
+    });
+
+    // Then only clearStore should be called
+    expect(operationOrder).toEqual(["clearStore"]);
+  });
+
+  it("should handle concurrent cache operations safely", async () => {
+    // Simulate concurrent operations (would happen if auth state changes rapidly)
+    const promises = [
+      cacheManager.resetOnAuthChange({ reason: "op1" }),
+      cacheManager.resetOnAuthChange({ reason: "op2" }),
+      cacheManager.resetOnAuthChange({ reason: "op3" }),
+    ];
+
+    const results = await Promise.all(promises);
+
+    // Only first operation should execute due to debouncing
+    expect(results[0].success).toBe(true);
+    expect(results[0].message).not.toContain("debounced");
+    expect(results[1].message).toContain("debounced");
+    expect(results[2].message).toContain("debounced");
+
+    // Verify only one clearStore call
+    expect(client.clearStore).toHaveBeenCalledTimes(1);
+  });
+
+  it("should maintain cache integrity during error scenarios", async () => {
+    // Simulate a failure during clearStore
+    vi.spyOn(client, "clearStore").mockRejectedValueOnce(
+      new Error("Network error")
+    );
+
+    const result = await cacheManager.resetOnAuthChange({ reason: "test" });
+
+    // Operation should fail gracefully
+    expect(result.success).toBe(false);
+
+    // refetchQueries should NOT be called if clearStore failed
+    expect(client.refetchQueries).not.toHaveBeenCalled();
+  });
+
+  it("should handle interleaved entity invalidations correctly", async () => {
+    // Simulate rapid document and corpus operations
+    const docResult1 = await cacheManager.invalidateDocumentQueries(
+      "corpus-1",
+      "upload"
+    );
+    const corpusResult = await cacheManager.invalidateCorpusQueries("create");
+    const docResult2 = await cacheManager.invalidateDocumentQueries(
+      "corpus-2",
+      "upload"
+    );
+
+    // Document ops for different corpuses should not debounce each other
+    expect(docResult1.success).toBe(true);
+    expect(corpusResult.success).toBe(true);
+    expect(docResult2.success).toBe(true);
+
+    // All should execute since they're different cache keys
+    expect(client.refetchQueries).toHaveBeenCalledTimes(3);
+  });
+});
+
+// ============================================================================
+// Performance Tests
+// ============================================================================
+
+describe("Cache Performance", () => {
+  let client: ApolloClient<NormalizedCacheObject>;
+  let cacheManager: CacheManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    client = createMockApolloClient();
+    cacheManager = new CacheManager(client);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("should report operation duration", async () => {
+    // Simulate some delay in clearStore
+    vi.spyOn(client, "clearStore").mockImplementation(async () => {
+      // Advance time to simulate work
+      vi.advanceTimersByTime(50);
+      return [];
+    });
+
+    const result = await cacheManager.resetOnAuthChange({ reason: "test" });
+
+    // Duration should be reported
+    expect(result.duration).toBeDefined();
+    expect(result.duration).toBeGreaterThanOrEqual(0);
+  });
+
+  it("should handle large number of sequential operations with debouncing", async () => {
+    const operationCount = 100;
+    const results: CacheOperationResult[] = [];
+
+    // Fire 100 operations rapidly
+    for (let i = 0; i < operationCount; i++) {
+      results.push(
+        await cacheManager.invalidateDocumentQueries("corpus-1", `op_${i}`)
+      );
+    }
+
+    // First should succeed, rest should be debounced
+    expect(results[0].success).toBe(true);
+    expect(results[0].message).not.toContain("debounced");
+
+    // Count debounced operations
+    const debouncedCount = results.filter((r) =>
+      r.message.includes("debounced")
+    ).length;
+    expect(debouncedCount).toBe(operationCount - 1);
+
+    // Only one actual refetch should occur
+    expect(client.refetchQueries).toHaveBeenCalledTimes(1);
+  });
+
+  it("should efficiently handle operations across multiple cache keys", async () => {
+    // Create operations for different cache keys
+    const corpusIds = [
+      "corpus-1",
+      "corpus-2",
+      "corpus-3",
+      "corpus-4",
+      "corpus-5",
+    ];
+
+    const results = await Promise.all(
+      corpusIds.map((id) =>
+        cacheManager.invalidateDocumentQueries(id, "operation")
+      )
+    );
+
+    // All should succeed since they're different cache keys
+    expect(results.every((r) => r.success)).toBe(true);
+    expect(client.refetchQueries).toHaveBeenCalledTimes(corpusIds.length);
+  });
+
+  it("should not accumulate memory in debounce tracking over time", async () => {
+    // Perform many operations with different keys
+    for (let i = 0; i < 50; i++) {
+      await cacheManager.invalidateDocumentQueries(`corpus-${i}`, "op");
+      // Advance time to allow debounce to clear
+      vi.advanceTimersByTime(600);
+    }
+
+    // All operations should have executed
+    expect(client.refetchQueries).toHaveBeenCalledTimes(50);
+  });
+
+  it("should complete cache reset within reasonable time bounds", async () => {
+    // Mock a slow but successful operation
+    let clearStoreCallTime: number;
+    let refetchCallTime: number;
+
+    vi.spyOn(client, "clearStore").mockImplementation(async () => {
+      clearStoreCallTime = Date.now();
+      vi.advanceTimersByTime(100);
+      return [];
+    });
+
+    vi.spyOn(client, "refetchQueries").mockImplementation((async () => {
+      refetchCallTime = Date.now();
+      vi.advanceTimersByTime(200);
+      return [];
+    }) as any);
+
+    const result = await cacheManager.resetOnAuthChange({
+      reason: "test",
+      refetchActive: true,
+    });
+
+    // Operation should complete successfully
+    expect(result.success).toBe(true);
+
+    // Duration should be tracked
+    expect(result.duration).toBeDefined();
   });
 });

--- a/frontend/src/services/cacheManager.ts
+++ b/frontend/src/services/cacheManager.ts
@@ -15,7 +15,11 @@
  * @see https://github.com/Open-Source-Legal/OpenContracts/issues/694
  */
 
-import { ApolloClient, NormalizedCacheObject } from "@apollo/client";
+import {
+  ApolloClient,
+  NormalizedCacheObject,
+  DocumentNode,
+} from "@apollo/client";
 import { GET_CORPUSES, GET_DOCUMENTS } from "../graphql/queries";
 import { GET_CORPUS_FOLDERS } from "../graphql/queries/folders";
 
@@ -46,7 +50,11 @@ export interface CacheResetOptions {
 /**
  * Entity types that can trigger targeted cache invalidation
  */
-export type InvalidatableEntity = "document" | "corpus" | "annotation" | "thread";
+export type InvalidatableEntity =
+  | "document"
+  | "corpus"
+  | "annotation"
+  | "thread";
 
 /**
  * Options for targeted cache invalidation
@@ -128,9 +136,7 @@ export class CacheManager {
     // Debounce: prevent multiple resets within the threshold
     const now = Date.now();
     if (now - this.lastResetTime < CacheManager.RESET_DEBOUNCE_MS) {
-      console.debug(
-        `[CacheManager] Skipping reset (debounced): ${reason}`
-      );
+      console.debug(`[CacheManager] Skipping reset (debounced): ${reason}`);
       return {
         success: true,
         message: "Reset skipped (debounced)",
@@ -170,7 +176,9 @@ export class CacheManager {
 
       return {
         success: false,
-        message: `Cache reset failed: ${error instanceof Error ? error.message : "Unknown error"}`,
+        message: `Cache reset failed: ${
+          error instanceof Error ? error.message : "Unknown error"
+        }`,
         duration,
       };
     }
@@ -185,7 +193,9 @@ export class CacheManager {
    * @param reason - Reason for the refresh (for logging)
    * @returns Result of the operation
    */
-  async refreshActiveQueries(reason: string = "manual_refresh"): Promise<CacheOperationResult> {
+  async refreshActiveQueries(
+    reason: string = "manual_refresh"
+  ): Promise<CacheOperationResult> {
     const startTime = performance.now();
 
     console.log(`[CacheManager] Refreshing active queries: ${reason}`);
@@ -211,7 +221,9 @@ export class CacheManager {
 
       return {
         success: false,
-        message: `Query refresh failed: ${error instanceof Error ? error.message : "Unknown error"}`,
+        message: `Query refresh failed: ${
+          error instanceof Error ? error.message : "Unknown error"
+        }`,
         duration,
       };
     }
@@ -239,7 +251,12 @@ export class CacheManager {
   async invalidateEntityQueries(
     options: InvalidationOptions
   ): Promise<CacheOperationResult> {
-    const { entityType, corpusId, documentId, reason = "entity_change" } = options;
+    const {
+      entityType,
+      corpusId,
+      documentId,
+      reason = "entity_change",
+    } = options;
     const startTime = performance.now();
     const cacheKey = `${entityType}:${corpusId || ""}:${documentId || ""}`;
 
@@ -258,9 +275,7 @@ export class CacheManager {
     }
     this.lastInvalidationTime.set(cacheKey, now);
 
-    console.log(
-      `[CacheManager] Invalidating ${entityType} queries: ${reason}`
-    );
+    console.log(`[CacheManager] Invalidating ${entityType} queries: ${reason}`);
 
     try {
       const queriesToRefetch = this.getQueriesToRefetch(entityType, {
@@ -269,7 +284,10 @@ export class CacheManager {
       });
 
       if (queriesToRefetch.length === 0) {
-        console.debug("[CacheManager] No queries to refetch for entity type:", entityType);
+        console.debug(
+          "[CacheManager] No queries to refetch for entity type:",
+          entityType
+        );
         return {
           success: true,
           message: "No queries to refetch",
@@ -283,7 +301,9 @@ export class CacheManager {
 
       const duration = performance.now() - startTime;
       console.log(
-        `[CacheManager] Invalidated ${queriesToRefetch.length} queries in ${duration.toFixed(1)}ms`
+        `[CacheManager] Invalidated ${
+          queriesToRefetch.length
+        } queries in ${duration.toFixed(1)}ms`
       );
 
       return {
@@ -297,7 +317,9 @@ export class CacheManager {
 
       return {
         success: false,
-        message: `Invalidation failed: ${error instanceof Error ? error.message : "Unknown error"}`,
+        message: `Invalidation failed: ${
+          error instanceof Error ? error.message : "Unknown error"
+        }`,
         duration,
       };
     }
@@ -352,7 +374,7 @@ export class CacheManager {
   private getQueriesToRefetch(
     entityType: InvalidatableEntity,
     context: { corpusId?: string; documentId?: string }
-  ): Array<ReturnType<typeof GET_DOCUMENTS> | ReturnType<typeof GET_CORPUSES>> {
+  ): DocumentNode[] {
     switch (entityType) {
       case "document":
         // Document changes affect document lists and folder contents
@@ -406,9 +428,7 @@ export class CacheManager {
       const sizeKB = (cacheString.length / 1024).toFixed(2);
       const entryCount = Object.keys(cache).length;
 
-      console.log(
-        `[CacheManager] Cache: ${entryCount} entries, ${sizeKB} KB`
-      );
+      console.log(`[CacheManager] Cache: ${entryCount} entries, ${sizeKB} KB`);
     } catch (error) {
       console.error("[CacheManager] Error logging cache size:", error);
     }
@@ -416,15 +436,30 @@ export class CacheManager {
 }
 
 // ============================================================================
-// Singleton Instance and Hook
+// Singleton Instance (for non-React contexts)
 // ============================================================================
 
+/**
+ * Singleton instance for use in non-React contexts (e.g., external scripts,
+ * service workers, or utility functions that don't have access to React hooks).
+ *
+ * NOTE: In React components, prefer using the `useCacheManager` hook from
+ * `hooks/useCacheManager.ts` instead. The hook provides proper memoization
+ * and integrates with React's lifecycle.
+ *
+ * These singleton functions are primarily used for:
+ * 1. Testing - allows tests to manage the singleton lifecycle
+ * 2. Non-React contexts - rare cases where hooks aren't available
+ *
+ * @see useCacheManager for React component usage
+ */
 let cacheManagerInstance: CacheManager | null = null;
 
 /**
  * Initializes the CacheManager singleton with an Apollo Client.
  *
- * This should be called once during app initialization, typically in App.tsx.
+ * NOTE: In React components, use the `useCacheManager` hook instead.
+ * This function is intended for non-React contexts or testing scenarios.
  *
  * @param client - The Apollo Client instance
  */
@@ -432,7 +467,9 @@ export function initializeCacheManager(
   client: ApolloClient<NormalizedCacheObject>
 ): CacheManager {
   if (cacheManagerInstance) {
-    console.warn("[CacheManager] Already initialized, returning existing instance");
+    console.warn(
+      "[CacheManager] Already initialized, returning existing instance"
+    );
     return cacheManagerInstance;
   }
 
@@ -443,6 +480,8 @@ export function initializeCacheManager(
 
 /**
  * Gets the CacheManager singleton instance.
+ *
+ * NOTE: In React components, use the `useCacheManager` hook instead.
  *
  * @throws Error if CacheManager has not been initialized
  */
@@ -463,7 +502,10 @@ export function isCacheManagerInitialized(): boolean {
 }
 
 /**
- * Resets the CacheManager singleton (primarily for testing).
+ * Resets the CacheManager singleton. Used in tests to ensure clean state
+ * between test cases.
+ *
+ * @internal This function is intended for testing only.
  */
 export function resetCacheManagerForTesting(): void {
   cacheManagerInstance = null;

--- a/frontend/src/services/cacheManager.ts
+++ b/frontend/src/services/cacheManager.ts
@@ -1,0 +1,472 @@
+/**
+ * CacheManager - Proactive Apollo Cache Management
+ *
+ * This module provides surgical cache invalidation and refresh capabilities
+ * for critical application events such as authentication changes and entity CRUD.
+ *
+ * Design Principles:
+ * 1. Full reset on identity change (login/logout) - ensures data freshness and security
+ * 2. Targeted invalidation for entity CRUD - avoids unnecessary full cache clears
+ * 3. Debouncing to prevent rapid repeated operations
+ * 4. Clear separation of concerns - each function handles one type of cache operation
+ *
+ * Related to Issue #694 - Apollo Cache Stale Data Problem
+ *
+ * @see https://github.com/Open-Source-Legal/OpenContracts/issues/694
+ */
+
+import { ApolloClient, NormalizedCacheObject } from "@apollo/client";
+import { GET_CORPUSES, GET_DOCUMENTS } from "../graphql/queries";
+import { GET_CORPUS_FOLDERS } from "../graphql/queries/folders";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * Result of a cache operation
+ */
+export interface CacheOperationResult {
+  success: boolean;
+  message: string;
+  /** Time taken in milliseconds */
+  duration?: number;
+}
+
+/**
+ * Options for cache reset operations
+ */
+export interface CacheResetOptions {
+  /** Whether to refetch active queries after reset (default: true) */
+  refetchActive?: boolean;
+  /** Reason for the reset (for logging) */
+  reason?: string;
+}
+
+/**
+ * Entity types that can trigger targeted cache invalidation
+ */
+export type InvalidatableEntity = "document" | "corpus" | "annotation" | "thread";
+
+/**
+ * Options for targeted cache invalidation
+ */
+export interface InvalidationOptions {
+  /** The entity type being affected */
+  entityType: InvalidatableEntity;
+  /** Optional corpus ID to scope the invalidation */
+  corpusId?: string;
+  /** Optional document ID to scope the invalidation */
+  documentId?: string;
+  /** Reason for the invalidation (for logging) */
+  reason?: string;
+}
+
+// ============================================================================
+// Cache Manager Class
+// ============================================================================
+
+/**
+ * CacheManager provides methods for proactive Apollo cache management.
+ *
+ * This class is designed to be instantiated once and used throughout the app.
+ * It handles both full cache resets (for auth changes) and targeted invalidation
+ * (for entity CRUD operations).
+ *
+ * @example
+ * ```tsx
+ * // In a component
+ * const { resetOnAuthChange, invalidateEntityQueries } = useCacheManager();
+ *
+ * // On logout
+ * await resetOnAuthChange({ reason: "user_logout" });
+ *
+ * // After document upload
+ * await invalidateEntityQueries({
+ *   entityType: "document",
+ *   corpusId: "corpus-123",
+ *   reason: "document_upload"
+ * });
+ * ```
+ */
+export class CacheManager {
+  private client: ApolloClient<NormalizedCacheObject>;
+  private lastResetTime: number = 0;
+  private lastInvalidationTime: Map<string, number> = new Map();
+
+  /** Minimum time (ms) between full cache resets */
+  private static readonly RESET_DEBOUNCE_MS = 1000;
+  /** Minimum time (ms) between same-type invalidations */
+  private static readonly INVALIDATION_DEBOUNCE_MS = 500;
+
+  constructor(client: ApolloClient<NormalizedCacheObject>) {
+    this.client = client;
+  }
+
+  // ==========================================================================
+  // Full Cache Reset Operations
+  // ==========================================================================
+
+  /**
+   * Completely clears the Apollo cache and optionally refetches active queries.
+   *
+   * This should be called on authentication state changes:
+   * - User login (to clear any anonymous/previous user data)
+   * - User logout (to clear authenticated user data for security)
+   *
+   * The operation is debounced to prevent rapid repeated clears.
+   *
+   * @param options - Configuration for the reset operation
+   * @returns Result of the operation
+   */
+  async resetOnAuthChange(
+    options: CacheResetOptions = {}
+  ): Promise<CacheOperationResult> {
+    const { refetchActive = true, reason = "auth_change" } = options;
+    const startTime = performance.now();
+
+    // Debounce: prevent multiple resets within the threshold
+    const now = Date.now();
+    if (now - this.lastResetTime < CacheManager.RESET_DEBOUNCE_MS) {
+      console.debug(
+        `[CacheManager] Skipping reset (debounced): ${reason}`
+      );
+      return {
+        success: true,
+        message: "Reset skipped (debounced)",
+        duration: 0,
+      };
+    }
+    this.lastResetTime = now;
+
+    console.log(`[CacheManager] Resetting cache: ${reason}`);
+
+    try {
+      // Clear all cache data
+      await this.client.clearStore();
+      console.debug("[CacheManager] Cache cleared successfully");
+
+      // Optionally refetch active queries to repopulate with fresh data
+      if (refetchActive) {
+        await this.client.refetchQueries({
+          include: "active",
+        });
+        console.debug("[CacheManager] Active queries refetched");
+      }
+
+      const duration = performance.now() - startTime;
+      console.log(
+        `[CacheManager] Cache reset completed in ${duration.toFixed(1)}ms`
+      );
+
+      return {
+        success: true,
+        message: `Cache reset completed: ${reason}`,
+        duration,
+      };
+    } catch (error) {
+      const duration = performance.now() - startTime;
+      console.error("[CacheManager] Error resetting cache:", error);
+
+      return {
+        success: false,
+        message: `Cache reset failed: ${error instanceof Error ? error.message : "Unknown error"}`,
+        duration,
+      };
+    }
+  }
+
+  /**
+   * Performs a "soft reset" by only refetching active queries without clearing the cache.
+   *
+   * This is useful for refreshing data after operations that might have made
+   * the cache stale, but where a full clear isn't necessary.
+   *
+   * @param reason - Reason for the refresh (for logging)
+   * @returns Result of the operation
+   */
+  async refreshActiveQueries(reason: string = "manual_refresh"): Promise<CacheOperationResult> {
+    const startTime = performance.now();
+
+    console.log(`[CacheManager] Refreshing active queries: ${reason}`);
+
+    try {
+      await this.client.refetchQueries({
+        include: "active",
+      });
+
+      const duration = performance.now() - startTime;
+      console.log(
+        `[CacheManager] Active queries refreshed in ${duration.toFixed(1)}ms`
+      );
+
+      return {
+        success: true,
+        message: `Active queries refreshed: ${reason}`,
+        duration,
+      };
+    } catch (error) {
+      const duration = performance.now() - startTime;
+      console.error("[CacheManager] Error refreshing queries:", error);
+
+      return {
+        success: false,
+        message: `Query refresh failed: ${error instanceof Error ? error.message : "Unknown error"}`,
+        duration,
+      };
+    }
+  }
+
+  // ==========================================================================
+  // Targeted Cache Invalidation
+  // ==========================================================================
+
+  /**
+   * Invalidates cache entries related to a specific entity type.
+   *
+   * This provides surgical cache invalidation for CRUD operations,
+   * avoiding the overhead of a full cache reset.
+   *
+   * Entity-specific behavior:
+   * - **document**: Refetches GET_DOCUMENTS, GET_CORPUS_FOLDERS
+   * - **corpus**: Refetches GET_CORPUSES
+   * - **annotation**: Refetches annotations for the specified document/corpus
+   * - **thread**: Refetches conversation threads for the specified document/corpus
+   *
+   * @param options - Configuration for the invalidation
+   * @returns Result of the operation
+   */
+  async invalidateEntityQueries(
+    options: InvalidationOptions
+  ): Promise<CacheOperationResult> {
+    const { entityType, corpusId, documentId, reason = "entity_change" } = options;
+    const startTime = performance.now();
+    const cacheKey = `${entityType}:${corpusId || ""}:${documentId || ""}`;
+
+    // Debounce: prevent rapid repeated invalidations for the same entity
+    const now = Date.now();
+    const lastTime = this.lastInvalidationTime.get(cacheKey) || 0;
+    if (now - lastTime < CacheManager.INVALIDATION_DEBOUNCE_MS) {
+      console.debug(
+        `[CacheManager] Skipping invalidation (debounced): ${cacheKey}`
+      );
+      return {
+        success: true,
+        message: "Invalidation skipped (debounced)",
+        duration: 0,
+      };
+    }
+    this.lastInvalidationTime.set(cacheKey, now);
+
+    console.log(
+      `[CacheManager] Invalidating ${entityType} queries: ${reason}`
+    );
+
+    try {
+      const queriesToRefetch = this.getQueriesToRefetch(entityType, {
+        corpusId,
+        documentId,
+      });
+
+      if (queriesToRefetch.length === 0) {
+        console.debug("[CacheManager] No queries to refetch for entity type:", entityType);
+        return {
+          success: true,
+          message: "No queries to refetch",
+          duration: 0,
+        };
+      }
+
+      await this.client.refetchQueries({
+        include: queriesToRefetch,
+      });
+
+      const duration = performance.now() - startTime;
+      console.log(
+        `[CacheManager] Invalidated ${queriesToRefetch.length} queries in ${duration.toFixed(1)}ms`
+      );
+
+      return {
+        success: true,
+        message: `Invalidated ${entityType} queries: ${reason}`,
+        duration,
+      };
+    } catch (error) {
+      const duration = performance.now() - startTime;
+      console.error("[CacheManager] Error invalidating queries:", error);
+
+      return {
+        success: false,
+        message: `Invalidation failed: ${error instanceof Error ? error.message : "Unknown error"}`,
+        duration,
+      };
+    }
+  }
+
+  /**
+   * Invalidates queries related to document operations.
+   *
+   * Convenience method for document CRUD operations.
+   *
+   * @param corpusId - Optional corpus ID to scope the invalidation
+   * @param reason - Reason for the invalidation
+   */
+  async invalidateDocumentQueries(
+    corpusId?: string,
+    reason: string = "document_change"
+  ): Promise<CacheOperationResult> {
+    return this.invalidateEntityQueries({
+      entityType: "document",
+      corpusId,
+      reason,
+    });
+  }
+
+  /**
+   * Invalidates queries related to corpus operations.
+   *
+   * Convenience method for corpus CRUD operations.
+   *
+   * @param reason - Reason for the invalidation
+   */
+  async invalidateCorpusQueries(
+    reason: string = "corpus_change"
+  ): Promise<CacheOperationResult> {
+    return this.invalidateEntityQueries({
+      entityType: "corpus",
+      reason,
+    });
+  }
+
+  // ==========================================================================
+  // Private Helpers
+  // ==========================================================================
+
+  /**
+   * Determines which queries should be refetched based on entity type.
+   *
+   * @param entityType - The type of entity being modified
+   * @param context - Additional context for scoping the queries
+   * @returns Array of query document nodes to refetch
+   */
+  private getQueriesToRefetch(
+    entityType: InvalidatableEntity,
+    context: { corpusId?: string; documentId?: string }
+  ): Array<ReturnType<typeof GET_DOCUMENTS> | ReturnType<typeof GET_CORPUSES>> {
+    switch (entityType) {
+      case "document":
+        // Document changes affect document lists and folder contents
+        return [GET_DOCUMENTS, GET_CORPUS_FOLDERS];
+
+      case "corpus":
+        // Corpus changes affect corpus lists
+        return [GET_CORPUSES];
+
+      case "annotation":
+        // Annotation changes are typically handled by the mutation's refetchQueries
+        // But if we need to manually invalidate, refetch document-related queries
+        return [GET_DOCUMENTS];
+
+      case "thread":
+        // Thread changes are typically handled by mutation refetchQueries
+        // This is a fallback for manual invalidation
+        return [];
+
+      default:
+        console.warn(`[CacheManager] Unknown entity type: ${entityType}`);
+        return [];
+    }
+  }
+
+  // ==========================================================================
+  // Cache State Inspection (for debugging)
+  // ==========================================================================
+
+  /**
+   * Returns the current cache contents for debugging purposes.
+   *
+   * @returns Extracted cache data
+   */
+  extractCacheForDebug(): Record<string, unknown> {
+    try {
+      return this.client.cache.extract();
+    } catch (error) {
+      console.error("[CacheManager] Error extracting cache:", error);
+      return {};
+    }
+  }
+
+  /**
+   * Logs the current cache size for debugging.
+   */
+  logCacheSize(): void {
+    try {
+      const cache = this.client.cache.extract();
+      const cacheString = JSON.stringify(cache);
+      const sizeKB = (cacheString.length / 1024).toFixed(2);
+      const entryCount = Object.keys(cache).length;
+
+      console.log(
+        `[CacheManager] Cache: ${entryCount} entries, ${sizeKB} KB`
+      );
+    } catch (error) {
+      console.error("[CacheManager] Error logging cache size:", error);
+    }
+  }
+}
+
+// ============================================================================
+// Singleton Instance and Hook
+// ============================================================================
+
+let cacheManagerInstance: CacheManager | null = null;
+
+/**
+ * Initializes the CacheManager singleton with an Apollo Client.
+ *
+ * This should be called once during app initialization, typically in App.tsx.
+ *
+ * @param client - The Apollo Client instance
+ */
+export function initializeCacheManager(
+  client: ApolloClient<NormalizedCacheObject>
+): CacheManager {
+  if (cacheManagerInstance) {
+    console.warn("[CacheManager] Already initialized, returning existing instance");
+    return cacheManagerInstance;
+  }
+
+  cacheManagerInstance = new CacheManager(client);
+  console.log("[CacheManager] Initialized");
+  return cacheManagerInstance;
+}
+
+/**
+ * Gets the CacheManager singleton instance.
+ *
+ * @throws Error if CacheManager has not been initialized
+ */
+export function getCacheManager(): CacheManager {
+  if (!cacheManagerInstance) {
+    throw new Error(
+      "[CacheManager] Not initialized. Call initializeCacheManager() first."
+    );
+  }
+  return cacheManagerInstance;
+}
+
+/**
+ * Checks if the CacheManager has been initialized.
+ */
+export function isCacheManagerInitialized(): boolean {
+  return cacheManagerInstance !== null;
+}
+
+/**
+ * Resets the CacheManager singleton (primarily for testing).
+ */
+export function resetCacheManagerForTesting(): void {
+  cacheManagerInstance = null;
+}
+
+export default CacheManager;

--- a/frontend/src/services/cacheManager.ts
+++ b/frontend/src/services/cacheManager.ts
@@ -106,9 +106,50 @@ export class CacheManager {
   private static readonly RESET_DEBOUNCE_MS = 1000;
   /** Minimum time (ms) between same-type invalidations */
   private static readonly INVALIDATION_DEBOUNCE_MS = 500;
+  /** Maximum entries in lastInvalidationTime to prevent memory leak */
+  private static readonly MAX_INVALIDATION_ENTRIES = 100;
+  /** Entries older than this (ms) are eligible for cleanup */
+  private static readonly INVALIDATION_ENTRY_TTL_MS = 60000;
 
   constructor(client: ApolloClient<NormalizedCacheObject>) {
     this.client = client;
+  }
+
+  // ==========================================================================
+  // Private Helpers - Debounce Map Cleanup
+  // ==========================================================================
+
+  /**
+   * Cleans up stale entries from the invalidation debounce map to prevent memory leaks.
+   * Called automatically when new entries are added.
+   *
+   * Cleanup strategy:
+   * 1. Remove entries older than TTL (they can't affect debouncing anyway)
+   * 2. If still over max size, remove oldest entries until under limit
+   */
+  private cleanupInvalidationMap(): void {
+    const now = Date.now();
+
+    // First pass: remove entries older than TTL
+    for (const [key, timestamp] of this.lastInvalidationTime) {
+      if (now - timestamp > CacheManager.INVALIDATION_ENTRY_TTL_MS) {
+        this.lastInvalidationTime.delete(key);
+      }
+    }
+
+    // Second pass: if still over limit, remove oldest entries
+    if (
+      this.lastInvalidationTime.size > CacheManager.MAX_INVALIDATION_ENTRIES
+    ) {
+      const entries = Array.from(this.lastInvalidationTime.entries());
+      entries.sort((a, b) => a[1] - b[1]); // Sort by timestamp ascending (oldest first)
+
+      const entriesToRemove =
+        entries.length - CacheManager.MAX_INVALIDATION_ENTRIES;
+      for (let i = 0; i < entriesToRemove; i++) {
+        this.lastInvalidationTime.delete(entries[i][0]);
+      }
+    }
   }
 
   // ==========================================================================
@@ -274,6 +315,7 @@ export class CacheManager {
       };
     }
     this.lastInvalidationTime.set(cacheKey, now);
+    this.cleanupInvalidationMap(); // Prevent unbounded map growth
 
     console.log(`[CacheManager] Invalidating ${entityType} queries: ${reason}`);
 
@@ -377,7 +419,10 @@ export class CacheManager {
   ): DocumentNode[] {
     switch (entityType) {
       case "document":
-        // Document changes affect document lists and folder contents
+        // Document changes affect document lists and folder contents.
+        // NOTE: This refetches ALL documents and corpus folders globally.
+        // Future optimization: use corpusId/documentId from context to scope
+        // refetches with query variables for large corpora.
         return [GET_DOCUMENTS, GET_CORPUS_FOLDERS];
 
       case "corpus":

--- a/frontend/src/views/Login.tsx
+++ b/frontend/src/views/Login.tsx
@@ -11,6 +11,7 @@ import {
 import { toast } from "react-toastify";
 import { User, Lock } from "lucide-react";
 import logo from "../assets/images/os_legal_128_regular.png";
+import { useCacheManager } from "../hooks/useCacheManager";
 
 const PageWrapper = styled.div`
   width: 100vw;
@@ -98,10 +99,15 @@ export const Login = () => {
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const navigate = useNavigate();
+  const { resetOnAuthChange } = useCacheManager();
 
   const [tryLogin, { loading: login_loading, error: login_error }] =
     useMutation<LoginOutputs, LoginInputs>(LOGIN_MUTATION, {
-      onCompleted: (data) => {
+      onCompleted: async (data) => {
+        // Clear cache before setting new auth state to ensure fresh data
+        // This prevents stale data from anonymous/previous user session
+        await resetOnAuthChange({ reason: "user_login", refetchActive: false });
+
         authToken(data.tokenAuth.token);
         userObj(data.tokenAuth.user);
         authStatusVar("AUTHENTICATED");

--- a/frontend/src/views/Login.tsx
+++ b/frontend/src/views/Login.tsx
@@ -104,13 +104,15 @@ export const Login = () => {
   const [tryLogin, { loading: login_loading, error: login_error }] =
     useMutation<LoginOutputs, LoginInputs>(LOGIN_MUTATION, {
       onCompleted: async (data) => {
-        // Clear cache before setting new auth state to ensure fresh data
-        // This prevents stale data from anonymous/previous user session
-        await resetOnAuthChange({ reason: "user_login", refetchActive: false });
-
+        // Set auth state FIRST - ensures any subsequent queries use the new
+        // auth context. This prevents race condition where cache clear might
+        // trigger queries with the old (anonymous) auth state.
         authToken(data.tokenAuth.token);
         userObj(data.tokenAuth.user);
         authStatusVar("AUTHENTICATED");
+
+        // Now clear cache - refetched queries will use new auth context
+        await resetOnAuthChange({ reason: "user_login", refetchActive: false });
         navigate("/");
       },
     });


### PR DESCRIPTION
Implements cache management to address Apollo cache stale data issues (closes #694).

Key changes:
- Add CacheManager service with debounced cache reset and targeted invalidation
- Add useCacheManager hook for React components
- Clear cache on login (both Auth0 and non-Auth0 modes) to remove stale anonymous data
- Clear cache on logout for security and data freshness
- Add comprehensive tests with human-readable scenario descriptions

The CacheManager provides:
- resetOnAuthChange() - full cache clear with optional active query refetch
- refreshActiveQueries() - soft refresh without cache clear
- invalidateEntityQueries() - targeted invalidation for document/corpus CRUD
- Debouncing to prevent rapid repeated operations
- Error handling with meaningful result objects

Files added:
- frontend/src/services/cacheManager.ts - Core cache management service
- frontend/src/hooks/useCacheManager.ts - React hook for cache operations
- frontend/src/services/__tests__/cacheManager.test.ts - Unit tests
- frontend/src/hooks/__tests__/useCacheManager.test.tsx - Hook tests

Files modified:
- frontend/src/components/auth/AuthGate.tsx - Add cache reset on Auth0 login
- frontend/src/components/layout/useNavMenu.ts - Add cache reset on logout
- frontend/src/views/Login.tsx - Add cache reset on non-Auth0 login