### PR TITLE
Fix telemetry not firing due to missing Installation record

### DIFF
--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -113,4 +113,6 @@ STATICFILES_STORAGE = "django.contrib.staticfiles.storage.StaticFilesStorage"
 
 # Telemetry
 # ------------------------------------------------------------------------------
+# Explicitly disable telemetry in tests to prevent polluting PostHog with test data
 MODE = "TEST"
+TELEMETRY_ENABLED = False

--- a/opencontractserver/users/migrations/0022_create_installation_record.py
+++ b/opencontractserver/users/migrations/0022_create_installation_record.py
@@ -1,0 +1,27 @@
+# Data migration to create the Installation singleton record for telemetry
+
+from django.db import migrations
+
+
+def create_installation(apps, schema_editor):
+    """Create the Installation singleton if it doesn't exist."""
+    Installation = apps.get_model("users", "Installation")
+    if not Installation.objects.exists():
+        Installation.objects.create()
+
+
+def reverse_installation(apps, schema_editor):
+    """Remove the Installation record (reversible migration)."""
+    Installation = apps.get_model("users", "Installation")
+    Installation.objects.all().delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("users", "0021_alter_userimport_backend_lock"),
+    ]
+
+    operations = [
+        migrations.RunPython(create_installation, reverse_code=reverse_installation),
+    ]


### PR DESCRIPTION
## Summary

- Adds a data migration to create the Installation singleton record required for telemetry to function
- Explicitly disables telemetry in test settings to prevent polluting PostHog with test data

## Background

The telemetry system relies on the `Installation` model to track the installation ID, but no migration existed to create this singleton record. Without it, telemetry calls would fail silently.

## Test plan

- [x] Verify migration creates Installation record on fresh databases
- [x] Verify migration is reversible
- [ ] Deploy and confirm telemetry events appear in PostHog