### PR TITLE
fix: Improve Corpus Modal mobile experience and loading performance

### DIFF
--- a/frontend/src/components/corpuses/CorpusModal.tsx
+++ b/frontend/src/components/corpuses/CorpusModal.tsx
@@ -90,9 +90,9 @@ const ModalBody = styled.div`
   overflow-y: auto;
 
   @media (max-width: 768px) {
-    padding: 1.25rem;
+    padding: 1rem;
     /* Add extra bottom padding so content (including dropdowns) can scroll above sticky footer */
-    padding-bottom: 200px;
+    padding-bottom: 160px;
     max-height: calc(100vh - 80px);
     /* Smooth scrolling on iOS */
     -webkit-overflow-scrolling: touch;
@@ -114,8 +114,8 @@ const FormSection = styled.div`
   border: 1px solid #e5e5e5;
 
   @media (max-width: 768px) {
-    padding: 1rem;
-    margin-bottom: 1rem;
+    padding: 0.875rem;
+    margin-bottom: 0.75rem;
     border-radius: 10px;
   }
 
@@ -136,8 +136,9 @@ const SectionTitle = styled.h3`
   gap: 0.5rem;
 
   @media (max-width: 768px) {
-    font-size: 0.8rem;
-    margin-bottom: 0.75rem;
+    font-size: 0.75rem;
+    margin-bottom: 0.5rem;
+    gap: 0.375rem;
   }
 `;
 
@@ -149,7 +150,7 @@ const FormField = styled.div`
   }
 
   @media (max-width: 768px) {
-    margin-bottom: 1rem;
+    margin-bottom: 0.75rem;
   }
 `;
 
@@ -325,11 +326,11 @@ const SubmitButton = styled(Button)`
 `;
 
 const IconUploadWrapper = styled.div`
-  max-width: 280px;
+  max-width: 200px;
   margin: 0 auto;
 
   @media (max-width: 768px) {
-    max-width: 150px;
+    max-width: 120px;
   }
 `;
 

--- a/frontend/src/components/widgets/CRUD/EmbedderSelector.tsx
+++ b/frontend/src/components/widgets/CRUD/EmbedderSelector.tsx
@@ -1,19 +1,42 @@
-import { useEffect } from "react";
 import { useQuery } from "@apollo/client";
-import {
-  Header,
-  Segment,
-  Loader,
-  Dimmer,
-  Dropdown,
-  Message,
-} from "semantic-ui-react";
+import { Header, Segment, Dropdown, Message } from "semantic-ui-react";
+import styled from "styled-components";
 import {
   GetEmbeddersInput,
   GetEmbeddersOutput,
   GET_EMBEDDERS,
 } from "../../../graphql/queries";
 import { PipelineComponentType } from "../../../types/graphql-api";
+
+// Mobile-responsive wrapper for EmbedderSelector
+const MobileFriendlyWrapper = styled.div`
+  width: 100%;
+
+  @media (max-width: 768px) {
+    /* Ensure dropdown has adequate touch target size */
+    .ui.dropdown {
+      min-height: 44px; /* iOS minimum touch target */
+      font-size: 16px; /* Prevents iOS zoom on focus */
+    }
+
+    /* Make header text readable on mobile */
+    h5.ui.header {
+      font-size: 1rem;
+      padding: 0.75rem 1rem;
+    }
+
+    /* Add padding to segment for better mobile spacing */
+    .ui.segment {
+      padding: 1rem;
+    }
+
+    /* Ensure dropdown options are large enough to tap */
+    .ui.dropdown .menu > .item {
+      padding: 0.875rem 1rem !important;
+      min-height: 44px;
+    }
+  }
+`;
 
 interface EmbedderSelectorProps {
   read_only?: boolean;
@@ -76,15 +99,11 @@ export const EmbedderSelector = ({
   }));
 
   return (
-    <div style={{ width: "100%" }}>
+    <MobileFriendlyWrapper>
       <Header as="h5" attached="top">
         Preferred Embedder:
       </Header>
       <Segment attached>
-        <Dimmer active={loading} inverted>
-          <Loader content="Loading embedders..." />
-        </Dimmer>
-
         {error && (
           <Message negative compact size="tiny">
             <Message.Header>Failed to load embedders</Message.Header>
@@ -100,7 +119,7 @@ export const EmbedderSelector = ({
         )}
 
         <Dropdown
-          disabled={read_only || loading || !hasEmbedders}
+          disabled={read_only || (!loading && !hasEmbedders)}
           selection
           clearable
           fluid
@@ -115,6 +134,6 @@ export const EmbedderSelector = ({
           loading={loading}
         />
       </Segment>
-    </div>
+    </MobileFriendlyWrapper>
   );
 };

--- a/frontend/src/components/widgets/file-controls/FilePreviewAndUpload.tsx
+++ b/frontend/src/components/widgets/file-controls/FilePreviewAndUpload.tsx
@@ -52,8 +52,8 @@ const ImagePreview = styled.img`
   display: block;
 
   @media (max-width: 768px) {
-    height: 100px;
-    padding: 0.5rem;
+    height: 80px;
+    padding: 0.375rem;
   }
 `;
 


### PR DESCRIPTION
Addresses issue #702 with three improvements:

1. Mobile layout: Reduced icon size, padding, and margins for a less
   cramped experience on mobile devices. Icon wrapper reduced from
   280px/150px to 200px/120px, form sections now have tighter spacing.

2. Embedder loading: Removed blocking Dimmer overlay and improved the
   loading state. Dropdown now shows inline loading indicator while
   remaining interactive. Added mobile-friendly touch targets and
   font sizes to prevent iOS zoom on focus.

3. Field data retention: The existing prevOpenRef implementation
   already correctly prevents field clearing on mobile focus changes.

Files changed:
- CorpusModal.tsx: Reduced mobile padding and icon area sizes
- EmbedderSelector.tsx: Removed Dimmer, added mobile-friendly wrapper
- FilePreviewAndUpload.tsx: Reduced image preview height on mobile