### PR TITLE
feat: Add PDF token extraction for LlamaParse annotations

### DIFF
--- a/opencontractserver/pipeline/parsers/llamaparse_parser.py
+++ b/opencontractserver/pipeline/parsers/llamaparse_parser.py
@@ -3,6 +3,10 @@ LlamaParse Parser for OpenContracts.
 
 This parser uses the LlamaParse API (from LlamaIndex) to parse PDF documents
 and extract structural annotations with bounding boxes.
+
+Token extraction is performed using pdfplumber to enable word-level highlighting
+in the frontend. The token extraction and bbox intersection logic is based on
+the Docsling microservice implementation.
 """
 
 import logging
@@ -24,6 +28,11 @@ from opencontractserver.types.dicts import (
     OpenContractsSinglePageAnnotationType,
     PawlsPagePythonType,
     PawlsTokenPythonType,
+    TokenIdPythonType,
+)
+from opencontractserver.utils.pdf_token_extraction import (
+    extract_pawls_tokens_from_pdf,
+    find_tokens_in_bbox,
 )
 
 logger = logging.getLogger(__name__)
@@ -199,8 +208,9 @@ class LlamaParseParser(BaseParser):
                         return None
 
                     # Convert to OpenContracts format
+                    # Pass doc_bytes for token extraction
                     return self._convert_json_to_opencontracts(
-                        document, json_results, extract_layout
+                        document, json_results, extract_layout, doc_bytes
                     )
                 else:
                     # For markdown/text output, use load_data
@@ -236,6 +246,7 @@ class LlamaParseParser(BaseParser):
         document: Document,
         json_results: list[dict[str, Any]],
         extract_layout: bool = True,
+        pdf_bytes: Optional[bytes] = None,
     ) -> OpenContractDocExport:
         """
         Convert LlamaParse JSON results to OpenContracts format.
@@ -244,6 +255,8 @@ class LlamaParseParser(BaseParser):
             document: The Document model instance.
             json_results: List of JSON results from LlamaParse.
             extract_layout: Whether layout data with bounding boxes is included.
+            pdf_bytes: Raw PDF bytes for token extraction. If provided, tokens
+                      will be extracted and mapped to annotation bounding boxes.
 
         Returns:
             OpenContractDocExport with parsed data.
@@ -252,14 +265,16 @@ class LlamaParseParser(BaseParser):
         result = json_results[0] if json_results else {}
         pages = result.get("pages", [])
 
-        # Build the full text content
+        # Build the full text content and collect page dimensions
         full_text_parts = []
-        pawls_pages: list[PawlsPagePythonType] = []
         annotations: list[OpenContractsAnnotationPythonType] = []
+        page_dimensions: dict[int, tuple[float, float]] = {}
 
-        # Track annotation IDs
-        annotation_id_counter = 0
+        # Default page dimensions
+        DEFAULT_WIDTH = 612
+        DEFAULT_HEIGHT = 792
 
+        # First pass: collect page dimensions from LlamaParse
         for page_idx, page in enumerate(pages):
             page_text = page.get("text", "")
             full_text_parts.append(page_text)
@@ -269,11 +284,7 @@ class LlamaParseParser(BaseParser):
                 page_keys = list(page.keys())
                 logger.info(f"DEBUG: Page keys: {page_keys}")
 
-            # Get page dimensions (default to standard US Letter size in points: 8.5" x 11")
-            # Note: A4 size would be 595 x 842 points
-            # LlamaParse may use different key names for dimensions
-            DEFAULT_WIDTH = 612
-            DEFAULT_HEIGHT = 792
+            # Get page dimensions
             page_width = page.get("width", page.get("w", page.get("pageWidth")))
             page_height = page.get("height", page.get("h", page.get("pageHeight")))
 
@@ -289,29 +300,76 @@ class LlamaParseParser(BaseParser):
                     f"Page {page_idx} has invalid height, using default: {page_height}"
                 )
 
-            # Create PAWLS page structure
-            pawls_page: PawlsPagePythonType = {
-                "page": {
-                    "width": page_width,
-                    "height": page_height,
-                    "index": page_idx,
-                },
-                "tokens": [],
-            }
+            page_dimensions[page_idx] = (float(page_width), float(page_height))
+
+        # Extract tokens from PDF if bytes are provided
+        pawls_pages: list[PawlsPagePythonType] = []
+        spatial_indices = {}
+        tokens_by_page = {}
+        token_indices_by_page = {}
+        extracted_page_dims = {}
+
+        if pdf_bytes:
+            try:
+                logger.info("Extracting tokens from PDF for annotation mapping...")
+                (
+                    pawls_pages,
+                    spatial_indices,
+                    tokens_by_page,
+                    token_indices_by_page,
+                    extracted_page_dims,
+                    _,  # content - we already have it from LlamaParse
+                ) = extract_pawls_tokens_from_pdf(pdf_bytes, page_dimensions)
+                logger.info(
+                    f"Extracted tokens from {len(pawls_pages)} pages. "
+                    f"Token counts: {[len(p.get('tokens', [])) for p in pawls_pages]}"
+                )
+            except Exception as e:
+                logger.warning(
+                    f"Failed to extract tokens from PDF: {e}. "
+                    "Annotations will have empty tokensJsons."
+                )
+                # Fall back to empty PAWLS pages
+                pawls_pages = []
+                spatial_indices = {}
+                tokens_by_page = {}
+                token_indices_by_page = {}
+
+        # If token extraction failed or wasn't attempted, create empty PAWLS pages
+        if not pawls_pages:
+            for page_idx in range(len(pages)):
+                width, height = page_dimensions.get(
+                    page_idx, (DEFAULT_WIDTH, DEFAULT_HEIGHT)
+                )
+                pawls_page: PawlsPagePythonType = {
+                    "page": {
+                        "width": width,
+                        "height": height,
+                        "index": page_idx,
+                    },
+                    "tokens": [],
+                }
+                pawls_pages.append(pawls_page)
+
+        # Track annotation IDs
+        annotation_id_counter = 0
+
+        # Second pass: process items and create annotations with token references
+        for page_idx, page in enumerate(pages):
+            page_width, page_height = page_dimensions.get(
+                page_idx, (DEFAULT_WIDTH, DEFAULT_HEIGHT)
+            )
 
             # Extract layout elements if available
             layout_elements = page.get("layout", []) if extract_layout else []
             items = page.get("items", [])
 
-            # Process items (elements with text and positions)
             # Debug: Log first few items to understand bbox format
             if page_idx == 0 and items:
                 logger.info(f"DEBUG: Page dimensions: {page_width}x{page_height}")
-                # Log full structure of first item for debugging
                 if items:
                     logger.info(f"DEBUG: Full first item structure: {items[0]}")
                 for i, debug_item in enumerate(items[:3]):
-                    # Check all possible bbox key names
                     bbox_val = debug_item.get(
                         "bBox",
                         debug_item.get("bbox", debug_item.get("bounding_box", "NONE")),
@@ -325,22 +383,30 @@ class LlamaParseParser(BaseParser):
             for item in items:
                 item_text = item.get("text", "") or item.get("value", "")
                 item_type = item.get("type", "text").lower()
-                # LlamaParse uses 'bBox' (camelCase), also check 'bbox' and 'bounding_box'
                 bbox = item.get("bBox", item.get("bbox", item.get("bounding_box", {})))
 
                 if not item_text.strip():
                     continue
 
-                # Parse bbox to get bounds (no tokens - LlamaParse doesn't provide them)
+                # Parse bbox to get bounds
                 _, bounds = self._create_pawls_tokens_from_bbox(
                     item_text,
                     bbox,
                     page_width,
                     page_height,
-                    annotation_id_counter,  # Just used for debug logging
+                    annotation_id_counter,
                 )
 
-                # Create annotation for this element
+                # Find tokens that intersect with this annotation's bounding box
+                token_refs = find_tokens_in_bbox(
+                    bounds,
+                    page_idx,
+                    spatial_indices.get(page_idx),
+                    token_indices_by_page.get(page_idx),
+                    tokens_by_page.get(page_idx),
+                )
+
+                # Create annotation with token references
                 label = self.ELEMENT_TYPE_MAPPING.get(item_type, "Text Block")
                 annotation = self._create_annotation(
                     annotation_id=str(annotation_id_counter),
@@ -348,6 +414,7 @@ class LlamaParseParser(BaseParser):
                     raw_text=item_text,
                     page_idx=page_idx,
                     bounds=bounds,
+                    token_refs=token_refs,
                 )
                 annotations.append(annotation)
                 annotation_id_counter += 1
@@ -356,7 +423,6 @@ class LlamaParseParser(BaseParser):
             if not items and layout_elements:
                 for element in layout_elements:
                     element_type = element.get("label", "text").lower()
-                    # Check all possible bbox key names (bBox, bbox, bounding_box)
                     bbox = element.get(
                         "bBox", element.get("bbox", element.get("bounding_box", {}))
                     )
@@ -365,13 +431,21 @@ class LlamaParseParser(BaseParser):
                     if not element_text and element_type not in ["figure", "image"]:
                         continue
 
-                    # Parse bbox to get bounds (no tokens - LlamaParse doesn't provide them)
                     _, bounds = self._create_pawls_tokens_from_bbox(
                         element_text or f"[{element_type}]",
                         bbox,
                         page_width,
                         page_height,
-                        annotation_id_counter,  # Just used for debug logging
+                        annotation_id_counter,
+                    )
+
+                    # Find tokens that intersect with this annotation's bounding box
+                    token_refs = find_tokens_in_bbox(
+                        bounds,
+                        page_idx,
+                        spatial_indices.get(page_idx),
+                        token_indices_by_page.get(page_idx),
+                        tokens_by_page.get(page_idx),
                     )
 
                     label = self.ELEMENT_TYPE_MAPPING.get(element_type, "Text Block")
@@ -381,11 +455,10 @@ class LlamaParseParser(BaseParser):
                         raw_text=element_text or f"[{element_type}]",
                         page_idx=page_idx,
                         bounds=bounds,
+                        token_refs=token_refs,
                     )
                     annotations.append(annotation)
                     annotation_id_counter += 1
-
-            pawls_pages.append(pawls_page)
 
         # Combine all text
         full_text = "\n\n".join(full_text_parts)
@@ -402,9 +475,19 @@ class LlamaParseParser(BaseParser):
             "relationships": [],
         }
 
+        # Log summary
+        total_tokens = sum(len(p.get("tokens", [])) for p in pawls_pages)
+        annotations_with_tokens = sum(
+            1
+            for a in annotations
+            if a.get("annotation_json", {})
+            .get(str(a.get("page", 0)), {})
+            .get("tokensJsons")
+        )
         logger.info(
             f"Converted LlamaParse output: {len(pages)} pages, "
-            f"{len(annotations)} annotations"
+            f"{len(annotations)} annotations, {total_tokens} tokens, "
+            f"{annotations_with_tokens} annotations with token references"
         )
 
         return export
@@ -624,6 +707,7 @@ class LlamaParseParser(BaseParser):
         raw_text: str,
         page_idx: int,
         bounds: BoundingBoxPythonType,
+        token_refs: Optional[list[TokenIdPythonType]] = None,
     ) -> OpenContractsAnnotationPythonType:
         """
         Create an OpenContracts annotation.
@@ -634,18 +718,20 @@ class LlamaParseParser(BaseParser):
             raw_text: The text content.
             page_idx: Page index (0-based).
             bounds: Bounding box.
+            token_refs: Optional list of token references ({pageIndex, tokenIndex})
+                       that fall within the annotation's bounding box. If None or
+                       empty, the annotation will have an empty tokensJsons array.
 
         Returns:
             OpenContractsAnnotationPythonType annotation.
         """
-        # NOTE: We use empty tokensJsons because LlamaParse only provides element-level
-        # bounding boxes, not token-level data. The frontend handles this gracefully
-        # by showing just the bounding box without individual token highlights.
+        # Use provided token references, or empty list if none provided
+        tokens_jsons = token_refs if token_refs else []
 
-        # Create page annotation with empty token references
+        # Create page annotation with token references
         page_annotation: OpenContractsSinglePageAnnotationType = {
             "bounds": bounds,
-            "tokensJsons": [],  # Empty - no token data from LlamaParse
+            "tokensJsons": tokens_jsons,
             "rawText": raw_text,
         }
 

--- a/opencontractserver/tests/test_doc_parser_llamaparse.py
+++ b/opencontractserver/tests/test_doc_parser_llamaparse.py
@@ -4,18 +4,19 @@ Tests for the LlamaParseParser class.
 Tests cover:
 - Successful document parsing with JSON/layout output
 - Bounding box parsing and conversion
-- Structural annotation creation (without token-level data)
+- Structural annotation creation with token-level data
 - Error handling (missing API key, API errors, etc.)
 - Configuration via environment variables
 
-Note: LlamaParse only provides element-level bounding boxes, not token-level data.
-Annotations are created with empty tokensJsons - the frontend handles this gracefully
-by showing just the bounding box outline without individual token highlights.
+Note: LlamaParse provides element-level bounding boxes, and the parser uses
+pdfplumber to extract word-level tokens from the PDF. These tokens are then
+mapped to annotations using spatial intersection (shapely STRtree).
 """
 
 import sys
 from unittest.mock import MagicMock, patch
 
+import numpy as np
 from django.contrib.auth import get_user_model
 from django.core.files.base import ContentFile
 from django.db import transaction
@@ -30,6 +31,60 @@ User = get_user_model()
 mock_llama_parse = MagicMock()
 mock_llama_parse.LlamaParse = MagicMock()
 sys.modules["llama_parse"] = mock_llama_parse
+
+
+def create_mock_token_extraction_result(page_count=1, tokens_per_page=5):
+    """
+    Create mock token extraction result for testing.
+
+    Returns a tuple matching the signature of extract_pawls_tokens_from_pdf:
+    (pawls_pages, spatial_indices, tokens_by_page, token_indices_by_page,
+     page_dims, content)
+    """
+    pawls_pages = []
+    spatial_indices = {}
+    tokens_by_page = {}
+    token_indices_by_page = {}
+    page_dims = {}
+
+    for page_idx in range(page_count):
+        # Create mock tokens for this page
+        tokens = []
+        for i in range(tokens_per_page):
+            tokens.append(
+                {
+                    "x": 100 + (i * 60),
+                    "y": 100,
+                    "width": 50,
+                    "height": 20,
+                    "text": f"word{i}",
+                }
+            )
+
+        pawls_pages.append(
+            {
+                "page": {"width": 612, "height": 792, "index": page_idx},
+                "tokens": tokens,
+            }
+        )
+
+        # Create mock spatial index (MagicMock since we don't need real STRtree)
+        spatial_indices[page_idx] = MagicMock()
+        tokens_by_page[page_idx] = tokens
+        token_indices_by_page[page_idx] = np.array(
+            list(range(len(tokens))), dtype=np.intp
+        )
+        page_dims[page_idx] = (612.0, 792.0)
+
+    content = " ".join([f"word{i}" for i in range(tokens_per_page)])
+    return (
+        pawls_pages,
+        spatial_indices,
+        tokens_by_page,
+        token_indices_by_page,
+        page_dims,
+        content,
+    )
 
 
 class MockLlamaDocument:
@@ -138,12 +193,16 @@ class TestLlamaParseParser(TestCase):
         ]
 
     @override_settings(LLAMAPARSE_API_KEY="test-api-key-123")
+    @patch("opencontractserver.pipeline.parsers.llamaparse_parser.find_tokens_in_bbox")
+    @patch(
+        "opencontractserver.pipeline.parsers.llamaparse_parser.extract_pawls_tokens_from_pdf"
+    )
     @patch("llama_parse.LlamaParse")
     @patch("opencontractserver.pipeline.parsers.llamaparse_parser.default_storage.open")
     def test_parse_document_success_with_layout(
-        self, mock_open, mock_llama_parse_class
+        self, mock_open, mock_llama_parse_class, mock_extract_tokens, mock_find_tokens
     ):
-        """Test successful document parsing with layout extraction."""
+        """Test successful document parsing with layout extraction and token mapping."""
         # Mock file reading
         mock_file = MagicMock()
         mock_file.read.return_value = b"mock pdf content"
@@ -154,6 +213,17 @@ class TestLlamaParseParser(TestCase):
         mock_parser.get_json_result.return_value = self.sample_json_response
         mock_llama_parse_class.return_value = mock_parser
 
+        # Mock token extraction
+        mock_extract_tokens.return_value = create_mock_token_extraction_result(
+            page_count=2, tokens_per_page=5
+        )
+
+        # Mock find_tokens_in_bbox to return some token references
+        mock_find_tokens.return_value = [
+            {"pageIndex": 0, "tokenIndex": 0},
+            {"pageIndex": 0, "tokenIndex": 1},
+        ]
+
         # Create parser and parse document
         parser = LlamaParseParser()
         result = parser.parse_document(user_id=self.user.id, doc_id=self.doc.id)
@@ -163,17 +233,17 @@ class TestLlamaParseParser(TestCase):
         self.assertEqual(result["title"], "Test LlamaParse Document")
         self.assertEqual(result["page_count"], 2)
 
-        # Verify PAWLS content was generated
+        # Verify PAWLS content was generated with tokens
         self.assertIn("pawls_file_content", result)
         self.assertEqual(len(result["pawls_file_content"]), 2)
 
-        # Verify first page structure
+        # Verify first page structure - now has tokens from mock
         first_page = result["pawls_file_content"][0]
         self.assertEqual(first_page["page"]["index"], 0)
         self.assertEqual(first_page["page"]["width"], 612)
         self.assertEqual(first_page["page"]["height"], 792)
-        # LlamaParse doesn't provide token-level data, so tokens list is empty
-        self.assertEqual(len(first_page["tokens"]), 0)
+        # Tokens should now be populated from the mock
+        self.assertEqual(len(first_page["tokens"]), 5)
 
         # Verify annotations were created
         self.assertIn("labelled_text", result)
@@ -185,6 +255,11 @@ class TestLlamaParseParser(TestCase):
         self.assertEqual(first_annotation["structural"], True)
         self.assertEqual(first_annotation["annotation_type"], "TOKEN_LABEL")
         self.assertIn("annotation_json", first_annotation)
+
+        # Verify annotation has token references (from mock)
+        page_anno = first_annotation["annotation_json"]["0"]
+        self.assertEqual(len(page_anno["tokensJsons"]), 2)
+        self.assertEqual(page_anno["tokensJsons"][0], {"pageIndex": 0, "tokenIndex": 0})
 
     @override_settings(LLAMAPARSE_API_KEY="test-api-key-123")
     @patch("llama_parse.LlamaParse")
@@ -470,16 +545,15 @@ class TestLlamaParseParserBboxConversion(TestCase):
 class TestLlamaParseParserAnnotations(TestCase):
     """Tests for annotation creation methods.
 
-    Note: LlamaParse annotations use empty tokensJsons since LlamaParse
-    only provides element-level bounding boxes, not token-level data.
+    Annotations can now include tokensJsons when token extraction succeeds.
     """
 
     def setUp(self):
         """Set up test environment."""
         self.parser = LlamaParseParser()
 
-    def test_create_annotation_structure(self):
-        """Test annotation creation has correct structure."""
+    def test_create_annotation_structure_without_tokens(self):
+        """Test annotation creation has correct structure without token refs."""
         bounds = {"left": 100, "top": 100, "right": 300, "bottom": 150}
 
         annotation = self.parser._create_annotation(
@@ -504,8 +578,32 @@ class TestLlamaParseParserAnnotations(TestCase):
         page_anno = annotation["annotation_json"]["0"]
         self.assertEqual(page_anno["bounds"], bounds)
         self.assertEqual(page_anno["rawText"], "Sample Title")
-        # tokensJsons is empty - LlamaParse doesn't provide token-level data
+        # tokensJsons is empty when no token_refs provided
         self.assertEqual(len(page_anno["tokensJsons"]), 0)
+
+    def test_create_annotation_structure_with_tokens(self):
+        """Test annotation creation with token references."""
+        bounds = {"left": 100, "top": 100, "right": 300, "bottom": 150}
+        token_refs = [
+            {"pageIndex": 0, "tokenIndex": 0},
+            {"pageIndex": 0, "tokenIndex": 1},
+            {"pageIndex": 0, "tokenIndex": 2},
+        ]
+
+        annotation = self.parser._create_annotation(
+            annotation_id="anno-2",
+            label="Paragraph",
+            raw_text="Sample paragraph text",
+            page_idx=0,
+            bounds=bounds,
+            token_refs=token_refs,
+        )
+
+        # Check annotation_json structure includes tokens
+        page_anno = annotation["annotation_json"]["0"]
+        self.assertEqual(len(page_anno["tokensJsons"]), 3)
+        self.assertEqual(page_anno["tokensJsons"][0], {"pageIndex": 0, "tokenIndex": 0})
+        self.assertEqual(page_anno["tokensJsons"][2], {"pageIndex": 0, "tokenIndex": 2})
 
     def test_element_type_mapping(self):
         """Test that element types are properly mapped to labels."""
@@ -687,14 +785,18 @@ class TestLlamaParseParserLayoutOnlyProcessing(TestCase):
         ]
 
     @override_settings(LLAMAPARSE_API_KEY="test-api-key-123")
+    @patch("opencontractserver.pipeline.parsers.llamaparse_parser.find_tokens_in_bbox")
+    @patch(
+        "opencontractserver.pipeline.parsers.llamaparse_parser.extract_pawls_tokens_from_pdf"
+    )
     @patch("llama_parse.LlamaParse")
     @patch("opencontractserver.pipeline.parsers.llamaparse_parser.default_storage.open")
     def test_parse_document_layout_only_processing(
-        self, mock_open, mock_llama_parse_class
+        self, mock_open, mock_llama_parse_class, mock_extract_tokens, mock_find_tokens
     ):
         """Test document parsing when items are empty but layout exists.
 
-        This tests lines 344-381 in llamaparse_parser.py.
+        This tests the layout-only processing path in _convert_json_to_opencontracts.
         """
         mock_file = MagicMock()
         mock_file.read.return_value = b"mock pdf content"
@@ -704,6 +806,12 @@ class TestLlamaParseParserLayoutOnlyProcessing(TestCase):
         mock_parser.get_json_result.return_value = self.layout_only_response
         mock_llama_parse_class.return_value = mock_parser
 
+        # Mock token extraction
+        mock_extract_tokens.return_value = create_mock_token_extraction_result(
+            page_count=1, tokens_per_page=5
+        )
+        mock_find_tokens.return_value = [{"pageIndex": 0, "tokenIndex": 0}]
+
         parser = LlamaParseParser()
         result = parser.parse_document(user_id=self.user.id, doc_id=self.doc.id)
 
@@ -712,12 +820,12 @@ class TestLlamaParseParserLayoutOnlyProcessing(TestCase):
         self.assertEqual(result["title"], "Layout Test Document")
         self.assertEqual(result["page_count"], 1)
 
-        # Verify PAWLS content structure (tokens are empty - no token-level data)
+        # Verify PAWLS content structure (now has tokens from extraction)
         self.assertIn("pawls_file_content", result)
         self.assertEqual(len(result["pawls_file_content"]), 1)
         first_page = result["pawls_file_content"][0]
-        # LlamaParse doesn't provide token-level data
-        self.assertEqual(len(first_page["tokens"]), 0)
+        # Tokens should now be populated from the mock
+        self.assertEqual(len(first_page["tokens"]), 5)
 
         # Verify annotations were created from layout elements
         self.assertIn("labelled_text", result)
@@ -732,10 +840,14 @@ class TestLlamaParseParserLayoutOnlyProcessing(TestCase):
         self.assertIn("Figure", labels)
 
     @override_settings(LLAMAPARSE_API_KEY="test-api-key-123")
+    @patch("opencontractserver.pipeline.parsers.llamaparse_parser.find_tokens_in_bbox")
+    @patch(
+        "opencontractserver.pipeline.parsers.llamaparse_parser.extract_pawls_tokens_from_pdf"
+    )
     @patch("llama_parse.LlamaParse")
     @patch("opencontractserver.pipeline.parsers.llamaparse_parser.default_storage.open")
     def test_parse_document_layout_figure_without_text(
-        self, mock_open, mock_llama_parse_class
+        self, mock_open, mock_llama_parse_class, mock_extract_tokens, mock_find_tokens
     ):
         """Test that figures/images with empty text are processed correctly.
 
@@ -784,6 +896,12 @@ class TestLlamaParseParserLayoutOnlyProcessing(TestCase):
         mock_parser.get_json_result.return_value = layout_with_images
         mock_llama_parse_class.return_value = mock_parser
 
+        # Mock token extraction
+        mock_extract_tokens.return_value = create_mock_token_extraction_result(
+            page_count=1, tokens_per_page=5
+        )
+        mock_find_tokens.return_value = []
+
         parser = LlamaParseParser()
         result = parser.parse_document(user_id=self.user.id, doc_id=self.doc.id)
 
@@ -796,10 +914,14 @@ class TestLlamaParseParserLayoutOnlyProcessing(TestCase):
             self.assertIn(anno["rawText"], ["[image]", "[figure]"])
 
     @override_settings(LLAMAPARSE_API_KEY="test-api-key-123")
+    @patch("opencontractserver.pipeline.parsers.llamaparse_parser.find_tokens_in_bbox")
+    @patch(
+        "opencontractserver.pipeline.parsers.llamaparse_parser.extract_pawls_tokens_from_pdf"
+    )
     @patch("llama_parse.LlamaParse")
     @patch("opencontractserver.pipeline.parsers.llamaparse_parser.default_storage.open")
     def test_parse_document_layout_skips_empty_text_non_figures(
-        self, mock_open, mock_llama_parse_class
+        self, mock_open, mock_llama_parse_class, mock_extract_tokens, mock_find_tokens
     ):
         """Test that non-figure elements with empty text are skipped."""
         layout_with_empty_text = [
@@ -864,6 +986,12 @@ class TestLlamaParseParserLayoutOnlyProcessing(TestCase):
         mock_parser = MagicMock()
         mock_parser.get_json_result.return_value = layout_with_empty_text
         mock_llama_parse_class.return_value = mock_parser
+
+        # Mock token extraction
+        mock_extract_tokens.return_value = create_mock_token_extraction_result(
+            page_count=1, tokens_per_page=5
+        )
+        mock_find_tokens.return_value = []
 
         parser = LlamaParseParser()
         result = parser.parse_document(user_id=self.user.id, doc_id=self.doc.id)

--- a/opencontractserver/tests/test_pdf_token_extraction.py
+++ b/opencontractserver/tests/test_pdf_token_extraction.py
@@ -1,0 +1,420 @@
+"""
+Tests for the PDF token extraction utility module.
+
+Tests cover:
+- Token extraction from PDFs using pdfplumber
+- Spatial intersection queries using shapely STRtree
+- Edge cases (empty PDFs, invalid coordinates)
+- has_extractable_text detection
+
+Uses mock-based testing to avoid needing real PDF fixtures.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+from django.test import TestCase
+from shapely.geometry import box
+from shapely.strtree import STRtree
+
+from opencontractserver.utils.pdf_token_extraction import (
+    extract_pawls_tokens_from_pdf,
+    find_tokens_in_bbox,
+    has_extractable_text,
+)
+
+
+class TestHasExtractableText(TestCase):
+    """Tests for the has_extractable_text function."""
+
+    @patch("pdfplumber.open")
+    def test_has_extractable_text_returns_true_for_text_pdf(self, mock_pdfplumber_open):
+        """Test that has_extractable_text returns True for PDFs with text."""
+        # Mock pdfplumber to return a PDF with text
+        mock_page = MagicMock()
+        mock_page.extract_text.return_value = (
+            "This is sample text content that is long enough."
+        )
+
+        mock_pdf = MagicMock()
+        mock_pdf.pages = [mock_page]
+        mock_pdfplumber_open.return_value.__enter__.return_value = mock_pdf
+
+        result = has_extractable_text(b"fake pdf bytes")
+
+        self.assertTrue(result)
+
+    @patch("pdfplumber.open")
+    def test_has_extractable_text_returns_false_for_scanned_pdf(
+        self, mock_pdfplumber_open
+    ):
+        """Test that has_extractable_text returns False for scanned PDFs."""
+        # Mock pdfplumber to return a PDF with no text
+        mock_page = MagicMock()
+        mock_page.extract_text.return_value = ""
+
+        mock_pdf = MagicMock()
+        mock_pdf.pages = [mock_page, mock_page, mock_page]
+        mock_pdfplumber_open.return_value.__enter__.return_value = mock_pdf
+
+        result = has_extractable_text(b"fake scanned pdf bytes")
+
+        self.assertFalse(result)
+
+    @patch("pdfplumber.open")
+    def test_has_extractable_text_returns_false_for_empty_pdf(
+        self, mock_pdfplumber_open
+    ):
+        """Test that has_extractable_text returns False for PDFs with no pages."""
+        mock_pdf = MagicMock()
+        mock_pdf.pages = []
+        mock_pdfplumber_open.return_value.__enter__.return_value = mock_pdf
+
+        result = has_extractable_text(b"empty pdf")
+
+        self.assertFalse(result)
+
+    @patch("pdfplumber.open")
+    def test_has_extractable_text_min_chars_threshold(self, mock_pdfplumber_open):
+        """Test that min_chars threshold works correctly."""
+        mock_page = MagicMock()
+        mock_page.extract_text.return_value = "short"  # Less than 10 chars
+
+        mock_pdf = MagicMock()
+        mock_pdf.pages = [mock_page]
+        mock_pdfplumber_open.return_value.__enter__.return_value = mock_pdf
+
+        # Default min_chars=10, "short" is only 5 chars
+        result = has_extractable_text(b"pdf", min_chars=10)
+        self.assertFalse(result)
+
+        # With lower threshold, should pass
+        mock_page.extract_text.return_value = "short"
+        result = has_extractable_text(b"pdf", min_chars=3)
+        self.assertTrue(result)
+
+
+class TestExtractPawlsTokensFromPdf(TestCase):
+    """Tests for the extract_pawls_tokens_from_pdf function."""
+
+    @patch("pdfplumber.open")
+    def test_extract_tokens_returns_correct_format(self, mock_pdfplumber_open):
+        """Test that token extraction returns correct PAWLS format."""
+        # Mock pdfplumber page with words
+        mock_page = MagicMock()
+        mock_page.width = 612
+        mock_page.height = 792
+        mock_page.extract_words.return_value = [
+            {"x0": 100, "top": 100, "x1": 150, "bottom": 120, "text": "Hello"},
+            {"x0": 160, "top": 100, "x1": 210, "bottom": 120, "text": "World"},
+        ]
+
+        mock_pdf = MagicMock()
+        mock_pdf.pages = [mock_page]
+        mock_pdfplumber_open.return_value.__enter__.return_value = mock_pdf
+
+        (
+            pawls_pages,
+            spatial_indices,
+            tokens_by_page,
+            token_indices_by_page,
+            page_dims,
+            content,
+        ) = extract_pawls_tokens_from_pdf(b"fake pdf bytes")
+
+        # Check PAWLS pages structure
+        self.assertEqual(len(pawls_pages), 1)
+        self.assertEqual(pawls_pages[0]["page"]["width"], 612)
+        self.assertEqual(pawls_pages[0]["page"]["height"], 792)
+        self.assertEqual(pawls_pages[0]["page"]["index"], 0)
+
+        # Check tokens
+        tokens = pawls_pages[0]["tokens"]
+        self.assertEqual(len(tokens), 2)
+        self.assertEqual(tokens[0]["text"], "Hello")
+        self.assertEqual(tokens[0]["x"], 100)
+        self.assertEqual(tokens[0]["y"], 100)
+        self.assertEqual(tokens[0]["width"], 50)  # 150 - 100
+        self.assertEqual(tokens[0]["height"], 20)  # 120 - 100
+
+        # Check spatial index was created
+        self.assertIn(0, spatial_indices)
+        self.assertIsInstance(spatial_indices[0], STRtree)
+
+        # Check tokens_by_page
+        self.assertIn(0, tokens_by_page)
+        self.assertEqual(len(tokens_by_page[0]), 2)
+
+        # Check token_indices_by_page
+        self.assertIn(0, token_indices_by_page)
+        self.assertEqual(len(token_indices_by_page[0]), 2)
+
+        # Check page dimensions
+        self.assertEqual(page_dims[0], (612.0, 792.0))
+
+        # Check content
+        self.assertIn("Hello", content)
+        self.assertIn("World", content)
+
+    @patch("pdfplumber.open")
+    def test_extract_tokens_multiple_pages(self, mock_pdfplumber_open):
+        """Test token extraction from multiple pages."""
+        mock_page1 = MagicMock()
+        mock_page1.width = 612
+        mock_page1.height = 792
+        mock_page1.extract_words.return_value = [
+            {"x0": 100, "top": 100, "x1": 150, "bottom": 120, "text": "Page1"},
+        ]
+
+        mock_page2 = MagicMock()
+        mock_page2.width = 612
+        mock_page2.height = 792
+        mock_page2.extract_words.return_value = [
+            {"x0": 100, "top": 100, "x1": 150, "bottom": 120, "text": "Page2"},
+        ]
+
+        mock_pdf = MagicMock()
+        mock_pdf.pages = [mock_page1, mock_page2]
+        mock_pdfplumber_open.return_value.__enter__.return_value = mock_pdf
+
+        (pawls_pages, spatial_indices, tokens_by_page, _, _, content) = (
+            extract_pawls_tokens_from_pdf(b"multi-page pdf")
+        )
+
+        self.assertEqual(len(pawls_pages), 2)
+        self.assertEqual(pawls_pages[0]["page"]["index"], 0)
+        self.assertEqual(pawls_pages[1]["page"]["index"], 1)
+        self.assertIn(0, spatial_indices)
+        self.assertIn(1, spatial_indices)
+
+    @patch("pdfplumber.open")
+    def test_extract_tokens_empty_page(self, mock_pdfplumber_open):
+        """Test handling of pages with no words."""
+        mock_page = MagicMock()
+        mock_page.width = 612
+        mock_page.height = 792
+        mock_page.extract_words.return_value = []
+
+        mock_pdf = MagicMock()
+        mock_pdf.pages = [mock_page]
+        mock_pdfplumber_open.return_value.__enter__.return_value = mock_pdf
+
+        (pawls_pages, spatial_indices, tokens_by_page, token_indices_by_page, _, _) = (
+            extract_pawls_tokens_from_pdf(b"empty page pdf")
+        )
+
+        self.assertEqual(len(pawls_pages), 1)
+        self.assertEqual(len(pawls_pages[0]["tokens"]), 0)
+        # No spatial index for empty page
+        self.assertNotIn(0, spatial_indices)
+        self.assertEqual(len(tokens_by_page[0]), 0)
+
+    @patch("pdfplumber.open")
+    def test_extract_tokens_with_page_dimensions_override(self, mock_pdfplumber_open):
+        """Test that page_dimensions parameter scales coordinates."""
+        mock_page = MagicMock()
+        mock_page.width = 612  # Native width
+        mock_page.height = 792  # Native height
+        mock_page.extract_words.return_value = [
+            {"x0": 100, "top": 100, "x1": 200, "bottom": 120, "text": "Test"},
+        ]
+
+        mock_pdf = MagicMock()
+        mock_pdf.pages = [mock_page]
+        mock_pdfplumber_open.return_value.__enter__.return_value = mock_pdf
+
+        # Override with double the dimensions
+        page_dimensions = {0: (1224.0, 1584.0)}  # 2x the native dimensions
+
+        (pawls_pages, _, _, _, page_dims, _) = extract_pawls_tokens_from_pdf(
+            b"pdf", page_dimensions=page_dimensions
+        )
+
+        # Coordinates should be scaled
+        token = pawls_pages[0]["tokens"][0]
+        self.assertEqual(token["x"], 200)  # 100 * 2
+        self.assertEqual(token["y"], 200)  # 100 * 2
+        self.assertEqual(token["width"], 200)  # 100 * 2
+        self.assertEqual(token["height"], 40)  # 20 * 2
+
+        # Page dimensions should match override
+        self.assertEqual(page_dims[0], (1224.0, 1584.0))
+
+    @patch("pdfplumber.open")
+    def test_extract_tokens_skips_invalid_tokens(self, mock_pdfplumber_open):
+        """Test that tokens with zero width/height or empty text are skipped."""
+        mock_page = MagicMock()
+        mock_page.width = 612
+        mock_page.height = 792
+        mock_page.extract_words.return_value = [
+            {
+                "x0": 100,
+                "top": 100,
+                "x1": 100,
+                "bottom": 120,
+                "text": "ZeroWidth",
+            },  # Skip
+            {
+                "x0": 100,
+                "top": 100,
+                "x1": 150,
+                "bottom": 100,
+                "text": "ZeroHeight",
+            },  # Skip
+            {
+                "x0": 100,
+                "top": 100,
+                "x1": 150,
+                "bottom": 120,
+                "text": "   ",
+            },  # Skip whitespace
+            {"x0": 200, "top": 100, "x1": 250, "bottom": 120, "text": "Valid"},  # Keep
+        ]
+
+        mock_pdf = MagicMock()
+        mock_pdf.pages = [mock_page]
+        mock_pdfplumber_open.return_value.__enter__.return_value = mock_pdf
+
+        (pawls_pages, _, _, _, _, _) = extract_pawls_tokens_from_pdf(b"pdf")
+
+        # Only the valid token should be included
+        self.assertEqual(len(pawls_pages[0]["tokens"]), 1)
+        self.assertEqual(pawls_pages[0]["tokens"][0]["text"], "Valid")
+
+
+class TestFindTokensInBbox(TestCase):
+    """Tests for the find_tokens_in_bbox function."""
+
+    def setUp(self):
+        """Create a test spatial index with some tokens."""
+        # Create tokens at known positions
+        self.tokens = [
+            {"x": 100, "y": 100, "width": 50, "height": 20, "text": "Token0"},
+            {"x": 160, "y": 100, "width": 50, "height": 20, "text": "Token1"},
+            {"x": 220, "y": 100, "width": 50, "height": 20, "text": "Token2"},
+            {"x": 100, "y": 200, "width": 50, "height": 20, "text": "Token3"},
+        ]
+
+        # Create geometries for spatial index
+        geometries = []
+        for token in self.tokens:
+            geom = box(
+                token["x"],
+                token["y"],
+                token["x"] + token["width"],
+                token["y"] + token["height"],
+            )
+            geometries.append(geom)
+
+        self.spatial_index = STRtree(geometries)
+        self.token_indices = np.array([0, 1, 2, 3], dtype=np.intp)
+
+    def test_find_tokens_in_bbox_returns_intersecting_tokens(self):
+        """Test that find_tokens_in_bbox returns tokens that intersect the bbox."""
+        # Bbox that should intersect Token0 and Token1
+        bbox = {"left": 80, "top": 90, "right": 200, "bottom": 130}
+
+        token_refs = find_tokens_in_bbox(
+            bbox=bbox,
+            page_idx=0,
+            spatial_index=self.spatial_index,
+            token_indices=self.token_indices,
+            tokens=self.tokens,
+        )
+
+        # Should find Token0 and Token1
+        self.assertEqual(len(token_refs), 2)
+        self.assertIn({"pageIndex": 0, "tokenIndex": 0}, token_refs)
+        self.assertIn({"pageIndex": 0, "tokenIndex": 1}, token_refs)
+
+    def test_find_tokens_in_bbox_returns_empty_for_no_intersection(self):
+        """Test that find_tokens_in_bbox returns empty list when no intersection."""
+        # Bbox that doesn't intersect any tokens
+        bbox = {"left": 500, "top": 500, "right": 600, "bottom": 600}
+
+        token_refs = find_tokens_in_bbox(
+            bbox=bbox,
+            page_idx=0,
+            spatial_index=self.spatial_index,
+            token_indices=self.token_indices,
+            tokens=self.tokens,
+        )
+
+        self.assertEqual(len(token_refs), 0)
+
+    def test_find_tokens_in_bbox_handles_no_spatial_index(self):
+        """Test that find_tokens_in_bbox returns empty list when no spatial index."""
+        bbox = {"left": 100, "top": 100, "right": 200, "bottom": 200}
+
+        token_refs = find_tokens_in_bbox(
+            bbox=bbox,
+            page_idx=0,
+            spatial_index=None,
+            token_indices=None,
+            tokens=None,
+        )
+
+        self.assertEqual(len(token_refs), 0)
+
+    def test_find_tokens_in_bbox_handles_empty_token_indices(self):
+        """Test that find_tokens_in_bbox returns empty list for empty indices."""
+        bbox = {"left": 100, "top": 100, "right": 200, "bottom": 200}
+
+        token_refs = find_tokens_in_bbox(
+            bbox=bbox,
+            page_idx=0,
+            spatial_index=self.spatial_index,
+            token_indices=np.array([], dtype=np.intp),
+            tokens=[],
+        )
+
+        self.assertEqual(len(token_refs), 0)
+
+    def test_find_tokens_in_bbox_handles_swapped_coordinates(self):
+        """Test that find_tokens_in_bbox handles left > right or top > bottom."""
+        # Swapped coordinates (right < left, bottom < top)
+        bbox = {"left": 200, "top": 130, "right": 80, "bottom": 90}
+
+        token_refs = find_tokens_in_bbox(
+            bbox=bbox,
+            page_idx=0,
+            spatial_index=self.spatial_index,
+            token_indices=self.token_indices,
+            tokens=self.tokens,
+        )
+
+        # Should still find Token0 and Token1 after coordinates are swapped
+        self.assertEqual(len(token_refs), 2)
+
+    def test_find_tokens_in_bbox_returns_sorted_indices(self):
+        """Test that token refs are sorted by token index."""
+        # Bbox that should intersect all tokens
+        bbox = {"left": 0, "top": 0, "right": 500, "bottom": 500}
+
+        token_refs = find_tokens_in_bbox(
+            bbox=bbox,
+            page_idx=0,
+            spatial_index=self.spatial_index,
+            token_indices=self.token_indices,
+            tokens=self.tokens,
+        )
+
+        # Should be sorted by token index
+        indices = [ref["tokenIndex"] for ref in token_refs]
+        self.assertEqual(indices, sorted(indices))
+
+    def test_find_tokens_in_bbox_uses_correct_page_index(self):
+        """Test that returned token refs use the provided page index."""
+        bbox = {"left": 80, "top": 90, "right": 200, "bottom": 130}
+
+        token_refs = find_tokens_in_bbox(
+            bbox=bbox,
+            page_idx=5,  # Use a different page index
+            spatial_index=self.spatial_index,
+            token_indices=self.token_indices,
+            tokens=self.tokens,
+        )
+
+        # All refs should have pageIndex=5
+        for ref in token_refs:
+            self.assertEqual(ref["pageIndex"], 5)

--- a/opencontractserver/utils/pdf_token_extraction.py
+++ b/opencontractserver/utils/pdf_token_extraction.py
@@ -1,0 +1,372 @@
+"""
+PDF Token Extraction Utility.
+
+This module provides functions to extract word-level tokens from PDFs
+and calculate which tokens fall within annotation bounding boxes.
+
+Based on the Docsling microservice implementation:
+https://github.com/JSv4/Docsling/blob/main/app/core/parser.py
+"""
+
+import io
+import logging
+from typing import Optional
+
+import numpy as np
+from shapely.geometry import box
+from shapely.strtree import STRtree
+
+from opencontractserver.types.dicts import (
+    BoundingBoxPythonType,
+    PawlsPagePythonType,
+    PawlsTokenPythonType,
+    TokenIdPythonType,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def has_extractable_text(pdf_bytes: bytes, min_chars: int = 10) -> bool:
+    """
+    Check if a PDF has extractable text content.
+
+    This is a detection function only - no OCR is performed. PDFs without
+    embedded text (scanned documents) will return False.
+
+    Args:
+        pdf_bytes: The raw bytes of the PDF file.
+        min_chars: Minimum number of non-whitespace characters to consider
+                   the PDF as having extractable text. Default: 10.
+
+    Returns:
+        True if the PDF has extractable text, False otherwise.
+    """
+    try:
+        import pdfplumber
+    except ImportError:
+        logger.warning("pdfplumber not installed. Cannot check for extractable text.")
+        return False
+
+    try:
+        with pdfplumber.open(io.BytesIO(pdf_bytes)) as pdf:
+            if not pdf.pages:
+                logger.warning("PDF has no pages.")
+                return False
+
+            # Check the first few pages for text content
+            pages_to_check = min(len(pdf.pages), 3)
+            for i in range(pages_to_check):
+                try:
+                    page_text = pdf.pages[i].extract_text(x_tolerance=2, y_tolerance=2)
+                    if page_text and len(page_text.strip()) > min_chars:
+                        logger.debug(f"Text found on page {i + 1} using pdfplumber.")
+                        return True
+                except Exception as page_error:
+                    logger.warning(
+                        f"Could not extract text from page {i + 1}: {page_error}"
+                    )
+                    continue
+
+            logger.info(
+                f"No significant text found in first {pages_to_check} pages. "
+                "PDF may be scanned."
+            )
+            return False
+
+    except Exception as e:
+        logger.error(f"Error checking PDF for extractable text: {e}")
+        return False
+
+
+def extract_pawls_tokens_from_pdf(
+    pdf_bytes: bytes,
+    page_dimensions: Optional[dict[int, tuple[float, float]]] = None,
+) -> tuple[
+    list[PawlsPagePythonType],
+    dict[int, STRtree],
+    dict[int, list[PawlsTokenPythonType]],
+    dict[int, np.ndarray],
+    dict[int, tuple[float, float]],
+    str,
+]:
+    """
+    Extract word-level tokens from a PDF with bounding boxes.
+
+    Uses pdfplumber for text extraction. Returns PAWLS-compatible token data
+    and spatial indices for intersection queries.
+
+    This function is based on Docsling's _generate_pawls_content() function,
+    simplified to remove OCR support.
+
+    Args:
+        pdf_bytes: The raw bytes of the PDF file.
+        page_dimensions: Optional dict mapping 0-based page index to (width, height)
+                        tuples. If provided, coordinates are scaled to match.
+                        If None, pdfplumber's native dimensions are used.
+
+    Returns:
+        A tuple containing:
+        - pawls_pages: List of PawlsPagePythonType with tokens per page
+        - spatial_indices: Dict mapping 0-based page index to STRtree spatial index
+        - tokens_by_page: Dict mapping 0-based page index to list of tokens
+        - token_indices_by_page: Dict mapping 0-based page index to numpy array
+                                 of original token indices
+        - page_dims: Dict mapping 0-based page index to (width, height) tuple
+        - content: Full text content concatenated across pages
+
+    Raises:
+        ImportError: If pdfplumber is not installed.
+    """
+    try:
+        import pdfplumber
+    except ImportError:
+        logger.error("pdfplumber not installed. Install with: pip install pdfplumber")
+        raise
+
+    pawls_pages: list[PawlsPagePythonType] = []
+    spatial_indices_by_page: dict[int, STRtree] = {}
+    tokens_by_page: dict[int, list[PawlsTokenPythonType]] = {}
+    token_indices_by_page: dict[int, np.ndarray] = {}
+    page_dims: dict[int, tuple[float, float]] = {}
+    content_parts: list[str] = []
+
+    try:
+        with pdfplumber.open(io.BytesIO(pdf_bytes)) as pdf:
+            if not pdf.pages:
+                logger.warning("PDF has no pages.")
+                return (
+                    pawls_pages,
+                    spatial_indices_by_page,
+                    tokens_by_page,
+                    token_indices_by_page,
+                    page_dims,
+                    "",
+                )
+
+            for page_num_0based, pdf_page in enumerate(pdf.pages):
+                logger.debug(f"Processing page {page_num_0based + 1} with pdfplumber")
+
+                # Get page dimensions
+                native_width = float(pdf_page.width)
+                native_height = float(pdf_page.height)
+
+                # Use provided dimensions if available, otherwise use native
+                if page_dimensions and page_num_0based in page_dimensions:
+                    width, height = page_dimensions[page_num_0based]
+                    scale_x = width / native_width
+                    scale_y = height / native_height
+                else:
+                    width, height = native_width, native_height
+                    scale_x, scale_y = 1.0, 1.0
+
+                page_dims[page_num_0based] = (width, height)
+
+                current_page_tokens: list[PawlsTokenPythonType] = []
+                current_page_geometries: list[box] = []
+                current_page_token_indices: list[int] = []
+                page_content_parts: list[str] = []
+
+                # Extract words using pdfplumber
+                # Match Docsling's extraction options for consistency
+                words = pdf_page.extract_words(
+                    x_tolerance=2,
+                    y_tolerance=2,
+                    keep_blank_chars=False,
+                    use_text_flow=True,
+                )
+
+                if not words:
+                    logger.debug(f"No words found on page {page_num_0based + 1}.")
+                    content_parts.append("")
+                    pawls_page: PawlsPagePythonType = {
+                        "page": {
+                            "width": width,
+                            "height": height,
+                            "index": page_num_0based,
+                        },
+                        "tokens": [],
+                    }
+                    pawls_pages.append(pawls_page)
+                    tokens_by_page[page_num_0based] = []
+                    token_indices_by_page[page_num_0based] = np.array([], dtype=np.intp)
+                    continue
+
+                for token_index, word in enumerate(words):
+                    # pdfplumber coordinates: x0, top, x1, bottom (origin top-left)
+                    x0 = float(word["x0"]) * scale_x
+                    top = float(word["top"]) * scale_y
+                    x1 = float(word["x1"]) * scale_x
+                    bottom = float(word["bottom"]) * scale_y
+                    text = word["text"]
+
+                    # PAWLS uses top-left corner (x, y) and width, height
+                    token_x = x0
+                    token_y = top
+                    token_width = x1 - x0
+                    token_height = bottom - top
+
+                    # Skip potentially invalid boxes
+                    if token_width <= 0 or token_height <= 0 or not text.strip():
+                        continue
+
+                    token: PawlsTokenPythonType = {
+                        "x": token_x,
+                        "y": token_y,
+                        "width": token_width,
+                        "height": token_height,
+                        "text": text,
+                    }
+                    current_page_tokens.append(token)
+                    page_content_parts.append(text)
+
+                    # Create geometry for STRtree (minx, miny, maxx, maxy)
+                    token_bbox = box(
+                        token_x, token_y, token_x + token_width, token_y + token_height
+                    )
+                    current_page_geometries.append(token_bbox)
+                    current_page_token_indices.append(len(current_page_tokens) - 1)
+
+                content_parts.append(" ".join(page_content_parts))
+
+                # Build spatial index for the page if tokens were found
+                if current_page_geometries:
+                    geometries_array = np.array(current_page_geometries)
+                    token_indices_array = np.array(
+                        current_page_token_indices, dtype=np.intp
+                    )
+                    spatial_index = STRtree(geometries_array)
+                    spatial_indices_by_page[page_num_0based] = spatial_index
+                    tokens_by_page[page_num_0based] = current_page_tokens
+                    token_indices_by_page[page_num_0based] = token_indices_array
+                    logger.debug(
+                        f"Built STRtree for page {page_num_0based + 1} with "
+                        f"{len(current_page_geometries)} tokens."
+                    )
+                else:
+                    tokens_by_page[page_num_0based] = []
+                    token_indices_by_page[page_num_0based] = np.array([], dtype=np.intp)
+
+                # Create PAWLS page structure
+                pawls_page = {
+                    "page": {
+                        "width": width,
+                        "height": height,
+                        "index": page_num_0based,
+                    },
+                    "tokens": current_page_tokens,
+                }
+                pawls_pages.append(pawls_page)
+
+        full_content = "\n".join(content_parts)
+        logger.info(f"Extracted tokens from {len(pawls_pages)} pages.")
+
+        return (
+            pawls_pages,
+            spatial_indices_by_page,
+            tokens_by_page,
+            token_indices_by_page,
+            page_dims,
+            full_content,
+        )
+
+    except Exception as e:
+        logger.error(f"Error extracting tokens from PDF: {e}")
+        raise
+
+
+def find_tokens_in_bbox(
+    bbox: BoundingBoxPythonType,
+    page_idx: int,
+    spatial_index: Optional[STRtree],
+    token_indices: Optional[np.ndarray],
+    tokens: Optional[list[PawlsTokenPythonType]] = None,
+) -> list[TokenIdPythonType]:
+    """
+    Find all tokens that intersect with a bounding box.
+
+    Uses spatial indexing (STRtree) to efficiently find tokens that overlap
+    with the given bounding box.
+
+    This function is based on the spatial query portion of Docsling's
+    convert_docling_item_to_annotation() function.
+
+    Args:
+        bbox: The bounding box to find intersecting tokens for.
+              Uses {left, top, right, bottom} format.
+        page_idx: 0-based page index.
+        spatial_index: STRtree spatial index for the page (from extract_pawls_tokens_from_pdf).
+        token_indices: Numpy array of token indices for the page.
+        tokens: Optional list of tokens for validation (unused, kept for API compatibility).
+
+    Returns:
+        List of TokenIdPythonType references ({pageIndex, tokenIndex}) for tokens
+        that intersect with the bounding box. Returns empty list if no spatial
+        index is available or no tokens intersect.
+    """
+    if spatial_index is None or token_indices is None:
+        logger.debug(f"No spatial index for page {page_idx}, returning empty tokens.")
+        return []
+
+    if len(token_indices) == 0:
+        return []
+
+    try:
+        # Create bbox geometry for query
+        left = float(bbox["left"])
+        top = float(bbox["top"])
+        right = float(bbox["right"])
+        bottom = float(bbox["bottom"])
+
+        # Ensure valid bounds
+        if left > right:
+            left, right = right, left
+        if top > bottom:
+            top, bottom = bottom, top
+
+        query_bbox = box(left, top, right, bottom)
+
+        # Perform spatial query
+        candidate_indices = spatial_index.query(query_bbox)
+
+        if not isinstance(candidate_indices, np.ndarray) or candidate_indices.size == 0:
+            return []
+
+        # Filter to only valid indices
+        valid_indices = candidate_indices[
+            candidate_indices < len(spatial_index.geometries)
+        ]
+
+        if len(valid_indices) == 0:
+            return []
+
+        # Check for actual intersection (STRtree.query returns bounding box overlaps)
+        candidate_geometries = spatial_index.geometries.take(valid_indices)
+        intersects_mask = np.array(
+            [
+                geom.intersects(query_bbox) if geom.is_valid else False
+                for geom in candidate_geometries
+            ]
+        )
+        actual_indices = valid_indices[intersects_mask]
+
+        if actual_indices.size == 0:
+            return []
+
+        # Map back to token indices and ensure they're valid
+        valid_actual_indices = actual_indices[actual_indices < len(token_indices)]
+        if valid_actual_indices.size == 0:
+            return []
+
+        result_token_indices = token_indices[valid_actual_indices]
+
+        # Create token reference list
+        token_refs: list[TokenIdPythonType] = [
+            {"pageIndex": page_idx, "tokenIndex": int(idx)}
+            for idx in sorted(result_token_indices)
+        ]
+
+        return token_refs
+
+    except Exception as e:
+        logger.error(f"Error during spatial query for page {page_idx}: {e}")
+        return []

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -52,6 +52,8 @@ openai==1.102.0  # https://github.com/openai/openai-python
 pytesseract
 pydantic-ai==0.2.*
 spacy
+pdfplumber>=0.10.0  # https://github.com/jsvine/pdfplumber - PDF token extraction
+shapely>=2.0.0  # https://github.com/shapely/shapely - spatial operations for bbox intersection
 
 # Data Processing Tools
 # -------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add PDF token extraction utility module (`opencontractserver/utils/pdf_token_extraction.py`) that extracts word-level tokens from PDFs using pdfplumber and calculates spatial intersections using shapely STRtree
- Update LlamaParse parser to populate `tokensJsons` arrays with actual token references instead of empty lists
- This enables the frontend to highlight individual words within annotation bounding boxes

## Changes

- **New utility module**: `pdf_token_extraction.py` with three main functions:
  - `has_extractable_text()` - Detect if PDF has embedded text
  - `extract_pawls_tokens_from_pdf()` - Extract tokens with spatial indices
  - `find_tokens_in_bbox()` - Find tokens intersecting annotation bboxes

- **Updated LlamaParse parser**: Now uses the utility to populate token references for each annotation

- **New dependencies**: Added `pdfplumber>=0.10.0` and `shapely>=2.0.0` to requirements

- **Tests**: Added comprehensive mock-based tests for the utility module and updated LlamaParse tests

## Test plan

- [x] All 16 token extraction utility tests pass
- [x] All 24 LlamaParse parser tests pass
- [x] Pre-commit hooks pass