### PR TITLE
Fix routing audit follow-up issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+#### Routing Audit Follow-ups
+- **Notification navigation fallback** (`frontend/src/components/notifications/NotificationDropdown.tsx:182-188`, `NotificationCenter.tsx:207-213`): Added fallback navigation to `/discussions` when corpus slug data is missing. Previously, users clicking notifications with missing slug data would see no response.
+- **Network-only fetch policy optimization** (`frontend/src/routing/CentralRouteManager.tsx:621-632`): Changed thread resolution corpus query from `network-only` to `cache-and-network` since `authInitComplete` now ensures `clearStore()` completes before route queries run. This improves navigation performance when corpus data is already cached.
+- **Unit test coverage** (`frontend/src/utils/__tests__/navigationUtils.test.ts:497-503`): Added missing test for `parseRoute("/discussions")` to prevent regression of discussions route parsing.
+
 #### Type Safety and Bug Fixes
 - **User email detection** (`frontend/src/components/corpuses/CorpusListView.tsx:345-349`): Fixed currentUserEmail logic to use `userObj` reactive variable from Apollo cache instead of inferring from corpus permissions - prevents filter failures when no corpus has CAN_REMOVE permission
 - **TypeScript type casts** (`frontend/src/components/corpuses/CorpusListView.tsx`, `CorpusModal.tsx`): Removed 7 `as any` type casts by correcting `CorpusType.categories` type from `CorpusCategoryTypeConnection` to `CorpusCategoryType[]` to match backend GraphQL schema

--- a/frontend/src/components/notifications/NotificationCenter.tsx
+++ b/frontend/src/components/notifications/NotificationCenter.tsx
@@ -205,10 +205,11 @@ export function NotificationCenter() {
         if (threadUrl !== "#") {
           navigate(`${threadUrl}${messageParam}`);
         } else {
-          // Fallback if corpus is missing slug data
+          // Fallback if corpus is missing slug data - navigate to global discussions
           console.warn(
-            "[NotificationCenter] Cannot navigate - corpus missing slug data"
+            "[NotificationCenter] Cannot navigate - corpus missing slug data, falling back to /discussions"
           );
+          navigate(`/discussions${messageParam}`);
         }
       } else {
         // General discussion: navigate to global discussions page

--- a/frontend/src/components/notifications/NotificationDropdown.tsx
+++ b/frontend/src/components/notifications/NotificationDropdown.tsx
@@ -180,10 +180,11 @@ export function NotificationDropdown({
         if (threadUrl !== "#") {
           navigate(`${threadUrl}${messageParam}`);
         } else {
-          // Fallback if corpus is missing slug data
+          // Fallback if corpus is missing slug data - navigate to global discussions
           console.warn(
-            "[NotificationDropdown] Cannot navigate - corpus missing slug data"
+            "[NotificationDropdown] Cannot navigate - corpus missing slug data, falling back to /discussions"
           );
+          navigate(`/discussions${messageParam}`);
         }
       } else {
         // General discussion: navigate to global discussions page

--- a/frontend/src/routing/CentralRouteManager.tsx
+++ b/frontend/src/routing/CentralRouteManager.tsx
@@ -619,14 +619,16 @@ export function CentralRouteManager() {
             routingLogger.debug("[RouteManager] Resolving thread");
 
             // First, resolve the corpus (needed for context and navigation)
-            // Use network-only to bypass any stale cache from before authentication
+            // Note: Using cache-and-network for corpus resolution since authInitComplete
+            // now ensures clearStore() completes before any route queries run.
+            // This allows faster navigation when corpus data is already cached.
             const { data: corpusData, error: corpusError } =
               await resolveCorpus({
                 variables: {
                   userSlug: route.userIdent || "",
                   corpusSlug: route.corpusIdent,
                 },
-                fetchPolicy: "network-only", // Force network fetch for thread resolution
+                fetchPolicy: "cache-and-network", // Use cache if available, refresh in background
               });
 
             if (corpusError) {

--- a/frontend/src/utils/__tests__/navigationUtils.test.ts
+++ b/frontend/src/utils/__tests__/navigationUtils.test.ts
@@ -493,6 +493,14 @@ describe("parseRoute()", () => {
         browsePath: "label_sets",
       });
     });
+
+    it("should parse discussions route", () => {
+      const result = parseRoute("/discussions");
+      expect(result).toEqual({
+        type: "browse",
+        browsePath: "discussions",
+      });
+    });
   });
 
   describe("invalid routes", () => {


### PR DESCRIPTION
## Summary

Addresses follow-up issues from the routing audit PR (#768):

- **Notification navigation fallback**: Users clicking notifications with missing corpus slug data now navigate to `/discussions` instead of seeing no response
- **Cache policy optimization**: Thread resolution now uses `cache-and-network` instead of `network-only` since `authInitComplete` ensures fresh cache state
- **Test coverage**: Added missing unit test for `parseRoute("/discussions")` to prevent regression

## Test plan

- [x] TypeScript compilation passes
- [x] Pre-commit hooks pass
- [x] Unit tests pass (96 tests including new discussions route test)
- [ ] Manual test: Click notification with missing corpus slug → should navigate to /discussions
- [ ] Manual test: Navigate to thread route → should use cached corpus data when available