### PR TITLE
Add LabelSet detail page with responsive layout and inline editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **Deleted CorpusCards component** (`frontend/src/components/corpuses/CorpusCards.tsx`): Replaced by CorpusListView with @os-legal/ui components
 
+#### LabelSet Detail Page Refactoring
+- **LabelSetDetailPage component split** (`frontend/src/components/labelsets/LabelSetDetailPage.tsx`): Reduced from 2,064 lines to ~1,100 lines
+  - Extracted 16 SVG icons to `detail/LabelSetIcons.tsx`
+  - Extracted 40+ styled-components to `detail/LabelSetDetailStyles.ts`
+  - Added barrel exports in `detail/index.ts`
+- **Color constants centralized** (`frontend/src/assets/configurations/constants.ts`): Added `DEFAULT_LABEL_COLOR` and `PRIMARY_LABEL_COLOR`
+
+### Security
+- **Frontend permission checks** (`frontend/src/components/labelsets/LabelSetDetailPage.tsx:1189-1344`): Added defensive permission checks to all mutation handlers
+  - `handleDeleteLabel` now verifies `canRemove` before deletion
+  - `handleSaveEdit` now verifies `canUpdate` before updating
+  - `handleSaveCreate` now verifies `canUpdate` before creation
+  - `handleDelete` (labelset) now verifies `canRemove` before deletion
+- **Color input sanitization** (`frontend/src/components/labelsets/LabelSetDetailPage.tsx:125-143`): Added `isValidHexColor` and `sanitizeColor` utilities
+  - Validates hex color format (3 or 6 character, with or without #)
+  - Prevents potential XSS via CSS color injection
+
+### Technical Details
+- New test file: `frontend/tests/LabelSetDetailPage.ct.tsx` with comprehensive component tests
+  - Rendering tests for all tabs (Overview, Text/Doc/Span/Relationship Labels)
+  - Permission-based UI visibility tests
+  - Search functionality tests
+  - Mobile navigation tests
+
 ---
 
 ## [Unreleased] - 2025-12-31

--- a/config/graphql/graphene_types.py
+++ b/config/graphql/graphene_types.py
@@ -670,7 +670,7 @@ class LabelSetType(AnnotatePermissionsForReadMixin, DjangoObjectType):
     def resolve_corpus_count(self, info):
         """Return count of corpuses using this label set that are visible to the user."""
         user = info.context.user
-        return self.corpus_set.visible_to_user(user).count()
+        return self.used_by_corpuses.visible_to_user(user).count()
 
     # To get ALL labels for a given labelset
     all_annotation_labels = graphene.Field(graphene.List(AnnotationLabelType))

--- a/frontend/src/assets/configurations/constants.ts
+++ b/frontend/src/assets/configurations/constants.ts
@@ -6,3 +6,9 @@ export const TABLET_BREAKPOINT = 768;
 // Mention preview character limit (Issue #689)
 // Used for truncating annotation text in mention chips and pickers
 export const MENTION_PREVIEW_LENGTH = 24;
+
+// Label/UI colors
+// Default neutral gray color (Tailwind slate-400) used for inactive/placeholder states
+export const DEFAULT_LABEL_COLOR = "94a3b8";
+// Primary teal color used for new label creation
+export const PRIMARY_LABEL_COLOR = "0F766E";

--- a/frontend/src/components/labelsets/LabelSetDetailPage.tsx
+++ b/frontend/src/components/labelsets/LabelSetDetailPage.tsx
@@ -24,11 +24,7 @@ import {
 } from "../../graphql/mutations";
 import { ConfirmModal } from "../widgets/modals/ConfirmModal";
 import { openedLabelset, userObj } from "../../graphql/cache";
-import {
-  AnnotationLabelType,
-  LabelSetType,
-  LabelType,
-} from "../../types/graphql-api";
+import { AnnotationLabelType, LabelType } from "../../types/graphql-api";
 import { toast } from "react-toastify";
 import { getPermissions } from "../../utils/transform";
 import { PermissionTypes } from "../types";
@@ -124,6 +120,7 @@ import {
 const fuse_options = {
   includeScore: false,
   findAllMatches: true,
+  threshold: 0.3, // Stricter matching (0 = exact, 1 = match anything)
   keys: ["text", "description"],
 };
 
@@ -160,9 +157,10 @@ const isValidHexColor = (color: string): boolean => {
  * Strips leading # and validates format
  */
 const sanitizeColor = (
-  color: string,
+  color: string | null | undefined,
   fallback: string = DEFAULT_LABEL_COLOR
 ): string => {
+  if (!color) return fallback;
   const cleaned = color.replace("#", "");
   return isValidHexColor(cleaned) ? cleaned : fallback;
 };
@@ -480,6 +478,8 @@ export const LabelSetDetailPage: React.FC<LabelSetDetailPageProps> = ({
   );
 
   // Setup fuzzy search
+  // Note: Not using useMemo here as it causes React error #310 in Playwright component tests
+  // This is a known issue with Playwright CT and certain hook usage patterns
   const text_label_fuse = new Fuse(text_labels, fuse_options);
   const doc_label_fuse = new Fuse(doc_type_labels, fuse_options);
   const relationship_label_fuse = new Fuse(relationship_labels, fuse_options);

--- a/frontend/src/components/labelsets/LabelSetDetailPage.tsx
+++ b/frontend/src/components/labelsets/LabelSetDetailPage.tsx
@@ -1,0 +1,1838 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+import { useNavigate } from "react-router-dom";
+import { Dimmer, Loader, Message } from "semantic-ui-react";
+import Fuse from "fuse.js";
+import { useQuery, useMutation, useReactiveVar } from "@apollo/client";
+import {
+  GetLabelsetWithLabelsInputs,
+  GetLabelsetWithLabelsOutputs,
+  GET_LABELSET_WITH_ALL_LABELS,
+} from "../../graphql/queries";
+import {
+  DeleteMultipleAnnotationLabelOutputs,
+  DeleteMultipleAnnotationLabelInputs,
+  DELETE_MULTIPLE_ANNOTATION_LABELS,
+  CreateAnnotationLabelForLabelsetOutputs,
+  CreateAnnotationLabelForLabelsetInputs,
+  CREATE_ANNOTATION_LABEL_FOR_LABELSET,
+  DeleteLabelsetInputs,
+  DeleteLabelsetOutputs,
+  DELETE_LABELSET,
+  UpdateAnnotationLabelInputs,
+  UpdateAnnotationLabelOutputs,
+  UPDATE_ANNOTATION_LABEL,
+} from "../../graphql/mutations";
+import { ConfirmModal } from "../widgets/modals/ConfirmModal";
+import { openedLabelset, userObj } from "../../graphql/cache";
+import {
+  AnnotationLabelType,
+  LabelSetType,
+  LabelType,
+} from "../../types/graphql-api";
+import { toast } from "react-toastify";
+import { getPermissions } from "../../utils/transform";
+import { PermissionTypes } from "../types";
+
+const fuse_options = {
+  includeScore: false,
+  findAllMatches: true,
+  keys: ["text", "description"],
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// ICONS
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const ChevronLeftIcon = () => (
+  <svg
+    width="18"
+    height="18"
+    viewBox="0 0 18 18"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M11.25 13.5L6.75 9l4.5-4.5" />
+  </svg>
+);
+
+const OverviewIcon = () => (
+  <svg
+    width="18"
+    height="18"
+    viewBox="0 0 18 18"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <rect x="3" y="3" width="5" height="5" rx="1" />
+    <rect x="10" y="3" width="5" height="5" rx="1" />
+    <rect x="3" y="10" width="5" height="5" rx="1" />
+    <rect x="10" y="10" width="5" height="5" rx="1" />
+  </svg>
+);
+
+const DocLabelIcon = () => (
+  <svg
+    width="18"
+    height="18"
+    viewBox="0 0 18 18"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M10.5 1.5H4.5a1.5 1.5 0 00-1.5 1.5v12a1.5 1.5 0 001.5 1.5h9a1.5 1.5 0 001.5-1.5V6L10.5 1.5z" />
+    <path d="M10.5 1.5V6H15" />
+    <path d="M6 9h6M6 12h4" />
+  </svg>
+);
+
+const SpanLabelIcon = () => (
+  <svg
+    width="18"
+    height="18"
+    viewBox="0 0 18 18"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M3 5.25h12M3 9h8M3 12.75h10" />
+    <rect
+      x="11"
+      y="7.5"
+      width="4"
+      height="3"
+      rx="0.5"
+      fill="currentColor"
+      opacity="0.2"
+      stroke="currentColor"
+    />
+  </svg>
+);
+
+const TextLabelIcon = () => (
+  <svg
+    width="18"
+    height="18"
+    viewBox="0 0 18 18"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M3 4.5h12M6 9h6M4.5 13.5h9" />
+    <path d="M9 3v12" strokeOpacity="0.3" />
+  </svg>
+);
+
+const RelationshipIcon = () => (
+  <svg
+    width="18"
+    height="18"
+    viewBox="0 0 18 18"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <circle cx="4.5" cy="9" r="2.5" />
+    <circle cx="13.5" cy="9" r="2.5" />
+    <path d="M7 9h4" />
+    <path d="M10 7l2 2-2 2" />
+  </svg>
+);
+
+const ShareIcon = () => (
+  <svg
+    width="18"
+    height="18"
+    viewBox="0 0 18 18"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <circle cx="13.5" cy="3.75" r="2.25" />
+    <circle cx="4.5" cy="9" r="2.25" />
+    <circle cx="13.5" cy="14.25" r="2.25" />
+    <path d="M6.54 10.11l4.92 3.03M11.46 4.86L6.54 7.89" />
+  </svg>
+);
+
+const EditIcon = () => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M11.5 2.5a1.77 1.77 0 012.5 2.5L5.25 13.75 1.5 14.5l.75-3.75L11.5 2.5z" />
+  </svg>
+);
+
+const TrashIcon = () => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M2 4h12M5.33 4V2.67a.67.67 0 01.67-.67h4a.67.67 0 01.67.67V4M12.67 4v9.33a.67.67 0 01-.67.67H4a.67.67 0 01-.67-.67V4" />
+  </svg>
+);
+
+const DownloadIcon = () => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M8 2v9M4.5 7.5L8 11l3.5-3.5M2 14h12" />
+  </svg>
+);
+
+const SaveIcon = () => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M13.33 5.33L6.67 12 2.67 8" />
+  </svg>
+);
+
+const CloseIcon = () => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M12 4L4 12M4 4l8 8" />
+  </svg>
+);
+
+const GripIcon = () => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    fill="currentColor"
+    opacity="0.4"
+  >
+    <circle cx="5" cy="4" r="1.5" />
+    <circle cx="11" cy="4" r="1.5" />
+    <circle cx="5" cy="8" r="1.5" />
+    <circle cx="11" cy="8" r="1.5" />
+    <circle cx="5" cy="12" r="1.5" />
+    <circle cx="11" cy="12" r="1.5" />
+  </svg>
+);
+
+const SearchIcon = () => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <circle cx="7" cy="7" r="5" />
+    <path d="M14 14l-3.5-3.5" />
+  </svg>
+);
+
+const PlusIcon = () => (
+  <svg
+    width="18"
+    height="18"
+    viewBox="0 0 18 18"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+  >
+    <path d="M9 3.75v10.5M3.75 9h10.5" />
+  </svg>
+);
+
+const LabelSetIcon = () => (
+  <svg
+    width="48"
+    height="48"
+    viewBox="0 0 48 48"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M20 8H10a4 4 0 00-4 4v24a4 4 0 004 4h28a4 4 0 004-4V20" />
+    <path d="M32 6l8 8-16 16H16v-8L32 6z" />
+  </svg>
+);
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// STYLED COMPONENTS
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const PageContainer = styled.div`
+  display: flex;
+  height: calc(100vh - 60px);
+  background: #fafafa;
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
+`;
+
+const Sidebar = styled.aside`
+  width: 260px;
+  min-width: 260px;
+  background: #fff;
+  border-right: 1px solid #e2e8f0;
+  display: flex;
+  flex-direction: column;
+`;
+
+const SidebarHeader = styled.div`
+  padding: 24px 20px;
+  border-bottom: 1px solid #e2e8f0;
+`;
+
+const BackLink = styled.button`
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  font-weight: 500;
+  color: #475569;
+  text-decoration: none;
+  padding: 6px 10px 6px 6px;
+  margin: -6px -10px -6px -6px;
+  border-radius: 6px;
+  transition: all 0.15s ease;
+  cursor: pointer;
+  background: none;
+  border: none;
+
+  &:hover {
+    background: #f1f5f9;
+    color: #1e293b;
+  }
+`;
+
+const SidebarNav = styled.nav`
+  flex: 1;
+  padding: 12px 0;
+  overflow-y: auto;
+`;
+
+interface NavItemProps {
+  $active?: boolean;
+}
+
+const NavItem = styled.button<NavItemProps>`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 20px;
+  font-size: 14px;
+  font-weight: 500;
+  color: ${(props) => (props.$active ? "#0f766e" : "#475569")};
+  cursor: pointer;
+  transition: all 0.15s ease;
+  border: none;
+  background: ${(props) =>
+    props.$active
+      ? "linear-gradient(90deg, rgba(15, 118, 110, 0.08) 0%, transparent 100%)"
+      : "none"};
+  width: 100%;
+  text-align: left;
+  border-left: 2px solid
+    ${(props) => (props.$active ? "#0f766e" : "transparent")};
+  padding-left: ${(props) => (props.$active ? "18px" : "20px")};
+
+  &:hover {
+    background: ${(props) => (props.$active ? undefined : "#f8fafc")};
+    color: ${(props) => (props.$active ? "#0f766e" : "#1e293b")};
+  }
+
+  .nav-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+    flex-shrink: 0;
+  }
+
+  .nav-badge {
+    margin-left: auto;
+    font-size: 12px;
+    font-weight: 600;
+    color: ${(props) => (props.$active ? "#fff" : "#94a3b8")};
+    background: ${(props) => (props.$active ? "#0f766e" : "#f1f5f9")};
+    padding: 2px 8px;
+    border-radius: 10px;
+  }
+`;
+
+const SidebarFooter = styled.div`
+  padding: 16px 20px;
+  border-top: 1px solid #e2e8f0;
+`;
+
+const EditDetailsButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  width: 100%;
+  padding: 10px 16px;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  color: #475569;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s ease;
+
+  &:hover {
+    background: #f8fafc;
+    border-color: #cbd5e1;
+  }
+`;
+
+const MainContainer = styled.main`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+`;
+
+const MainHeader = styled.header`
+  padding: 24px 40px;
+  background: #fff;
+  border-bottom: 1px solid #e2e8f0;
+`;
+
+const HeaderRow = styled.div`
+  display: flex;
+  align-items: flex-start;
+  gap: 20px;
+`;
+
+const HeaderContent = styled.div`
+  flex: 1;
+  min-width: 0;
+`;
+
+const TitleRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 4px;
+`;
+
+const Title = styled.h1`
+  font-size: 24px;
+  font-weight: 600;
+  color: #1e293b;
+  margin: 0;
+`;
+
+const Badge = styled.span`
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  background: #f1f5f9;
+  border: 1px solid #e2e8f0;
+  border-radius: 16px;
+  font-size: 12px;
+  font-weight: 500;
+  color: #475569;
+`;
+
+const Meta = styled.div`
+  font-size: 14px;
+  color: #475569;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
+const MetaSep = styled.span`
+  color: #e2e8f0;
+`;
+
+const HeaderActions = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+`;
+
+const ShareButton = styled.button`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 16px;
+  background: #0f766e;
+  border: none;
+  border-radius: 6px;
+  color: #fff;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s ease;
+
+  &:hover {
+    background: #0d9488;
+  }
+`;
+
+const MainContent = styled.div`
+  flex: 1;
+  overflow-y: auto;
+  padding: 32px 40px;
+`;
+
+const ContentInner = styled.div`
+  max-width: 900px;
+`;
+
+// Overview styles
+const OverviewSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+`;
+
+const OverviewHero = styled.div`
+  display: flex;
+  gap: 32px;
+  align-items: flex-start;
+`;
+
+const OverviewIconBox = styled.div`
+  width: 120px;
+  height: 120px;
+  background: linear-gradient(135deg, #f8fafc 0%, #f1f5f9 100%);
+  border: 1px solid #e2e8f0;
+  border-radius: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #94a3b8;
+  flex-shrink: 0;
+  overflow: hidden;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: 16px;
+  }
+`;
+
+const OverviewDetails = styled.div`
+  flex: 1;
+  min-width: 0;
+`;
+
+const OverviewDescription = styled.p`
+  font-size: 15px;
+  line-height: 1.6;
+  color: #475569;
+  margin: 0 0 24px 0;
+  max-width: 600px;
+`;
+
+const OverviewStats = styled.div`
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+  max-width: 500px;
+  margin-bottom: 24px;
+`;
+
+const StatCard = styled.div`
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 16px 20px;
+`;
+
+const StatValue = styled.div`
+  font-size: 28px;
+  font-weight: 600;
+  color: #0f766e;
+  line-height: 1;
+  margin-bottom: 4px;
+`;
+
+const StatLabel = styled.div`
+  font-size: 13px;
+  color: #475569;
+`;
+
+const OverviewActions = styled.div`
+  display: flex;
+  gap: 12px;
+`;
+
+const ActionButton = styled.button`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  color: #475569;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s ease;
+
+  &:hover {
+    background: #f8fafc;
+    border-color: #cbd5e1;
+  }
+
+  &.danger {
+    color: #dc2626;
+
+    &:hover {
+      background: #fef2f2;
+      border-color: #fecaca;
+    }
+  }
+`;
+
+// Labels section styles
+const LabelsSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+`;
+
+const SearchContainer = styled.div`
+  position: relative;
+  max-width: 400px;
+`;
+
+const SearchInput = styled.input`
+  width: 100%;
+  padding: 10px 12px 10px 40px;
+  font-size: 14px;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  background: #fff;
+  color: #1e293b;
+  outline: none;
+  transition: all 0.15s ease;
+
+  &:focus {
+    border-color: #0f766e;
+    box-shadow: 0 0 0 3px rgba(15, 118, 110, 0.1);
+  }
+
+  &::placeholder {
+    color: #94a3b8;
+  }
+`;
+
+const SearchIconWrapper = styled.span`
+  position: absolute;
+  left: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: #94a3b8;
+  pointer-events: none;
+`;
+
+const LabelsList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;
+
+const LabelItem = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 16px 20px;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  transition: all 0.15s ease;
+
+  &:hover {
+    border-color: #cbd5e1;
+    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+  }
+
+  &:hover .label-actions {
+    opacity: 1;
+  }
+`;
+
+const LabelGrip = styled.div`
+  cursor: grab;
+  color: #94a3b8;
+  flex-shrink: 0;
+
+  &:active {
+    cursor: grabbing;
+  }
+`;
+
+const LabelColor = styled.div<{ $color: string }>`
+  width: 14px;
+  height: 14px;
+  border-radius: 4px;
+  background-color: ${(props) => props.$color || "#94a3b8"};
+  flex-shrink: 0;
+`;
+
+const LabelContent = styled.div`
+  flex: 1;
+  min-width: 0;
+`;
+
+const LabelName = styled.p`
+  font-size: 15px;
+  font-weight: 500;
+  color: #1e293b;
+  margin: 0 0 2px 0;
+`;
+
+const LabelDescription = styled.p`
+  font-size: 13px;
+  color: #475569;
+  margin: 0;
+`;
+
+const LabelUsage = styled.span`
+  font-size: 12px;
+  color: #94a3b8;
+  flex-shrink: 0;
+`;
+
+const LabelActions = styled.div`
+  display: flex;
+  gap: 4px;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+`;
+
+const LabelActionButton = styled.button`
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  color: #94a3b8;
+  cursor: pointer;
+  transition: all 0.15s ease;
+
+  &:hover {
+    background: #f1f5f9;
+    color: #1e293b;
+  }
+
+  &.danger {
+    background: #fef2f2;
+    color: #f87171;
+    border: 1px solid #fecaca;
+
+    &:hover {
+      background: #fee2e2;
+      color: #dc2626;
+    }
+  }
+
+  &.success {
+    background: #f0fdf4;
+    color: #4ade80;
+    border: 1px solid #bbf7d0;
+
+    &:hover {
+      background: #dcfce7;
+      color: #16a34a;
+    }
+  }
+`;
+
+const LabelEditForm = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px 20px;
+  background: #fff;
+  border: 2px solid #0f766e;
+  border-radius: 10px;
+`;
+
+const LabelEditRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+`;
+
+const LabelEditInput = styled.input`
+  flex: 1;
+  padding: 8px 12px;
+  font-size: 14px;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  background: #fff;
+  color: #1e293b;
+  outline: none;
+  transition: all 0.15s ease;
+
+  &:focus {
+    border-color: #0f766e;
+    box-shadow: 0 0 0 3px rgba(15, 118, 110, 0.1);
+  }
+`;
+
+const LabelEditTextarea = styled.textarea`
+  flex: 1;
+  padding: 8px 12px;
+  font-size: 14px;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  background: #fff;
+  color: #1e293b;
+  outline: none;
+  resize: vertical;
+  min-height: 60px;
+  transition: all 0.15s ease;
+
+  &:focus {
+    border-color: #0f766e;
+    box-shadow: 0 0 0 3px rgba(15, 118, 110, 0.1);
+  }
+`;
+
+const LabelEditLabel = styled.label`
+  font-size: 13px;
+  font-weight: 500;
+  color: #475569;
+  min-width: 80px;
+`;
+
+const ColorInput = styled.input`
+  width: 40px;
+  height: 32px;
+  padding: 2px;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  cursor: pointer;
+`;
+
+const LabelEditActions = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 4px;
+`;
+
+const AddLabelButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  color: #475569;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  align-self: flex-start;
+
+  &:hover {
+    background: #f8fafc;
+    border-color: #cbd5e1;
+  }
+`;
+
+const EmptyState = styled.div`
+  text-align: center;
+  padding: 48px 24px;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+`;
+
+const EmptyStateIcon = styled.div`
+  width: 64px;
+  height: 64px;
+  margin: 0 auto 16px;
+  color: #94a3b8;
+`;
+
+const EmptyStateTitle = styled.h3`
+  font-size: 16px;
+  font-weight: 600;
+  color: #1e293b;
+  margin: 0 0 8px;
+`;
+
+const EmptyStateDescription = styled.p`
+  font-size: 14px;
+  color: #475569;
+  margin: 0 0 20px;
+`;
+
+const LoadingContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 400px;
+`;
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TYPES
+// ═══════════════════════════════════════════════════════════════════════════════
+
+type TabType =
+  | "overview"
+  | "text_labels"
+  | "doc_labels"
+  | "relationship_labels"
+  | "span_labels"
+  | "sharing";
+
+interface LabelSetDetailPageProps {
+  onClose?: () => void;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// MAIN COMPONENT
+// ═══════════════════════════════════════════════════════════════════════════════
+
+export const LabelSetDetailPage: React.FC<LabelSetDetailPageProps> = ({
+  onClose,
+}) => {
+  const navigate = useNavigate();
+  const opened_labelset = useReactiveVar(openedLabelset);
+  const currentUser = useReactiveVar(userObj);
+
+  const [activeTab, setActiveTab] = useState<TabType>("overview");
+  const [searchTerm, setSearchTerm] = useState<string>("");
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState<boolean>(false);
+  const [editingLabelId, setEditingLabelId] = useState<string | null>(null);
+  const [creatingLabelType, setCreatingLabelType] = useState<LabelType | null>(
+    null
+  );
+  const [editForm, setEditForm] = useState<{
+    text: string;
+    description: string;
+    color: string;
+  }>({ text: "", description: "", color: "" });
+
+  const my_permissions = getPermissions(
+    opened_labelset?.myPermissions ? opened_labelset.myPermissions : []
+  );
+  const canUpdate = my_permissions.includes(PermissionTypes.CAN_UPDATE);
+  const canRemove = my_permissions.includes(PermissionTypes.CAN_REMOVE);
+
+  // Mutations
+  const [createAnnotationLabelForLabelset] = useMutation<
+    CreateAnnotationLabelForLabelsetOutputs,
+    CreateAnnotationLabelForLabelsetInputs
+  >(CREATE_ANNOTATION_LABEL_FOR_LABELSET);
+
+  const [deleteMultipleLabels] = useMutation<
+    DeleteMultipleAnnotationLabelOutputs,
+    DeleteMultipleAnnotationLabelInputs
+  >(DELETE_MULTIPLE_ANNOTATION_LABELS);
+
+  const [updateAnnotationLabel] = useMutation<
+    UpdateAnnotationLabelOutputs,
+    UpdateAnnotationLabelInputs
+  >(UPDATE_ANNOTATION_LABEL);
+
+  const [deleteLabelset, { loading: delete_loading }] = useMutation<
+    DeleteLabelsetOutputs,
+    DeleteLabelsetInputs
+  >(DELETE_LABELSET);
+
+  // Query
+  const {
+    refetch,
+    loading: label_set_loading,
+    error: label_set_fetch_error,
+    data: label_set_data,
+  } = useQuery<GetLabelsetWithLabelsOutputs, GetLabelsetWithLabelsInputs>(
+    GET_LABELSET_WITH_ALL_LABELS,
+    {
+      variables: {
+        id: opened_labelset?.id ? opened_labelset.id : "",
+      },
+      skip: !opened_labelset?.id,
+      notifyOnNetworkStatusChange: true,
+    }
+  );
+
+  // Handlers
+  const handleBack = () => {
+    if (onClose) {
+      onClose();
+    } else {
+      openedLabelset(null);
+      navigate("/label_sets");
+    }
+  };
+
+  const handleDeleteLabel = (labels: AnnotationLabelType[]) => {
+    deleteMultipleLabels({
+      variables: {
+        annotationLabelIdsToDelete: labels.map((label) => label.id),
+      },
+    })
+      .then((result) => {
+        if (result.data?.deleteMultipleAnnotationLabels?.ok) {
+          refetch();
+          toast.success("Label deleted successfully");
+        } else {
+          toast.error(
+            result.data?.deleteMultipleAnnotationLabels?.message ||
+              "Failed to delete label"
+          );
+        }
+      })
+      .catch((err) => {
+        console.error("Error deleting label", err);
+        toast.error("Failed to delete label");
+      });
+  };
+
+  const handleStartEdit = (label: AnnotationLabelType) => {
+    setEditingLabelId(label.id);
+    setEditForm({
+      text: label.text || "",
+      description: label.description || "",
+      color: label.color || "94a3b8",
+    });
+  };
+
+  const handleCancelEdit = () => {
+    setEditingLabelId(null);
+    setCreatingLabelType(null);
+    setEditForm({ text: "", description: "", color: "" });
+  };
+
+  const handleSaveEdit = () => {
+    if (!editingLabelId) return;
+
+    updateAnnotationLabel({
+      variables: {
+        id: editingLabelId,
+        text: editForm.text,
+        description: editForm.description,
+        color: editForm.color.replace("#", ""),
+      },
+    })
+      .then((result) => {
+        if (result.data?.updateAnnotationLabel?.ok) {
+          refetch();
+          toast.success("Label updated successfully");
+          handleCancelEdit();
+        } else {
+          toast.error(
+            result.data?.updateAnnotationLabel?.message ||
+              "Failed to update label"
+          );
+        }
+      })
+      .catch((err) => {
+        console.error("Error updating label", err);
+        toast.error("Failed to update label");
+      });
+  };
+
+  const handleStartCreate = (labelType: LabelType) => {
+    // Cancel any existing edit
+    setEditingLabelId(null);
+    // Start creating a new label
+    setCreatingLabelType(labelType);
+    setEditForm({
+      text: "",
+      description: "",
+      color: "0F766E", // Default teal color
+    });
+  };
+
+  const handleSaveCreate = () => {
+    if (!creatingLabelType || !editForm.text.trim()) {
+      toast.error("Please enter a label name");
+      return;
+    }
+
+    createAnnotationLabelForLabelset({
+      variables: {
+        color: editForm.color.replace("#", ""),
+        description: editForm.description,
+        icon: "tag",
+        text: editForm.text,
+        labelType: creatingLabelType,
+        labelsetId: opened_labelset?.id ? opened_labelset.id : "",
+      },
+    })
+      .then(() => {
+        toast.success("Label created successfully");
+        refetch();
+        handleCancelEdit();
+      })
+      .catch((err) => {
+        toast.error("Failed to create label");
+        console.error("Error creating label:", err);
+      });
+  };
+
+  const handleExportJSON = () => {
+    if (!label_set_data?.labelset) return;
+    const exportData = {
+      title: label_set_data.labelset.title,
+      description: label_set_data.labelset.description,
+      labels: label_set_data.labelset.allAnnotationLabels?.map((label) => ({
+        text: label?.text,
+        description: label?.description,
+        color: label?.color,
+        icon: label?.icon,
+        labelType: label?.labelType,
+      })),
+    };
+    const blob = new Blob([JSON.stringify(exportData, null, 2)], {
+      type: "application/json",
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `${label_set_data.labelset.title || "labelset"}.json`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+    toast.success("Label set exported successfully");
+  };
+
+  const handleDelete = () => {
+    if (!opened_labelset?.id) return;
+
+    deleteLabelset({
+      variables: { id: opened_labelset.id },
+    })
+      .then((result) => {
+        if (result.data?.deleteLabelset?.ok) {
+          toast.success("Label set deleted successfully");
+          openedLabelset(null);
+          navigate("/label_sets");
+        } else {
+          toast.error(
+            result.data?.deleteLabelset?.message || "Failed to delete label set"
+          );
+        }
+      })
+      .catch((err) => {
+        console.error("Error deleting labelset:", err);
+        toast.error("Failed to delete label set");
+      });
+    setShowDeleteConfirm(false);
+  };
+
+  const handleShare = () => {
+    toast.info("Share functionality coming soon");
+  };
+
+  const handleEditDetails = () => {
+    toast.info("Edit details functionality coming soon");
+  };
+
+  // Loading state
+  if (label_set_loading && !label_set_data) {
+    return (
+      <PageContainer>
+        <LoadingContainer>
+          <Dimmer active inverted>
+            <Loader size="large">Loading label set...</Loader>
+          </Dimmer>
+        </LoadingContainer>
+      </PageContainer>
+    );
+  }
+
+  // Error state
+  if (label_set_fetch_error) {
+    return (
+      <PageContainer>
+        <MainContent>
+          <Message negative>
+            <Message.Header>Error loading label set</Message.Header>
+            <p>{label_set_fetch_error.message}</p>
+          </Message>
+        </MainContent>
+      </PageContainer>
+    );
+  }
+
+  // Get labels from data
+  const labels: AnnotationLabelType[] = label_set_data?.labelset
+    ?.allAnnotationLabels
+    ? (label_set_data.labelset.allAnnotationLabels.filter(
+        (item) => item!!
+      ) as AnnotationLabelType[])
+    : [];
+
+  // Filter labels by type
+  const text_labels = labels.filter(
+    (label) => label.labelType === LabelType.TokenLabel
+  );
+  const doc_type_labels = labels.filter(
+    (label) => label.labelType === LabelType.DocTypeLabel
+  );
+  const relationship_labels = labels.filter(
+    (label) => label.labelType === LabelType.RelationshipLabel
+  );
+  const span_labels = labels.filter(
+    (label) => label.labelType === LabelType.SpanLabel
+  );
+
+  // Setup fuzzy search
+  const text_label_fuse = new Fuse(text_labels, fuse_options);
+  const doc_label_fuse = new Fuse(doc_type_labels, fuse_options);
+  const relationship_label_fuse = new Fuse(relationship_labels, fuse_options);
+  const span_label_fuse = new Fuse(span_labels, fuse_options);
+
+  // Apply search filter
+  const filterLabels = (
+    labels: AnnotationLabelType[],
+    fuse: Fuse<AnnotationLabelType>
+  ) => {
+    if (searchTerm.length > 0) {
+      return fuse.search(searchTerm).map((item) => item.item);
+    }
+    return labels;
+  };
+
+  const text_label_results = filterLabels(text_labels, text_label_fuse);
+  const doc_label_results = filterLabels(doc_type_labels, doc_label_fuse);
+  const relationship_label_results = filterLabels(
+    relationship_labels,
+    relationship_label_fuse
+  );
+  const span_label_results = filterLabels(span_labels, span_label_fuse);
+
+  const totalLabels =
+    (label_set_data?.labelset?.docLabelCount || 0) +
+    (label_set_data?.labelset?.spanLabelCount || 0) +
+    (label_set_data?.labelset?.tokenLabelCount || 0);
+
+  const labelset = label_set_data?.labelset || opened_labelset;
+
+  // Render label list
+  const renderLabelsList = (
+    labels: AnnotationLabelType[],
+    labelType: LabelType,
+    labelTypeName: string
+  ) => {
+    if (labels.length === 0 && !searchTerm) {
+      // If we're creating, show the form instead of empty state
+      if (creatingLabelType === labelType) {
+        return (
+          <LabelEditForm>
+            <LabelEditRow>
+              <LabelEditLabel>Name</LabelEditLabel>
+              <LabelEditInput
+                type="text"
+                value={editForm.text}
+                onChange={(e) =>
+                  setEditForm({ ...editForm, text: e.target.value })
+                }
+                placeholder="Enter label name"
+                autoFocus
+              />
+            </LabelEditRow>
+            <LabelEditRow>
+              <LabelEditLabel>Description</LabelEditLabel>
+              <LabelEditTextarea
+                value={editForm.description}
+                onChange={(e) =>
+                  setEditForm({ ...editForm, description: e.target.value })
+                }
+                placeholder="Describe what this label is used for"
+              />
+            </LabelEditRow>
+            <LabelEditRow>
+              <LabelEditLabel>Color</LabelEditLabel>
+              <ColorInput
+                type="color"
+                value={`#${editForm.color}`}
+                onChange={(e) =>
+                  setEditForm({
+                    ...editForm,
+                    color: e.target.value.replace("#", ""),
+                  })
+                }
+              />
+              <LabelColor $color={`#${editForm.color}`} />
+            </LabelEditRow>
+            <LabelEditActions>
+              <LabelActionButton
+                className="danger"
+                title="Cancel"
+                onClick={handleCancelEdit}
+              >
+                <CloseIcon />
+              </LabelActionButton>
+              <LabelActionButton
+                className="success"
+                title="Create"
+                onClick={handleSaveCreate}
+              >
+                <SaveIcon />
+              </LabelActionButton>
+            </LabelEditActions>
+          </LabelEditForm>
+        );
+      }
+
+      return (
+        <EmptyState>
+          <EmptyStateIcon>
+            <LabelSetIcon />
+          </EmptyStateIcon>
+          <EmptyStateTitle>
+            No {labelTypeName.toLowerCase()} yet
+          </EmptyStateTitle>
+          <EmptyStateDescription>
+            {labelTypeName} are used to categorize and annotate your documents.
+          </EmptyStateDescription>
+          {canUpdate && (
+            <AddLabelButton onClick={() => handleStartCreate(labelType)}>
+              <PlusIcon /> Add First Label
+            </AddLabelButton>
+          )}
+        </EmptyState>
+      );
+    }
+
+    if (labels.length === 0 && searchTerm) {
+      return (
+        <EmptyState>
+          <EmptyStateTitle>No labels match "{searchTerm}"</EmptyStateTitle>
+          <EmptyStateDescription>
+            Try a different search term or add a new label.
+          </EmptyStateDescription>
+        </EmptyState>
+      );
+    }
+
+    // Check if we're creating a new label of this type
+    const isCreating = creatingLabelType === labelType;
+
+    return (
+      <>
+        {/* Create form at top when adding new label */}
+        {isCreating && (
+          <LabelEditForm>
+            <LabelEditRow>
+              <LabelEditLabel>Name</LabelEditLabel>
+              <LabelEditInput
+                type="text"
+                value={editForm.text}
+                onChange={(e) =>
+                  setEditForm({ ...editForm, text: e.target.value })
+                }
+                placeholder="Enter label name"
+                autoFocus
+              />
+            </LabelEditRow>
+            <LabelEditRow>
+              <LabelEditLabel>Description</LabelEditLabel>
+              <LabelEditTextarea
+                value={editForm.description}
+                onChange={(e) =>
+                  setEditForm({ ...editForm, description: e.target.value })
+                }
+                placeholder="Describe what this label is used for"
+              />
+            </LabelEditRow>
+            <LabelEditRow>
+              <LabelEditLabel>Color</LabelEditLabel>
+              <ColorInput
+                type="color"
+                value={`#${editForm.color}`}
+                onChange={(e) =>
+                  setEditForm({
+                    ...editForm,
+                    color: e.target.value.replace("#", ""),
+                  })
+                }
+              />
+              <LabelColor $color={`#${editForm.color}`} />
+            </LabelEditRow>
+            <LabelEditActions>
+              <LabelActionButton
+                className="danger"
+                title="Cancel"
+                onClick={handleCancelEdit}
+              >
+                <CloseIcon />
+              </LabelActionButton>
+              <LabelActionButton
+                className="success"
+                title="Create"
+                onClick={handleSaveCreate}
+              >
+                <SaveIcon />
+              </LabelActionButton>
+            </LabelEditActions>
+          </LabelEditForm>
+        )}
+
+        {/* Existing labels list */}
+        <LabelsList>
+          {labels.map((label) =>
+            editingLabelId === label.id ? (
+              <LabelEditForm key={label.id}>
+                <LabelEditRow>
+                  <LabelEditLabel>Name</LabelEditLabel>
+                  <LabelEditInput
+                    type="text"
+                    value={editForm.text}
+                    onChange={(e) =>
+                      setEditForm({ ...editForm, text: e.target.value })
+                    }
+                    placeholder="Label name"
+                  />
+                </LabelEditRow>
+                <LabelEditRow>
+                  <LabelEditLabel>Description</LabelEditLabel>
+                  <LabelEditTextarea
+                    value={editForm.description}
+                    onChange={(e) =>
+                      setEditForm({ ...editForm, description: e.target.value })
+                    }
+                    placeholder="Label description"
+                  />
+                </LabelEditRow>
+                <LabelEditRow>
+                  <LabelEditLabel>Color</LabelEditLabel>
+                  <ColorInput
+                    type="color"
+                    value={`#${editForm.color}`}
+                    onChange={(e) =>
+                      setEditForm({
+                        ...editForm,
+                        color: e.target.value.replace("#", ""),
+                      })
+                    }
+                  />
+                  <LabelColor $color={`#${editForm.color}`} />
+                </LabelEditRow>
+                <LabelEditActions>
+                  <LabelActionButton
+                    className="danger"
+                    title="Cancel"
+                    onClick={handleCancelEdit}
+                  >
+                    <CloseIcon />
+                  </LabelActionButton>
+                  <LabelActionButton
+                    className="success"
+                    title="Save"
+                    onClick={handleSaveEdit}
+                  >
+                    <SaveIcon />
+                  </LabelActionButton>
+                </LabelEditActions>
+              </LabelEditForm>
+            ) : (
+              <LabelItem key={label.id}>
+                <LabelGrip>
+                  <GripIcon />
+                </LabelGrip>
+                <LabelColor $color={`#${label.color || "94a3b8"}`} />
+                <LabelContent>
+                  <LabelName>{label.text}</LabelName>
+                  <LabelDescription>{label.description}</LabelDescription>
+                </LabelContent>
+                <LabelUsage>0 uses</LabelUsage>
+                <LabelActions className="label-actions">
+                  {canUpdate && (
+                    <LabelActionButton
+                      title="Edit"
+                      onClick={() => handleStartEdit(label)}
+                    >
+                      <EditIcon />
+                    </LabelActionButton>
+                  )}
+                  {canUpdate && (
+                    <LabelActionButton
+                      className="danger"
+                      title="Delete"
+                      onClick={() => handleDeleteLabel([label])}
+                    >
+                      <TrashIcon />
+                    </LabelActionButton>
+                  )}
+                </LabelActions>
+              </LabelItem>
+            )
+          )}
+        </LabelsList>
+
+        {/* Add button - hidden when already creating */}
+        {canUpdate && !isCreating && (
+          <AddLabelButton onClick={() => handleStartCreate(labelType)}>
+            <PlusIcon /> Add Label
+          </AddLabelButton>
+        )}
+      </>
+    );
+  };
+
+  // Render content based on active tab
+  const renderContent = () => {
+    switch (activeTab) {
+      case "overview":
+        return (
+          <OverviewSection>
+            <OverviewHero>
+              <OverviewIconBox>
+                {labelset?.icon ? (
+                  <img src={labelset.icon} alt="Label set icon" />
+                ) : (
+                  <LabelSetIcon />
+                )}
+              </OverviewIconBox>
+              <OverviewDetails>
+                <OverviewDescription>
+                  {labelset?.description || "No description provided."}
+                </OverviewDescription>
+
+                <OverviewStats>
+                  <StatCard>
+                    <StatValue>{totalLabels}</StatValue>
+                    <StatLabel>Total Labels</StatLabel>
+                  </StatCard>
+                  <StatCard>
+                    <StatValue>
+                      {label_set_data?.labelset?.docLabelCount || 0}
+                    </StatValue>
+                    <StatLabel>Doc Labels</StatLabel>
+                  </StatCard>
+                  <StatCard>
+                    <StatValue>
+                      {label_set_data?.labelset?.spanLabelCount || 0}
+                    </StatValue>
+                    <StatLabel>Span Labels</StatLabel>
+                  </StatCard>
+                </OverviewStats>
+
+                <OverviewActions>
+                  <ActionButton onClick={handleExportJSON}>
+                    <DownloadIcon />
+                    Export JSON
+                  </ActionButton>
+                  {canRemove && (
+                    <ActionButton
+                      className="danger"
+                      onClick={() => setShowDeleteConfirm(true)}
+                    >
+                      <TrashIcon />
+                      Delete
+                    </ActionButton>
+                  )}
+                </OverviewActions>
+              </OverviewDetails>
+            </OverviewHero>
+          </OverviewSection>
+        );
+
+      case "text_labels":
+        return (
+          <LabelsSection>
+            <SearchContainer>
+              <SearchIconWrapper>
+                <SearchIcon />
+              </SearchIconWrapper>
+              <SearchInput
+                type="text"
+                placeholder="Search text labels..."
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+              />
+            </SearchContainer>
+            {renderLabelsList(
+              text_label_results,
+              LabelType.TokenLabel,
+              "Text Labels"
+            )}
+          </LabelsSection>
+        );
+
+      case "doc_labels":
+        return (
+          <LabelsSection>
+            <SearchContainer>
+              <SearchIconWrapper>
+                <SearchIcon />
+              </SearchIconWrapper>
+              <SearchInput
+                type="text"
+                placeholder="Search doc labels..."
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+              />
+            </SearchContainer>
+            {renderLabelsList(
+              doc_label_results,
+              LabelType.DocTypeLabel,
+              "Doc Labels"
+            )}
+          </LabelsSection>
+        );
+
+      case "relationship_labels":
+        return (
+          <LabelsSection>
+            <SearchContainer>
+              <SearchIconWrapper>
+                <SearchIcon />
+              </SearchIconWrapper>
+              <SearchInput
+                type="text"
+                placeholder="Search relationship labels..."
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+              />
+            </SearchContainer>
+            {renderLabelsList(
+              relationship_label_results,
+              LabelType.RelationshipLabel,
+              "Relationship Labels"
+            )}
+          </LabelsSection>
+        );
+
+      case "span_labels":
+        return (
+          <LabelsSection>
+            <SearchContainer>
+              <SearchIconWrapper>
+                <SearchIcon />
+              </SearchIconWrapper>
+              <SearchInput
+                type="text"
+                placeholder="Search labels..."
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+              />
+            </SearchContainer>
+            {renderLabelsList(
+              span_label_results,
+              LabelType.SpanLabel,
+              "Span Labels"
+            )}
+          </LabelsSection>
+        );
+
+      case "sharing":
+        return (
+          <Message info>
+            <Message.Header>Sharing Settings</Message.Header>
+            <p>Sharing configuration will be available here.</p>
+          </Message>
+        );
+
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <PageContainer>
+      {(label_set_loading || delete_loading) && (
+        <Dimmer active inverted>
+          <Loader size="large">
+            {delete_loading ? "Deleting..." : "Loading..."}
+          </Loader>
+        </Dimmer>
+      )}
+
+      <Sidebar>
+        <SidebarHeader>
+          <BackLink onClick={handleBack}>
+            <ChevronLeftIcon />
+            Label Sets
+          </BackLink>
+        </SidebarHeader>
+
+        <SidebarNav>
+          <NavItem
+            $active={activeTab === "overview"}
+            onClick={() => setActiveTab("overview")}
+          >
+            <span className="nav-icon">
+              <OverviewIcon />
+            </span>
+            Overview
+          </NavItem>
+          <NavItem
+            $active={activeTab === "text_labels"}
+            onClick={() => setActiveTab("text_labels")}
+          >
+            <span className="nav-icon">
+              <TextLabelIcon />
+            </span>
+            Text Labels
+            <span className="nav-badge">{text_labels.length}</span>
+          </NavItem>
+          <NavItem
+            $active={activeTab === "doc_labels"}
+            onClick={() => setActiveTab("doc_labels")}
+          >
+            <span className="nav-icon">
+              <DocLabelIcon />
+            </span>
+            Doc Labels
+            <span className="nav-badge">{doc_type_labels.length}</span>
+          </NavItem>
+          <NavItem
+            $active={activeTab === "relationship_labels"}
+            onClick={() => setActiveTab("relationship_labels")}
+          >
+            <span className="nav-icon">
+              <RelationshipIcon />
+            </span>
+            Relationships
+            <span className="nav-badge">{relationship_labels.length}</span>
+          </NavItem>
+          <NavItem
+            $active={activeTab === "span_labels"}
+            onClick={() => setActiveTab("span_labels")}
+          >
+            <span className="nav-icon">
+              <SpanLabelIcon />
+            </span>
+            Span Labels
+            <span className="nav-badge">{span_labels.length}</span>
+          </NavItem>
+          <NavItem
+            $active={activeTab === "sharing"}
+            onClick={() => setActiveTab("sharing")}
+          >
+            <span className="nav-icon">
+              <ShareIcon />
+            </span>
+            Sharing
+          </NavItem>
+        </SidebarNav>
+
+        {canUpdate && (
+          <SidebarFooter>
+            <EditDetailsButton onClick={handleEditDetails}>
+              <EditIcon />
+              Edit Details
+            </EditDetailsButton>
+          </SidebarFooter>
+        )}
+      </Sidebar>
+
+      <MainContainer>
+        <MainHeader>
+          <HeaderRow>
+            <HeaderContent>
+              <TitleRow>
+                <Title>{labelset?.title || "Untitled Label Set"}</Title>
+                <Badge>{labelset?.isPublic ? "Public" : "Private"}</Badge>
+              </TitleRow>
+              <Meta>
+                <span>
+                  Created by{" "}
+                  {labelset?.creator?.username ||
+                    currentUser?.email ||
+                    "Unknown"}
+                </span>
+                <MetaSep>·</MetaSep>
+                <span>
+                  {totalLabels} {totalLabels === 1 ? "label" : "labels"}
+                </span>
+              </Meta>
+            </HeaderContent>
+            <HeaderActions>
+              <ShareButton onClick={handleShare}>
+                <ShareIcon />
+                Share
+              </ShareButton>
+            </HeaderActions>
+          </HeaderRow>
+        </MainHeader>
+
+        <MainContent>
+          <ContentInner>{renderContent()}</ContentInner>
+        </MainContent>
+      </MainContainer>
+
+      {/* Delete Confirmation Modal */}
+      <ConfirmModal
+        message={`Are you sure you want to delete "${
+          labelset?.title || "this label set"
+        }"? This action cannot be undone.`}
+        visible={showDeleteConfirm}
+        yesAction={handleDelete}
+        noAction={() => setShowDeleteConfirm(false)}
+        toggleModal={() => setShowDeleteConfirm(false)}
+      />
+    </PageContainer>
+  );
+};
+
+export default LabelSetDetailPage;

--- a/frontend/src/components/labelsets/LabelSetDetailPage.tsx
+++ b/frontend/src/components/labelsets/LabelSetDetailPage.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-import styled from "styled-components";
 import { useNavigate } from "react-router-dom";
 import { Dimmer, Loader, Message } from "semantic-ui-react";
 import Fuse from "fuse.js";
@@ -34,1063 +33,99 @@ import { toast } from "react-toastify";
 import { getPermissions } from "../../utils/transform";
 import { PermissionTypes } from "../types";
 
+// Import extracted components from detail folder
+import {
+  // Icons
+  ChevronLeftIcon,
+  OverviewIcon,
+  DocLabelIcon,
+  SpanLabelIcon,
+  TextLabelIcon,
+  RelationshipIcon,
+  ShareIcon,
+  EditIcon,
+  TrashIcon,
+  DownloadIcon,
+  SaveIcon,
+  CloseIcon,
+  GripIcon,
+  SearchIcon,
+  PlusIcon,
+  LabelSetIcon,
+  // Styled Components
+  PageContainer,
+  PageLayout,
+  Sidebar,
+  SidebarHeader,
+  BackLink,
+  SidebarNav,
+  NavItem,
+  SidebarFooter,
+  MobileNav,
+  MobileNavTabs,
+  MobileNavTab,
+  EditDetailsButton,
+  MainContainer,
+  MainHeader,
+  MobileBackLink,
+  HeaderRow,
+  HeaderContent,
+  TitleRow,
+  Title,
+  Badge,
+  Meta,
+  MetaSep,
+  HeaderActions,
+  ShareButton,
+  MainContent,
+  ContentInner,
+  OverviewSection,
+  OverviewHero,
+  OverviewIconBox,
+  OverviewDetails,
+  OverviewDescription,
+  OverviewStats,
+  StatCard,
+  StatValue,
+  StatLabel,
+  OverviewActions,
+  ActionButton,
+  LabelsSection,
+  SearchContainer,
+  SearchInput,
+  SearchIconWrapper,
+  LabelsList,
+  LabelItem,
+  LabelGrip,
+  LabelColor,
+  LabelContent,
+  LabelName,
+  LabelDescription,
+  LabelActions,
+  LabelActionButton,
+  LabelEditForm,
+  LabelEditRow,
+  LabelEditInput,
+  LabelEditTextarea,
+  LabelEditLabel,
+  ColorInput,
+  LabelEditActions,
+  AddLabelButton,
+  EmptyState,
+  EmptyStateIcon,
+  EmptyStateTitle,
+  EmptyStateDescription,
+  LoadingContainer,
+  // Color constants
+  DEFAULT_LABEL_COLOR,
+  PRIMARY_LABEL_COLOR,
+} from "./detail";
+
 const fuse_options = {
   includeScore: false,
   findAllMatches: true,
   keys: ["text", "description"],
 };
-
-// ═══════════════════════════════════════════════════════════════════════════════
-// ICONS
-// ═══════════════════════════════════════════════════════════════════════════════
-
-const ChevronLeftIcon = () => (
-  <svg
-    width="18"
-    height="18"
-    viewBox="0 0 18 18"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="1.5"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <path d="M11.25 13.5L6.75 9l4.5-4.5" />
-  </svg>
-);
-
-const OverviewIcon = () => (
-  <svg
-    width="18"
-    height="18"
-    viewBox="0 0 18 18"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="1.5"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <rect x="3" y="3" width="5" height="5" rx="1" />
-    <rect x="10" y="3" width="5" height="5" rx="1" />
-    <rect x="3" y="10" width="5" height="5" rx="1" />
-    <rect x="10" y="10" width="5" height="5" rx="1" />
-  </svg>
-);
-
-const DocLabelIcon = () => (
-  <svg
-    width="18"
-    height="18"
-    viewBox="0 0 18 18"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="1.5"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <path d="M10.5 1.5H4.5a1.5 1.5 0 00-1.5 1.5v12a1.5 1.5 0 001.5 1.5h9a1.5 1.5 0 001.5-1.5V6L10.5 1.5z" />
-    <path d="M10.5 1.5V6H15" />
-    <path d="M6 9h6M6 12h4" />
-  </svg>
-);
-
-const SpanLabelIcon = () => (
-  <svg
-    width="18"
-    height="18"
-    viewBox="0 0 18 18"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="1.5"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <path d="M3 5.25h12M3 9h8M3 12.75h10" />
-    <rect
-      x="11"
-      y="7.5"
-      width="4"
-      height="3"
-      rx="0.5"
-      fill="currentColor"
-      opacity="0.2"
-      stroke="currentColor"
-    />
-  </svg>
-);
-
-const TextLabelIcon = () => (
-  <svg
-    width="18"
-    height="18"
-    viewBox="0 0 18 18"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="1.5"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <path d="M3 4.5h12M6 9h6M4.5 13.5h9" />
-    <path d="M9 3v12" strokeOpacity="0.3" />
-  </svg>
-);
-
-const RelationshipIcon = () => (
-  <svg
-    width="18"
-    height="18"
-    viewBox="0 0 18 18"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="1.5"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <circle cx="4.5" cy="9" r="2.5" />
-    <circle cx="13.5" cy="9" r="2.5" />
-    <path d="M7 9h4" />
-    <path d="M10 7l2 2-2 2" />
-  </svg>
-);
-
-const ShareIcon = () => (
-  <svg
-    width="18"
-    height="18"
-    viewBox="0 0 18 18"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="1.5"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <circle cx="13.5" cy="3.75" r="2.25" />
-    <circle cx="4.5" cy="9" r="2.25" />
-    <circle cx="13.5" cy="14.25" r="2.25" />
-    <path d="M6.54 10.11l4.92 3.03M11.46 4.86L6.54 7.89" />
-  </svg>
-);
-
-const EditIcon = () => (
-  <svg
-    width="16"
-    height="16"
-    viewBox="0 0 16 16"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="1.5"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <path d="M11.5 2.5a1.77 1.77 0 012.5 2.5L5.25 13.75 1.5 14.5l.75-3.75L11.5 2.5z" />
-  </svg>
-);
-
-const TrashIcon = () => (
-  <svg
-    width="16"
-    height="16"
-    viewBox="0 0 16 16"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="1.5"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <path d="M2 4h12M5.33 4V2.67a.67.67 0 01.67-.67h4a.67.67 0 01.67.67V4M12.67 4v9.33a.67.67 0 01-.67.67H4a.67.67 0 01-.67-.67V4" />
-  </svg>
-);
-
-const DownloadIcon = () => (
-  <svg
-    width="16"
-    height="16"
-    viewBox="0 0 16 16"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="1.5"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <path d="M8 2v9M4.5 7.5L8 11l3.5-3.5M2 14h12" />
-  </svg>
-);
-
-const SaveIcon = () => (
-  <svg
-    width="16"
-    height="16"
-    viewBox="0 0 16 16"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="1.5"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <path d="M13.33 5.33L6.67 12 2.67 8" />
-  </svg>
-);
-
-const CloseIcon = () => (
-  <svg
-    width="16"
-    height="16"
-    viewBox="0 0 16 16"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="1.5"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <path d="M12 4L4 12M4 4l8 8" />
-  </svg>
-);
-
-const GripIcon = () => (
-  <svg
-    width="16"
-    height="16"
-    viewBox="0 0 16 16"
-    fill="currentColor"
-    opacity="0.4"
-  >
-    <circle cx="5" cy="4" r="1.5" />
-    <circle cx="11" cy="4" r="1.5" />
-    <circle cx="5" cy="8" r="1.5" />
-    <circle cx="11" cy="8" r="1.5" />
-    <circle cx="5" cy="12" r="1.5" />
-    <circle cx="11" cy="12" r="1.5" />
-  </svg>
-);
-
-const SearchIcon = () => (
-  <svg
-    width="16"
-    height="16"
-    viewBox="0 0 16 16"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="1.5"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <circle cx="7" cy="7" r="5" />
-    <path d="M14 14l-3.5-3.5" />
-  </svg>
-);
-
-const PlusIcon = () => (
-  <svg
-    width="18"
-    height="18"
-    viewBox="0 0 18 18"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="1.5"
-    strokeLinecap="round"
-  >
-    <path d="M9 3.75v10.5M3.75 9h10.5" />
-  </svg>
-);
-
-const LabelSetIcon = () => (
-  <svg
-    width="48"
-    height="48"
-    viewBox="0 0 48 48"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <path d="M20 8H10a4 4 0 00-4 4v24a4 4 0 004 4h28a4 4 0 004-4V20" />
-    <path d="M32 6l8 8-16 16H16v-8L32 6z" />
-  </svg>
-);
-
-// ═══════════════════════════════════════════════════════════════════════════════
-// STYLED COMPONENTS
-// ═══════════════════════════════════════════════════════════════════════════════
-
-const PageContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  height: calc(100vh - 60px);
-  background: #fafafa;
-  font-family: "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
-`;
-
-const PageLayout = styled.div`
-  display: flex;
-  flex: 1;
-  overflow: hidden;
-`;
-
-const Sidebar = styled.aside`
-  width: 260px;
-  min-width: 260px;
-  background: #fff;
-  border-right: 1px solid #e2e8f0;
-  display: flex;
-  flex-direction: column;
-
-  @media (max-width: 900px) {
-    display: none;
-  }
-`;
-
-const SidebarHeader = styled.div`
-  padding: 24px 20px;
-  border-bottom: 1px solid #e2e8f0;
-`;
-
-const BackLink = styled.button`
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  font-size: 13px;
-  font-weight: 500;
-  color: #475569;
-  text-decoration: none;
-  padding: 6px 10px 6px 6px;
-  margin: -6px -10px -6px -6px;
-  border-radius: 6px;
-  transition: all 0.15s ease;
-  cursor: pointer;
-  background: none;
-  border: none;
-
-  &:hover {
-    background: #f1f5f9;
-    color: #1e293b;
-  }
-`;
-
-const SidebarNav = styled.nav`
-  flex: 1;
-  padding: 12px 0;
-  overflow-y: auto;
-`;
-
-interface NavItemProps {
-  $active?: boolean;
-}
-
-const NavItem = styled.button<NavItemProps>`
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 10px 20px;
-  font-size: 14px;
-  font-weight: 500;
-  color: ${(props) => (props.$active ? "#0f766e" : "#475569")};
-  cursor: pointer;
-  transition: all 0.15s ease;
-  border: none;
-  background: ${(props) =>
-    props.$active
-      ? "linear-gradient(90deg, rgba(15, 118, 110, 0.08) 0%, transparent 100%)"
-      : "none"};
-  width: 100%;
-  text-align: left;
-  border-left: 2px solid
-    ${(props) => (props.$active ? "#0f766e" : "transparent")};
-  padding-left: ${(props) => (props.$active ? "18px" : "20px")};
-
-  &:hover {
-    background: ${(props) => (props.$active ? undefined : "#f8fafc")};
-    color: ${(props) => (props.$active ? "#0f766e" : "#1e293b")};
-  }
-
-  .nav-icon {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 20px;
-    height: 20px;
-    flex-shrink: 0;
-  }
-
-  .nav-badge {
-    margin-left: auto;
-    font-size: 12px;
-    font-weight: 600;
-    color: ${(props) => (props.$active ? "#fff" : "#94a3b8")};
-    background: ${(props) => (props.$active ? "#0f766e" : "#f1f5f9")};
-    padding: 2px 8px;
-    border-radius: 10px;
-  }
-`;
-
-const SidebarFooter = styled.div`
-  padding: 16px 20px;
-  border-top: 1px solid #e2e8f0;
-`;
-
-// Mobile Navigation
-const MobileNav = styled.nav`
-  display: none;
-  background: #fff;
-  border-bottom: 1px solid #e2e8f0;
-  padding: 0 24px;
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
-  scrollbar-width: none;
-
-  &::-webkit-scrollbar {
-    display: none;
-  }
-
-  @media (max-width: 900px) {
-    display: block;
-  }
-`;
-
-const MobileNavTabs = styled.div`
-  display: flex;
-  gap: 4px;
-  min-width: max-content;
-`;
-
-interface MobileNavTabProps {
-  $active?: boolean;
-}
-
-const MobileNavTab = styled.button<MobileNavTabProps>`
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 12px 16px;
-  font-size: 14px;
-  font-weight: 500;
-  color: ${(props) => (props.$active ? "#0f766e" : "#475569")};
-  background: none;
-  border: none;
-  border-bottom: 2px solid
-    ${(props) => (props.$active ? "#0f766e" : "transparent")};
-  cursor: pointer;
-  white-space: nowrap;
-  transition: all 0.15s ease;
-
-  &:first-child {
-    padding-left: 0;
-  }
-
-  &:hover {
-    color: ${(props) => (props.$active ? "#0f766e" : "#1e293b")};
-  }
-
-  .nav-icon {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 18px;
-    height: 18px;
-  }
-
-  .nav-badge {
-    font-size: 11px;
-    font-weight: 600;
-    padding: 2px 6px;
-    border-radius: 10px;
-    background: ${(props) => (props.$active ? "#0f766e" : "#f1f5f9")};
-    color: ${(props) => (props.$active ? "#fff" : "#94a3b8")};
-  }
-`;
-
-const EditDetailsButton = styled.button`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  width: 100%;
-  padding: 10px 16px;
-  background: #fff;
-  border: 1px solid #e2e8f0;
-  border-radius: 8px;
-  color: #475569;
-  font-size: 14px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: all 0.15s ease;
-
-  &:hover {
-    background: #f8fafc;
-    border-color: #cbd5e1;
-  }
-`;
-
-const MainContainer = styled.main`
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-`;
-
-const MainHeader = styled.header`
-  padding: 24px 40px;
-  background: #fff;
-  border-bottom: 1px solid #e2e8f0;
-
-  @media (max-width: 900px) {
-    padding: 16px 24px;
-  }
-`;
-
-const MobileBackLink = styled.button`
-  display: none;
-  align-items: center;
-  gap: 6px;
-  font-size: 13px;
-  font-weight: 500;
-  color: #475569;
-  text-decoration: none;
-  padding: 6px 10px 6px 6px;
-  margin: -6px -10px 12px -6px;
-  border-radius: 6px;
-  transition: all 0.15s ease;
-  cursor: pointer;
-  background: none;
-  border: none;
-
-  &:hover {
-    background: #f1f5f9;
-    color: #1e293b;
-  }
-
-  @media (max-width: 900px) {
-    display: inline-flex;
-  }
-`;
-
-const HeaderRow = styled.div`
-  display: flex;
-  align-items: flex-start;
-  gap: 20px;
-`;
-
-const HeaderContent = styled.div`
-  flex: 1;
-  min-width: 0;
-`;
-
-const TitleRow = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  margin-bottom: 4px;
-`;
-
-const Title = styled.h1`
-  font-size: 24px;
-  font-weight: 600;
-  color: #1e293b;
-  margin: 0;
-
-  @media (max-width: 900px) {
-    font-size: 20px;
-  }
-`;
-
-const Badge = styled.span`
-  display: inline-flex;
-  align-items: center;
-  padding: 4px 10px;
-  background: #f1f5f9;
-  border: 1px solid #e2e8f0;
-  border-radius: 16px;
-  font-size: 12px;
-  font-weight: 500;
-  color: #475569;
-`;
-
-const Meta = styled.div`
-  font-size: 14px;
-  color: #475569;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-`;
-
-const MetaSep = styled.span`
-  color: #e2e8f0;
-`;
-
-const HeaderActions = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  flex-shrink: 0;
-`;
-
-const ShareButton = styled.button`
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 8px 16px;
-  background: #0f766e;
-  border: none;
-  border-radius: 6px;
-  color: #fff;
-  font-size: 14px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: all 0.15s ease;
-
-  &:hover {
-    background: #0d9488;
-  }
-`;
-
-const MainContent = styled.div`
-  flex: 1;
-  overflow-y: auto;
-  padding: 32px 40px;
-
-  @media (max-width: 900px) {
-    padding: 24px;
-  }
-`;
-
-const ContentInner = styled.div`
-  max-width: 900px;
-`;
-
-// Overview styles
-const OverviewSection = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 32px;
-`;
-
-const OverviewHero = styled.div`
-  display: flex;
-  gap: 32px;
-  align-items: flex-start;
-
-  @media (max-width: 900px) {
-    flex-direction: column;
-    align-items: center;
-    text-align: center;
-  }
-`;
-
-const OverviewIconBox = styled.div`
-  width: 120px;
-  height: 120px;
-  background: linear-gradient(135deg, #f8fafc 0%, #f1f5f9 100%);
-  border: 1px solid #e2e8f0;
-  border-radius: 16px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: #94a3b8;
-  flex-shrink: 0;
-  overflow: hidden;
-
-  img {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    border-radius: 16px;
-  }
-
-  @media (max-width: 900px) {
-    width: 80px;
-    height: 80px;
-  }
-`;
-
-const OverviewDetails = styled.div`
-  flex: 1;
-  min-width: 0;
-`;
-
-const OverviewDescription = styled.p`
-  font-size: 15px;
-  line-height: 1.6;
-  color: #475569;
-  margin: 0 0 24px 0;
-  max-width: 600px;
-
-  @media (max-width: 900px) {
-    max-width: none;
-  }
-`;
-
-const OverviewStats = styled.div`
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 16px;
-  max-width: 500px;
-  margin-bottom: 24px;
-
-  @media (max-width: 900px) {
-    max-width: none;
-    width: 100%;
-    grid-template-columns: 1fr;
-    gap: 12px;
-  }
-`;
-
-const StatCard = styled.div`
-  background: #fff;
-  border: 1px solid #e2e8f0;
-  border-radius: 12px;
-  padding: 16px 20px;
-
-  @media (max-width: 900px) {
-    padding: 12px 16px;
-  }
-`;
-
-const StatValue = styled.div`
-  font-size: 28px;
-  font-weight: 600;
-  color: #0f766e;
-  line-height: 1;
-  margin-bottom: 4px;
-
-  @media (max-width: 900px) {
-    font-size: 24px;
-  }
-`;
-
-const StatLabel = styled.div`
-  font-size: 13px;
-  color: #475569;
-`;
-
-const OverviewActions = styled.div`
-  display: flex;
-  gap: 12px;
-
-  @media (max-width: 900px) {
-    flex-wrap: wrap;
-    justify-content: center;
-  }
-`;
-
-const ActionButton = styled.button`
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 8px 14px;
-  background: #fff;
-  border: 1px solid #e2e8f0;
-  border-radius: 6px;
-  color: #475569;
-  font-size: 14px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: all 0.15s ease;
-
-  &:hover {
-    background: #f8fafc;
-    border-color: #cbd5e1;
-  }
-
-  &.danger {
-    color: #dc2626;
-
-    &:hover {
-      background: #fef2f2;
-      border-color: #fecaca;
-    }
-  }
-`;
-
-// Labels section styles
-const LabelsSection = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
-`;
-
-const SearchContainer = styled.div`
-  position: relative;
-  max-width: 400px;
-`;
-
-const SearchInput = styled.input`
-  width: 100%;
-  padding: 10px 12px 10px 40px;
-  font-size: 14px;
-  border: 1px solid #e2e8f0;
-  border-radius: 8px;
-  background: #fff;
-  color: #1e293b;
-  outline: none;
-  transition: all 0.15s ease;
-
-  &:focus {
-    border-color: #0f766e;
-    box-shadow: 0 0 0 3px rgba(15, 118, 110, 0.1);
-  }
-
-  &::placeholder {
-    color: #94a3b8;
-  }
-`;
-
-const SearchIconWrapper = styled.span`
-  position: absolute;
-  left: 12px;
-  top: 50%;
-  transform: translateY(-50%);
-  color: #94a3b8;
-  pointer-events: none;
-`;
-
-const LabelsList = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-`;
-
-const LabelItem = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 16px;
-  padding: 16px 20px;
-  background: #fff;
-  border: 1px solid #e2e8f0;
-  border-radius: 10px;
-  transition: all 0.15s ease;
-
-  &:hover {
-    border-color: #cbd5e1;
-    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
-  }
-
-  &:hover .label-actions {
-    opacity: 1;
-  }
-
-  @media (max-width: 900px) {
-    padding: 12px 16px;
-
-    .label-actions {
-      opacity: 1;
-    }
-  }
-`;
-
-const LabelGrip = styled.div`
-  cursor: grab;
-  color: #94a3b8;
-  flex-shrink: 0;
-
-  &:active {
-    cursor: grabbing;
-  }
-`;
-
-const LabelColor = styled.div<{ $color: string }>`
-  width: 14px;
-  height: 14px;
-  border-radius: 4px;
-  background-color: ${(props) => props.$color || "#94a3b8"};
-  flex-shrink: 0;
-`;
-
-const LabelContent = styled.div`
-  flex: 1;
-  min-width: 0;
-`;
-
-const LabelName = styled.p`
-  font-size: 15px;
-  font-weight: 500;
-  color: #1e293b;
-  margin: 0 0 2px 0;
-`;
-
-const LabelDescription = styled.p`
-  font-size: 13px;
-  color: #475569;
-  margin: 0;
-`;
-
-const LabelActions = styled.div`
-  display: flex;
-  gap: 4px;
-  opacity: 0;
-  transition: opacity 0.15s ease;
-`;
-
-const LabelActionButton = styled.button`
-  width: 32px;
-  height: 32px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: transparent;
-  border: none;
-  border-radius: 6px;
-  color: #94a3b8;
-  cursor: pointer;
-  transition: all 0.15s ease;
-
-  &:hover {
-    background: #f1f5f9;
-    color: #1e293b;
-  }
-
-  &.danger {
-    background: #fef2f2;
-    color: #f87171;
-    border: 1px solid #fecaca;
-
-    &:hover {
-      background: #fee2e2;
-      color: #dc2626;
-    }
-  }
-
-  &.success {
-    background: #f0fdf4;
-    color: #4ade80;
-    border: 1px solid #bbf7d0;
-
-    &:hover {
-      background: #dcfce7;
-      color: #16a34a;
-    }
-  }
-`;
-
-const LabelEditForm = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  padding: 16px 20px;
-  background: #fff;
-  border: 2px solid #0f766e;
-  border-radius: 10px;
-`;
-
-const LabelEditRow = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 12px;
-`;
-
-const LabelEditInput = styled.input`
-  flex: 1;
-  padding: 8px 12px;
-  font-size: 14px;
-  border: 1px solid #e2e8f0;
-  border-radius: 6px;
-  background: #fff;
-  color: #1e293b;
-  outline: none;
-  transition: all 0.15s ease;
-
-  &:focus {
-    border-color: #0f766e;
-    box-shadow: 0 0 0 3px rgba(15, 118, 110, 0.1);
-  }
-`;
-
-const LabelEditTextarea = styled.textarea`
-  flex: 1;
-  padding: 8px 12px;
-  font-size: 14px;
-  border: 1px solid #e2e8f0;
-  border-radius: 6px;
-  background: #fff;
-  color: #1e293b;
-  outline: none;
-  resize: vertical;
-  min-height: 60px;
-  transition: all 0.15s ease;
-
-  &:focus {
-    border-color: #0f766e;
-    box-shadow: 0 0 0 3px rgba(15, 118, 110, 0.1);
-  }
-`;
-
-const LabelEditLabel = styled.label`
-  font-size: 13px;
-  font-weight: 500;
-  color: #475569;
-  min-width: 80px;
-`;
-
-const ColorInput = styled.input`
-  width: 40px;
-  height: 32px;
-  padding: 2px;
-  border: 1px solid #e2e8f0;
-  border-radius: 6px;
-  cursor: pointer;
-`;
-
-const LabelEditActions = styled.div`
-  display: flex;
-  justify-content: flex-end;
-  gap: 8px;
-  margin-top: 4px;
-`;
-
-const AddLabelButton = styled.button`
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 8px 14px;
-  background: #fff;
-  border: 1px solid #e2e8f0;
-  border-radius: 6px;
-  color: #475569;
-  font-size: 14px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: all 0.15s ease;
-  align-self: flex-start;
-
-  &:hover {
-    background: #f8fafc;
-    border-color: #cbd5e1;
-  }
-`;
-
-const EmptyState = styled.div`
-  text-align: center;
-  padding: 48px 24px;
-  background: #fff;
-  border: 1px solid #e2e8f0;
-  border-radius: 12px;
-`;
-
-const EmptyStateIcon = styled.div`
-  width: 64px;
-  height: 64px;
-  margin: 0 auto 16px;
-  color: #94a3b8;
-`;
-
-const EmptyStateTitle = styled.h3`
-  font-size: 16px;
-  font-weight: 600;
-  color: #1e293b;
-  margin: 0 0 8px;
-`;
-
-const EmptyStateDescription = styled.p`
-  font-size: 14px;
-  color: #475569;
-  margin: 0 0 20px;
-`;
-
-const LoadingContainer = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 400px;
-`;
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // TYPES
@@ -1107,6 +142,30 @@ type TabType =
 interface LabelSetDetailPageProps {
   onClose?: () => void;
 }
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// COLOR UTILITIES
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Validates if a string is a valid hex color (3 or 6 character format)
+ * Accepts with or without leading #
+ */
+const isValidHexColor = (color: string): boolean => {
+  return /^#?([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/.test(color);
+};
+
+/**
+ * Sanitizes a color value, returning the fallback if invalid
+ * Strips leading # and validates format
+ */
+const sanitizeColor = (
+  color: string,
+  fallback: string = DEFAULT_LABEL_COLOR
+): string => {
+  const cleaned = color.replace("#", "");
+  return isValidHexColor(cleaned) ? cleaned : fallback;
+};
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // MAIN COMPONENT
@@ -1187,6 +246,11 @@ export const LabelSetDetailPage: React.FC<LabelSetDetailPageProps> = ({
   };
 
   const handleDeleteLabel = (labels: AnnotationLabelType[]) => {
+    if (!canRemove) {
+      toast.error("You don't have permission to delete labels");
+      return;
+    }
+
     deleteMultipleLabels({
       variables: {
         annotationLabelIdsToDelete: labels.map((label) => label.id),
@@ -1214,7 +278,7 @@ export const LabelSetDetailPage: React.FC<LabelSetDetailPageProps> = ({
     setEditForm({
       text: label.text || "",
       description: label.description || "",
-      color: label.color || "94a3b8",
+      color: label.color || DEFAULT_LABEL_COLOR,
     });
   };
 
@@ -1225,6 +289,11 @@ export const LabelSetDetailPage: React.FC<LabelSetDetailPageProps> = ({
   };
 
   const handleSaveEdit = () => {
+    if (!canUpdate) {
+      toast.error("You don't have permission to edit labels");
+      return;
+    }
+
     if (!editingLabelId) return;
 
     updateAnnotationLabel({
@@ -1232,7 +301,7 @@ export const LabelSetDetailPage: React.FC<LabelSetDetailPageProps> = ({
         id: editingLabelId,
         text: editForm.text,
         description: editForm.description,
-        color: editForm.color.replace("#", ""),
+        color: sanitizeColor(editForm.color),
       },
     })
       .then((result) => {
@@ -1261,11 +330,16 @@ export const LabelSetDetailPage: React.FC<LabelSetDetailPageProps> = ({
     setEditForm({
       text: "",
       description: "",
-      color: "0F766E", // Default teal color
+      color: PRIMARY_LABEL_COLOR,
     });
   };
 
   const handleSaveCreate = () => {
+    if (!canUpdate) {
+      toast.error("You don't have permission to create labels");
+      return;
+    }
+
     if (!creatingLabelType || !editForm.text.trim()) {
       toast.error("Please enter a label name");
       return;
@@ -1273,7 +347,7 @@ export const LabelSetDetailPage: React.FC<LabelSetDetailPageProps> = ({
 
     createAnnotationLabelForLabelset({
       variables: {
-        color: editForm.color.replace("#", ""),
+        color: sanitizeColor(editForm.color, PRIMARY_LABEL_COLOR),
         description: editForm.description,
         icon: "tag",
         text: editForm.text,
@@ -1320,6 +394,11 @@ export const LabelSetDetailPage: React.FC<LabelSetDetailPageProps> = ({
   };
 
   const handleDelete = () => {
+    if (!canRemove) {
+      toast.error("You don't have permission to delete this labelset");
+      return;
+    }
+
     if (!opened_labelset?.id) return;
 
     deleteLabelset({
@@ -1655,7 +734,7 @@ export const LabelSetDetailPage: React.FC<LabelSetDetailPageProps> = ({
                 <LabelGrip>
                   <GripIcon />
                 </LabelGrip>
-                <LabelColor $color={`#${label.color || "94a3b8"}`} />
+                <LabelColor $color={`#${label.color || DEFAULT_LABEL_COLOR}`} />
                 <LabelContent>
                   <LabelName>{label.text}</LabelName>
                   <LabelDescription>{label.description}</LabelDescription>

--- a/frontend/src/components/labelsets/LabelSetDetailPage.tsx
+++ b/frontend/src/components/labelsets/LabelSetDetailPage.tsx
@@ -315,9 +315,16 @@ const LabelSetIcon = () => (
 
 const PageContainer = styled.div`
   display: flex;
+  flex-direction: column;
   height: calc(100vh - 60px);
   background: #fafafa;
   font-family: "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
+`;
+
+const PageLayout = styled.div`
+  display: flex;
+  flex: 1;
+  overflow: hidden;
 `;
 
 const Sidebar = styled.aside`
@@ -327,6 +334,10 @@ const Sidebar = styled.aside`
   border-right: 1px solid #e2e8f0;
   display: flex;
   flex-direction: column;
+
+  @media (max-width: 900px) {
+    display: none;
+  }
 `;
 
 const SidebarHeader = styled.div`
@@ -417,6 +428,77 @@ const SidebarFooter = styled.div`
   border-top: 1px solid #e2e8f0;
 `;
 
+// Mobile Navigation
+const MobileNav = styled.nav`
+  display: none;
+  background: #fff;
+  border-bottom: 1px solid #e2e8f0;
+  padding: 0 24px;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+
+  @media (max-width: 900px) {
+    display: block;
+  }
+`;
+
+const MobileNavTabs = styled.div`
+  display: flex;
+  gap: 4px;
+  min-width: max-content;
+`;
+
+interface MobileNavTabProps {
+  $active?: boolean;
+}
+
+const MobileNavTab = styled.button<MobileNavTabProps>`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 12px 16px;
+  font-size: 14px;
+  font-weight: 500;
+  color: ${(props) => (props.$active ? "#0f766e" : "#475569")};
+  background: none;
+  border: none;
+  border-bottom: 2px solid
+    ${(props) => (props.$active ? "#0f766e" : "transparent")};
+  cursor: pointer;
+  white-space: nowrap;
+  transition: all 0.15s ease;
+
+  &:first-child {
+    padding-left: 0;
+  }
+
+  &:hover {
+    color: ${(props) => (props.$active ? "#0f766e" : "#1e293b")};
+  }
+
+  .nav-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 18px;
+    height: 18px;
+  }
+
+  .nav-badge {
+    font-size: 11px;
+    font-weight: 600;
+    padding: 2px 6px;
+    border-radius: 10px;
+    background: ${(props) => (props.$active ? "#0f766e" : "#f1f5f9")};
+    color: ${(props) => (props.$active ? "#fff" : "#94a3b8")};
+  }
+`;
+
 const EditDetailsButton = styled.button`
   display: flex;
   align-items: center;
@@ -450,6 +532,36 @@ const MainHeader = styled.header`
   padding: 24px 40px;
   background: #fff;
   border-bottom: 1px solid #e2e8f0;
+
+  @media (max-width: 900px) {
+    padding: 16px 24px;
+  }
+`;
+
+const MobileBackLink = styled.button`
+  display: none;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  font-weight: 500;
+  color: #475569;
+  text-decoration: none;
+  padding: 6px 10px 6px 6px;
+  margin: -6px -10px 12px -6px;
+  border-radius: 6px;
+  transition: all 0.15s ease;
+  cursor: pointer;
+  background: none;
+  border: none;
+
+  &:hover {
+    background: #f1f5f9;
+    color: #1e293b;
+  }
+
+  @media (max-width: 900px) {
+    display: inline-flex;
+  }
 `;
 
 const HeaderRow = styled.div`
@@ -475,6 +587,10 @@ const Title = styled.h1`
   font-weight: 600;
   color: #1e293b;
   margin: 0;
+
+  @media (max-width: 900px) {
+    font-size: 20px;
+  }
 `;
 
 const Badge = styled.span`
@@ -531,6 +647,10 @@ const MainContent = styled.div`
   flex: 1;
   overflow-y: auto;
   padding: 32px 40px;
+
+  @media (max-width: 900px) {
+    padding: 24px;
+  }
 `;
 
 const ContentInner = styled.div`
@@ -548,6 +668,12 @@ const OverviewHero = styled.div`
   display: flex;
   gap: 32px;
   align-items: flex-start;
+
+  @media (max-width: 900px) {
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+  }
 `;
 
 const OverviewIconBox = styled.div`
@@ -569,6 +695,11 @@ const OverviewIconBox = styled.div`
     object-fit: cover;
     border-radius: 16px;
   }
+
+  @media (max-width: 900px) {
+    width: 80px;
+    height: 80px;
+  }
 `;
 
 const OverviewDetails = styled.div`
@@ -582,6 +713,10 @@ const OverviewDescription = styled.p`
   color: #475569;
   margin: 0 0 24px 0;
   max-width: 600px;
+
+  @media (max-width: 900px) {
+    max-width: none;
+  }
 `;
 
 const OverviewStats = styled.div`
@@ -590,6 +725,13 @@ const OverviewStats = styled.div`
   gap: 16px;
   max-width: 500px;
   margin-bottom: 24px;
+
+  @media (max-width: 900px) {
+    max-width: none;
+    width: 100%;
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
 `;
 
 const StatCard = styled.div`
@@ -597,6 +739,10 @@ const StatCard = styled.div`
   border: 1px solid #e2e8f0;
   border-radius: 12px;
   padding: 16px 20px;
+
+  @media (max-width: 900px) {
+    padding: 12px 16px;
+  }
 `;
 
 const StatValue = styled.div`
@@ -605,6 +751,10 @@ const StatValue = styled.div`
   color: #0f766e;
   line-height: 1;
   margin-bottom: 4px;
+
+  @media (max-width: 900px) {
+    font-size: 24px;
+  }
 `;
 
 const StatLabel = styled.div`
@@ -615,6 +765,11 @@ const StatLabel = styled.div`
 const OverviewActions = styled.div`
   display: flex;
   gap: 12px;
+
+  @media (max-width: 900px) {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
 `;
 
 const ActionButton = styled.button`
@@ -711,6 +866,14 @@ const LabelItem = styled.div`
 
   &:hover .label-actions {
     opacity: 1;
+  }
+
+  @media (max-width: 900px) {
+    padding: 12px 16px;
+
+    .label-actions {
+      opacity: 1;
+    }
   }
 `;
 
@@ -1707,119 +1870,189 @@ export const LabelSetDetailPage: React.FC<LabelSetDetailPageProps> = ({
         </Dimmer>
       )}
 
-      <Sidebar>
-        <SidebarHeader>
-          <BackLink onClick={handleBack}>
-            <ChevronLeftIcon />
-            Label Sets
-          </BackLink>
-        </SidebarHeader>
+      <PageLayout>
+        <Sidebar>
+          <SidebarHeader>
+            <BackLink onClick={handleBack}>
+              <ChevronLeftIcon />
+              Label Sets
+            </BackLink>
+          </SidebarHeader>
 
-        <SidebarNav>
-          <NavItem
-            $active={activeTab === "overview"}
-            onClick={() => setActiveTab("overview")}
-          >
-            <span className="nav-icon">
-              <OverviewIcon />
-            </span>
-            Overview
-          </NavItem>
-          <NavItem
-            $active={activeTab === "text_labels"}
-            onClick={() => setActiveTab("text_labels")}
-          >
-            <span className="nav-icon">
-              <TextLabelIcon />
-            </span>
-            Text Labels
-            <span className="nav-badge">{text_labels.length}</span>
-          </NavItem>
-          <NavItem
-            $active={activeTab === "doc_labels"}
-            onClick={() => setActiveTab("doc_labels")}
-          >
-            <span className="nav-icon">
-              <DocLabelIcon />
-            </span>
-            Doc Labels
-            <span className="nav-badge">{doc_type_labels.length}</span>
-          </NavItem>
-          <NavItem
-            $active={activeTab === "relationship_labels"}
-            onClick={() => setActiveTab("relationship_labels")}
-          >
-            <span className="nav-icon">
-              <RelationshipIcon />
-            </span>
-            Relationships
-            <span className="nav-badge">{relationship_labels.length}</span>
-          </NavItem>
-          <NavItem
-            $active={activeTab === "span_labels"}
-            onClick={() => setActiveTab("span_labels")}
-          >
-            <span className="nav-icon">
-              <SpanLabelIcon />
-            </span>
-            Span Labels
-            <span className="nav-badge">{span_labels.length}</span>
-          </NavItem>
-          <NavItem
-            $active={activeTab === "sharing"}
-            onClick={() => setActiveTab("sharing")}
-          >
-            <span className="nav-icon">
-              <ShareIcon />
-            </span>
-            Sharing
-          </NavItem>
-        </SidebarNav>
-
-        {canUpdate && (
-          <SidebarFooter>
-            <EditDetailsButton onClick={handleEditDetails}>
-              <EditIcon />
-              Edit Details
-            </EditDetailsButton>
-          </SidebarFooter>
-        )}
-      </Sidebar>
-
-      <MainContainer>
-        <MainHeader>
-          <HeaderRow>
-            <HeaderContent>
-              <TitleRow>
-                <Title>{labelset?.title || "Untitled Label Set"}</Title>
-                <Badge>{labelset?.isPublic ? "Public" : "Private"}</Badge>
-              </TitleRow>
-              <Meta>
-                <span>
-                  Created by{" "}
-                  {labelset?.creator?.username ||
-                    currentUser?.email ||
-                    "Unknown"}
-                </span>
-                <MetaSep>·</MetaSep>
-                <span>
-                  {totalLabels} {totalLabels === 1 ? "label" : "labels"}
-                </span>
-              </Meta>
-            </HeaderContent>
-            <HeaderActions>
-              <ShareButton onClick={handleShare}>
+          <SidebarNav>
+            <NavItem
+              $active={activeTab === "overview"}
+              onClick={() => setActiveTab("overview")}
+            >
+              <span className="nav-icon">
+                <OverviewIcon />
+              </span>
+              Overview
+            </NavItem>
+            <NavItem
+              $active={activeTab === "text_labels"}
+              onClick={() => setActiveTab("text_labels")}
+            >
+              <span className="nav-icon">
+                <TextLabelIcon />
+              </span>
+              Text Labels
+              <span className="nav-badge">{text_labels.length}</span>
+            </NavItem>
+            <NavItem
+              $active={activeTab === "doc_labels"}
+              onClick={() => setActiveTab("doc_labels")}
+            >
+              <span className="nav-icon">
+                <DocLabelIcon />
+              </span>
+              Doc Labels
+              <span className="nav-badge">{doc_type_labels.length}</span>
+            </NavItem>
+            <NavItem
+              $active={activeTab === "relationship_labels"}
+              onClick={() => setActiveTab("relationship_labels")}
+            >
+              <span className="nav-icon">
+                <RelationshipIcon />
+              </span>
+              Relationships
+              <span className="nav-badge">{relationship_labels.length}</span>
+            </NavItem>
+            <NavItem
+              $active={activeTab === "span_labels"}
+              onClick={() => setActiveTab("span_labels")}
+            >
+              <span className="nav-icon">
+                <SpanLabelIcon />
+              </span>
+              Span Labels
+              <span className="nav-badge">{span_labels.length}</span>
+            </NavItem>
+            <NavItem
+              $active={activeTab === "sharing"}
+              onClick={() => setActiveTab("sharing")}
+            >
+              <span className="nav-icon">
                 <ShareIcon />
-                Share
-              </ShareButton>
-            </HeaderActions>
-          </HeaderRow>
-        </MainHeader>
+              </span>
+              Sharing
+            </NavItem>
+          </SidebarNav>
 
-        <MainContent>
-          <ContentInner>{renderContent()}</ContentInner>
-        </MainContent>
-      </MainContainer>
+          {canUpdate && (
+            <SidebarFooter>
+              <EditDetailsButton onClick={handleEditDetails}>
+                <EditIcon />
+                Edit Details
+              </EditDetailsButton>
+            </SidebarFooter>
+          )}
+        </Sidebar>
+
+        <MainContainer>
+          <MainHeader>
+            <MobileBackLink onClick={handleBack}>
+              <ChevronLeftIcon />
+              Label Sets
+            </MobileBackLink>
+            <HeaderRow>
+              <HeaderContent>
+                <TitleRow>
+                  <Title>{labelset?.title || "Untitled Label Set"}</Title>
+                  <Badge>{labelset?.isPublic ? "Public" : "Private"}</Badge>
+                </TitleRow>
+                <Meta>
+                  <span>
+                    Created by{" "}
+                    {labelset?.creator?.username ||
+                      currentUser?.email ||
+                      "Unknown"}
+                  </span>
+                  <MetaSep>·</MetaSep>
+                  <span>
+                    {totalLabels} {totalLabels === 1 ? "label" : "labels"}
+                  </span>
+                </Meta>
+              </HeaderContent>
+              <HeaderActions>
+                <ShareButton onClick={handleShare}>
+                  <ShareIcon />
+                  Share
+                </ShareButton>
+              </HeaderActions>
+            </HeaderRow>
+          </MainHeader>
+
+          {/* Mobile Navigation */}
+          <MobileNav>
+            <MobileNavTabs>
+              <MobileNavTab
+                $active={activeTab === "overview"}
+                onClick={() => setActiveTab("overview")}
+              >
+                <span className="nav-icon">
+                  <OverviewIcon />
+                </span>
+                Overview
+              </MobileNavTab>
+              <MobileNavTab
+                $active={activeTab === "text_labels"}
+                onClick={() => setActiveTab("text_labels")}
+              >
+                <span className="nav-icon">
+                  <TextLabelIcon />
+                </span>
+                Text Labels
+                <span className="nav-badge">{text_labels.length}</span>
+              </MobileNavTab>
+              <MobileNavTab
+                $active={activeTab === "doc_labels"}
+                onClick={() => setActiveTab("doc_labels")}
+              >
+                <span className="nav-icon">
+                  <DocLabelIcon />
+                </span>
+                Doc Labels
+                <span className="nav-badge">{doc_type_labels.length}</span>
+              </MobileNavTab>
+              <MobileNavTab
+                $active={activeTab === "relationship_labels"}
+                onClick={() => setActiveTab("relationship_labels")}
+              >
+                <span className="nav-icon">
+                  <RelationshipIcon />
+                </span>
+                Relationships
+                <span className="nav-badge">{relationship_labels.length}</span>
+              </MobileNavTab>
+              <MobileNavTab
+                $active={activeTab === "span_labels"}
+                onClick={() => setActiveTab("span_labels")}
+              >
+                <span className="nav-icon">
+                  <SpanLabelIcon />
+                </span>
+                Span Labels
+                <span className="nav-badge">{span_labels.length}</span>
+              </MobileNavTab>
+              <MobileNavTab
+                $active={activeTab === "sharing"}
+                onClick={() => setActiveTab("sharing")}
+              >
+                <span className="nav-icon">
+                  <ShareIcon />
+                </span>
+                Sharing
+              </MobileNavTab>
+            </MobileNavTabs>
+          </MobileNav>
+
+          <MainContent>
+            <ContentInner>{renderContent()}</ContentInner>
+          </MainContent>
+        </MainContainer>
+      </PageLayout>
 
       {/* Delete Confirmation Modal */}
       <ConfirmModal

--- a/frontend/src/components/labelsets/LabelSetDetailPage.tsx
+++ b/frontend/src/components/labelsets/LabelSetDetailPage.tsx
@@ -153,8 +153,22 @@ const isValidHexColor = (color: string): boolean => {
 };
 
 /**
+ * Expands a 3-character hex color to 6-character format
+ * e.g., "abc" becomes "aabbcc"
+ */
+const expandHexColor = (color: string): string => {
+  if (color.length === 3) {
+    return color
+      .split("")
+      .map((c) => c + c)
+      .join("");
+  }
+  return color;
+};
+
+/**
  * Sanitizes a color value, returning the fallback if invalid
- * Strips leading # and validates format
+ * Strips leading #, validates format, and expands 3-char to 6-char
  */
 const sanitizeColor = (
   color: string | null | undefined,
@@ -162,7 +176,8 @@ const sanitizeColor = (
 ): string => {
   if (!color) return fallback;
   const cleaned = color.replace("#", "");
-  return isValidHexColor(cleaned) ? cleaned : fallback;
+  if (!isValidHexColor(cleaned)) return fallback;
+  return expandHexColor(cleaned);
 };
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -195,18 +210,19 @@ export const LabelSetDetailPage: React.FC<LabelSetDetailPageProps> = ({
   const canUpdate = my_permissions.includes(PermissionTypes.CAN_UPDATE);
   const canRemove = my_permissions.includes(PermissionTypes.CAN_REMOVE);
 
-  // Mutations
-  const [createAnnotationLabelForLabelset] = useMutation<
-    CreateAnnotationLabelForLabelsetOutputs,
-    CreateAnnotationLabelForLabelsetInputs
-  >(CREATE_ANNOTATION_LABEL_FOR_LABELSET);
+  // Mutations with loading states to prevent race conditions
+  const [createAnnotationLabelForLabelset, { loading: createLoading }] =
+    useMutation<
+      CreateAnnotationLabelForLabelsetOutputs,
+      CreateAnnotationLabelForLabelsetInputs
+    >(CREATE_ANNOTATION_LABEL_FOR_LABELSET);
 
-  const [deleteMultipleLabels] = useMutation<
+  const [deleteMultipleLabels, { loading: deleteLabelsLoading }] = useMutation<
     DeleteMultipleAnnotationLabelOutputs,
     DeleteMultipleAnnotationLabelInputs
   >(DELETE_MULTIPLE_ANNOTATION_LABELS);
 
-  const [updateAnnotationLabel] = useMutation<
+  const [updateAnnotationLabel, { loading: updateLoading }] = useMutation<
     UpdateAnnotationLabelOutputs,
     UpdateAnnotationLabelInputs
   >(UPDATE_ANNOTATION_LABEL);
@@ -215,6 +231,10 @@ export const LabelSetDetailPage: React.FC<LabelSetDetailPageProps> = ({
     DeleteLabelsetOutputs,
     DeleteLabelsetInputs
   >(DELETE_LABELSET);
+
+  // Combined loading state for any mutation in progress
+  const isMutating =
+    createLoading || deleteLabelsLoading || updateLoading || delete_loading;
 
   // Query
   const {
@@ -244,8 +264,18 @@ export const LabelSetDetailPage: React.FC<LabelSetDetailPageProps> = ({
   };
 
   const handleDeleteLabel = (labels: AnnotationLabelType[]) => {
+    if (!labels || labels.length === 0) {
+      toast.error("No labels selected for deletion");
+      return;
+    }
+
     if (!canRemove) {
       toast.error("You don't have permission to delete labels");
+      return;
+    }
+
+    if (isMutating) {
+      toast.warning("Please wait for current operation to complete");
       return;
     }
 
@@ -272,7 +302,12 @@ export const LabelSetDetailPage: React.FC<LabelSetDetailPageProps> = ({
   };
 
   const handleStartEdit = (label: AnnotationLabelType) => {
+    if (isMutating) {
+      toast.warning("Please wait for current operation to complete");
+      return;
+    }
     setEditingLabelId(label.id);
+    setCreatingLabelType(null); // Cancel any create in progress
     setEditForm({
       text: label.text || "",
       description: label.description || "",
@@ -293,6 +328,10 @@ export const LabelSetDetailPage: React.FC<LabelSetDetailPageProps> = ({
     }
 
     if (!editingLabelId) return;
+
+    if (isMutating) {
+      return; // Already submitting, prevent double-click
+    }
 
     updateAnnotationLabel({
       variables: {
@@ -321,6 +360,10 @@ export const LabelSetDetailPage: React.FC<LabelSetDetailPageProps> = ({
   };
 
   const handleStartCreate = (labelType: LabelType) => {
+    if (isMutating) {
+      toast.warning("Please wait for current operation to complete");
+      return;
+    }
     // Cancel any existing edit
     setEditingLabelId(null);
     // Start creating a new label
@@ -341,6 +384,10 @@ export const LabelSetDetailPage: React.FC<LabelSetDetailPageProps> = ({
     if (!creatingLabelType || !editForm.text.trim()) {
       toast.error("Please enter a label name");
       return;
+    }
+
+    if (isMutating) {
+      return; // Already submitting, prevent double-click
     }
 
     createAnnotationLabelForLabelset({

--- a/frontend/src/components/labelsets/LabelSetDetailPage.tsx
+++ b/frontend/src/components/labelsets/LabelSetDetailPage.tsx
@@ -913,12 +913,6 @@ const LabelDescription = styled.p`
   margin: 0;
 `;
 
-const LabelUsage = styled.span`
-  font-size: 12px;
-  color: #94a3b8;
-  flex-shrink: 0;
-`;
-
 const LabelActions = styled.div`
   display: flex;
   gap: 4px;
@@ -1666,7 +1660,6 @@ export const LabelSetDetailPage: React.FC<LabelSetDetailPageProps> = ({
                   <LabelName>{label.text}</LabelName>
                   <LabelDescription>{label.description}</LabelDescription>
                 </LabelContent>
-                <LabelUsage>0 uses</LabelUsage>
                 <LabelActions className="label-actions">
                   {canUpdate && (
                     <LabelActionButton

--- a/frontend/src/components/labelsets/LabelSetEditModal.tsx
+++ b/frontend/src/components/labelsets/LabelSetEditModal.tsx
@@ -352,10 +352,14 @@ export const LabelSetEditModal = ({
 
   const handleDeleteLabel = (labels: AnnotationLabelType[]) => {
     deleteMultipleLabels({
-      variables: { labelIdsToDelete: labels.map((label) => label.id) },
+      variables: {
+        annotationLabelIdsToDelete: labels.map((label) => label.id),
+      },
     })
-      .then((data) => {
-        refetch();
+      .then((result) => {
+        if (result.data?.deleteMultipleAnnotationLabels?.ok) {
+          refetch();
+        }
       })
       .catch((err) => {
         console.log("Error deleting label", err);

--- a/frontend/src/components/labelsets/detail/LabelSetDetailStyles.ts
+++ b/frontend/src/components/labelsets/detail/LabelSetDetailStyles.ts
@@ -787,5 +787,4 @@ export const LoadingContainer = styled.div`
   min-height: 400px;
 `;
 
-// Re-export the color constants for use in component logic
-export { DEFAULT_LABEL_COLOR, PRIMARY_LABEL_COLOR };
+// Note: Color constants are re-exported from index.ts for component logic

--- a/frontend/src/components/labelsets/detail/LabelSetDetailStyles.ts
+++ b/frontend/src/components/labelsets/detail/LabelSetDetailStyles.ts
@@ -1,0 +1,791 @@
+import styled from "styled-components";
+import {
+  DEFAULT_LABEL_COLOR,
+  PRIMARY_LABEL_COLOR,
+} from "../../../assets/configurations/constants";
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// STYLED COMPONENTS FOR LABELSET DETAIL PAGE
+// ═══════════════════════════════════════════════════════════════════════════════
+
+export const PageContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 60px);
+  background: #fafafa;
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
+`;
+
+export const PageLayout = styled.div`
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+`;
+
+export const Sidebar = styled.aside`
+  width: 260px;
+  min-width: 260px;
+  background: #fff;
+  border-right: 1px solid #e2e8f0;
+  display: flex;
+  flex-direction: column;
+
+  @media (max-width: 900px) {
+    display: none;
+  }
+`;
+
+export const SidebarHeader = styled.div`
+  padding: 24px 20px;
+  border-bottom: 1px solid #e2e8f0;
+`;
+
+export const BackLink = styled.button`
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  font-weight: 500;
+  color: #475569;
+  text-decoration: none;
+  padding: 6px 10px 6px 6px;
+  margin: -6px -10px -6px -6px;
+  border-radius: 6px;
+  transition: all 0.15s ease;
+  cursor: pointer;
+  background: none;
+  border: none;
+
+  &:hover {
+    background: #f1f5f9;
+    color: #1e293b;
+  }
+`;
+
+export const SidebarNav = styled.nav`
+  flex: 1;
+  padding: 12px 0;
+  overflow-y: auto;
+`;
+
+export interface NavItemProps {
+  $active?: boolean;
+}
+
+export const NavItem = styled.button<NavItemProps>`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 20px;
+  font-size: 14px;
+  font-weight: 500;
+  color: ${(props) => (props.$active ? "#0f766e" : "#475569")};
+  cursor: pointer;
+  transition: all 0.15s ease;
+  border: none;
+  background: ${(props) =>
+    props.$active
+      ? "linear-gradient(90deg, rgba(15, 118, 110, 0.08) 0%, transparent 100%)"
+      : "none"};
+  width: 100%;
+  text-align: left;
+  border-left: 2px solid
+    ${(props) => (props.$active ? "#0f766e" : "transparent")};
+  padding-left: ${(props) => (props.$active ? "18px" : "20px")};
+
+  &:hover {
+    background: ${(props) => (props.$active ? undefined : "#f8fafc")};
+    color: ${(props) => (props.$active ? "#0f766e" : "#1e293b")};
+  }
+
+  .nav-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+    flex-shrink: 0;
+  }
+
+  .nav-badge {
+    margin-left: auto;
+    font-size: 12px;
+    font-weight: 600;
+    color: ${(props) => (props.$active ? "#fff" : `#${DEFAULT_LABEL_COLOR}`)};
+    background: ${(props) => (props.$active ? "#0f766e" : "#f1f5f9")};
+    padding: 2px 8px;
+    border-radius: 10px;
+  }
+`;
+
+export const SidebarFooter = styled.div`
+  padding: 16px 20px;
+  border-top: 1px solid #e2e8f0;
+`;
+
+// Mobile Navigation
+export const MobileNav = styled.nav`
+  display: none;
+  background: #fff;
+  border-bottom: 1px solid #e2e8f0;
+  padding: 0 24px;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+
+  @media (max-width: 900px) {
+    display: block;
+  }
+`;
+
+export const MobileNavTabs = styled.div`
+  display: flex;
+  gap: 4px;
+  min-width: max-content;
+`;
+
+export interface MobileNavTabProps {
+  $active?: boolean;
+}
+
+export const MobileNavTab = styled.button<MobileNavTabProps>`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 12px 16px;
+  font-size: 14px;
+  font-weight: 500;
+  color: ${(props) => (props.$active ? "#0f766e" : "#475569")};
+  background: none;
+  border: none;
+  border-bottom: 2px solid
+    ${(props) => (props.$active ? "#0f766e" : "transparent")};
+  cursor: pointer;
+  white-space: nowrap;
+  transition: all 0.15s ease;
+
+  &:first-child {
+    padding-left: 0;
+  }
+
+  &:hover {
+    color: ${(props) => (props.$active ? "#0f766e" : "#1e293b")};
+  }
+
+  .nav-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 18px;
+    height: 18px;
+  }
+
+  .nav-badge {
+    font-size: 11px;
+    font-weight: 600;
+    padding: 2px 6px;
+    border-radius: 10px;
+    background: ${(props) => (props.$active ? "#0f766e" : "#f1f5f9")};
+    color: ${(props) => (props.$active ? "#fff" : `#${DEFAULT_LABEL_COLOR}`)};
+  }
+`;
+
+export const EditDetailsButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  width: 100%;
+  padding: 10px 16px;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  color: #475569;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s ease;
+
+  &:hover {
+    background: #f8fafc;
+    border-color: #cbd5e1;
+  }
+`;
+
+export const MainContainer = styled.main`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+`;
+
+export const MainHeader = styled.header`
+  padding: 24px 40px;
+  background: #fff;
+  border-bottom: 1px solid #e2e8f0;
+
+  @media (max-width: 900px) {
+    padding: 16px 24px;
+  }
+`;
+
+export const MobileBackLink = styled.button`
+  display: none;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  font-weight: 500;
+  color: #475569;
+  text-decoration: none;
+  padding: 6px 10px 6px 6px;
+  margin: -6px -10px 12px -6px;
+  border-radius: 6px;
+  transition: all 0.15s ease;
+  cursor: pointer;
+  background: none;
+  border: none;
+
+  &:hover {
+    background: #f1f5f9;
+    color: #1e293b;
+  }
+
+  @media (max-width: 900px) {
+    display: inline-flex;
+  }
+`;
+
+export const HeaderRow = styled.div`
+  display: flex;
+  align-items: flex-start;
+  gap: 20px;
+`;
+
+export const HeaderContent = styled.div`
+  flex: 1;
+  min-width: 0;
+`;
+
+export const TitleRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 4px;
+`;
+
+export const Title = styled.h1`
+  font-size: 24px;
+  font-weight: 600;
+  color: #1e293b;
+  margin: 0;
+
+  @media (max-width: 900px) {
+    font-size: 20px;
+  }
+`;
+
+export const Badge = styled.span`
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  background: #f1f5f9;
+  border: 1px solid #e2e8f0;
+  border-radius: 16px;
+  font-size: 12px;
+  font-weight: 500;
+  color: #475569;
+`;
+
+export const Meta = styled.div`
+  font-size: 14px;
+  color: #475569;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
+export const MetaSep = styled.span`
+  color: #e2e8f0;
+`;
+
+export const HeaderActions = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+`;
+
+export const ShareButton = styled.button`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 16px;
+  background: #0f766e;
+  border: none;
+  border-radius: 6px;
+  color: #fff;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s ease;
+
+  &:hover {
+    background: #0d9488;
+  }
+`;
+
+export const MainContent = styled.div`
+  flex: 1;
+  overflow-y: auto;
+  padding: 32px 40px;
+
+  @media (max-width: 900px) {
+    padding: 24px;
+  }
+`;
+
+export const ContentInner = styled.div`
+  max-width: 900px;
+`;
+
+// Overview styles
+export const OverviewSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+`;
+
+export const OverviewHero = styled.div`
+  display: flex;
+  gap: 32px;
+  align-items: flex-start;
+
+  @media (max-width: 900px) {
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+  }
+`;
+
+export const OverviewIconBox = styled.div`
+  width: 120px;
+  height: 120px;
+  background: linear-gradient(135deg, #f8fafc 0%, #f1f5f9 100%);
+  border: 1px solid #e2e8f0;
+  border-radius: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #${DEFAULT_LABEL_COLOR};
+  flex-shrink: 0;
+  overflow: hidden;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: 16px;
+  }
+
+  @media (max-width: 900px) {
+    width: 80px;
+    height: 80px;
+  }
+`;
+
+export const OverviewDetails = styled.div`
+  flex: 1;
+  min-width: 0;
+`;
+
+export const OverviewDescription = styled.p`
+  font-size: 15px;
+  line-height: 1.6;
+  color: #475569;
+  margin: 0 0 24px 0;
+  max-width: 600px;
+
+  @media (max-width: 900px) {
+    max-width: none;
+  }
+`;
+
+export const OverviewStats = styled.div`
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+  max-width: 500px;
+  margin-bottom: 24px;
+
+  @media (max-width: 900px) {
+    max-width: none;
+    width: 100%;
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
+`;
+
+export const StatCard = styled.div`
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 16px 20px;
+
+  @media (max-width: 900px) {
+    padding: 12px 16px;
+  }
+`;
+
+export const StatValue = styled.div`
+  font-size: 28px;
+  font-weight: 600;
+  color: #0f766e;
+  line-height: 1;
+  margin-bottom: 4px;
+
+  @media (max-width: 900px) {
+    font-size: 24px;
+  }
+`;
+
+export const StatLabel = styled.div`
+  font-size: 13px;
+  color: #475569;
+`;
+
+export const OverviewActions = styled.div`
+  display: flex;
+  gap: 12px;
+
+  @media (max-width: 900px) {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+`;
+
+export const ActionButton = styled.button`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  color: #475569;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s ease;
+
+  &:hover {
+    background: #f8fafc;
+    border-color: #cbd5e1;
+  }
+
+  &.danger {
+    color: #dc2626;
+
+    &:hover {
+      background: #fef2f2;
+      border-color: #fecaca;
+    }
+  }
+`;
+
+// Labels section styles
+export const LabelsSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+`;
+
+export const SearchContainer = styled.div`
+  position: relative;
+  max-width: 400px;
+`;
+
+export const SearchInput = styled.input`
+  width: 100%;
+  padding: 10px 12px 10px 40px;
+  font-size: 14px;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  background: #fff;
+  color: #1e293b;
+  outline: none;
+  transition: all 0.15s ease;
+
+  &:focus {
+    border-color: #0f766e;
+    box-shadow: 0 0 0 3px rgba(15, 118, 110, 0.1);
+  }
+
+  &::placeholder {
+    color: #${DEFAULT_LABEL_COLOR};
+  }
+`;
+
+export const SearchIconWrapper = styled.span`
+  position: absolute;
+  left: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: #${DEFAULT_LABEL_COLOR};
+  pointer-events: none;
+`;
+
+export const LabelsList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;
+
+export const LabelItem = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 16px 20px;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  transition: all 0.15s ease;
+
+  &:hover {
+    border-color: #cbd5e1;
+    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+  }
+
+  &:hover .label-actions {
+    opacity: 1;
+  }
+
+  @media (max-width: 900px) {
+    padding: 12px 16px;
+
+    .label-actions {
+      opacity: 1;
+    }
+  }
+`;
+
+export const LabelGrip = styled.div`
+  cursor: grab;
+  color: #${DEFAULT_LABEL_COLOR};
+  flex-shrink: 0;
+
+  &:active {
+    cursor: grabbing;
+  }
+`;
+
+export const LabelColor = styled.div<{ $color: string }>`
+  width: 14px;
+  height: 14px;
+  border-radius: 4px;
+  background-color: ${(props) => props.$color || `#${DEFAULT_LABEL_COLOR}`};
+  flex-shrink: 0;
+`;
+
+export const LabelContent = styled.div`
+  flex: 1;
+  min-width: 0;
+`;
+
+export const LabelName = styled.p`
+  font-size: 15px;
+  font-weight: 500;
+  color: #1e293b;
+  margin: 0 0 2px 0;
+`;
+
+export const LabelDescription = styled.p`
+  font-size: 13px;
+  color: #475569;
+  margin: 0;
+`;
+
+export const LabelActions = styled.div`
+  display: flex;
+  gap: 4px;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+`;
+
+export const LabelActionButton = styled.button`
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  color: #${DEFAULT_LABEL_COLOR};
+  cursor: pointer;
+  transition: all 0.15s ease;
+
+  &:hover {
+    background: #f1f5f9;
+    color: #1e293b;
+  }
+
+  &.danger {
+    background: #fef2f2;
+    color: #f87171;
+    border: 1px solid #fecaca;
+
+    &:hover {
+      background: #fee2e2;
+      color: #dc2626;
+    }
+  }
+
+  &.success {
+    background: #f0fdf4;
+    color: #4ade80;
+    border: 1px solid #bbf7d0;
+
+    &:hover {
+      background: #dcfce7;
+      color: #16a34a;
+    }
+  }
+`;
+
+export const LabelEditForm = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px 20px;
+  background: #fff;
+  border: 2px solid #0f766e;
+  border-radius: 10px;
+`;
+
+export const LabelEditRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+`;
+
+export const LabelEditInput = styled.input`
+  flex: 1;
+  padding: 8px 12px;
+  font-size: 14px;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  background: #fff;
+  color: #1e293b;
+  outline: none;
+  transition: all 0.15s ease;
+
+  &:focus {
+    border-color: #0f766e;
+    box-shadow: 0 0 0 3px rgba(15, 118, 110, 0.1);
+  }
+`;
+
+export const LabelEditTextarea = styled.textarea`
+  flex: 1;
+  padding: 8px 12px;
+  font-size: 14px;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  background: #fff;
+  color: #1e293b;
+  outline: none;
+  resize: vertical;
+  min-height: 60px;
+  transition: all 0.15s ease;
+
+  &:focus {
+    border-color: #0f766e;
+    box-shadow: 0 0 0 3px rgba(15, 118, 110, 0.1);
+  }
+`;
+
+export const LabelEditLabel = styled.label`
+  font-size: 13px;
+  font-weight: 500;
+  color: #475569;
+  min-width: 80px;
+`;
+
+export const ColorInput = styled.input`
+  width: 40px;
+  height: 32px;
+  padding: 2px;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  cursor: pointer;
+`;
+
+export const LabelEditActions = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 4px;
+`;
+
+export const AddLabelButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  color: #475569;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  align-self: flex-start;
+
+  &:hover {
+    background: #f8fafc;
+    border-color: #cbd5e1;
+  }
+`;
+
+export const EmptyState = styled.div`
+  text-align: center;
+  padding: 48px 24px;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+`;
+
+export const EmptyStateIcon = styled.div`
+  width: 64px;
+  height: 64px;
+  margin: 0 auto 16px;
+  color: #${DEFAULT_LABEL_COLOR};
+`;
+
+export const EmptyStateTitle = styled.h3`
+  font-size: 16px;
+  font-weight: 600;
+  color: #1e293b;
+  margin: 0 0 8px;
+`;
+
+export const EmptyStateDescription = styled.p`
+  font-size: 14px;
+  color: #475569;
+  margin: 0 0 20px;
+`;
+
+export const LoadingContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 400px;
+`;
+
+// Re-export the color constants for use in component logic
+export { DEFAULT_LABEL_COLOR, PRIMARY_LABEL_COLOR };

--- a/frontend/src/components/labelsets/detail/LabelSetIcons.tsx
+++ b/frontend/src/components/labelsets/detail/LabelSetIcons.tsx
@@ -1,0 +1,270 @@
+import React from "react";
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// LABELSET DETAIL PAGE ICONS
+// ═══════════════════════════════════════════════════════════════════════════════
+
+export const ChevronLeftIcon = () => (
+  <svg
+    width="18"
+    height="18"
+    viewBox="0 0 18 18"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M11.25 13.5L6.75 9l4.5-4.5" />
+  </svg>
+);
+
+export const OverviewIcon = () => (
+  <svg
+    width="18"
+    height="18"
+    viewBox="0 0 18 18"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <rect x="3" y="3" width="5" height="5" rx="1" />
+    <rect x="10" y="3" width="5" height="5" rx="1" />
+    <rect x="3" y="10" width="5" height="5" rx="1" />
+    <rect x="10" y="10" width="5" height="5" rx="1" />
+  </svg>
+);
+
+export const DocLabelIcon = () => (
+  <svg
+    width="18"
+    height="18"
+    viewBox="0 0 18 18"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M10.5 1.5H4.5a1.5 1.5 0 00-1.5 1.5v12a1.5 1.5 0 001.5 1.5h9a1.5 1.5 0 001.5-1.5V6L10.5 1.5z" />
+    <path d="M10.5 1.5V6H15" />
+    <path d="M6 9h6M6 12h4" />
+  </svg>
+);
+
+export const SpanLabelIcon = () => (
+  <svg
+    width="18"
+    height="18"
+    viewBox="0 0 18 18"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M3 5.25h12M3 9h8M3 12.75h10" />
+    <rect
+      x="11"
+      y="7.5"
+      width="4"
+      height="3"
+      rx="0.5"
+      fill="currentColor"
+      opacity="0.2"
+      stroke="currentColor"
+    />
+  </svg>
+);
+
+export const TextLabelIcon = () => (
+  <svg
+    width="18"
+    height="18"
+    viewBox="0 0 18 18"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M3 4.5h12M6 9h6M4.5 13.5h9" />
+    <path d="M9 3v12" strokeOpacity="0.3" />
+  </svg>
+);
+
+export const RelationshipIcon = () => (
+  <svg
+    width="18"
+    height="18"
+    viewBox="0 0 18 18"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <circle cx="4.5" cy="9" r="2.5" />
+    <circle cx="13.5" cy="9" r="2.5" />
+    <path d="M7 9h4" />
+    <path d="M10 7l2 2-2 2" />
+  </svg>
+);
+
+export const ShareIcon = () => (
+  <svg
+    width="18"
+    height="18"
+    viewBox="0 0 18 18"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <circle cx="13.5" cy="3.75" r="2.25" />
+    <circle cx="4.5" cy="9" r="2.25" />
+    <circle cx="13.5" cy="14.25" r="2.25" />
+    <path d="M6.54 10.11l4.92 3.03M11.46 4.86L6.54 7.89" />
+  </svg>
+);
+
+export const EditIcon = () => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M11.5 2.5a1.77 1.77 0 012.5 2.5L5.25 13.75 1.5 14.5l.75-3.75L11.5 2.5z" />
+  </svg>
+);
+
+export const TrashIcon = () => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M2 4h12M5.33 4V2.67a.67.67 0 01.67-.67h4a.67.67 0 01.67.67V4M12.67 4v9.33a.67.67 0 01-.67.67H4a.67.67 0 01-.67-.67V4" />
+  </svg>
+);
+
+export const DownloadIcon = () => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M8 2v9M4.5 7.5L8 11l3.5-3.5M2 14h12" />
+  </svg>
+);
+
+export const SaveIcon = () => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M13.33 5.33L6.67 12 2.67 8" />
+  </svg>
+);
+
+export const CloseIcon = () => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M12 4L4 12M4 4l8 8" />
+  </svg>
+);
+
+export const GripIcon = () => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    fill="currentColor"
+    opacity="0.4"
+  >
+    <circle cx="5" cy="4" r="1.5" />
+    <circle cx="11" cy="4" r="1.5" />
+    <circle cx="5" cy="8" r="1.5" />
+    <circle cx="11" cy="8" r="1.5" />
+    <circle cx="5" cy="12" r="1.5" />
+    <circle cx="11" cy="12" r="1.5" />
+  </svg>
+);
+
+export const SearchIcon = () => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <circle cx="7" cy="7" r="5" />
+    <path d="M14 14l-3.5-3.5" />
+  </svg>
+);
+
+export const PlusIcon = () => (
+  <svg
+    width="18"
+    height="18"
+    viewBox="0 0 18 18"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+  >
+    <path d="M9 3.75v10.5M3.75 9h10.5" />
+  </svg>
+);
+
+export const LabelSetIcon = () => (
+  <svg
+    width="48"
+    height="48"
+    viewBox="0 0 48 48"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M20 8H10a4 4 0 00-4 4v24a4 4 0 004 4h28a4 4 0 004-4V20" />
+    <path d="M32 6l8 8-16 16H16v-8L32 6z" />
+  </svg>
+);

--- a/frontend/src/components/labelsets/detail/index.ts
+++ b/frontend/src/components/labelsets/detail/index.ts
@@ -3,3 +3,9 @@
 
 export * from "./LabelSetIcons";
 export * from "./LabelSetDetailStyles";
+
+// Re-export color constants from the canonical source for component logic
+export {
+  DEFAULT_LABEL_COLOR,
+  PRIMARY_LABEL_COLOR,
+} from "../../../assets/configurations/constants";

--- a/frontend/src/components/labelsets/detail/index.ts
+++ b/frontend/src/components/labelsets/detail/index.ts
@@ -1,0 +1,5 @@
+// LabelSet Detail Page Sub-components
+// Barrel exports for clean imports
+
+export * from "./LabelSetIcons";
+export * from "./LabelSetDetailStyles";

--- a/frontend/src/components/routes/LabelSetLandingRoute.tsx
+++ b/frontend/src/components/routes/LabelSetLandingRoute.tsx
@@ -6,7 +6,7 @@ import { ModernLoadingDisplay } from "../widgets/ModernLoadingDisplay";
 import { ModernErrorDisplay } from "../widgets/ModernErrorDisplay";
 import { ErrorBoundary } from "../widgets/ErrorBoundary";
 import { openedLabelset, routeLoading, routeError } from "../../graphql/cache";
-import { LabelSetEditModal } from "../labelsets/LabelSetEditModal";
+import { LabelSetDetailPage } from "../labelsets/LabelSetDetailPage";
 
 /**
  * LabelSetLandingRoute - Handles labelset routes with /label_sets/:id pattern
@@ -15,7 +15,7 @@ import { LabelSetEditModal } from "../labelsets/LabelSetEditModal";
  * - /label_sets/:labelsetId (ID-based, labelsets don't have slugs)
  *
  * This component is a DUMB CONSUMER - it just reads state set by CentralRouteManager.
- * It displays the LabelSetEditModal as a full-page view until a proper detail page is created.
+ * It displays the LabelSetDetailPage for a full-page experience.
  */
 export const LabelSetLandingRoute: React.FC = () => {
   const navigate = useNavigate();
@@ -31,8 +31,8 @@ export const LabelSetLandingRoute: React.FC = () => {
     hasError: !!error,
   });
 
-  // Handle modal close by navigating back to list
-  const handleModalClose = () => {
+  // Handle close by navigating back to list
+  const handleClose = () => {
     openedLabelset(null);
     navigate("/label_sets");
   };
@@ -56,9 +56,7 @@ export const LabelSetLandingRoute: React.FC = () => {
         title={labelset.title || "Label Set"}
         description={labelset.description || `Label Set: ${labelset.title}`}
       />
-      {/* Using LabelSetEditModal as full-screen overlay for now */}
-      {/* TODO: Replace with LabelSetDetailPage for a true full-page experience */}
-      <LabelSetEditModal open={true} toggleModal={handleModalClose} />
+      <LabelSetDetailPage onClose={handleClose} />
     </ErrorBoundary>
   );
 };

--- a/frontend/src/graphql/mutations.ts
+++ b/frontend/src/graphql/mutations.ts
@@ -405,8 +405,10 @@ export interface DeleteLabelsetInputs {
 }
 
 export interface DeleteLabelsetOutputs {
-  ok?: boolean;
-  message?: string;
+  deleteLabelset: {
+    ok?: boolean;
+    message?: string;
+  };
 }
 
 export const DELETE_LABELSET = gql`
@@ -496,8 +498,10 @@ export interface UpdateAnnotationLabelInputs {
 }
 
 export interface UpdateAnnotationLabelOutputs {
-  ok?: boolean;
-  message?: string;
+  updateAnnotationLabel: {
+    ok?: boolean;
+    message?: string;
+  };
 }
 
 export const UPDATE_ANNOTATION_LABEL = gql`
@@ -737,17 +741,21 @@ export const DELETE_ANNOTATION_LABEL = gql`
 `;
 
 export interface DeleteMultipleAnnotationLabelInputs {
-  labelIdsToDelete: string[];
+  annotationLabelIdsToDelete: string[];
 }
 
 export interface DeleteMultipleAnnotationLabelOutputs {
-  ok?: boolean;
-  message?: string;
+  deleteMultipleAnnotationLabels: {
+    ok?: boolean;
+    message?: string;
+  };
 }
 
 export const DELETE_MULTIPLE_ANNOTATION_LABELS = gql`
-  mutation ($labelIdsToDelete: [String]!) {
-    deleteMultipleLabels(labelIdsToDelete: $labelIdsToDelete) {
+  mutation ($annotationLabelIdsToDelete: [String]!) {
+    deleteMultipleAnnotationLabels(
+      annotationLabelIdsToDelete: $annotationLabelIdsToDelete
+    ) {
       ok
       message
     }

--- a/frontend/src/views/LabelSets.tsx
+++ b/frontend/src/views/LabelSets.tsx
@@ -6,6 +6,7 @@ import React, {
   useRef,
 } from "react";
 import styled from "styled-components";
+import { useNavigate } from "react-router-dom";
 import { useMutation, useQuery, useReactiveVar } from "@apollo/client";
 import {
   SearchBox,
@@ -25,7 +26,6 @@ import { LabelSetType } from "../types/graphql-api";
 import {
   authToken,
   labelsetSearchTerm,
-  openedLabelset,
   showNewLabelsetModal,
   userObj,
   deletingLabelset,
@@ -47,9 +47,9 @@ import {
 } from "../components/forms/schemas";
 import { CRUDModal } from "../components/widgets/CRUD/CRUDModal";
 import { LabelSetListCard } from "../components/labelsets/LabelSetListCard";
-import { LabelSetEditModal } from "../components/labelsets/LabelSetEditModal";
 import { FetchMoreOnVisible } from "../components/widgets/infinite_scroll/FetchMoreOnVisible";
 import { LoadingOverlay } from "../components/common/LoadingOverlay";
+import { getLabelsetUrl } from "../utils/navigationUtils";
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // STYLED COMPONENTS - Following DiscoveryLanding patterns
@@ -180,10 +180,10 @@ const TagsIcon = () => (
 // ═══════════════════════════════════════════════════════════════════════════════
 
 export const Labelsets = () => {
+  const navigate = useNavigate();
   const auth_token = useReactiveVar(authToken);
   const currentUser = useReactiveVar(userObj);
   const labelset_search_term = useReactiveVar(labelsetSearchTerm);
-  const opened_labelset = useReactiveVar(openedLabelset);
   const show_new_label_modal = useReactiveVar(showNewLabelsetModal);
   const isAuthenticated = Boolean(auth_token);
   const currentUserEmail = currentUser?.email;
@@ -373,13 +373,6 @@ export const Labelsets = () => {
     <PageContainer>
       <ContentContainer>
         {/* Modals */}
-        {opened_labelset && (
-          <LabelSetEditModal
-            open={opened_labelset !== null}
-            toggleModal={() => openedLabelset(null)}
-          />
-        )}
-
         {show_new_label_modal && (
           <CRUDModal
             open={show_new_label_modal}
@@ -487,7 +480,7 @@ export const Labelsets = () => {
                     labelset={labelset}
                     currentUserEmail={currentUserEmail}
                     onEdit={(ls) => editingLabelset(ls)}
-                    onView={(ls) => openedLabelset(ls)}
+                    onView={(ls) => navigate(getLabelsetUrl(ls))}
                     onDelete={(ls) => deletingLabelset(ls)}
                     isMenuOpen={openMenuId === labelset.id}
                     menuPosition={

--- a/frontend/src/views/LabelSets.tsx
+++ b/frontend/src/views/LabelSets.tsx
@@ -40,7 +40,11 @@ import {
   CreateLabelsetInputs,
   CreateLabelsetOutputs,
   CREATE_LABELSET,
+  DeleteLabelsetInputs,
+  DeleteLabelsetOutputs,
+  DELETE_LABELSET,
 } from "../graphql/mutations";
+import { ConfirmModal } from "../components/widgets/modals/ConfirmModal";
 import {
   newLabelSetForm_Schema,
   newLabelSetForm_Ui_Schema,
@@ -185,6 +189,7 @@ export const Labelsets = () => {
   const currentUser = useReactiveVar(userObj);
   const labelset_search_term = useReactiveVar(labelsetSearchTerm);
   const show_new_label_modal = useReactiveVar(showNewLabelsetModal);
+  const labelset_to_delete = useReactiveVar(deletingLabelset);
   const isAuthenticated = Boolean(auth_token);
   const currentUserEmail = currentUser?.email;
 
@@ -225,6 +230,12 @@ export const Labelsets = () => {
     CreateLabelsetOutputs,
     CreateLabelsetInputs
   >(CREATE_LABELSET);
+
+  // Delete mutation
+  const [deleteLabelset, { loading: delete_labelset_loading }] = useMutation<
+    DeleteLabelsetOutputs,
+    DeleteLabelsetInputs
+  >(DELETE_LABELSET);
 
   // Extract labelsets from query data
   const labelsets: LabelSetType[] = useMemo(() => {
@@ -311,6 +322,28 @@ export const Labelsets = () => {
       });
   };
 
+  const handleDeleteLabelset = () => {
+    if (!labelset_to_delete?.id) return;
+
+    deleteLabelset({ variables: { id: labelset_to_delete.id } })
+      .then((result) => {
+        if (result.data?.deleteLabelset?.ok) {
+          toast.success("Label set deleted successfully.");
+          refetch();
+        } else {
+          toast.error(
+            result.data?.deleteLabelset?.message ||
+              "Failed to delete label set."
+          );
+        }
+        deletingLabelset(null);
+      })
+      .catch(() => {
+        toast.error("Failed to delete label set.");
+        deletingLabelset(null);
+      });
+  };
+
   const handleFetchMore = useCallback(() => {
     if (!loading && data?.labelsets?.pageInfo?.hasNextPage) {
       fetchMore({
@@ -391,6 +424,17 @@ export const Labelsets = () => {
             loading={create_labelset_loading}
           />
         )}
+
+        {/* Delete Confirmation Modal */}
+        <ConfirmModal
+          message={`Are you sure you want to delete "${
+            labelset_to_delete?.title || "this label set"
+          }"? This action cannot be undone.`}
+          visible={Boolean(labelset_to_delete)}
+          yesAction={handleDeleteLabelset}
+          noAction={() => deletingLabelset(null)}
+          toggleModal={() => deletingLabelset(null)}
+        />
 
         {/* Hero Section */}
         <HeroSection>

--- a/frontend/tests/LabelSetDetailPage.ct.tsx
+++ b/frontend/tests/LabelSetDetailPage.ct.tsx
@@ -11,14 +11,9 @@
 
 import React from "react";
 import { test, expect } from "@playwright/experimental-ct-react";
-import { MockedProvider, MockedResponse } from "@apollo/client/testing";
-import { MemoryRouter, Routes, Route } from "react-router-dom";
-import { Provider as JotaiProvider } from "jotai";
-import { LabelSetDetailPage } from "../src/components/labelsets/LabelSetDetailPage";
-import {
-  GET_LABELSET_WITH_ALL_LABELS,
-  GetLabelsetWithLabelsOutputs,
-} from "../src/graphql/queries";
+import { MockedResponse } from "@apollo/client/testing";
+import { LabelSetDetailPageTestWrapper } from "./LabelSetDetailPageTestWrapper";
+import { GET_LABELSET_WITH_ALL_LABELS } from "../src/graphql/queries";
 import {
   DELETE_MULTIPLE_ANNOTATION_LABELS,
   UPDATE_ANNOTATION_LABEL,
@@ -26,13 +21,13 @@ import {
   DELETE_LABELSET,
 } from "../src/graphql/mutations";
 import { openedLabelset } from "../src/graphql/cache";
-import { InMemoryCache } from "@apollo/client";
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // MOCK DATA
 // ═══════════════════════════════════════════════════════════════════════════════
 
 const mockLabelsetBase = {
+  __typename: "LabelSetType" as const,
   id: "TGFiZWxTZXRUeXBlOjE=",
   icon: null,
   title: "Test Label Set",
@@ -45,6 +40,7 @@ const mockLabelsetBase = {
   tokenLabelCount: 1,
   corpusCount: 5,
   creator: {
+    __typename: "UserType" as const,
     id: "user-1",
     slug: "testuser",
     username: "testuser",
@@ -54,6 +50,7 @@ const mockLabelsetBase = {
 
 const mockTextLabels = [
   {
+    __typename: "AnnotationLabelType" as const,
     id: "label-text-1",
     icon: "tag",
     labelType: "TOKEN_LABEL",
@@ -69,6 +66,7 @@ const mockTextLabels = [
 
 const mockDocLabels = [
   {
+    __typename: "AnnotationLabelType" as const,
     id: "label-doc-1",
     icon: "file",
     labelType: "DOC_TYPE_LABEL",
@@ -81,6 +79,7 @@ const mockDocLabels = [
     analyzer: null,
   },
   {
+    __typename: "AnnotationLabelType" as const,
     id: "label-doc-2",
     icon: "file",
     labelType: "DOC_TYPE_LABEL",
@@ -96,6 +95,7 @@ const mockDocLabels = [
 
 const mockSpanLabels = [
   {
+    __typename: "AnnotationLabelType" as const,
     id: "label-span-1",
     icon: "tag",
     labelType: "SPAN_LABEL",
@@ -108,6 +108,7 @@ const mockSpanLabels = [
     analyzer: null,
   },
   {
+    __typename: "AnnotationLabelType" as const,
     id: "label-span-2",
     icon: "tag",
     labelType: "SPAN_LABEL",
@@ -120,6 +121,7 @@ const mockSpanLabels = [
     analyzer: null,
   },
   {
+    __typename: "AnnotationLabelType" as const,
     id: "label-span-3",
     icon: "tag",
     labelType: "SPAN_LABEL",
@@ -135,6 +137,7 @@ const mockSpanLabels = [
 
 const mockRelationshipLabels = [
   {
+    __typename: "AnnotationLabelType" as const,
     id: "label-rel-1",
     icon: "arrows alternate horizontal",
     labelType: "RELATIONSHIP_LABEL",
@@ -155,17 +158,17 @@ const allLabels = [
   ...mockRelationshipLabels,
 ];
 
-// Labelset with full permissions
+// Labelset with full permissions (format: action_modelname for getPermissions)
 const mockLabelsetWithPermissions = {
   ...mockLabelsetBase,
-  myPermissions: ["READ", "UPDATE", "DELETE"],
+  myPermissions: ["read_labelset", "update_labelset", "remove_labelset"],
   allAnnotationLabels: allLabels,
 };
 
 // Labelset with read-only permissions
 const mockLabelsetReadOnly = {
   ...mockLabelsetBase,
-  myPermissions: ["READ"],
+  myPermissions: ["read_labelset"],
   allAnnotationLabels: allLabels,
 };
 
@@ -185,6 +188,7 @@ const createLabelsetMock = (
       labelset,
     },
   },
+  maxUsageCount: Infinity, // Allow unlimited reuse of this mock
 });
 
 const createDeleteLabelMock = (
@@ -279,40 +283,35 @@ const createDeleteLabelsetMock = (
 });
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// TEST WRAPPER
+// MOUNT HELPER
 // ═══════════════════════════════════════════════════════════════════════════════
 
-interface TestWrapperProps {
-  children: React.ReactNode;
-  mocks: MockedResponse[];
-  labelsetId: string;
-}
+/**
+ * Helper to mount LabelSetDetailPage with proper setup.
+ * Sets reactive var BEFORE mount (critical for Playwright component tests).
+ */
+const mountLabelSetDetailPage = (
+  mount: any,
+  mocks: MockedResponse[],
+  labelsetId: string,
+  permissions: string[] = [
+    "read_labelset",
+    "update_labelset",
+    "remove_labelset",
+  ]
+) => {
+  // Set reactive var BEFORE mount - this runs in browser context
+  openedLabelset({
+    id: labelsetId,
+    myPermissions: permissions,
+  } as any);
 
-const TestWrapper: React.FC<TestWrapperProps> = ({
-  children,
-  mocks,
-  labelsetId,
-}) => {
-  // Set the opened labelset in Apollo cache
-  React.useEffect(() => {
-    openedLabelset({
-      id: labelsetId,
-      myPermissions: ["READ", "UPDATE", "DELETE"],
-    } as any);
-  }, [labelsetId]);
-
-  const cache = new InMemoryCache();
-
-  return (
-    <JotaiProvider>
-      <MockedProvider mocks={mocks} addTypename={false} cache={cache}>
-        <MemoryRouter initialEntries={["/label_sets"]}>
-          <Routes>
-            <Route path="/label_sets" element={children} />
-          </Routes>
-        </MemoryRouter>
-      </MockedProvider>
-    </JotaiProvider>
+  return mount(
+    <LabelSetDetailPageTestWrapper
+      mocks={mocks}
+      labelsetId={labelsetId}
+      permissions={permissions}
+    />
   );
 };
 
@@ -334,10 +333,10 @@ test.describe("LabelSetDetailPage", () => {
         createLabelsetMock(mockLabelsetWithPermissions), // For refetch
       ];
 
-      const component = await mount(
-        <TestWrapper mocks={mocks} labelsetId={mockLabelsetWithPermissions.id}>
-          <LabelSetDetailPage />
-        </TestWrapper>
+      const component = await mountLabelSetDetailPage(
+        mount,
+        mocks,
+        mockLabelsetWithPermissions.id
       );
 
       // Wait for data to load
@@ -359,10 +358,10 @@ test.describe("LabelSetDetailPage", () => {
         createLabelsetMock(mockLabelsetWithPermissions),
       ];
 
-      const component = await mount(
-        <TestWrapper mocks={mocks} labelsetId={mockLabelsetWithPermissions.id}>
-          <LabelSetDetailPage />
-        </TestWrapper>
+      const component = await mountLabelSetDetailPage(
+        mount,
+        mocks,
+        mockLabelsetWithPermissions.id
       );
 
       await expect(component.getByText("Test Label Set")).toBeVisible({
@@ -372,8 +371,10 @@ test.describe("LabelSetDetailPage", () => {
       // Click on Text Labels tab
       await component.getByRole("button", { name: /Text Labels/i }).click();
 
-      // Verify text label is visible
-      await expect(component.getByText("Important Text")).toBeVisible();
+      // Verify text label is visible (use exact match to avoid matching description)
+      await expect(
+        component.getByText("Important Text", { exact: true })
+      ).toBeVisible();
     });
 
     test("renders Doc Labels tab with correct label count", async ({
@@ -384,10 +385,10 @@ test.describe("LabelSetDetailPage", () => {
         createLabelsetMock(mockLabelsetWithPermissions),
       ];
 
-      const component = await mount(
-        <TestWrapper mocks={mocks} labelsetId={mockLabelsetWithPermissions.id}>
-          <LabelSetDetailPage />
-        </TestWrapper>
+      const component = await mountLabelSetDetailPage(
+        mount,
+        mocks,
+        mockLabelsetWithPermissions.id
       );
 
       await expect(component.getByText("Test Label Set")).toBeVisible({
@@ -397,9 +398,13 @@ test.describe("LabelSetDetailPage", () => {
       // Click on Doc Labels tab
       await component.getByRole("button", { name: /Doc Labels/i }).click();
 
-      // Verify doc labels are visible
-      await expect(component.getByText("Contract")).toBeVisible();
-      await expect(component.getByText("Invoice")).toBeVisible();
+      // Verify doc labels are visible (use exact match to avoid matching description)
+      await expect(
+        component.getByText("Contract", { exact: true })
+      ).toBeVisible();
+      await expect(
+        component.getByText("Invoice", { exact: true })
+      ).toBeVisible();
     });
 
     test("renders Span Labels tab with correct labels", async ({ mount }) => {
@@ -408,10 +413,10 @@ test.describe("LabelSetDetailPage", () => {
         createLabelsetMock(mockLabelsetWithPermissions),
       ];
 
-      const component = await mount(
-        <TestWrapper mocks={mocks} labelsetId={mockLabelsetWithPermissions.id}>
-          <LabelSetDetailPage />
-        </TestWrapper>
+      const component = await mountLabelSetDetailPage(
+        mount,
+        mocks,
+        mockLabelsetWithPermissions.id
       );
 
       await expect(component.getByText("Test Label Set")).toBeVisible({
@@ -421,10 +426,14 @@ test.describe("LabelSetDetailPage", () => {
       // Click on Span Labels tab
       await component.getByRole("button", { name: /Span Labels/i }).click();
 
-      // Verify span labels are visible
-      await expect(component.getByText("Entity Name")).toBeVisible();
-      await expect(component.getByText("Date")).toBeVisible();
-      await expect(component.getByText("Amount")).toBeVisible();
+      // Verify span labels are visible (use exact match to avoid matching description)
+      await expect(
+        component.getByText("Entity Name", { exact: true })
+      ).toBeVisible();
+      await expect(component.getByText("Date", { exact: true })).toBeVisible();
+      await expect(
+        component.getByText("Amount", { exact: true })
+      ).toBeVisible();
     });
 
     test("displays loading state while fetching", async ({ mount }) => {
@@ -442,13 +451,10 @@ test.describe("LabelSetDetailPage", () => {
         delay: 5000,
       };
 
-      const component = await mount(
-        <TestWrapper
-          mocks={[delayedMock]}
-          labelsetId={mockLabelsetWithPermissions.id}
-        >
-          <LabelSetDetailPage />
-        </TestWrapper>
+      const component = await mountLabelSetDetailPage(
+        mount,
+        [delayedMock],
+        mockLabelsetWithPermissions.id
       );
 
       // Should show loading state
@@ -467,10 +473,10 @@ test.describe("LabelSetDetailPage", () => {
         createLabelsetMock(mockLabelsetWithPermissions),
       ];
 
-      const component = await mount(
-        <TestWrapper mocks={mocks} labelsetId={mockLabelsetWithPermissions.id}>
-          <LabelSetDetailPage />
-        </TestWrapper>
+      const component = await mountLabelSetDetailPage(
+        mount,
+        mocks,
+        mockLabelsetWithPermissions.id
       );
 
       await expect(component.getByText("Test Label Set")).toBeVisible({
@@ -495,10 +501,10 @@ test.describe("LabelSetDetailPage", () => {
         createLabelsetMock(mockLabelsetWithPermissions),
       ];
 
-      const component = await mount(
-        <TestWrapper mocks={mocks} labelsetId={mockLabelsetWithPermissions.id}>
-          <LabelSetDetailPage />
-        </TestWrapper>
+      const component = await mountLabelSetDetailPage(
+        mount,
+        mocks,
+        mockLabelsetWithPermissions.id
       );
 
       await expect(component.getByText("Test Label Set")).toBeVisible({
@@ -509,10 +515,14 @@ test.describe("LabelSetDetailPage", () => {
       await component.getByRole("button", { name: /Span Labels/i }).click();
 
       // Wait for labels to be visible
-      await expect(component.getByText("Entity Name")).toBeVisible();
+      await expect(
+        component.getByText("Entity Name", { exact: true })
+      ).toBeVisible();
 
       // Hover over a label to reveal action buttons
-      const labelItem = component.getByText("Entity Name").locator("..");
+      const labelItem = component
+        .getByText("Entity Name", { exact: true })
+        .locator("..");
       await labelItem.hover();
 
       // Edit button should become visible (actions have opacity 0 by default)
@@ -528,28 +538,17 @@ test.describe("LabelSetDetailPage", () => {
     test("hides Add Label button when user lacks UPDATE permission", async ({
       mount,
     }) => {
-      // Set read-only permissions in the reactive var
-      const component = await mount(
-        <JotaiProvider>
-          <MockedProvider
-            mocks={[
-              createLabelsetMock(mockLabelsetReadOnly),
-              createLabelsetMock(mockLabelsetReadOnly),
-            ]}
-            addTypename={false}
-          >
-            <MemoryRouter>
-              <LabelSetDetailPage />
-            </MemoryRouter>
-          </MockedProvider>
-        </JotaiProvider>
-      );
+      const mocks = [
+        createLabelsetMock(mockLabelsetReadOnly),
+        createLabelsetMock(mockLabelsetReadOnly),
+      ];
 
-      // Set opened labelset with READ only permissions
-      openedLabelset({
-        id: mockLabelsetReadOnly.id,
-        myPermissions: ["READ"],
-      } as any);
+      const component = await mountLabelSetDetailPage(
+        mount,
+        mocks,
+        mockLabelsetReadOnly.id,
+        ["read_labelset"]
+      );
 
       await expect(component.getByText("Test Label Set")).toBeVisible({
         timeout: 10000,
@@ -576,10 +575,10 @@ test.describe("LabelSetDetailPage", () => {
         createLabelsetMock(mockLabelsetWithPermissions),
       ];
 
-      const component = await mount(
-        <TestWrapper mocks={mocks} labelsetId={mockLabelsetWithPermissions.id}>
-          <LabelSetDetailPage />
-        </TestWrapper>
+      const component = await mountLabelSetDetailPage(
+        mount,
+        mocks,
+        mockLabelsetWithPermissions.id
       );
 
       await expect(component.getByText("Test Label Set")).toBeVisible({
@@ -589,21 +588,31 @@ test.describe("LabelSetDetailPage", () => {
       // Navigate to Span Labels tab
       await component.getByRole("button", { name: /Span Labels/i }).click();
 
-      // All span labels should be visible
-      await expect(component.getByText("Entity Name")).toBeVisible();
-      await expect(component.getByText("Date")).toBeVisible();
-      await expect(component.getByText("Amount")).toBeVisible();
+      // All span labels should be visible (use exact match to avoid matching description)
+      await expect(
+        component.getByText("Entity Name", { exact: true })
+      ).toBeVisible();
+      await expect(component.getByText("Date", { exact: true })).toBeVisible();
+      await expect(
+        component.getByText("Amount", { exact: true })
+      ).toBeVisible();
 
       // Search for "Entity"
       const searchInput = component.getByPlaceholder(/Search labels/i);
       await searchInput.fill("Entity");
 
       // Only "Entity Name" should be visible
-      await expect(component.getByText("Entity Name")).toBeVisible();
+      await expect(
+        component.getByText("Entity Name", { exact: true })
+      ).toBeVisible();
 
       // These should not be visible after filtering
-      await expect(component.getByText("Date")).not.toBeVisible();
-      await expect(component.getByText("Amount")).not.toBeVisible();
+      await expect(
+        component.getByText("Date", { exact: true })
+      ).not.toBeVisible();
+      await expect(
+        component.getByText("Amount", { exact: true })
+      ).not.toBeVisible();
     });
 
     test("clears filter when search cleared", async ({ mount }) => {
@@ -612,10 +621,10 @@ test.describe("LabelSetDetailPage", () => {
         createLabelsetMock(mockLabelsetWithPermissions),
       ];
 
-      const component = await mount(
-        <TestWrapper mocks={mocks} labelsetId={mockLabelsetWithPermissions.id}>
-          <LabelSetDetailPage />
-        </TestWrapper>
+      const component = await mountLabelSetDetailPage(
+        mount,
+        mocks,
+        mockLabelsetWithPermissions.id
       );
 
       await expect(component.getByText("Test Label Set")).toBeVisible({
@@ -629,17 +638,25 @@ test.describe("LabelSetDetailPage", () => {
       const searchInput = component.getByPlaceholder(/Search labels/i);
       await searchInput.fill("Entity");
 
-      // Only Entity Name should be visible
-      await expect(component.getByText("Entity Name")).toBeVisible();
-      await expect(component.getByText("Date")).not.toBeVisible();
+      // Only Entity Name should be visible (use exact match)
+      await expect(
+        component.getByText("Entity Name", { exact: true })
+      ).toBeVisible();
+      await expect(
+        component.getByText("Date", { exact: true })
+      ).not.toBeVisible();
 
       // Clear search
       await searchInput.fill("");
 
-      // All labels should be visible again
-      await expect(component.getByText("Entity Name")).toBeVisible();
-      await expect(component.getByText("Date")).toBeVisible();
-      await expect(component.getByText("Amount")).toBeVisible();
+      // All labels should be visible again (use exact match)
+      await expect(
+        component.getByText("Entity Name", { exact: true })
+      ).toBeVisible();
+      await expect(component.getByText("Date", { exact: true })).toBeVisible();
+      await expect(
+        component.getByText("Amount", { exact: true })
+      ).toBeVisible();
     });
 
     test("shows empty state when no matches", async ({ mount }) => {
@@ -648,10 +665,10 @@ test.describe("LabelSetDetailPage", () => {
         createLabelsetMock(mockLabelsetWithPermissions),
       ];
 
-      const component = await mount(
-        <TestWrapper mocks={mocks} labelsetId={mockLabelsetWithPermissions.id}>
-          <LabelSetDetailPage />
-        </TestWrapper>
+      const component = await mountLabelSetDetailPage(
+        mount,
+        mocks,
+        mockLabelsetWithPermissions.id
       );
 
       await expect(component.getByText("Test Label Set")).toBeVisible({
@@ -665,10 +682,16 @@ test.describe("LabelSetDetailPage", () => {
       const searchInput = component.getByPlaceholder(/Search labels/i);
       await searchInput.fill("xyznonexistent");
 
-      // Should show empty state or no results
-      await expect(component.getByText("Entity Name")).not.toBeVisible();
-      await expect(component.getByText("Date")).not.toBeVisible();
-      await expect(component.getByText("Amount")).not.toBeVisible();
+      // Should show empty state or no results (use exact match)
+      await expect(
+        component.getByText("Entity Name", { exact: true })
+      ).not.toBeVisible();
+      await expect(
+        component.getByText("Date", { exact: true })
+      ).not.toBeVisible();
+      await expect(
+        component.getByText("Amount", { exact: true })
+      ).not.toBeVisible();
     });
   });
 
@@ -686,10 +709,10 @@ test.describe("LabelSetDetailPage", () => {
         createLabelsetMock(mockLabelsetWithPermissions),
       ];
 
-      const component = await mount(
-        <TestWrapper mocks={mocks} labelsetId={mockLabelsetWithPermissions.id}>
-          <LabelSetDetailPage />
-        </TestWrapper>
+      const component = await mountLabelSetDetailPage(
+        mount,
+        mocks,
+        mockLabelsetWithPermissions.id
       );
 
       await expect(component.getByText("Test Label Set")).toBeVisible({
@@ -709,10 +732,10 @@ test.describe("LabelSetDetailPage", () => {
         createLabelsetMock(mockLabelsetWithPermissions),
       ];
 
-      const component = await mount(
-        <TestWrapper mocks={mocks} labelsetId={mockLabelsetWithPermissions.id}>
-          <LabelSetDetailPage />
-        </TestWrapper>
+      const component = await mountLabelSetDetailPage(
+        mount,
+        mocks,
+        mockLabelsetWithPermissions.id
       );
 
       await expect(component.getByText("Test Label Set")).toBeVisible({
@@ -722,8 +745,10 @@ test.describe("LabelSetDetailPage", () => {
       // Click on Span Labels tab in mobile view
       await component.getByRole("button", { name: /Span/i }).first().click();
 
-      // Span labels should be visible
-      await expect(component.getByText("Entity Name")).toBeVisible();
+      // Span labels should be visible (use exact match)
+      await expect(
+        component.getByText("Entity Name", { exact: true })
+      ).toBeVisible();
     });
   });
 });

--- a/frontend/tests/LabelSetDetailPage.ct.tsx
+++ b/frontend/tests/LabelSetDetailPage.ct.tsx
@@ -1,0 +1,729 @@
+/**
+ * Playwright Component Tests for LabelSetDetailPage
+ *
+ * Tests cover:
+ * - Rendering each tab
+ * - Permission-based UI visibility
+ * - Label CRUD operations
+ * - Search functionality
+ * - Mobile navigation
+ */
+
+import React from "react";
+import { test, expect } from "@playwright/experimental-ct-react";
+import { MockedProvider, MockedResponse } from "@apollo/client/testing";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { Provider as JotaiProvider } from "jotai";
+import { LabelSetDetailPage } from "../src/components/labelsets/LabelSetDetailPage";
+import {
+  GET_LABELSET_WITH_ALL_LABELS,
+  GetLabelsetWithLabelsOutputs,
+} from "../src/graphql/queries";
+import {
+  DELETE_MULTIPLE_ANNOTATION_LABELS,
+  UPDATE_ANNOTATION_LABEL,
+  CREATE_ANNOTATION_LABEL_FOR_LABELSET,
+  DELETE_LABELSET,
+} from "../src/graphql/mutations";
+import { openedLabelset } from "../src/graphql/cache";
+import { InMemoryCache } from "@apollo/client";
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// MOCK DATA
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const mockLabelsetBase = {
+  id: "TGFiZWxTZXRUeXBlOjE=",
+  icon: null,
+  title: "Test Label Set",
+  description: "A comprehensive label set for testing",
+  created: "2024-01-15T10:00:00Z",
+  modified: "2024-01-20T15:30:00Z",
+  isPublic: false,
+  docLabelCount: 2,
+  spanLabelCount: 3,
+  tokenLabelCount: 1,
+  corpusCount: 5,
+  creator: {
+    id: "user-1",
+    slug: "testuser",
+    username: "testuser",
+    email: "test@example.com",
+  },
+};
+
+const mockTextLabels = [
+  {
+    id: "label-text-1",
+    icon: "tag",
+    labelType: "TOKEN_LABEL",
+    readOnly: false,
+    text: "Important Text",
+    description: "Marks important text passages",
+    color: "0066cc",
+    myPermissions: ["READ", "UPDATE", "DELETE"],
+    isPublic: false,
+    analyzer: null,
+  },
+];
+
+const mockDocLabels = [
+  {
+    id: "label-doc-1",
+    icon: "file",
+    labelType: "DOC_TYPE_LABEL",
+    readOnly: false,
+    text: "Contract",
+    description: "Legal contract document",
+    color: "00cc66",
+    myPermissions: ["READ", "UPDATE", "DELETE"],
+    isPublic: false,
+    analyzer: null,
+  },
+  {
+    id: "label-doc-2",
+    icon: "file",
+    labelType: "DOC_TYPE_LABEL",
+    readOnly: false,
+    text: "Invoice",
+    description: "Financial invoice document",
+    color: "cc6600",
+    myPermissions: ["READ", "UPDATE", "DELETE"],
+    isPublic: false,
+    analyzer: null,
+  },
+];
+
+const mockSpanLabels = [
+  {
+    id: "label-span-1",
+    icon: "tag",
+    labelType: "SPAN_LABEL",
+    readOnly: false,
+    text: "Entity Name",
+    description: "Identifies entity names",
+    color: "cc0066",
+    myPermissions: ["READ", "UPDATE", "DELETE"],
+    isPublic: false,
+    analyzer: null,
+  },
+  {
+    id: "label-span-2",
+    icon: "tag",
+    labelType: "SPAN_LABEL",
+    readOnly: false,
+    text: "Date",
+    description: "Date annotations",
+    color: "6600cc",
+    myPermissions: ["READ", "UPDATE", "DELETE"],
+    isPublic: false,
+    analyzer: null,
+  },
+  {
+    id: "label-span-3",
+    icon: "tag",
+    labelType: "SPAN_LABEL",
+    readOnly: false,
+    text: "Amount",
+    description: "Monetary amounts",
+    color: "66cc00",
+    myPermissions: ["READ", "UPDATE", "DELETE"],
+    isPublic: false,
+    analyzer: null,
+  },
+];
+
+const mockRelationshipLabels = [
+  {
+    id: "label-rel-1",
+    icon: "arrows alternate horizontal",
+    labelType: "RELATIONSHIP_LABEL",
+    readOnly: false,
+    text: "References",
+    description: "Document references another document",
+    color: "0099cc",
+    myPermissions: ["READ", "UPDATE", "DELETE"],
+    isPublic: false,
+    analyzer: null,
+  },
+];
+
+const allLabels = [
+  ...mockTextLabels,
+  ...mockDocLabels,
+  ...mockSpanLabels,
+  ...mockRelationshipLabels,
+];
+
+// Labelset with full permissions
+const mockLabelsetWithPermissions = {
+  ...mockLabelsetBase,
+  myPermissions: ["READ", "UPDATE", "DELETE"],
+  allAnnotationLabels: allLabels,
+};
+
+// Labelset with read-only permissions
+const mockLabelsetReadOnly = {
+  ...mockLabelsetBase,
+  myPermissions: ["READ"],
+  allAnnotationLabels: allLabels,
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// MOCK FACTORIES
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const createLabelsetMock = (
+  labelset: typeof mockLabelsetWithPermissions
+): MockedResponse => ({
+  request: {
+    query: GET_LABELSET_WITH_ALL_LABELS,
+    variables: { id: labelset.id },
+  },
+  result: {
+    data: {
+      labelset,
+    },
+  },
+});
+
+const createDeleteLabelMock = (
+  labelIds: string[],
+  success: boolean = true
+): MockedResponse => ({
+  request: {
+    query: DELETE_MULTIPLE_ANNOTATION_LABELS,
+    variables: { annotationLabelIdsToDelete: labelIds },
+  },
+  result: {
+    data: {
+      deleteMultipleAnnotationLabels: {
+        ok: success,
+        message: success ? null : "Failed to delete",
+      },
+    },
+  },
+});
+
+const createUpdateLabelMock = (
+  id: string,
+  updates: { text?: string; description?: string; color?: string },
+  success: boolean = true
+): MockedResponse => ({
+  request: {
+    query: UPDATE_ANNOTATION_LABEL,
+    variables: {
+      id,
+      text: updates.text,
+      description: updates.description,
+      color: updates.color,
+    },
+  },
+  result: {
+    data: {
+      updateAnnotationLabel: {
+        ok: success,
+        message: success ? null : "Failed to update",
+      },
+    },
+  },
+});
+
+const createCreateLabelMock = (
+  labelsetId: string,
+  label: {
+    text: string;
+    description: string;
+    color: string;
+    labelType: string;
+  },
+  success: boolean = true
+): MockedResponse => ({
+  request: {
+    query: CREATE_ANNOTATION_LABEL_FOR_LABELSET,
+    variables: {
+      color: label.color,
+      description: label.description,
+      icon: "tag",
+      text: label.text,
+      labelType: label.labelType,
+      labelsetId,
+    },
+  },
+  result: {
+    data: {
+      createAnnotationLabelForLabelset: {
+        ok: success,
+        message: success ? null : "Failed to create",
+      },
+    },
+  },
+});
+
+const createDeleteLabelsetMock = (
+  id: string,
+  success: boolean = true
+): MockedResponse => ({
+  request: {
+    query: DELETE_LABELSET,
+    variables: { id },
+  },
+  result: {
+    data: {
+      deleteLabelset: {
+        ok: success,
+        message: success ? null : "Failed to delete labelset",
+      },
+    },
+  },
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST WRAPPER
+// ═══════════════════════════════════════════════════════════════════════════════
+
+interface TestWrapperProps {
+  children: React.ReactNode;
+  mocks: MockedResponse[];
+  labelsetId: string;
+}
+
+const TestWrapper: React.FC<TestWrapperProps> = ({
+  children,
+  mocks,
+  labelsetId,
+}) => {
+  // Set the opened labelset in Apollo cache
+  React.useEffect(() => {
+    openedLabelset({
+      id: labelsetId,
+      myPermissions: ["READ", "UPDATE", "DELETE"],
+    } as any);
+  }, [labelsetId]);
+
+  const cache = new InMemoryCache();
+
+  return (
+    <JotaiProvider>
+      <MockedProvider mocks={mocks} addTypename={false} cache={cache}>
+        <MemoryRouter initialEntries={["/label_sets"]}>
+          <Routes>
+            <Route path="/label_sets" element={children} />
+          </Routes>
+        </MemoryRouter>
+      </MockedProvider>
+    </JotaiProvider>
+  );
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TESTS
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test.describe("LabelSetDetailPage", () => {
+  // ─────────────────────────────────────────────────────────────────────────────
+  // RENDERING TESTS
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  test.describe("Rendering", () => {
+    test("renders overview tab by default with labelset info", async ({
+      mount,
+    }) => {
+      const mocks = [
+        createLabelsetMock(mockLabelsetWithPermissions),
+        createLabelsetMock(mockLabelsetWithPermissions), // For refetch
+      ];
+
+      const component = await mount(
+        <TestWrapper mocks={mocks} labelsetId={mockLabelsetWithPermissions.id}>
+          <LabelSetDetailPage />
+        </TestWrapper>
+      );
+
+      // Wait for data to load
+      await expect(component.getByText("Test Label Set")).toBeVisible({
+        timeout: 10000,
+      });
+
+      // Verify overview elements are visible
+      await expect(
+        component.getByText("A comprehensive label set for testing")
+      ).toBeVisible();
+    });
+
+    test("renders Text Labels tab with correct label count", async ({
+      mount,
+    }) => {
+      const mocks = [
+        createLabelsetMock(mockLabelsetWithPermissions),
+        createLabelsetMock(mockLabelsetWithPermissions),
+      ];
+
+      const component = await mount(
+        <TestWrapper mocks={mocks} labelsetId={mockLabelsetWithPermissions.id}>
+          <LabelSetDetailPage />
+        </TestWrapper>
+      );
+
+      await expect(component.getByText("Test Label Set")).toBeVisible({
+        timeout: 10000,
+      });
+
+      // Click on Text Labels tab
+      await component.getByRole("button", { name: /Text Labels/i }).click();
+
+      // Verify text label is visible
+      await expect(component.getByText("Important Text")).toBeVisible();
+    });
+
+    test("renders Doc Labels tab with correct label count", async ({
+      mount,
+    }) => {
+      const mocks = [
+        createLabelsetMock(mockLabelsetWithPermissions),
+        createLabelsetMock(mockLabelsetWithPermissions),
+      ];
+
+      const component = await mount(
+        <TestWrapper mocks={mocks} labelsetId={mockLabelsetWithPermissions.id}>
+          <LabelSetDetailPage />
+        </TestWrapper>
+      );
+
+      await expect(component.getByText("Test Label Set")).toBeVisible({
+        timeout: 10000,
+      });
+
+      // Click on Doc Labels tab
+      await component.getByRole("button", { name: /Doc Labels/i }).click();
+
+      // Verify doc labels are visible
+      await expect(component.getByText("Contract")).toBeVisible();
+      await expect(component.getByText("Invoice")).toBeVisible();
+    });
+
+    test("renders Span Labels tab with correct labels", async ({ mount }) => {
+      const mocks = [
+        createLabelsetMock(mockLabelsetWithPermissions),
+        createLabelsetMock(mockLabelsetWithPermissions),
+      ];
+
+      const component = await mount(
+        <TestWrapper mocks={mocks} labelsetId={mockLabelsetWithPermissions.id}>
+          <LabelSetDetailPage />
+        </TestWrapper>
+      );
+
+      await expect(component.getByText("Test Label Set")).toBeVisible({
+        timeout: 10000,
+      });
+
+      // Click on Span Labels tab
+      await component.getByRole("button", { name: /Span Labels/i }).click();
+
+      // Verify span labels are visible
+      await expect(component.getByText("Entity Name")).toBeVisible();
+      await expect(component.getByText("Date")).toBeVisible();
+      await expect(component.getByText("Amount")).toBeVisible();
+    });
+
+    test("displays loading state while fetching", async ({ mount }) => {
+      // Create a mock that delays response
+      const delayedMock: MockedResponse = {
+        request: {
+          query: GET_LABELSET_WITH_ALL_LABELS,
+          variables: { id: mockLabelsetWithPermissions.id },
+        },
+        result: {
+          data: {
+            labelset: mockLabelsetWithPermissions,
+          },
+        },
+        delay: 5000,
+      };
+
+      const component = await mount(
+        <TestWrapper
+          mocks={[delayedMock]}
+          labelsetId={mockLabelsetWithPermissions.id}
+        >
+          <LabelSetDetailPage />
+        </TestWrapper>
+      );
+
+      // Should show loading state
+      await expect(component.getByText(/Loading/i)).toBeVisible();
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // PERMISSION TESTS - WITH UPDATE PERMISSION
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  test.describe("Permission Checks - With UPDATE Permission", () => {
+    test("shows Add Label button in Text Labels tab", async ({ mount }) => {
+      const mocks = [
+        createLabelsetMock(mockLabelsetWithPermissions),
+        createLabelsetMock(mockLabelsetWithPermissions),
+      ];
+
+      const component = await mount(
+        <TestWrapper mocks={mocks} labelsetId={mockLabelsetWithPermissions.id}>
+          <LabelSetDetailPage />
+        </TestWrapper>
+      );
+
+      await expect(component.getByText("Test Label Set")).toBeVisible({
+        timeout: 10000,
+      });
+
+      // Navigate to Text Labels tab
+      await component.getByRole("button", { name: /Text Labels/i }).click();
+
+      // Should show Add Label button
+      await expect(
+        component.getByRole("button", { name: /Add Label/i })
+      ).toBeVisible();
+    });
+
+    test("shows edit button on individual labels on hover", async ({
+      mount,
+      page,
+    }) => {
+      const mocks = [
+        createLabelsetMock(mockLabelsetWithPermissions),
+        createLabelsetMock(mockLabelsetWithPermissions),
+      ];
+
+      const component = await mount(
+        <TestWrapper mocks={mocks} labelsetId={mockLabelsetWithPermissions.id}>
+          <LabelSetDetailPage />
+        </TestWrapper>
+      );
+
+      await expect(component.getByText("Test Label Set")).toBeVisible({
+        timeout: 10000,
+      });
+
+      // Navigate to Span Labels tab
+      await component.getByRole("button", { name: /Span Labels/i }).click();
+
+      // Wait for labels to be visible
+      await expect(component.getByText("Entity Name")).toBeVisible();
+
+      // Hover over a label to reveal action buttons
+      const labelItem = component.getByText("Entity Name").locator("..");
+      await labelItem.hover();
+
+      // Edit button should become visible (actions have opacity 0 by default)
+      // We check the DOM structure rather than visibility due to CSS opacity
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // PERMISSION TESTS - WITHOUT UPDATE PERMISSION
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  test.describe("Permission Checks - Without UPDATE Permission", () => {
+    test("hides Add Label button when user lacks UPDATE permission", async ({
+      mount,
+    }) => {
+      // Set read-only permissions in the reactive var
+      const component = await mount(
+        <JotaiProvider>
+          <MockedProvider
+            mocks={[
+              createLabelsetMock(mockLabelsetReadOnly),
+              createLabelsetMock(mockLabelsetReadOnly),
+            ]}
+            addTypename={false}
+          >
+            <MemoryRouter>
+              <LabelSetDetailPage />
+            </MemoryRouter>
+          </MockedProvider>
+        </JotaiProvider>
+      );
+
+      // Set opened labelset with READ only permissions
+      openedLabelset({
+        id: mockLabelsetReadOnly.id,
+        myPermissions: ["READ"],
+      } as any);
+
+      await expect(component.getByText("Test Label Set")).toBeVisible({
+        timeout: 10000,
+      });
+
+      // Navigate to Text Labels tab
+      await component.getByRole("button", { name: /Text Labels/i }).click();
+
+      // Add Label button should NOT be visible
+      await expect(
+        component.getByRole("button", { name: /Add Label/i })
+      ).not.toBeVisible();
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // SEARCH FUNCTIONALITY
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  test.describe("Search", () => {
+    test("filters labels by name match", async ({ mount }) => {
+      const mocks = [
+        createLabelsetMock(mockLabelsetWithPermissions),
+        createLabelsetMock(mockLabelsetWithPermissions),
+      ];
+
+      const component = await mount(
+        <TestWrapper mocks={mocks} labelsetId={mockLabelsetWithPermissions.id}>
+          <LabelSetDetailPage />
+        </TestWrapper>
+      );
+
+      await expect(component.getByText("Test Label Set")).toBeVisible({
+        timeout: 10000,
+      });
+
+      // Navigate to Span Labels tab
+      await component.getByRole("button", { name: /Span Labels/i }).click();
+
+      // All span labels should be visible
+      await expect(component.getByText("Entity Name")).toBeVisible();
+      await expect(component.getByText("Date")).toBeVisible();
+      await expect(component.getByText("Amount")).toBeVisible();
+
+      // Search for "Entity"
+      const searchInput = component.getByPlaceholder(/Search labels/i);
+      await searchInput.fill("Entity");
+
+      // Only "Entity Name" should be visible
+      await expect(component.getByText("Entity Name")).toBeVisible();
+
+      // These should not be visible after filtering
+      await expect(component.getByText("Date")).not.toBeVisible();
+      await expect(component.getByText("Amount")).not.toBeVisible();
+    });
+
+    test("clears filter when search cleared", async ({ mount }) => {
+      const mocks = [
+        createLabelsetMock(mockLabelsetWithPermissions),
+        createLabelsetMock(mockLabelsetWithPermissions),
+      ];
+
+      const component = await mount(
+        <TestWrapper mocks={mocks} labelsetId={mockLabelsetWithPermissions.id}>
+          <LabelSetDetailPage />
+        </TestWrapper>
+      );
+
+      await expect(component.getByText("Test Label Set")).toBeVisible({
+        timeout: 10000,
+      });
+
+      // Navigate to Span Labels tab
+      await component.getByRole("button", { name: /Span Labels/i }).click();
+
+      // Search for something
+      const searchInput = component.getByPlaceholder(/Search labels/i);
+      await searchInput.fill("Entity");
+
+      // Only Entity Name should be visible
+      await expect(component.getByText("Entity Name")).toBeVisible();
+      await expect(component.getByText("Date")).not.toBeVisible();
+
+      // Clear search
+      await searchInput.fill("");
+
+      // All labels should be visible again
+      await expect(component.getByText("Entity Name")).toBeVisible();
+      await expect(component.getByText("Date")).toBeVisible();
+      await expect(component.getByText("Amount")).toBeVisible();
+    });
+
+    test("shows empty state when no matches", async ({ mount }) => {
+      const mocks = [
+        createLabelsetMock(mockLabelsetWithPermissions),
+        createLabelsetMock(mockLabelsetWithPermissions),
+      ];
+
+      const component = await mount(
+        <TestWrapper mocks={mocks} labelsetId={mockLabelsetWithPermissions.id}>
+          <LabelSetDetailPage />
+        </TestWrapper>
+      );
+
+      await expect(component.getByText("Test Label Set")).toBeVisible({
+        timeout: 10000,
+      });
+
+      // Navigate to Span Labels tab
+      await component.getByRole("button", { name: /Span Labels/i }).click();
+
+      // Search for non-existent term
+      const searchInput = component.getByPlaceholder(/Search labels/i);
+      await searchInput.fill("xyznonexistent");
+
+      // Should show empty state or no results
+      await expect(component.getByText("Entity Name")).not.toBeVisible();
+      await expect(component.getByText("Date")).not.toBeVisible();
+      await expect(component.getByText("Amount")).not.toBeVisible();
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // MOBILE NAVIGATION
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  test.describe("Mobile Navigation", () => {
+    test("shows mobile tab bar on small viewport", async ({ mount, page }) => {
+      // Set mobile viewport
+      await page.setViewportSize({ width: 375, height: 667 });
+
+      const mocks = [
+        createLabelsetMock(mockLabelsetWithPermissions),
+        createLabelsetMock(mockLabelsetWithPermissions),
+      ];
+
+      const component = await mount(
+        <TestWrapper mocks={mocks} labelsetId={mockLabelsetWithPermissions.id}>
+          <LabelSetDetailPage />
+        </TestWrapper>
+      );
+
+      await expect(component.getByText("Test Label Set")).toBeVisible({
+        timeout: 10000,
+      });
+
+      // Mobile navigation should be visible (displays at max-width: 900px)
+      // The mobile nav contains the same tabs but in a different layout
+    });
+
+    test("switches tabs on mobile tab click", async ({ mount, page }) => {
+      // Set mobile viewport
+      await page.setViewportSize({ width: 375, height: 667 });
+
+      const mocks = [
+        createLabelsetMock(mockLabelsetWithPermissions),
+        createLabelsetMock(mockLabelsetWithPermissions),
+      ];
+
+      const component = await mount(
+        <TestWrapper mocks={mocks} labelsetId={mockLabelsetWithPermissions.id}>
+          <LabelSetDetailPage />
+        </TestWrapper>
+      );
+
+      await expect(component.getByText("Test Label Set")).toBeVisible({
+        timeout: 10000,
+      });
+
+      // Click on Span Labels tab in mobile view
+      await component.getByRole("button", { name: /Span/i }).first().click();
+
+      // Span labels should be visible
+      await expect(component.getByText("Entity Name")).toBeVisible();
+    });
+  });
+});

--- a/frontend/tests/LabelSetDetailPage.ct.tsx
+++ b/frontend/tests/LabelSetDetailPage.ct.tsx
@@ -751,4 +751,188 @@ test.describe("LabelSetDetailPage", () => {
       ).toBeVisible();
     });
   });
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // CRUD OPERATIONS
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  test.describe("CRUD Operations", () => {
+    test("shows create form when Add Label clicked", async ({ mount }) => {
+      const mocks = [
+        createLabelsetMock(mockLabelsetWithPermissions),
+        createLabelsetMock(mockLabelsetWithPermissions),
+      ];
+
+      const component = await mountLabelSetDetailPage(
+        mount,
+        mocks,
+        mockLabelsetWithPermissions.id
+      );
+
+      await expect(component.getByText("Test Label Set")).toBeVisible({
+        timeout: 10000,
+      });
+
+      // Navigate to Span Labels tab
+      await component.getByRole("button", { name: /Span Labels/i }).click();
+
+      // Click Add Label button
+      await component.getByRole("button", { name: /Add Label/i }).click();
+
+      // Verify create form appears with correct fields
+      await expect(
+        component.getByPlaceholder("Enter label name")
+      ).toBeVisible();
+      await expect(
+        component.getByPlaceholder("Describe what this label is used for")
+      ).toBeVisible();
+
+      // Verify Create and Cancel buttons are present
+      await expect(component.getByTitle("Create")).toBeVisible();
+      await expect(component.getByTitle("Cancel")).toBeVisible();
+    });
+
+    test("can cancel create form", async ({ mount }) => {
+      const mocks = [
+        createLabelsetMock(mockLabelsetWithPermissions),
+        createLabelsetMock(mockLabelsetWithPermissions),
+      ];
+
+      const component = await mountLabelSetDetailPage(
+        mount,
+        mocks,
+        mockLabelsetWithPermissions.id
+      );
+
+      await expect(component.getByText("Test Label Set")).toBeVisible({
+        timeout: 10000,
+      });
+
+      // Navigate to Span Labels tab
+      await component.getByRole("button", { name: /Span Labels/i }).click();
+
+      // Click Add Label button
+      await component.getByRole("button", { name: /Add Label/i }).click();
+
+      // Verify form is visible
+      await expect(
+        component.getByPlaceholder("Enter label name")
+      ).toBeVisible();
+
+      // Click Cancel
+      await component.getByTitle("Cancel").click();
+
+      // Form should be hidden
+      await expect(
+        component.getByPlaceholder("Enter label name")
+      ).not.toBeVisible();
+
+      // Add Label button should be visible again
+      await expect(
+        component.getByRole("button", { name: /Add Label/i })
+      ).toBeVisible();
+    });
+
+    test("validates create form requires label name", async ({ mount }) => {
+      const mocks = [
+        createLabelsetMock(mockLabelsetWithPermissions),
+        createLabelsetMock(mockLabelsetWithPermissions),
+      ];
+
+      const component = await mountLabelSetDetailPage(
+        mount,
+        mocks,
+        mockLabelsetWithPermissions.id
+      );
+
+      await expect(component.getByText("Test Label Set")).toBeVisible({
+        timeout: 10000,
+      });
+
+      // Navigate to Span Labels tab
+      await component.getByRole("button", { name: /Span Labels/i }).click();
+
+      // Click Add Label button
+      await component.getByRole("button", { name: /Add Label/i }).click();
+
+      // Try to submit without filling in name
+      await component.getByTitle("Create").click();
+
+      // Form should still be visible (validation prevents submission)
+      await expect(
+        component.getByPlaceholder("Enter label name")
+      ).toBeVisible();
+    });
+
+    test("shows empty state with Add First Label when no labels exist", async ({
+      mount,
+    }) => {
+      // Create labelset with no span labels
+      const noSpanLabelsLabelset = {
+        ...mockLabelsetWithPermissions,
+        allAnnotationLabels: [
+          ...mockTextLabels,
+          ...mockDocLabels,
+          ...mockRelationshipLabels,
+          // No span labels
+        ],
+        spanLabelCount: 0,
+      };
+
+      const mocks = [
+        createLabelsetMock(noSpanLabelsLabelset),
+        createLabelsetMock(noSpanLabelsLabelset),
+      ];
+
+      const component = await mountLabelSetDetailPage(
+        mount,
+        mocks,
+        noSpanLabelsLabelset.id
+      );
+
+      await expect(component.getByText("Test Label Set")).toBeVisible({
+        timeout: 10000,
+      });
+
+      // Navigate to Span Labels tab
+      await component.getByRole("button", { name: /Span Labels/i }).click();
+
+      // Should show empty state with "Add First Label" button
+      await expect(component.getByText(/No span labels yet/i)).toBeVisible();
+      await expect(
+        component.getByRole("button", { name: /Add First Label/i })
+      ).toBeVisible();
+    });
+
+    test("shows no matches message when search has no results", async ({
+      mount,
+    }) => {
+      const mocks = [
+        createLabelsetMock(mockLabelsetWithPermissions),
+        createLabelsetMock(mockLabelsetWithPermissions),
+      ];
+
+      const component = await mountLabelSetDetailPage(
+        mount,
+        mocks,
+        mockLabelsetWithPermissions.id
+      );
+
+      await expect(component.getByText("Test Label Set")).toBeVisible({
+        timeout: 10000,
+      });
+
+      // Navigate to Span Labels tab
+      await component.getByRole("button", { name: /Span Labels/i }).click();
+
+      // Search for non-existent term
+      const searchInput = component.getByPlaceholder(/Search labels/i);
+      await searchInput.fill("xyznonexistent");
+
+      // Should show no matches message
+      await expect(
+        component.getByText(/No labels match "xyznonexistent"/i)
+      ).toBeVisible();
+    });
+  });
 });

--- a/frontend/tests/LabelSetDetailPageTestWrapper.tsx
+++ b/frontend/tests/LabelSetDetailPageTestWrapper.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { MockedProvider, MockedResponse } from "@apollo/client/testing";
+import { MemoryRouter } from "react-router-dom";
+import { LabelSetDetailPage } from "../src/components/labelsets/LabelSetDetailPage";
+import { openedLabelset } from "../src/graphql/cache";
+import { InMemoryCache } from "@apollo/client";
+
+interface LabelSetDetailPageTestWrapperProps {
+  mocks: MockedResponse[];
+  labelsetId: string;
+  permissions?: string[];
+}
+
+// Create cache outside component like CorpusesTestWrapper does
+const createTestCache = () => new InMemoryCache();
+
+export const LabelSetDetailPageTestWrapper: React.FC<
+  LabelSetDetailPageTestWrapperProps
+> = ({
+  mocks,
+  labelsetId,
+  permissions = ["read_labelset", "update_labelset", "remove_labelset"],
+}) => {
+  const [ready, setReady] = React.useState(false);
+
+  // Set the reactive var in useEffect - same pattern as CorpusesTestWrapper
+  React.useEffect(() => {
+    openedLabelset({
+      id: labelsetId,
+      myPermissions: permissions,
+    } as any);
+    setReady(true);
+  }, [labelsetId, permissions]);
+
+  // Render component - wait for ready before rendering LabelSetDetailPage
+  // Note: JotaiProvider and ApolloProvider are provided by playwright/index.tsx
+  // We use MockedProvider to override the Apollo client with our mocks
+  return (
+    <MockedProvider mocks={mocks} cache={createTestCache()} addTypename>
+      <MemoryRouter initialEntries={["/label_sets"]}>
+        {ready ? (
+          <LabelSetDetailPage />
+        ) : (
+          <div data-testid="setting-up">Setting up...</div>
+        )}
+      </MemoryRouter>
+    </MockedProvider>
+  );
+};

--- a/opencontractserver/tests/permissioning/test_creator_based_permissions.py
+++ b/opencontractserver/tests/permissioning/test_creator_based_permissions.py
@@ -204,7 +204,8 @@ class CreatorBasedPermissionsPublicObjectTestCase(TestCase):
     def test_public_labelset_readable_by_all(self):
         """
         LabelSet with is_public=True should be readable by all users.
-        Note: LabelSet uses guardian permissions, but this tests the public fallback.
+        Note: LabelSet uses guardian permissions, but this tests the is_public check
+        in the guardian permission path (line 265-266 in permissioning.py)
         """
         # Create a public labelset
         with transaction.atomic():
@@ -227,6 +228,72 @@ class CreatorBasedPermissionsPublicObjectTestCase(TestCase):
             "read_labelset",
             permissions,
             "Public labelset should be readable by any user",
+        )
+
+    def test_public_object_without_guardian_permissions_readable_by_all(self):
+        """
+        Test the is_public branch in creator-based permissions code path.
+
+        This tests the case where a model without guardian permission tables
+        has is_public=True, which should grant read permission to any user.
+        We use a simple class to simulate this since AnnotationLabel doesn't
+        have an is_public field.
+        """
+
+        # Create a simple class that simulates a model without guardian permissions
+        # but with is_public=True
+        class MockModelMeta:
+            model_name = "mockmodel"
+            app_label = "mockapp"
+
+        class MockPublicModel:
+            _meta = MockModelMeta()
+            creator_id = -999  # Different from any real user
+            is_public = True
+
+        mock_instance = MockPublicModel()
+
+        permissions = get_users_permissions_for_obj(
+            user=self.user2,
+            instance=mock_instance,
+        )
+
+        # Should have read permission due to is_public=True
+        self.assertIn(
+            "read_mockmodel",
+            permissions,
+            "Public object without guardian permissions should be readable by any user",
+        )
+
+    def test_non_public_non_creator_object_without_guardian_permissions(self):
+        """
+        Test that non-public objects without guardian permissions are not readable
+        by non-creator, non-superuser users.
+        """
+
+        # Create a simple class that simulates a model without guardian permissions
+        # and is_public=False
+        class MockModelMeta:
+            model_name = "mockmodel"
+            app_label = "mockapp"
+
+        class MockPrivateModel:
+            _meta = MockModelMeta()
+            creator_id = -999  # Different from any real user
+            is_public = False
+
+        mock_instance = MockPrivateModel()
+
+        permissions = get_users_permissions_for_obj(
+            user=self.user2,
+            instance=mock_instance,
+        )
+
+        # Should have no permissions
+        self.assertEqual(
+            permissions,
+            set(),
+            "Non-public object without guardian permissions should not be readable by other users",
         )
 
 

--- a/opencontractserver/tests/permissioning/test_creator_based_permissions.py
+++ b/opencontractserver/tests/permissioning/test_creator_based_permissions.py
@@ -1,0 +1,294 @@
+"""
+Tests for creator-based permission fallback in get_users_permissions_for_obj.
+
+Models without django-guardian permission tables (like AnnotationLabel) use
+creator-based permissions instead. This test file verifies that:
+1. Superusers get all CRUD permissions
+2. Creators get all CRUD permissions on their own objects
+3. Other users get no permissions on private objects
+4. All users get read permission on public objects
+"""
+
+import logging
+
+from django.contrib.auth import get_user_model
+from django.db import transaction
+from django.test import TestCase
+
+from opencontractserver.annotations.models import AnnotationLabel, LabelSet, TOKEN_LABEL
+from opencontractserver.utils.permissioning import (
+    get_users_permissions_for_obj,
+    user_has_permission_for_obj,
+)
+from opencontractserver.types.enums import PermissionTypes
+
+User = get_user_model()
+logger = logging.getLogger(__name__)
+
+
+class CreatorBasedPermissionsTestCase(TestCase):
+    """
+    Tests that creator-based permission fallback works correctly for models
+    without django-guardian permission tables (e.g., AnnotationLabel).
+    """
+
+    def setUp(self):
+        """Set up test users and objects."""
+        # Create regular users
+        with transaction.atomic():
+            self.user1 = User.objects.create_user(
+                username="creator_user", password="test12345"
+            )
+            self.user2 = User.objects.create_user(
+                username="other_user", password="test12345"
+            )
+            self.superuser = User.objects.create_superuser(
+                username="super_user", password="super12345"
+            )
+
+        # Create a labelset owned by user1
+        with transaction.atomic():
+            self.labelset = LabelSet.objects.create(
+                title="Test LabelSet",
+                description="Test labelset for permissions",
+                creator=self.user1,
+            )
+
+        # Create an annotation label owned by user1 (linked to labelset)
+        with transaction.atomic():
+            self.annotation_label = AnnotationLabel.objects.create(
+                text="Test Label",
+                description="A test label",
+                color="#FF0000",
+                icon="tag",
+                label_type=TOKEN_LABEL,
+                creator=self.user1,
+            )
+            # Link to labelset
+            self.labelset.annotation_labels.add(self.annotation_label)
+
+    def test_annotation_label_lacks_guardian_permissions(self):
+        """Verify that AnnotationLabel doesn't have guardian permission tables."""
+        model_name = self.annotation_label._meta.model_name
+        has_guardian_perms = hasattr(
+            self.annotation_label, f"{model_name}userobjectpermission_set"
+        )
+        self.assertFalse(
+            has_guardian_perms,
+            "AnnotationLabel should NOT have django-guardian permission tables",
+        )
+
+    def test_superuser_gets_all_permissions_on_annotation_label(self):
+        """Superuser should get all CRUD permissions on AnnotationLabel."""
+        permissions = get_users_permissions_for_obj(
+            user=self.superuser,
+            instance=self.annotation_label,
+        )
+
+        expected_perms = {
+            "create_annotationlabel",
+            "read_annotationlabel",
+            "update_annotationlabel",
+            "remove_annotationlabel",
+        }
+
+        self.assertEqual(
+            permissions,
+            expected_perms,
+            f"Superuser should have all CRUD permissions, got: {permissions}",
+        )
+
+    def test_creator_gets_all_permissions_on_own_annotation_label(self):
+        """Creator should get all CRUD permissions on their own AnnotationLabel."""
+        permissions = get_users_permissions_for_obj(
+            user=self.user1,
+            instance=self.annotation_label,
+        )
+
+        expected_perms = {
+            "create_annotationlabel",
+            "read_annotationlabel",
+            "update_annotationlabel",
+            "remove_annotationlabel",
+        }
+
+        self.assertEqual(
+            permissions,
+            expected_perms,
+            f"Creator should have all CRUD permissions, got: {permissions}",
+        )
+
+    def test_other_user_gets_no_permissions_on_private_annotation_label(self):
+        """Non-creator, non-superuser should get no permissions on private label."""
+        permissions = get_users_permissions_for_obj(
+            user=self.user2,
+            instance=self.annotation_label,
+        )
+
+        self.assertEqual(
+            permissions,
+            set(),
+            f"Other user should have no permissions on private label, got: {permissions}",
+        )
+
+    def test_user_has_permission_for_obj_read_creator(self):
+        """user_has_permission_for_obj should return True for creator reading."""
+        has_read = user_has_permission_for_obj(
+            user_val=self.user1,
+            instance=self.annotation_label,
+            permission=PermissionTypes.READ,
+        )
+        self.assertTrue(has_read, "Creator should have READ permission")
+
+    def test_user_has_permission_for_obj_update_creator(self):
+        """user_has_permission_for_obj should return True for creator updating."""
+        has_update = user_has_permission_for_obj(
+            user_val=self.user1,
+            instance=self.annotation_label,
+            permission=PermissionTypes.UPDATE,
+        )
+        self.assertTrue(has_update, "Creator should have UPDATE permission")
+
+    def test_user_has_permission_for_obj_delete_creator(self):
+        """user_has_permission_for_obj should return True for creator deleting."""
+        has_delete = user_has_permission_for_obj(
+            user_val=self.user1,
+            instance=self.annotation_label,
+            permission=PermissionTypes.DELETE,
+        )
+        self.assertTrue(has_delete, "Creator should have DELETE permission")
+
+    def test_user_has_permission_for_obj_read_other_user(self):
+        """user_has_permission_for_obj should return False for other user reading private."""
+        has_read = user_has_permission_for_obj(
+            user_val=self.user2,
+            instance=self.annotation_label,
+            permission=PermissionTypes.READ,
+        )
+        self.assertFalse(has_read, "Other user should NOT have READ permission on private label")
+
+    def test_user_has_permission_for_obj_superuser(self):
+        """user_has_permission_for_obj should return True for superuser on any permission."""
+        for perm in [PermissionTypes.READ, PermissionTypes.UPDATE, PermissionTypes.DELETE]:
+            has_perm = user_has_permission_for_obj(
+                user_val=self.superuser,
+                instance=self.annotation_label,
+                permission=perm,
+            )
+            self.assertTrue(has_perm, f"Superuser should have {perm} permission")
+
+
+class CreatorBasedPermissionsPublicObjectTestCase(TestCase):
+    """
+    Tests for public objects with creator-based permissions.
+    Note: AnnotationLabel doesn't have is_public field, so we test with a mock
+    or skip this if there's no suitable model.
+    """
+
+    def setUp(self):
+        """Set up test users."""
+        with transaction.atomic():
+            self.user1 = User.objects.create_user(
+                username="creator_public", password="test12345"
+            )
+            self.user2 = User.objects.create_user(
+                username="reader_public", password="test12345"
+            )
+
+    def test_public_labelset_readable_by_all(self):
+        """
+        LabelSet with is_public=True should be readable by all users.
+        Note: LabelSet uses guardian permissions, but this tests the public fallback.
+        """
+        # Create a public labelset
+        with transaction.atomic():
+            public_labelset = LabelSet.objects.create(
+                title="Public LabelSet",
+                description="A public labelset",
+                creator=self.user1,
+                is_public=True,
+            )
+
+        # LabelSet has guardian permissions, so this tests the is_public check
+        # in the guardian permission path (line 265-266 in permissioning.py)
+        permissions = get_users_permissions_for_obj(
+            user=self.user2,
+            instance=public_labelset,
+        )
+
+        # Should at least have read permission due to is_public
+        self.assertIn(
+            "read_labelset",
+            permissions,
+            "Public labelset should be readable by any user",
+        )
+
+
+class CreatorBasedPermissionsEdgeCasesTestCase(TestCase):
+    """Edge cases for creator-based permission fallback."""
+
+    def setUp(self):
+        """Set up test users."""
+        with transaction.atomic():
+            self.user1 = User.objects.create_user(
+                username="edge_user1", password="test12345"
+            )
+            self.user2 = User.objects.create_user(
+                username="edge_user2", password="test12345"
+            )
+
+    def test_permissions_with_user_id_instead_of_user_object(self):
+        """user_has_permission_for_obj should work with user ID as well as user object."""
+        with transaction.atomic():
+            label = AnnotationLabel.objects.create(
+                text="ID Test Label",
+                description="Test",
+                color="#00FF00",
+                icon="tag",
+                label_type=TOKEN_LABEL,
+                creator=self.user1,
+            )
+
+        # Test with user ID (integer)
+        has_read = user_has_permission_for_obj(
+            user_val=self.user1.id,
+            instance=label,
+            permission=PermissionTypes.READ,
+        )
+        self.assertTrue(has_read, "Should work with user ID")
+
+        # Test with user ID (string)
+        has_read_str = user_has_permission_for_obj(
+            user_val=str(self.user1.id),
+            instance=label,
+            permission=PermissionTypes.READ,
+        )
+        self.assertTrue(has_read_str, "Should work with user ID as string")
+
+    def test_crud_permission_check(self):
+        """Test CRUD permission type checking for creator-based permissions."""
+        with transaction.atomic():
+            label = AnnotationLabel.objects.create(
+                text="CRUD Test Label",
+                description="Test",
+                color="#0000FF",
+                icon="tag",
+                label_type=TOKEN_LABEL,
+                creator=self.user1,
+            )
+
+        # Creator should have CRUD
+        has_crud = user_has_permission_for_obj(
+            user_val=self.user1,
+            instance=label,
+            permission=PermissionTypes.CRUD,
+        )
+        self.assertTrue(has_crud, "Creator should have CRUD permissions")
+
+        # Other user should NOT have CRUD
+        has_crud_other = user_has_permission_for_obj(
+            user_val=self.user2,
+            instance=label,
+            permission=PermissionTypes.CRUD,
+        )
+        self.assertFalse(has_crud_other, "Other user should NOT have CRUD permissions")

--- a/opencontractserver/tests/permissioning/test_creator_based_permissions.py
+++ b/opencontractserver/tests/permissioning/test_creator_based_permissions.py
@@ -15,12 +15,12 @@ from django.contrib.auth import get_user_model
 from django.db import transaction
 from django.test import TestCase
 
-from opencontractserver.annotations.models import AnnotationLabel, LabelSet, TOKEN_LABEL
+from opencontractserver.annotations.models import TOKEN_LABEL, AnnotationLabel, LabelSet
+from opencontractserver.types.enums import PermissionTypes
 from opencontractserver.utils.permissioning import (
     get_users_permissions_for_obj,
     user_has_permission_for_obj,
 )
-from opencontractserver.types.enums import PermissionTypes
 
 User = get_user_model()
 logger = logging.getLogger(__name__)
@@ -165,11 +165,17 @@ class CreatorBasedPermissionsTestCase(TestCase):
             instance=self.annotation_label,
             permission=PermissionTypes.READ,
         )
-        self.assertFalse(has_read, "Other user should NOT have READ permission on private label")
+        self.assertFalse(
+            has_read, "Other user should NOT have READ permission on private label"
+        )
 
     def test_user_has_permission_for_obj_superuser(self):
         """user_has_permission_for_obj should return True for superuser on any permission."""
-        for perm in [PermissionTypes.READ, PermissionTypes.UPDATE, PermissionTypes.DELETE]:
+        for perm in [
+            PermissionTypes.READ,
+            PermissionTypes.UPDATE,
+            PermissionTypes.DELETE,
+        ]:
             has_perm = user_has_permission_for_obj(
                 user_val=self.superuser,
                 instance=self.annotation_label,

--- a/opencontractserver/utils/permissioning.py
+++ b/opencontractserver/utils/permissioning.py
@@ -213,6 +213,38 @@ def get_users_permissions_for_obj(
     app_label = instance._meta.app_label
     logger.info(f"get_users_permissions_for_obj - App name: {app_label}")
 
+    # Check if the model has django-guardian permission tables
+    # Some models (like AnnotationLabel) use creator-based permissions instead
+    if not hasattr(instance, f"{model_name}userobjectpermission_set"):
+        logger.info(
+            f"Model {model_name} does not have guardian permissions, using creator-based permissions"
+        )
+        # For models without guardian permissions, use creator-based permissions
+        model_permissions_for_user: set[str] = set()
+
+        # Superusers have all permissions
+        if user.is_superuser:
+            model_permissions_for_user = {
+                f"create_{model_name}",
+                f"read_{model_name}",
+                f"update_{model_name}",
+                f"remove_{model_name}",
+            }
+        # Creator has full CRUD permissions
+        elif hasattr(instance, "creator_id") and instance.creator_id == user.id:
+            model_permissions_for_user = {
+                f"create_{model_name}",
+                f"read_{model_name}",
+                f"update_{model_name}",
+                f"remove_{model_name}",
+            }
+        # Public objects are readable by all
+        elif hasattr(instance, "is_public") and instance.is_public:
+            model_permissions_for_user.add(f"read_{model_name}")
+
+        logger.info(f"Creator-based permissions: {model_permissions_for_user}")
+        return model_permissions_for_user
+
     this_user_perms = getattr(instance, f"{model_name}userobjectpermission_set")
 
     logger.info(f"get_users_permissions_for_obj - this_user_perms: {this_user_perms}")


### PR DESCRIPTION
## Summary

- Add full-page LabelSet detail view with sidebar navigation and inline label editing
- Implement responsive layout with mobile navigation tabs (hidden sidebar on screens <900px)
- Add delete confirmation modal to LabelSets list view context menu
- Fix label CRUD operations (create, update, delete) with proper GraphQL mutations

## Changes

### New Features
- **LabelSetDetailPage**: Full-page detail view with:
  - Sidebar navigation for Overview, Text Labels, Doc Labels, Relationships, Span Labels, Sharing tabs
  - Inline label editing with color picker
  - Add/delete label functionality per category
  - Export JSON functionality
  - Delete labelset with confirmation

### Responsive Layout
- Mobile navigation tabs replace sidebar on screens <900px
- Mobile back button for navigation
- Adjusted padding, font sizes, and layouts for mobile
- Stacked overview hero on mobile
- Always-visible label actions on mobile (no hover required)

### Bug Fixes
- Wire up delete confirmation modal for labelset deletion from list view context menu
- Proper permission checking for edit/delete actions

## Test plan

- [x] Navigate to Label Sets page and verify list displays correctly
- [x] Right-click on a labelset card and verify context menu appears
- [x] Click "Delete" in context menu and verify confirmation modal appears
- [x] Click into a labelset and verify detail page loads with sidebar navigation
- [x] Test each tab (Overview, Text Labels, Doc Labels, etc.)
- [x] Test adding a new label in any category
- [x] Test editing an existing label (name, description, color)
- [x] Test deleting a label
- [x] Resize browser to <900px and verify mobile navigation appears
- [x] Verify mobile back button navigates to label sets list