### PR TITLE
Fix extract list card document count display

### DIFF
--- a/frontend/src/components/extracts/ExtractListCard.tsx
+++ b/frontend/src/components/extracts/ExtractListCard.tsx
@@ -106,11 +106,11 @@ const KebabIcon = () => (
 function formatStats(extract: ExtractType): string[] {
   const stats: string[] = [];
 
-  // Document count
-  const docCount = extract.documents?.length || 0;
+  // Document count (use fullDocumentList from GraphQL query)
+  const docCount = extract.fullDocumentList?.length || 0;
   stats.push(`${docCount} ${docCount === 1 ? "document" : "documents"}`);
 
-  // Column count (from fieldset)
+  // Column count (from fieldset's fullColumnList)
   const columnCount = extract.fieldset?.fullColumnList?.length || 0;
   if (columnCount > 0) {
     stats.push(`${columnCount} ${columnCount === 1 ? "column" : "columns"}`);

--- a/frontend/src/graphql/queries.ts
+++ b/frontend/src/graphql/queries.ts
@@ -1606,14 +1606,12 @@ export const GET_EXTRACTS = gql`
             id
             name
             inUse
-            columns {
-              edges {
-                node {
-                  id
-                  query
-                }
-              }
+            fullColumnList {
+              id
             }
+          }
+          fullDocumentList {
+            id
           }
           creator {
             id
@@ -1624,6 +1622,7 @@ export const GET_EXTRACTS = gql`
           started
           finished
           error
+          myPermissions
         }
       }
       pageInfo {

--- a/frontend/src/views/Extracts.tsx
+++ b/frontend/src/views/Extracts.tsx
@@ -295,7 +295,7 @@ export const Extracts = () => {
     let totalColumns = 0;
 
     extracts.forEach((ex) => {
-      totalDocuments += ex.documents?.length || 0;
+      totalDocuments += ex.fullDocumentList?.length || 0;
       totalColumns += ex.fieldset?.fullColumnList?.length || 0;
     });
 


### PR DESCRIPTION
## Summary
- Update GET_EXTRACTS query to include `fullDocumentList` and `fullColumnList` fields
- Update ExtractListCard and Extracts view to use these fields for accurate document and column counts
- Add `myPermissions` to query to enable permission-based UI in list view

## Test plan
- [x] Verify document counts display correctly on extract list cards
- [x] Verify column counts display correctly
- [x] All 13 component tests pass
- [x] Build succeeds