### PR TITLE
Add PostHog configuration to frontend env-config.js

### DIFF
--- a/frontend/public/env-config.js
+++ b/frontend/public/env-config.js
@@ -6,4 +6,6 @@ window._env_ = {
   REACT_APP_USE_AUTH0: "true",
   REACT_APP_USE_ANALYZERS: "",
   REACT_APP_ALLOW_IMPORTS: "",
+  REACT_APP_POSTHOG_API_KEY: "phc_wsTXvOFv6QLDMOA3yLl16awF4DTgILi4MSVLwhwyDeJ",
+  REACT_APP_POSTHOG_HOST: "https://us.i.posthog.com",
 };


### PR DESCRIPTION
## Summary
- Adds missing `REACT_APP_POSTHOG_API_KEY` and `REACT_APP_POSTHOG_HOST` to `frontend/public/env-config.js`
- Fixes PostHog analytics not initializing because the frontend had no API key configured

## Root Cause
The backend had PostHog configured in `config/settings/base.py`, but these values were never passed to the frontend's `window._env_` object. The analytics code in `frontend/src/utils/analytics.ts` was correctly checking for the API key and exiting early with a debug message when not found.

## Test plan
- [x] Hard refresh browser to reload env-config.js
- [x] Clear `oc_analyticsConsent` from localStorage (or accept cookie consent modal)
- [x] Verify `[Analytics] PostHog initialized successfully` appears in browser console
- [x] Verify events appear in PostHog dashboard