### PR TITLE
Add comprehensive telemetry documentation and daily usage heartbeat

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,11 @@ OpenContracts collects anonymous usage data to guide development priorities. We 
 
 We do not collect document contents, extracted data, user identities, or query contents.
 
-Disable with `TELEMETRY_ENABLED=False` in your settings.
+### Disabling Telemetry
+
+**Backend telemetry** (server-side events): Set `TELEMETRY_ENABLED=False` in your Django settings.
+
+**Frontend analytics** (browser-side tracking via PostHog): Leave `REACT_APP_POSTHOG_API_KEY` unset or empty in `frontend/public/env-config.js`. The frontend also respects the browser's Do Not Track setting and requires explicit user consent before any tracking occurs.
 
 ---
 

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -569,6 +569,8 @@ CELERY_RESULT_SERIALIZER = "json"
 # TODO: set to whatever value is adequate in your circumstances
 # CELERY_TASK_SOFT_TIME_LIMIT = 3600
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#beat-scheduler
+# Uses database scheduler - periodic tasks are set up via migrations
+# See: opencontractserver/users/migrations/0024_setup_telemetry_periodic_task.py
 CELERY_BEAT_SCHEDULER = "django_celery_beat.schedulers:DatabaseScheduler"
 CELERY_WORKER_MAX_MEMORY_PER_CHILD = 14240000  # 14 GB (thousands of kilobytes)
 CELERY_MAX_TASKS_PER_CHILD = 4

--- a/docs/telemetry/Backend.md
+++ b/docs/telemetry/Backend.md
@@ -1,0 +1,109 @@
+# Backend Telemetry
+
+OpenContracts backend uses PostHog to collect anonymous usage telemetry. This data helps guide development priorities by understanding how the platform is used.
+
+## What We Collect
+
+Backend telemetry records the following events:
+
+### Periodic Events
+
+| Event | Description | Frequency | Properties |
+|-------|-------------|-----------|------------|
+| `usage_heartbeat` | Aggregate usage statistics | Daily | See below |
+
+The `usage_heartbeat` event includes:
+- `user_count` — Active users
+- `document_count` — Non-deleted documents
+- `corpus_count` — Total corpuses
+- `annotation_count` — User annotations (excludes structural)
+- `conversation_count` — Active conversations/threads
+- `message_count` — Active messages
+- `version` — OpenContracts version
+- `installation_age_days` — Days since installation
+
+### Real-time Events
+
+| Event | Description | Properties |
+|-------|-------------|------------|
+| `user_created` | A new user account is created | `user_count` (total users) |
+| `document_uploaded` | A document is uploaded | `user_id`, `env` |
+
+All events include:
+- `installation_id` — Unique anonymous identifier for your installation
+- `timestamp` — When the event occurred
+- `package` — Always `opencontracts`
+
+## What We Do NOT Collect
+
+- Document contents or filenames
+- User identities, emails, or personal information
+- Extracted data or annotations
+- Query contents or search terms
+- IP addresses or location data
+
+## Configuration
+
+Backend telemetry is controlled by environment variables in your Django settings:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `TELEMETRY_ENABLED` | `True` | Master switch for backend telemetry |
+| `POSTHOG_API_KEY` | (set) | PostHog project API key |
+| `POSTHOG_HOST` | `https://us.i.posthog.com` | PostHog API endpoint |
+
+## Disabling Telemetry
+
+To disable backend telemetry, set the environment variable:
+
+```bash
+TELEMETRY_ENABLED=False
+```
+
+Or in your `.env` file:
+
+```env
+TELEMETRY_ENABLED=False
+```
+
+When disabled, no events are sent to PostHog and no data leaves your server.
+
+## Technical Details
+
+- **Location**: `config/telemetry.py`
+- **Singleton client**: PostHog client is lazily initialized and reused
+- **Async sending**: Events are queued and sent asynchronously by a background thread
+- **Graceful shutdown**: An `atexit` handler ensures pending events are flushed on process exit
+- **Test mode**: Telemetry is automatically disabled when `MODE=TEST`
+
+### Periodic Task Setup
+
+The daily `usage_heartbeat` task is automatically configured when you run migrations:
+
+```bash
+python manage.py migrate
+```
+
+This creates a `PeriodicTask` entry in django-celery-beat's database scheduler. The task:
+- Runs daily at midnight UTC
+- Is only created if `TELEMETRY_ENABLED=True` at migration time
+- Can be managed via Django admin under "Periodic Tasks"
+
+**Requirements**: Celery Beat must be running for periodic tasks to execute:
+
+```bash
+celery -A config.celery_app beat --loglevel=info
+```
+
+## Implementation
+
+Events are recorded via the `record_event()` function:
+
+```python
+from config.telemetry import record_event
+
+# Record an event with properties
+record_event("my_event", {"property": "value"})
+```
+
+The function returns `True` if the event was queued successfully, `False` otherwise. It never raises exceptions to avoid disrupting normal operations.

--- a/docs/telemetry/Frontend.md
+++ b/docs/telemetry/Frontend.md
@@ -1,0 +1,119 @@
+# Frontend Analytics
+
+OpenContracts frontend uses PostHog for optional, consent-based analytics tracking. This helps understand how users interact with the interface to improve the experience.
+
+## Privacy-First Design
+
+Frontend analytics is designed with privacy as a priority:
+
+1. **Consent required** — Analytics only activates after explicit user consent via the cookie consent dialog
+2. **Do Not Track respected** — The browser's DNT setting is honored
+3. **No autocapture** — We don't automatically capture clicks or form submissions
+4. **CI/test detection** — Analytics is automatically disabled in test environments
+
+## What We Collect
+
+When enabled and consented, the frontend can track:
+
+| Event Type | Description |
+|------------|-------------|
+| Page views | Navigation between pages (manually triggered for SPA) |
+| Custom events | Feature usage statistics (opt-in per feature) |
+
+## What We Do NOT Collect
+
+- Document contents or extracted data
+- User credentials or personal information
+- Form inputs or search queries
+- Automatic click tracking (autocapture is disabled)
+
+## Configuration
+
+Frontend analytics is configured in `frontend/public/env-config.js`:
+
+```javascript
+window._env_ = {
+  // ... other settings ...
+  REACT_APP_POSTHOG_API_KEY: "your-api-key-here",
+  REACT_APP_POSTHOG_HOST: "https://us.i.posthog.com",
+};
+```
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `REACT_APP_POSTHOG_API_KEY` | (empty) | PostHog project API key |
+| `REACT_APP_POSTHOG_HOST` | `https://us.i.posthog.com` | PostHog API endpoint |
+
+## Disabling Analytics
+
+To disable frontend analytics entirely, leave `REACT_APP_POSTHOG_API_KEY` empty or unset:
+
+```javascript
+window._env_ = {
+  // ... other settings ...
+  REACT_APP_POSTHOG_API_KEY: "",  // Empty = disabled
+  REACT_APP_POSTHOG_HOST: "https://us.i.posthog.com",
+};
+```
+
+When disabled:
+- The cookie consent dialog won't mention analytics
+- No PostHog scripts are initialized
+- No data is sent to any analytics service
+
+## User Controls
+
+Even when analytics is configured, users have control:
+
+1. **Cookie consent** — Users must accept cookies to enable analytics
+2. **Browser DNT** — Do Not Track browser setting is respected
+3. **Opt-out** — Users can clear consent via browser localStorage
+
+## Technical Details
+
+- **Location**: `frontend/src/utils/analytics.ts`
+- **Consent storage**: `localStorage` key `oc_analyticsConsent`
+- **Initialization**: Lazy — only when consent is given and API key is configured
+
+### Available Functions
+
+```typescript
+import {
+  initializePostHog,      // Initialize PostHog (called automatically on consent)
+  shutdownPostHog,        // Shutdown and clear data
+  hasAnalyticsConsent,    // Check if user consented
+  setAnalyticsConsent,    // Set consent status
+  isPostHogConfigured,    // Check if API key is set
+  identifyUser,           // Associate events with user
+  trackEvent,             // Track custom event
+  trackPageView,          // Track page navigation
+  resetAnalytics,         // Reset identity (e.g., on logout)
+} from "./utils/analytics";
+```
+
+### Example Usage
+
+```typescript
+// Track a custom event
+trackEvent("feature_used", { feature_name: "document_export" });
+
+// Track a page view
+trackPageView("/documents/123");
+
+// Identify user after login
+identifyUser(userId, { plan: "enterprise" });
+
+// Reset on logout
+resetAnalytics();
+```
+
+## Test Environment Detection
+
+Analytics is automatically disabled when:
+
+- Running in Playwright or Cypress test environments
+- `import.meta.env.MODE === "test"` or `import.meta.env.VITEST` is set
+- Hostname includes "test" or "ci-"
+- `window._env_.CI === "true"`
+
+This ensures no test data pollutes production analytics.

--- a/opencontractserver/tasks/__init__.py
+++ b/opencontractserver/tasks/__init__.py
@@ -17,6 +17,7 @@ from .lookup_tasks import build_label_lookups_task
 
 # Materialized view tasks removed - using direct queries instead
 from .permissioning_tasks import make_analysis_public_task, make_corpus_public_task
+from .telemetry_tasks import send_usage_heartbeat
 
 # Great, quick guidance on how to restructure tasks into multiple modules:
 # https://blog.sneawo.com/blog/2018/12/05/how-to-split-celery-tasks-file/
@@ -40,4 +41,5 @@ __all__ = [
     "check_badges_for_all_users",
     "generate_agent_response",
     "trigger_agent_responses_for_message",
+    "send_usage_heartbeat",
 ]

--- a/opencontractserver/tasks/telemetry_tasks.py
+++ b/opencontractserver/tasks/telemetry_tasks.py
@@ -1,0 +1,79 @@
+"""
+Telemetry tasks for collecting and sending usage statistics.
+
+These tasks run periodically to send anonymous usage metrics to PostHog,
+helping guide development priorities without collecting any personal data.
+"""
+
+import logging
+
+from django.conf import settings
+from django.utils import timezone
+
+from config import celery_app
+from config.telemetry import record_event
+from opencontractserver import __version__
+from opencontractserver.annotations.models import Annotation
+from opencontractserver.conversations.models import ChatMessage, Conversation
+from opencontractserver.corpuses.models import Corpus
+from opencontractserver.documents.models import DocumentPath
+from opencontractserver.users.models import Installation, User
+
+logger = logging.getLogger(__name__)
+
+
+@celery_app.task()
+def send_usage_heartbeat() -> dict | None:
+    """
+    Send daily usage statistics heartbeat.
+
+    Collects aggregate counts of users, documents, corpuses, annotations,
+    and conversations, along with installation metadata.
+
+    Returns:
+        dict: The stats that were sent, or None if telemetry is disabled.
+    """
+    # Respect telemetry settings
+    if settings.MODE == "TEST":
+        logger.debug("Telemetry disabled in TEST mode")
+        return None
+
+    if not settings.TELEMETRY_ENABLED:
+        logger.debug("Telemetry disabled via TELEMETRY_ENABLED setting")
+        return None
+
+    try:
+        # Get installation metadata
+        installation = Installation.get()
+        age_days = (timezone.now() - installation.created).days
+
+        # Collect usage statistics
+        stats = {
+            # Usage counts
+            "user_count": User.objects.filter(is_active=True).count(),
+            "document_count": (
+                DocumentPath.objects.filter(is_deleted=False, is_current=True)
+                .values("document_id")
+                .distinct()
+                .count()
+            ),
+            "corpus_count": Corpus.objects.count(),
+            "annotation_count": Annotation.objects.filter(structural=False).count(),
+            "conversation_count": Conversation.objects.filter(
+                deleted_at__isnull=True
+            ).count(),
+            "message_count": ChatMessage.objects.filter(
+                deleted_at__isnull=True
+            ).count(),
+            # Installation metadata
+            "version": __version__,
+            "installation_age_days": age_days,
+        }
+
+        record_event("usage_heartbeat", stats)
+        logger.info(f"Usage heartbeat sent: {stats}")
+        return stats
+
+    except Exception as e:
+        logger.warning(f"Failed to send usage heartbeat: {e}")
+        return None

--- a/opencontractserver/tests/test_telemetry.py
+++ b/opencontractserver/tests/test_telemetry.py
@@ -4,7 +4,8 @@ from unittest.mock import MagicMock, patch
 from django.test import TestCase, override_settings
 
 from config.telemetry import _reset_posthog_client, record_event
-from opencontractserver.users.models import Installation
+from opencontractserver.tasks.telemetry_tasks import send_usage_heartbeat
+from opencontractserver.users.models import Installation, User
 
 
 class TelemetryTestCase(TestCase):
@@ -98,3 +99,85 @@ class TelemetryTestCase(TestCase):
         self.assertEqual(
             set(properties.keys()), {"package", "timestamp", "installation_id"}
         )
+
+
+class UsageHeartbeatTestCase(TestCase):
+    """Tests for the send_usage_heartbeat Celery task."""
+
+    def setUp(self):
+        # Ensure Installation exists
+        self.installation = Installation.get()
+
+        # Create a test user
+        self.user = User.objects.create_user(
+            username="testuser",
+            email="test@example.com",
+            password="testpass123",
+        )
+
+    def tearDown(self):
+        _reset_posthog_client()
+
+    @patch("opencontractserver.tasks.telemetry_tasks.record_event")
+    def test_heartbeat_collects_correct_stats(self, mock_record_event):
+        """Test that heartbeat collects and sends correct statistics."""
+        mock_record_event.return_value = True
+
+        with override_settings(MODE="DEV", TELEMETRY_ENABLED=True):
+            result = send_usage_heartbeat()
+
+        # Verify record_event was called
+        mock_record_event.assert_called_once()
+        call_args = mock_record_event.call_args
+
+        # Check event type
+        self.assertEqual(call_args[0][0], "usage_heartbeat")
+
+        # Check stats structure
+        stats = call_args[0][1]
+        self.assertIn("user_count", stats)
+        self.assertIn("document_count", stats)
+        self.assertIn("corpus_count", stats)
+        self.assertIn("annotation_count", stats)
+        self.assertIn("conversation_count", stats)
+        self.assertIn("message_count", stats)
+        self.assertIn("version", stats)
+        self.assertIn("installation_age_days", stats)
+
+        # Verify user count includes our test user
+        self.assertGreaterEqual(stats["user_count"], 1)
+
+        # Verify installation age is non-negative
+        self.assertGreaterEqual(stats["installation_age_days"], 0)
+
+        # Verify result matches stats
+        self.assertEqual(result, stats)
+
+    @patch("opencontractserver.tasks.telemetry_tasks.record_event")
+    def test_heartbeat_disabled_in_test_mode(self, mock_record_event):
+        """Test that heartbeat doesn't send in TEST mode."""
+        with override_settings(MODE="TEST", TELEMETRY_ENABLED=True):
+            result = send_usage_heartbeat()
+
+        mock_record_event.assert_not_called()
+        self.assertIsNone(result)
+
+    @patch("opencontractserver.tasks.telemetry_tasks.record_event")
+    def test_heartbeat_disabled_when_telemetry_off(self, mock_record_event):
+        """Test that heartbeat doesn't send when telemetry is disabled."""
+        with override_settings(MODE="DEV", TELEMETRY_ENABLED=False):
+            result = send_usage_heartbeat()
+
+        mock_record_event.assert_not_called()
+        self.assertIsNone(result)
+
+    @patch("opencontractserver.tasks.telemetry_tasks.record_event")
+    def test_heartbeat_handles_errors_gracefully(self, mock_record_event):
+        """Test that heartbeat handles errors without crashing."""
+        mock_record_event.side_effect = Exception("Network error")
+
+        with override_settings(MODE="DEV", TELEMETRY_ENABLED=True):
+            # Should not raise, just return None
+            result = send_usage_heartbeat()
+
+        self.assertIsNone(result)

--- a/opencontractserver/tests/test_telemetry.py
+++ b/opencontractserver/tests/test_telemetry.py
@@ -181,3 +181,80 @@ class UsageHeartbeatTestCase(TestCase):
             result = send_usage_heartbeat()
 
         self.assertIsNone(result)
+
+
+class TelemetryMigrationTestCase(TestCase):
+    """Tests for the telemetry periodic task migration."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Import migration module using importlib (can't use normal import for numeric names)
+        import importlib
+
+        cls.migration_module = importlib.import_module(
+            "opencontractserver.users.migrations.0024_setup_telemetry_periodic_task"
+        )
+
+    def test_setup_telemetry_task_creates_periodic_task(self):
+        """Test that the migration creates the periodic task when telemetry is enabled."""
+        from django.apps import apps
+        from django_celery_beat.models import PeriodicTask
+
+        # Clean up any existing task from previous test runs
+        PeriodicTask.objects.filter(name="usage-heartbeat-daily").delete()
+
+        with override_settings(TELEMETRY_ENABLED=True):
+            self.migration_module.setup_telemetry_task(apps, None)
+
+        # Verify task was created
+        task = PeriodicTask.objects.get(name="usage-heartbeat-daily")
+        self.assertEqual(
+            task.task,
+            "opencontractserver.tasks.telemetry_tasks.send_usage_heartbeat",
+        )
+        self.assertTrue(task.enabled)
+        self.assertIsNotNone(task.crontab)
+
+        # Verify crontab schedule
+        self.assertEqual(task.crontab.minute, "0")
+        self.assertEqual(task.crontab.hour, "0")
+
+    def test_setup_telemetry_task_skips_when_disabled(self):
+        """Test that the migration skips task creation when telemetry is disabled."""
+        from django.apps import apps
+        from django_celery_beat.models import PeriodicTask
+
+        # Clean up any existing task
+        PeriodicTask.objects.filter(name="usage-heartbeat-daily").delete()
+
+        with override_settings(TELEMETRY_ENABLED=False):
+            self.migration_module.setup_telemetry_task(apps, None)
+
+        # Verify task was NOT created
+        self.assertFalse(
+            PeriodicTask.objects.filter(name="usage-heartbeat-daily").exists()
+        )
+
+    def test_reverse_telemetry_task_removes_periodic_task(self):
+        """Test that the reverse migration removes the periodic task."""
+        from django.apps import apps
+        from django_celery_beat.models import PeriodicTask
+
+        # First create the task
+        PeriodicTask.objects.filter(name="usage-heartbeat-daily").delete()
+        with override_settings(TELEMETRY_ENABLED=True):
+            self.migration_module.setup_telemetry_task(apps, None)
+
+        # Verify it exists
+        self.assertTrue(
+            PeriodicTask.objects.filter(name="usage-heartbeat-daily").exists()
+        )
+
+        # Now reverse it
+        self.migration_module.reverse_telemetry_task(apps, None)
+
+        # Verify it's gone
+        self.assertFalse(
+            PeriodicTask.objects.filter(name="usage-heartbeat-daily").exists()
+        )

--- a/opencontractserver/users/migrations/0024_setup_telemetry_periodic_task.py
+++ b/opencontractserver/users/migrations/0024_setup_telemetry_periodic_task.py
@@ -1,0 +1,53 @@
+# Data migration to set up the telemetry heartbeat periodic task
+
+from django.conf import settings
+from django.db import migrations
+
+
+def setup_telemetry_task(apps, schema_editor):
+    """Create the periodic task for telemetry heartbeat if telemetry is enabled."""
+    # Check if telemetry is enabled
+    if not getattr(settings, "TELEMETRY_ENABLED", True):
+        return
+
+    CrontabSchedule = apps.get_model("django_celery_beat", "CrontabSchedule")
+    PeriodicTask = apps.get_model("django_celery_beat", "PeriodicTask")
+
+    # Create or get the crontab schedule for daily at midnight UTC
+    schedule, _ = CrontabSchedule.objects.get_or_create(
+        minute="0",
+        hour="0",
+        day_of_week="*",
+        day_of_month="*",
+        month_of_year="*",
+        defaults={"timezone": "UTC"},
+    )
+
+    # Create the periodic task if it doesn't exist
+    task_name = "usage-heartbeat-daily"
+    if not PeriodicTask.objects.filter(name=task_name).exists():
+        PeriodicTask.objects.create(
+            name=task_name,
+            task="opencontractserver.tasks.telemetry_tasks.send_usage_heartbeat",
+            crontab=schedule,
+            enabled=True,
+            description="Daily telemetry heartbeat - sends anonymous usage statistics",
+        )
+
+
+def reverse_telemetry_task(apps, schema_editor):
+    """Remove the telemetry periodic task."""
+    PeriodicTask = apps.get_model("django_celery_beat", "PeriodicTask")
+    PeriodicTask.objects.filter(name="usage-heartbeat-daily").delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("users", "0023_add_dismissed_getting_started"),
+        ("django_celery_beat", "0018_improve_crontab_helptext"),
+    ]
+
+    operations = [
+        migrations.RunPython(setup_telemetry_task, reverse_code=reverse_telemetry_task),
+    ]


### PR DESCRIPTION
## Summary

- Document both backend and frontend telemetry in `docs/telemetry/`
- Update README.md with clear instructions for disabling both backend and frontend tracking
- Add daily `usage_heartbeat` Celery task that sends aggregate statistics
- Create migration to automatically set up the periodic task (respects `TELEMETRY_ENABLED`)

## Usage Heartbeat Stats

The daily heartbeat sends:
- `user_count` — Active users
- `document_count` — Non-deleted documents
- `corpus_count` — Total corpuses
- `annotation_count` — User annotations (excludes structural)
- `conversation_count` — Active conversations
- `message_count` — Active messages
- `version` — OpenContracts version (e.g., `3.0.0b3`)
- `installation_age_days` — Days since installation

## Disabling Telemetry

**Backend**: Set `TELEMETRY_ENABLED=False` in Django settings

**Frontend**: Leave `REACT_APP_POSTHOG_API_KEY` empty in `frontend/public/env-config.js`

## Test plan

- [x] Run telemetry tests: `python manage.py test opencontractserver.tests.test_telemetry`
- [x] Verify migration creates periodic task when telemetry is enabled
- [x] Pre-commit checks pass