### PR TITLE
Fix metadata handling for social sharing

### DIFF
--- a/cloudflare-og-worker/src/crawler.ts
+++ b/cloudflare-og-worker/src/crawler.ts
@@ -11,6 +11,7 @@
  * Sources:
  * - https://developers.cloudflare.com/bots/concepts/bot/verified-bots/
  * - https://radar.cloudflare.com/bots/directory
+ * - https://developers.google.com/business-communications/rcs-business-messaging/guides/release-notes
  */
 const SOCIAL_CRAWLERS = [
   // Social Media
@@ -24,11 +25,25 @@ const SOCIAL_CRAWLERS = [
   "whatsapp", // WhatsApp
   "telegrambot", // Telegram
 
-  // Messaging/Preview Services
+  // Google/Android RCS - Critical for Android messaging
+  "googlemessages", // Google Messages app (Android default SMS/RCS)
+  "google-pagerenderer", // Google's page rendering service for RCS previews
+  "developers.google.com/+/web/snippet", // Google snippet fetcher (legacy, still used)
+
+  // Apple/iOS
+  "applebot", // Apple (iMessage, Siri, Safari)
+
+  // Other Messaging/Preview Services
   "pinterest", // Pinterest
-  "applebot", // Apple (iMessage, Siri)
   "redditbot", // Reddit
   "embedly", // Embed.ly
+  "bluesky", // BlueSky social
+  "cardyb", // BlueSky's preview bot
+
+  // Generic preview patterns (catch edge cases)
+  "link preview", // Generic link preview services
+  "url preview", // URL preview services
+  "snippet", // Snippet fetchers
 
   // Optional: Search engines (uncomment for SEO benefits)
   // 'googlebot',  // Google
@@ -87,6 +102,14 @@ export function getCrawlerName(userAgent: string): string | null {
   if (ua.includes("redditbot")) return "Reddit";
   if (ua.includes("googlebot")) return "Google";
   if (ua.includes("bingbot")) return "Bing";
+
+  // Google/Android RCS
+  if (ua.includes("googlemessages")) return "Google Messages";
+  if (ua.includes("google-pagerenderer")) return "Google RCS";
+  if (ua.includes("developers.google.com/+/web/snippet")) return "Google Snippet";
+
+  // BlueSky
+  if (ua.includes("bluesky") || ua.includes("cardyb")) return "BlueSky";
 
   // Generic bot detection
   if (isKnownBot(userAgent)) return "Unknown Bot";

--- a/docs/architecture/social-media-previews.md
+++ b/docs/architecture/social-media-previews.md
@@ -109,10 +109,26 @@ const SOCIAL_CRAWLERS = [
   'discordbot',            // Discord
   'whatsapp',              // WhatsApp
   'telegrambot',           // Telegram
+
+  // Google/Android RCS - Critical for Android messaging
+  'googlemessages',        // Google Messages app (Android default SMS/RCS)
+  'google-pagerenderer',   // Google's page rendering service for RCS previews
+  'developers.google.com/+/web/snippet', // Google snippet fetcher
+
+  // Apple/iOS
+  'applebot',              // Apple (iMessage, Siri, Safari)
+
+  // Other Messaging/Preview Services
   'pinterest',             // Pinterest
-  'applebot',              // Apple (iMessage, Siri)
   'redditbot',             // Reddit
   'embedly',               // Embed.ly
+  'bluesky',               // BlueSky social
+  'cardyb',                // BlueSky's preview bot
+
+  // Generic preview patterns (catch edge cases)
+  'link preview',          // Generic link preview services
+  'url preview',           // URL preview services
+  'snippet',               // Snippet fetchers
 
   // Optional: search engines (only enable intentionally)
   // 'googlebot',


### PR DESCRIPTION
Expand Cloudflare worker crawler detection to support:
- Google Messages (googlemessages) - Android default SMS/RCS app
- Google Page Renderer (google-pagerenderer) - RCS preview service
- Google Snippet fetcher - legacy preview service
- BlueSky social and cardyb preview bot
- Generic preview patterns (link preview, url preview, snippet)

This ensures rich link previews work across Android messaging apps in addition to the existing iOS/iMessage support via Applebot.