### PR TITLE
Review backend forking functionality and test coverage

### DIFF
--- a/config/graphql/mutations.py
+++ b/config/graphql/mutations.py
@@ -152,6 +152,7 @@ from opencontractserver.tasks import (
     burn_doc_annotations,
     delete_analysis_and_annotations_task,
     fork_corpus,
+    fork_corpus_v2,
     import_corpus,
     import_document_to_corpus,
     package_annotated_docs,
@@ -1120,10 +1121,43 @@ class UpdateDocumentSummary(graphene.Mutation):
 
 
 class StartCorpusFork(graphene.Mutation):
+    """
+    Fork a corpus with all its content.
+
+    This mutation creates a copy of a corpus including:
+    - Documents (with file copies)
+    - LabelSet and AnnotationLabels
+    - Annotations (non-analysis)
+    - Relationships between annotations
+    - Extracts, Fieldsets, Columns, Datacells
+    - Conversations (chat type only)
+    - Notes and NoteRevisions
+    - Folder structure
+
+    What is NOT forked:
+    - Analyses and analyzer-created annotations
+    - Discussion threads (conversation_type='thread')
+    - Moderation actions and audit trails
+    - User reputation and moderator assignments
+    - CorpusActions (automation configs)
+    """
+
     class Arguments:
         corpus_id = graphene.String(
             required=True,
-            description="Graphene id of the corpus you want to package for export",
+            description="Graphene id of the corpus you want to fork",
+        )
+        fork_extracts = graphene.Boolean(
+            default_value=True,
+            description="Whether to fork extracts and datacells",
+        )
+        fork_conversations = graphene.Boolean(
+            default_value=True,
+            description="Whether to fork chat conversations",
+        )
+        fork_notes = graphene.Boolean(
+            default_value=True,
+            description="Whether to fork notes",
         )
 
     ok = graphene.Boolean()
@@ -1131,22 +1165,25 @@ class StartCorpusFork(graphene.Mutation):
     new_corpus = graphene.Field(CorpusType)
 
     @login_required
-    def mutate(root, info, corpus_id):
-
+    def mutate(
+        root,
+        info,
+        corpus_id,
+        fork_extracts=True,
+        fork_conversations=True,
+        fork_notes=True,
+    ):
         ok = False
         message = ""
         new_corpus = None
 
         try:
-
-            # Get annotation ids for the old corpus - these refer to a corpus, doc and label by id, so easaiest way to
-            # copy these is to first filter by annotations for our corpus. Then, later, we'll use a dict to map old ids
-            # for labels and docs to new obj ids
+            # Parse corpus ID
             corpus_pk = from_global_id(corpus_id)[1]
 
             # Get corpus obj with visibility check
             try:
-                corpus = Corpus.objects.visible_to_user(info.context.user).get(
+                source_corpus = Corpus.objects.visible_to_user(info.context.user).get(
                     pk=corpus_pk
                 )
             except Corpus.DoesNotExist:
@@ -1154,10 +1191,10 @@ class StartCorpusFork(graphene.Mutation):
                     ok=False, message="Corpus not found", new_corpus=None
                 )
 
-            # Verify READ permission
+            # Verify READ permission (IDOR protection - same error message)
             if not user_has_permission_for_obj(
                 info.context.user,
-                corpus,
+                source_corpus,
                 PermissionTypes.READ,
                 include_group_permissions=True,
             ):
@@ -1165,47 +1202,42 @@ class StartCorpusFork(graphene.Mutation):
                     ok=False, message="Corpus not found", new_corpus=None
                 )
 
-            annotation_ids = list(
-                Annotation.objects.filter(
-                    corpus_id=corpus_pk,
-                    analysis__isnull=True,
-                ).values_list("id", flat=True)
+            # Create new corpus (locked until async task completes)
+            # Using Django ORM copy trick - set pk to None and save
+            new_corpus_obj = Corpus(
+                title=f"[FORK] {source_corpus.title}",
+                description=source_corpus.description,
+                icon=source_corpus.icon,
+                allow_comments=source_corpus.allow_comments,
+                is_public=False,  # Forks start private
+                creator=info.context.user,
+                backend_lock=True,  # Lock until fork completes
+                parent_id=corpus_pk,  # Track lineage
+                # Copy agent instructions
+                corpus_agent_instructions=source_corpus.corpus_agent_instructions,
+                document_agent_instructions=source_corpus.document_agent_instructions,
+                preferred_embedder=source_corpus.preferred_embedder,
             )
+            new_corpus_obj.save()
 
-            # Get ids to related objects that need copyin'
-            # Use new DocumentPath-based method to get active documents
-            doc_ids = list(corpus.get_documents().values_list("id", flat=True))
-            label_set_id = corpus.label_set.pk if corpus.label_set else None
-
-            # Clone the corpus: https://docs.djangoproject.com/en/3.1/topics/db/queries/copying-model-instances
-            corpus.pk = None
-
-            # Adjust the title to indicate it's a fork
-            corpus.title = f"{corpus.title}"
-
-            # lock the corpus which will tell frontend to show this as loading and disable selection
-            corpus.backend_lock = True
-            corpus.creator = info.context.user  # switch the creator to the current user
-            corpus.parent_id = corpus_pk
-            corpus.save()
-
+            # Set full permissions for the user
             set_permissions_for_obj_to_user(
-                info.context.user, corpus, [PermissionTypes.CRUD]
+                info.context.user, new_corpus_obj, [PermissionTypes.CRUD]
             )
 
-            # Now remove references to related objects on our new object, as these point to original docs and labels
-            # Note: New corpus has no DocumentPath records yet, so this is safe
-            corpus.documents.clear()
-            corpus.label_set = None
-
-            # Copy docs and annotations using async task to avoid massive lag if we have large dataset or lots of
-            # users requesting copies.
-            fork_corpus.si(
-                corpus.id, doc_ids, label_set_id, annotation_ids, info.context.user.id
-            ).apply_async()
+            # Queue async fork task with new modular implementation
+            fork_corpus_v2.delay(
+                new_corpus_id=new_corpus_obj.id,
+                source_corpus_id=int(corpus_pk),
+                user_id=info.context.user.id,
+                fork_extracts_flag=fork_extracts,
+                fork_conversations_flag=fork_conversations,
+                fork_notes_flag=fork_notes,
+            )
 
             ok = True
-            new_corpus = corpus
+            new_corpus = new_corpus_obj
+            message = "Fork started successfully"
 
         except Exception as e:
             message = f"Error trying to fork corpus with id {corpus_id}: {e}"
@@ -1216,6 +1248,10 @@ class StartCorpusFork(graphene.Mutation):
             {
                 "env": settings.MODE,
                 "user_id": info.context.user.id,
+                "source_corpus_id": corpus_pk if "corpus_pk" in dir() else None,
+                "fork_extracts": fork_extracts,
+                "fork_conversations": fork_conversations,
+                "fork_notes": fork_notes,
             },
         )
 

--- a/opencontractserver/tasks/__init__.py
+++ b/opencontractserver/tasks/__init__.py
@@ -8,6 +8,7 @@ from .doc_tasks import burn_doc_annotations
 from .export_tasks import package_annotated_docs
 from .extract_orchestrator_tasks import run_extract
 from .fork_tasks import fork_corpus
+from .fork_tasks_v2 import fork_corpus_v2
 from .import_tasks import (
     import_corpus,
     import_document_to_corpus,
@@ -30,6 +31,7 @@ __all__ = [
     "package_annotated_docs",
     "burn_doc_annotations",
     "fork_corpus",
+    "fork_corpus_v2",
     "build_label_lookups_task",
     "import_corpus",
     "import_document_to_corpus",

--- a/opencontractserver/tasks/fork_tasks_v2.py
+++ b/opencontractserver/tasks/fork_tasks_v2.py
@@ -1,0 +1,272 @@
+"""
+Corpus forking task v2 - modular, enumerable forking system.
+
+This module provides an improved corpus forking implementation that:
+1. Is configuration-driven via ForkableModelType enum
+2. Forks all relevant models (documents, annotations, relationships, extracts, etc.)
+3. Uses proper permission handling per consolidated_permissioning_guide.md
+4. Provides better performance via batching where possible
+5. Has comprehensive error handling and logging
+
+Usage:
+    from opencontractserver.tasks.fork_tasks_v2 import fork_corpus_v2
+
+    # Trigger async forking
+    fork_corpus_v2.delay(
+        new_corpus_id=123,
+        source_corpus_id=456,
+        user_id=1,
+    )
+"""
+
+import logging
+from typing import Optional
+
+from django.contrib.auth import get_user_model
+from django.db import transaction
+
+from config import celery_app
+from opencontractserver.annotations.models import Annotation
+from opencontractserver.corpuses.models import Corpus
+from opencontractserver.utils.fork_handlers import (
+    fork_annotation_labels,
+    fork_annotations,
+    fork_chat_messages,
+    fork_columns,
+    fork_conversations,
+    fork_corpus_folders,
+    fork_datacells,
+    fork_documents,
+    fork_extracts,
+    fork_fieldsets,
+    fork_label_set,
+    fork_note_revisions,
+    fork_notes,
+    fork_relationships,
+)
+from opencontractserver.utils.fork_utils import ForkContext, ForkResult
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+User = get_user_model()
+
+
+@celery_app.task(bind=True, max_retries=3)
+def fork_corpus_v2(
+    self,
+    new_corpus_id: int,
+    source_corpus_id: int,
+    user_id: int,
+    fork_extracts_flag: bool = True,
+    fork_conversations_flag: bool = True,
+    fork_notes_flag: bool = True,
+) -> Optional[dict]:
+    """
+    Fork a corpus with all its content using modular handlers.
+
+    This is an improved version of fork_corpus that:
+    - Forks all relevant models (relationships, extracts, conversations, notes)
+    - Uses proper permission handling per the permission guide
+    - Provides better error handling and logging
+    - Returns detailed statistics
+
+    Args:
+        new_corpus_id: ID of the new (target) corpus (already created, locked)
+        source_corpus_id: ID of the source corpus to fork from
+        user_id: ID of the user performing the fork
+        fork_extracts_flag: Whether to fork extracts and datacells
+        fork_conversations_flag: Whether to fork conversations and messages
+        fork_notes_flag: Whether to fork notes and revisions
+
+    Returns:
+        Dictionary with fork results and statistics, or None on failure
+    """
+    logger.info(
+        f"Starting fork_corpus_v2:\n"
+        f"  source_corpus_id: {source_corpus_id}\n"
+        f"  new_corpus_id: {new_corpus_id}\n"
+        f"  user_id: {user_id}\n"
+        f"  fork_extracts: {fork_extracts_flag}\n"
+        f"  fork_conversations: {fork_conversations_flag}\n"
+        f"  fork_notes: {fork_notes_flag}"
+    )
+
+    # Get the target corpus (already created by mutation, locked)
+    try:
+        target_corpus = Corpus.objects.get(pk=new_corpus_id)
+    except Corpus.DoesNotExist:
+        logger.error(f"Target corpus {new_corpus_id} not found")
+        return None
+
+    try:
+        source_corpus = Corpus.objects.get(pk=source_corpus_id)
+    except Corpus.DoesNotExist:
+        logger.error(f"Source corpus {source_corpus_id} not found")
+        target_corpus.backend_lock = False
+        target_corpus.error = True
+        target_corpus.save()
+        return None
+
+    # Initialize fork context
+    ctx = ForkContext(
+        source_corpus_id=source_corpus_id,
+        target_corpus_id=new_corpus_id,
+        user_id=user_id,
+    )
+
+    result = ForkResult(success=False, new_corpus_id=new_corpus_id, context=ctx)
+
+    try:
+        with transaction.atomic():
+            # ========== Phase 1: Organization Models ==========
+            logger.info("Phase 1: Forking organization models...")
+
+            # Fork LabelSet
+            source_label_set_id = source_corpus.label_set_id
+            new_label_set_id = fork_label_set(ctx, source_label_set_id)
+
+            # Fork AnnotationLabels
+            labels_forked = fork_annotation_labels(
+                ctx, source_label_set_id, new_label_set_id
+            )
+            logger.info(f"Forked {labels_forked} annotation labels")
+
+            # Fork CorpusFolders
+            result.folders_forked = fork_corpus_folders(ctx)
+
+            # ========== Phase 2: Documents ==========
+            logger.info("Phase 2: Forking documents...")
+
+            # Get document IDs that user has read access to
+            doc_ids = list(
+                source_corpus.get_documents().values_list("id", flat=True)
+            )
+            result.documents_forked = fork_documents(ctx, doc_ids)
+
+            # ========== Phase 3: Annotations ==========
+            logger.info("Phase 3: Forking annotations...")
+
+            # Get annotation IDs (non-analysis only)
+            annotation_ids = list(
+                Annotation.objects.filter(
+                    corpus_id=source_corpus_id,
+                    analysis__isnull=True,
+                ).values_list("id", flat=True)
+            )
+            result.annotations_forked = fork_annotations(ctx, annotation_ids)
+
+            # ========== Phase 4: Relationships ==========
+            logger.info("Phase 4: Forking relationships...")
+            result.relationships_forked = fork_relationships(ctx)
+
+            # ========== Phase 5: Extracts (optional) ==========
+            if fork_extracts_flag:
+                logger.info("Phase 5: Forking extracts...")
+                result.fieldsets_forked = fork_fieldsets(ctx)
+                fork_columns(ctx)  # Columns don't count separately
+                result.extracts_forked = fork_extracts(ctx)
+                result.datacells_forked = fork_datacells(ctx)
+            else:
+                logger.info("Phase 5: Skipping extracts (disabled)")
+
+            # ========== Phase 6: Conversations (optional) ==========
+            if fork_conversations_flag:
+                logger.info("Phase 6: Forking conversations...")
+                result.conversations_forked = fork_conversations(ctx)
+                result.messages_forked = fork_chat_messages(ctx)
+            else:
+                logger.info("Phase 6: Skipping conversations (disabled)")
+
+            # ========== Phase 7: Notes (optional) ==========
+            if fork_notes_flag:
+                logger.info("Phase 7: Forking notes...")
+                result.notes_forked = fork_notes(ctx)
+                fork_note_revisions(ctx)  # Revisions don't count separately
+            else:
+                logger.info("Phase 7: Skipping notes (disabled)")
+
+            # ========== Finalize ==========
+            target_corpus.backend_lock = False
+            target_corpus.save()
+
+            result.success = True
+            logger.info(
+                f"Fork completed successfully:\n"
+                f"  Documents: {result.documents_forked}\n"
+                f"  Annotations: {result.annotations_forked}\n"
+                f"  Relationships: {result.relationships_forked}\n"
+                f"  Fieldsets: {result.fieldsets_forked}\n"
+                f"  Extracts: {result.extracts_forked}\n"
+                f"  Datacells: {result.datacells_forked}\n"
+                f"  Conversations: {result.conversations_forked}\n"
+                f"  Messages: {result.messages_forked}\n"
+                f"  Notes: {result.notes_forked}\n"
+                f"  Folders: {result.folders_forked}"
+            )
+
+            return {
+                "success": True,
+                "new_corpus_id": new_corpus_id,
+                "documents_forked": result.documents_forked,
+                "annotations_forked": result.annotations_forked,
+                "relationships_forked": result.relationships_forked,
+                "fieldsets_forked": result.fieldsets_forked,
+                "extracts_forked": result.extracts_forked,
+                "datacells_forked": result.datacells_forked,
+                "conversations_forked": result.conversations_forked,
+                "messages_forked": result.messages_forked,
+                "notes_forked": result.notes_forked,
+                "folders_forked": result.folders_forked,
+            }
+
+    except Exception as e:
+        logger.error(f"Error during fork: {e}", exc_info=True)
+
+        # Mark corpus as errored
+        target_corpus.backend_lock = False
+        target_corpus.error = True
+        target_corpus.save()
+
+        result.success = False
+        result.error_message = str(e)
+
+        return {
+            "success": False,
+            "new_corpus_id": new_corpus_id,
+            "error": str(e),
+        }
+
+
+# Backwards compatibility alias
+def fork_corpus_legacy(
+    new_corpus_id: str,
+    doc_ids: list[str],
+    label_set_id: str,
+    annotation_ids: list[str],
+    user_id: str,
+) -> Optional[str]:
+    """
+    Legacy fork_corpus signature for backwards compatibility.
+
+    Converts string IDs to ints and calls fork_corpus_v2.
+    """
+    from opencontractserver.corpuses.models import Corpus
+
+    # Get source corpus from new corpus's parent
+    target_corpus = Corpus.objects.get(pk=int(new_corpus_id))
+    source_corpus_id = target_corpus.parent_id
+
+    if not source_corpus_id:
+        logger.error("Cannot determine source corpus from parent")
+        return None
+
+    result = fork_corpus_v2(
+        new_corpus_id=int(new_corpus_id),
+        source_corpus_id=source_corpus_id,
+        user_id=int(user_id),
+    )
+
+    if result and result.get("success"):
+        return str(result["new_corpus_id"])
+    return None

--- a/opencontractserver/tests/test_fork_v2.py
+++ b/opencontractserver/tests/test_fork_v2.py
@@ -1,0 +1,995 @@
+"""
+Comprehensive tests for the v2 corpus forking system.
+
+These tests verify:
+1. All model types are forked correctly
+2. Ownership is transferred to forking user
+3. Permissions are set correctly per consolidated_permissioning_guide.md
+4. Data integrity is maintained
+5. ID mappings are correct
+6. Error handling works properly
+7. Edge cases (empty corpus, no labelset, etc.)
+"""
+
+import logging
+from typing import Optional
+
+from django.contrib.auth import get_user_model
+from django.db import transaction
+from django.test import TestCase
+
+from opencontractserver.annotations.models import (
+    Annotation,
+    AnnotationLabel,
+    LabelSet,
+    Note,
+    NoteRevision,
+    Relationship,
+    RELATIONSHIP_LABEL,
+    TOKEN_LABEL,
+)
+from opencontractserver.conversations.models import (
+    ChatMessage,
+    Conversation,
+    MessageTypeChoices,
+)
+from opencontractserver.corpuses.models import Corpus, CorpusFolder
+from opencontractserver.documents.models import Document
+from opencontractserver.extracts.models import Column, Datacell, Extract, Fieldset
+from opencontractserver.types.enums import PermissionTypes
+from opencontractserver.utils.fork_handlers import (
+    fork_annotation_labels,
+    fork_annotations,
+    fork_chat_messages,
+    fork_columns,
+    fork_conversations,
+    fork_corpus_folders,
+    fork_datacells,
+    fork_documents,
+    fork_extracts,
+    fork_fieldsets,
+    fork_label_set,
+    fork_note_revisions,
+    fork_notes,
+    fork_relationships,
+)
+from opencontractserver.utils.fork_utils import ForkContext, ForkResult
+from opencontractserver.utils.permissioning import (
+    set_permissions_for_obj_to_user,
+    user_has_permission_for_obj,
+)
+
+User = get_user_model()
+logger = logging.getLogger(__name__)
+
+
+class ForkContextTestCase(TestCase):
+    """Test the ForkContext dataclass."""
+
+    def test_fork_context_initialization(self):
+        """Test that ForkContext initializes with correct defaults."""
+        ctx = ForkContext(
+            source_corpus_id=1,
+            target_corpus_id=2,
+            user_id=3,
+        )
+
+        self.assertEqual(ctx.source_corpus_id, 1)
+        self.assertEqual(ctx.target_corpus_id, 2)
+        self.assertEqual(ctx.user_id, 3)
+        self.assertEqual(ctx.doc_map, {})
+        self.assertEqual(ctx.label_map, {})
+        self.assertEqual(ctx.annotation_map, {})
+        self.assertEqual(ctx.documents_forked, 0)
+
+
+class ForkLabelSetTestCase(TestCase):
+    """Test forking of LabelSet and AnnotationLabels."""
+
+    def setUp(self):
+        """Set up test data."""
+        self.owner = User.objects.create_user(username="owner", password="test123")
+        self.forker = User.objects.create_user(username="forker", password="test123")
+
+        # Create source corpus with label set
+        self.source_corpus = Corpus.objects.create(
+            title="Source Corpus",
+            creator=self.owner,
+        )
+        set_permissions_for_obj_to_user(
+            self.owner, self.source_corpus, [PermissionTypes.CRUD]
+        )
+
+        # Create label set with labels
+        self.label_set = LabelSet.objects.create(
+            title="Test Labels",
+            description="Test label set",
+            creator=self.owner,
+        )
+        self.source_corpus.label_set = self.label_set
+        self.source_corpus.save()
+
+        self.label1 = AnnotationLabel.objects.create(
+            text="Label 1",
+            label_type=TOKEN_LABEL,
+            color="#FF0000",
+            creator=self.owner,
+        )
+        self.label2 = AnnotationLabel.objects.create(
+            text="Label 2",
+            label_type=RELATIONSHIP_LABEL,
+            color="#00FF00",
+            creator=self.owner,
+        )
+        self.label_set.annotation_labels.add(self.label1, self.label2)
+
+        # Create target corpus
+        self.target_corpus = Corpus.objects.create(
+            title="Target Corpus",
+            creator=self.forker,
+            parent=self.source_corpus,
+        )
+
+    def test_fork_label_set(self):
+        """Test forking a label set."""
+        ctx = ForkContext(
+            source_corpus_id=self.source_corpus.id,
+            target_corpus_id=self.target_corpus.id,
+            user_id=self.forker.id,
+        )
+
+        new_label_set_id = fork_label_set(ctx, self.label_set.id)
+
+        self.assertIsNotNone(new_label_set_id)
+        new_label_set = LabelSet.objects.get(pk=new_label_set_id)
+
+        # Verify ownership transferred
+        self.assertEqual(new_label_set.creator_id, self.forker.id)
+
+        # Verify title has [FORK] prefix
+        self.assertTrue(new_label_set.title.startswith("[FORK]"))
+
+        # Verify target corpus has the new label set
+        self.target_corpus.refresh_from_db()
+        self.assertEqual(self.target_corpus.label_set_id, new_label_set_id)
+
+    def test_fork_label_set_none(self):
+        """Test forking with no label set."""
+        ctx = ForkContext(
+            source_corpus_id=self.source_corpus.id,
+            target_corpus_id=self.target_corpus.id,
+            user_id=self.forker.id,
+        )
+
+        new_label_set_id = fork_label_set(ctx, None)
+        self.assertIsNone(new_label_set_id)
+
+    def test_fork_annotation_labels(self):
+        """Test forking annotation labels."""
+        ctx = ForkContext(
+            source_corpus_id=self.source_corpus.id,
+            target_corpus_id=self.target_corpus.id,
+            user_id=self.forker.id,
+        )
+
+        # First fork the label set
+        new_label_set_id = fork_label_set(ctx, self.label_set.id)
+
+        # Then fork the labels
+        count = fork_annotation_labels(ctx, self.label_set.id, new_label_set_id)
+
+        self.assertEqual(count, 2)
+        self.assertEqual(len(ctx.label_map), 2)
+
+        # Verify mappings
+        self.assertIn(self.label1.id, ctx.label_map)
+        self.assertIn(self.label2.id, ctx.label_map)
+
+        # Verify new labels have correct owner
+        for old_id, new_id in ctx.label_map.items():
+            new_label = AnnotationLabel.objects.get(pk=new_id)
+            self.assertEqual(new_label.creator_id, self.forker.id)
+
+
+class ForkDocumentsTestCase(TestCase):
+    """Test forking of documents."""
+
+    def setUp(self):
+        """Set up test data."""
+        self.owner = User.objects.create_user(username="owner", password="test123")
+        self.forker = User.objects.create_user(username="forker", password="test123")
+
+        # Create source corpus
+        self.source_corpus = Corpus.objects.create(
+            title="Source Corpus",
+            creator=self.owner,
+        )
+        set_permissions_for_obj_to_user(
+            self.owner, self.source_corpus, [PermissionTypes.CRUD]
+        )
+
+        # Create documents
+        self.doc1 = Document.objects.create(
+            title="Document 1",
+            creator=self.owner,
+        )
+        self.doc2 = Document.objects.create(
+            title="Document 2",
+            creator=self.owner,
+        )
+
+        # Add documents to corpus
+        self.source_corpus.add_document(document=self.doc1, user=self.owner)
+        self.source_corpus.add_document(document=self.doc2, user=self.owner)
+
+        # Create target corpus
+        self.target_corpus = Corpus.objects.create(
+            title="Target Corpus",
+            creator=self.forker,
+            parent=self.source_corpus,
+        )
+        set_permissions_for_obj_to_user(
+            self.forker, self.target_corpus, [PermissionTypes.CRUD]
+        )
+
+    def test_fork_documents(self):
+        """Test forking documents."""
+        ctx = ForkContext(
+            source_corpus_id=self.source_corpus.id,
+            target_corpus_id=self.target_corpus.id,
+            user_id=self.forker.id,
+        )
+
+        # Get document IDs from source corpus
+        doc_ids = list(
+            self.source_corpus.get_documents().values_list("id", flat=True)
+        )
+
+        count = fork_documents(ctx, doc_ids)
+
+        self.assertEqual(count, 2)
+        self.assertEqual(len(ctx.doc_map), 2)
+        self.assertEqual(ctx.documents_forked, 2)
+
+        # Verify new documents have correct owner
+        for old_id, new_id in ctx.doc_map.items():
+            new_doc = Document.objects.get(pk=new_id)
+            self.assertEqual(new_doc.creator_id, self.forker.id)
+            self.assertTrue(new_doc.title.startswith("[FORK]"))
+
+        # Verify target corpus has the new documents
+        target_docs = list(self.target_corpus.get_documents())
+        self.assertEqual(len(target_docs), 2)
+
+    def test_fork_documents_with_folder(self):
+        """Test forking documents preserves folder structure."""
+        # Create folder in source corpus
+        folder = CorpusFolder.objects.create(
+            name="Test Folder",
+            corpus=self.source_corpus,
+            creator=self.owner,
+        )
+
+        # Create a new document in that folder
+        doc3 = Document.objects.create(
+            title="Document 3",
+            creator=self.owner,
+        )
+        self.source_corpus.add_document(document=doc3, user=self.owner, folder=folder)
+
+        ctx = ForkContext(
+            source_corpus_id=self.source_corpus.id,
+            target_corpus_id=self.target_corpus.id,
+            user_id=self.forker.id,
+        )
+
+        # Fork folders first
+        fork_corpus_folders(ctx)
+
+        # Then fork documents
+        doc_ids = list(
+            self.source_corpus.get_documents().values_list("id", flat=True)
+        )
+        fork_documents(ctx, doc_ids)
+
+        # Verify folder was forked
+        self.assertIn(folder.id, ctx.folder_map)
+
+
+class ForkAnnotationsTestCase(TestCase):
+    """Test forking of annotations and relationships."""
+
+    def setUp(self):
+        """Set up test data."""
+        self.owner = User.objects.create_user(username="owner", password="test123")
+        self.forker = User.objects.create_user(username="forker", password="test123")
+
+        # Create source corpus with label set
+        self.source_corpus = Corpus.objects.create(
+            title="Source Corpus",
+            creator=self.owner,
+        )
+
+        self.label_set = LabelSet.objects.create(
+            title="Test Labels",
+            creator=self.owner,
+        )
+        self.source_corpus.label_set = self.label_set
+        self.source_corpus.save()
+
+        self.token_label = AnnotationLabel.objects.create(
+            text="Token Label",
+            label_type=TOKEN_LABEL,
+            creator=self.owner,
+        )
+        self.rel_label = AnnotationLabel.objects.create(
+            text="Rel Label",
+            label_type=RELATIONSHIP_LABEL,
+            creator=self.owner,
+        )
+        self.label_set.annotation_labels.add(self.token_label, self.rel_label)
+
+        # Create document
+        self.doc = Document.objects.create(
+            title="Test Doc",
+            creator=self.owner,
+        )
+        self.source_corpus.add_document(document=self.doc, user=self.owner)
+
+        # Get the corpus-isolated doc
+        corpus_doc = self.source_corpus.get_documents().first()
+
+        # Create annotations
+        self.ann1 = Annotation.objects.create(
+            raw_text="Annotation 1",
+            annotation_label=self.token_label,
+            document=corpus_doc,
+            corpus=self.source_corpus,
+            creator=self.owner,
+        )
+        self.ann2 = Annotation.objects.create(
+            raw_text="Annotation 2",
+            annotation_label=self.token_label,
+            document=corpus_doc,
+            corpus=self.source_corpus,
+            creator=self.owner,
+        )
+
+        # Create relationship
+        self.rel = Relationship.objects.create(
+            relationship_label=self.rel_label,
+            corpus=self.source_corpus,
+            document=corpus_doc,
+            creator=self.owner,
+        )
+        self.rel.source_annotations.add(self.ann1)
+        self.rel.target_annotations.add(self.ann2)
+
+        # Create target corpus
+        self.target_corpus = Corpus.objects.create(
+            title="Target Corpus",
+            creator=self.forker,
+            parent=self.source_corpus,
+        )
+
+    def test_fork_annotations(self):
+        """Test forking annotations."""
+        ctx = ForkContext(
+            source_corpus_id=self.source_corpus.id,
+            target_corpus_id=self.target_corpus.id,
+            user_id=self.forker.id,
+        )
+
+        # Fork label set and labels first
+        new_label_set_id = fork_label_set(ctx, self.label_set.id)
+        fork_annotation_labels(ctx, self.label_set.id, new_label_set_id)
+
+        # Fork documents
+        doc_ids = list(
+            self.source_corpus.get_documents().values_list("id", flat=True)
+        )
+        fork_documents(ctx, doc_ids)
+
+        # Fork annotations
+        annotation_ids = list(
+            Annotation.objects.filter(
+                corpus=self.source_corpus,
+                analysis__isnull=True,
+            ).values_list("id", flat=True)
+        )
+        count = fork_annotations(ctx, annotation_ids)
+
+        self.assertEqual(count, 2)
+        self.assertEqual(len(ctx.annotation_map), 2)
+
+        # Verify new annotations have correct owner
+        for old_id, new_id in ctx.annotation_map.items():
+            new_ann = Annotation.objects.get(pk=new_id)
+            self.assertEqual(new_ann.creator_id, self.forker.id)
+            self.assertEqual(new_ann.corpus_id, self.target_corpus.id)
+
+    def test_fork_relationships(self):
+        """Test forking relationships."""
+        ctx = ForkContext(
+            source_corpus_id=self.source_corpus.id,
+            target_corpus_id=self.target_corpus.id,
+            user_id=self.forker.id,
+        )
+
+        # Fork dependencies first
+        new_label_set_id = fork_label_set(ctx, self.label_set.id)
+        fork_annotation_labels(ctx, self.label_set.id, new_label_set_id)
+        doc_ids = list(
+            self.source_corpus.get_documents().values_list("id", flat=True)
+        )
+        fork_documents(ctx, doc_ids)
+        annotation_ids = list(
+            Annotation.objects.filter(
+                corpus=self.source_corpus,
+                analysis__isnull=True,
+            ).values_list("id", flat=True)
+        )
+        fork_annotations(ctx, annotation_ids)
+
+        # Fork relationships
+        count = fork_relationships(ctx)
+
+        self.assertEqual(count, 1)
+        self.assertEqual(ctx.relationships_forked, 1)
+
+        # Verify relationship was forked
+        new_rels = Relationship.objects.filter(corpus=self.target_corpus)
+        self.assertEqual(new_rels.count(), 1)
+
+        new_rel = new_rels.first()
+        self.assertEqual(new_rel.creator_id, self.forker.id)
+        self.assertEqual(new_rel.source_annotations.count(), 1)
+        self.assertEqual(new_rel.target_annotations.count(), 1)
+
+
+class ForkExtractsTestCase(TestCase):
+    """Test forking of extracts and datacells."""
+
+    def setUp(self):
+        """Set up test data."""
+        self.owner = User.objects.create_user(username="owner", password="test123")
+        self.forker = User.objects.create_user(username="forker", password="test123")
+
+        # Create source corpus
+        self.source_corpus = Corpus.objects.create(
+            title="Source Corpus",
+            creator=self.owner,
+        )
+
+        # Create fieldset linked to corpus
+        self.fieldset = Fieldset.objects.create(
+            name="Test Fieldset",
+            description="Test description",
+            corpus=self.source_corpus,
+            creator=self.owner,
+        )
+
+        # Create columns
+        self.col1 = Column.objects.create(
+            name="Column 1",
+            fieldset=self.fieldset,
+            query="What is X?",
+            output_type="str",
+            creator=self.owner,
+        )
+        self.col2 = Column.objects.create(
+            name="Column 2",
+            fieldset=self.fieldset,
+            query="What is Y?",
+            output_type="str",
+            creator=self.owner,
+        )
+
+        # Create document
+        self.doc = Document.objects.create(
+            title="Test Doc",
+            creator=self.owner,
+        )
+        self.source_corpus.add_document(document=self.doc, user=self.owner)
+        corpus_doc = self.source_corpus.get_documents().first()
+
+        # Create extract
+        self.extract = Extract.objects.create(
+            name="Test Extract",
+            corpus=self.source_corpus,
+            fieldset=self.fieldset,
+            creator=self.owner,
+        )
+        self.extract.documents.add(corpus_doc)
+
+        # Create datacells
+        self.datacell1 = Datacell.objects.create(
+            extract=self.extract,
+            column=self.col1,
+            document=corpus_doc,
+            data={"value": "Result 1"},
+            data_definition="str",
+            creator=self.owner,
+        )
+        self.datacell2 = Datacell.objects.create(
+            extract=self.extract,
+            column=self.col2,
+            document=corpus_doc,
+            data={"value": "Result 2"},
+            data_definition="str",
+            creator=self.owner,
+        )
+
+        # Create target corpus
+        self.target_corpus = Corpus.objects.create(
+            title="Target Corpus",
+            creator=self.forker,
+            parent=self.source_corpus,
+        )
+
+    def test_fork_fieldsets(self):
+        """Test forking fieldsets."""
+        ctx = ForkContext(
+            source_corpus_id=self.source_corpus.id,
+            target_corpus_id=self.target_corpus.id,
+            user_id=self.forker.id,
+        )
+
+        count = fork_fieldsets(ctx)
+
+        self.assertEqual(count, 1)
+        self.assertEqual(len(ctx.fieldset_map), 1)
+
+        new_fieldset_id = ctx.fieldset_map[self.fieldset.id]
+        new_fieldset = Fieldset.objects.get(pk=new_fieldset_id)
+
+        self.assertEqual(new_fieldset.creator_id, self.forker.id)
+        self.assertTrue(new_fieldset.name.startswith("[FORK]"))
+        self.assertEqual(new_fieldset.corpus_id, self.target_corpus.id)
+
+    def test_fork_columns(self):
+        """Test forking columns."""
+        ctx = ForkContext(
+            source_corpus_id=self.source_corpus.id,
+            target_corpus_id=self.target_corpus.id,
+            user_id=self.forker.id,
+        )
+
+        # Fork fieldset first
+        fork_fieldsets(ctx)
+
+        # Fork columns
+        count = fork_columns(ctx)
+
+        self.assertEqual(count, 2)
+        self.assertEqual(len(ctx.column_map), 2)
+
+        # Verify columns belong to new fieldset
+        for old_id, new_id in ctx.column_map.items():
+            new_col = Column.objects.get(pk=new_id)
+            new_fieldset_id = ctx.fieldset_map[self.fieldset.id]
+            self.assertEqual(new_col.fieldset_id, new_fieldset_id)
+            self.assertEqual(new_col.creator_id, self.forker.id)
+
+    def test_fork_extracts_and_datacells(self):
+        """Test forking extracts and datacells."""
+        ctx = ForkContext(
+            source_corpus_id=self.source_corpus.id,
+            target_corpus_id=self.target_corpus.id,
+            user_id=self.forker.id,
+        )
+
+        # Fork dependencies
+        fork_fieldsets(ctx)
+        fork_columns(ctx)
+        doc_ids = list(
+            self.source_corpus.get_documents().values_list("id", flat=True)
+        )
+        fork_documents(ctx, doc_ids)
+
+        # Fork extracts
+        extract_count = fork_extracts(ctx)
+        self.assertEqual(extract_count, 1)
+        self.assertEqual(len(ctx.extract_map), 1)
+
+        # Fork datacells
+        datacell_count = fork_datacells(ctx)
+        self.assertEqual(datacell_count, 2)
+
+        # Verify datacells have correct mappings
+        new_extract_id = ctx.extract_map[self.extract.id]
+        new_datacells = Datacell.objects.filter(extract_id=new_extract_id)
+        self.assertEqual(new_datacells.count(), 2)
+
+        for datacell in new_datacells:
+            self.assertEqual(datacell.creator_id, self.forker.id)
+            self.assertIn(datacell.column_id, ctx.column_map.values())
+            self.assertIn(datacell.document_id, ctx.doc_map.values())
+
+
+class ForkConversationsTestCase(TestCase):
+    """Test forking of conversations and messages."""
+
+    def setUp(self):
+        """Set up test data."""
+        self.owner = User.objects.create_user(username="owner", password="test123")
+        self.forker = User.objects.create_user(username="forker", password="test123")
+
+        # Create source corpus
+        self.source_corpus = Corpus.objects.create(
+            title="Source Corpus",
+            creator=self.owner,
+        )
+
+        # Create document
+        self.doc = Document.objects.create(
+            title="Test Doc",
+            creator=self.owner,
+        )
+        self.source_corpus.add_document(document=self.doc, user=self.owner)
+        self.corpus_doc = self.source_corpus.get_documents().first()
+
+        # Create chat conversation
+        self.chat_conv = Conversation.objects.create(
+            title="Test Chat",
+            conversation_type="chat",
+            chat_with_corpus=self.source_corpus,
+            creator=self.owner,
+        )
+
+        # Create messages
+        self.msg1 = ChatMessage.objects.create(
+            conversation=self.chat_conv,
+            msg_type=MessageTypeChoices.HUMAN,
+            content="Hello, world!",
+            creator=self.owner,
+        )
+        self.msg2 = ChatMessage.objects.create(
+            conversation=self.chat_conv,
+            msg_type=MessageTypeChoices.LLM,
+            content="Hi there!",
+            parent_message=self.msg1,
+            creator=self.owner,
+        )
+
+        # Create a thread (discussion) - should NOT be forked
+        self.thread_conv = Conversation.objects.create(
+            title="Discussion Thread",
+            conversation_type="thread",
+            chat_with_corpus=self.source_corpus,
+            creator=self.owner,
+        )
+
+        # Create target corpus
+        self.target_corpus = Corpus.objects.create(
+            title="Target Corpus",
+            creator=self.forker,
+            parent=self.source_corpus,
+        )
+
+    def test_fork_conversations(self):
+        """Test forking chat conversations (not threads)."""
+        ctx = ForkContext(
+            source_corpus_id=self.source_corpus.id,
+            target_corpus_id=self.target_corpus.id,
+            user_id=self.forker.id,
+        )
+
+        count = fork_conversations(ctx)
+
+        # Only chat conversation should be forked, not thread
+        self.assertEqual(count, 1)
+        self.assertEqual(len(ctx.conversation_map), 1)
+        self.assertIn(self.chat_conv.id, ctx.conversation_map)
+        self.assertNotIn(self.thread_conv.id, ctx.conversation_map)
+
+        # Verify new conversation
+        new_conv_id = ctx.conversation_map[self.chat_conv.id]
+        new_conv = Conversation.objects.get(pk=new_conv_id)
+        self.assertEqual(new_conv.creator_id, self.forker.id)
+        self.assertEqual(new_conv.chat_with_corpus_id, self.target_corpus.id)
+
+    def test_fork_chat_messages(self):
+        """Test forking chat messages."""
+        ctx = ForkContext(
+            source_corpus_id=self.source_corpus.id,
+            target_corpus_id=self.target_corpus.id,
+            user_id=self.forker.id,
+        )
+
+        # Fork conversation first
+        fork_conversations(ctx)
+
+        # Fork messages
+        count = fork_chat_messages(ctx)
+
+        self.assertEqual(count, 2)
+
+        # Verify messages in new conversation
+        new_conv_id = ctx.conversation_map[self.chat_conv.id]
+        new_msgs = ChatMessage.objects.filter(conversation_id=new_conv_id).order_by(
+            "created_at"
+        )
+        self.assertEqual(new_msgs.count(), 2)
+
+        # Verify parent message relationship preserved
+        msg_list = list(new_msgs)
+        self.assertIsNone(msg_list[0].parent_message)
+        self.assertEqual(msg_list[1].parent_message_id, msg_list[0].id)
+
+
+class ForkNotesTestCase(TestCase):
+    """Test forking of notes and revisions."""
+
+    def setUp(self):
+        """Set up test data."""
+        self.owner = User.objects.create_user(username="owner", password="test123")
+        self.forker = User.objects.create_user(username="forker", password="test123")
+
+        # Create source corpus
+        self.source_corpus = Corpus.objects.create(
+            title="Source Corpus",
+            creator=self.owner,
+        )
+
+        # Create document
+        self.doc = Document.objects.create(
+            title="Test Doc",
+            creator=self.owner,
+        )
+        self.source_corpus.add_document(document=self.doc, user=self.owner)
+        self.corpus_doc = self.source_corpus.get_documents().first()
+
+        # Create note with revision
+        self.note = Note.objects.create(
+            title="Test Note",
+            content="Initial content",
+            document=self.corpus_doc,
+            corpus=self.source_corpus,
+            creator=self.owner,
+        )
+
+        # Create target corpus
+        self.target_corpus = Corpus.objects.create(
+            title="Target Corpus",
+            creator=self.forker,
+            parent=self.source_corpus,
+        )
+
+    def test_fork_notes(self):
+        """Test forking notes."""
+        ctx = ForkContext(
+            source_corpus_id=self.source_corpus.id,
+            target_corpus_id=self.target_corpus.id,
+            user_id=self.forker.id,
+        )
+
+        # Fork document first
+        doc_ids = list(
+            self.source_corpus.get_documents().values_list("id", flat=True)
+        )
+        fork_documents(ctx, doc_ids)
+
+        # Fork notes
+        count = fork_notes(ctx)
+
+        self.assertEqual(count, 1)
+        self.assertEqual(len(ctx.note_map), 1)
+
+        # Verify new note
+        new_note_id = ctx.note_map[self.note.id]
+        new_note = Note.objects.get(pk=new_note_id)
+        self.assertEqual(new_note.creator_id, self.forker.id)
+        self.assertTrue(new_note.title.startswith("[FORK]"))
+        self.assertEqual(new_note.corpus_id, self.target_corpus.id)
+
+
+class ForkCorpusFoldersTestCase(TestCase):
+    """Test forking of corpus folders."""
+
+    def setUp(self):
+        """Set up test data."""
+        self.owner = User.objects.create_user(username="owner", password="test123")
+        self.forker = User.objects.create_user(username="forker", password="test123")
+
+        # Create source corpus
+        self.source_corpus = Corpus.objects.create(
+            title="Source Corpus",
+            creator=self.owner,
+        )
+
+        # Create folder hierarchy
+        self.folder1 = CorpusFolder.objects.create(
+            name="Folder 1",
+            corpus=self.source_corpus,
+            creator=self.owner,
+        )
+        self.folder2 = CorpusFolder.objects.create(
+            name="Subfolder 1",
+            corpus=self.source_corpus,
+            parent=self.folder1,
+            creator=self.owner,
+        )
+        self.folder3 = CorpusFolder.objects.create(
+            name="Folder 2",
+            corpus=self.source_corpus,
+            creator=self.owner,
+        )
+
+        # Create target corpus
+        self.target_corpus = Corpus.objects.create(
+            title="Target Corpus",
+            creator=self.forker,
+            parent=self.source_corpus,
+        )
+
+    def test_fork_corpus_folders(self):
+        """Test forking folder hierarchy."""
+        ctx = ForkContext(
+            source_corpus_id=self.source_corpus.id,
+            target_corpus_id=self.target_corpus.id,
+            user_id=self.forker.id,
+        )
+
+        count = fork_corpus_folders(ctx)
+
+        self.assertEqual(count, 3)
+        self.assertEqual(len(ctx.folder_map), 3)
+
+        # Verify folder hierarchy preserved
+        new_folder1_id = ctx.folder_map[self.folder1.id]
+        new_folder2_id = ctx.folder_map[self.folder2.id]
+
+        new_folder2 = CorpusFolder.objects.get(pk=new_folder2_id)
+        self.assertEqual(new_folder2.parent_id, new_folder1_id)
+
+        # Verify all folders belong to target corpus
+        for old_id, new_id in ctx.folder_map.items():
+            new_folder = CorpusFolder.objects.get(pk=new_id)
+            self.assertEqual(new_folder.corpus_id, self.target_corpus.id)
+            self.assertEqual(new_folder.creator_id, self.forker.id)
+
+
+class ForkEmptyCorpusTestCase(TestCase):
+    """Test forking an empty corpus."""
+
+    def setUp(self):
+        """Set up test data."""
+        self.owner = User.objects.create_user(username="owner", password="test123")
+        self.forker = User.objects.create_user(username="forker", password="test123")
+
+        # Create empty source corpus
+        self.source_corpus = Corpus.objects.create(
+            title="Empty Corpus",
+            creator=self.owner,
+        )
+
+        # Create target corpus
+        self.target_corpus = Corpus.objects.create(
+            title="Target Corpus",
+            creator=self.forker,
+            parent=self.source_corpus,
+        )
+
+    def test_fork_empty_corpus(self):
+        """Test forking a corpus with no content."""
+        ctx = ForkContext(
+            source_corpus_id=self.source_corpus.id,
+            target_corpus_id=self.target_corpus.id,
+            user_id=self.forker.id,
+        )
+
+        # All operations should succeed with 0 items
+        label_set_id = fork_label_set(ctx, None)
+        self.assertIsNone(label_set_id)
+
+        labels_count = fork_annotation_labels(ctx, None, None)
+        self.assertEqual(labels_count, 0)
+
+        folders_count = fork_corpus_folders(ctx)
+        self.assertEqual(folders_count, 0)
+
+        docs_count = fork_documents(ctx, [])
+        self.assertEqual(docs_count, 0)
+
+        anns_count = fork_annotations(ctx, [])
+        self.assertEqual(anns_count, 0)
+
+        rels_count = fork_relationships(ctx)
+        self.assertEqual(rels_count, 0)
+
+        fieldsets_count = fork_fieldsets(ctx)
+        self.assertEqual(fieldsets_count, 0)
+
+        extracts_count = fork_extracts(ctx)
+        self.assertEqual(extracts_count, 0)
+
+        convs_count = fork_conversations(ctx)
+        self.assertEqual(convs_count, 0)
+
+        notes_count = fork_notes(ctx)
+        self.assertEqual(notes_count, 0)
+
+
+class ForkOwnershipTestCase(TestCase):
+    """Test that forked objects have correct ownership."""
+
+    def setUp(self):
+        """Set up test data."""
+        self.owner = User.objects.create_user(username="owner", password="test123")
+        self.forker = User.objects.create_user(username="forker", password="test123")
+
+        # Create source corpus with various objects
+        self.source_corpus = Corpus.objects.create(
+            title="Source Corpus",
+            creator=self.owner,
+        )
+
+        self.label_set = LabelSet.objects.create(
+            title="Test Labels",
+            creator=self.owner,
+        )
+        self.source_corpus.label_set = self.label_set
+        self.source_corpus.save()
+
+        self.label = AnnotationLabel.objects.create(
+            text="Test Label",
+            label_type=TOKEN_LABEL,
+            creator=self.owner,
+        )
+        self.label_set.annotation_labels.add(self.label)
+
+        self.doc = Document.objects.create(
+            title="Test Doc",
+            creator=self.owner,
+        )
+        self.source_corpus.add_document(document=self.doc, user=self.owner)
+
+        # Create target corpus
+        self.target_corpus = Corpus.objects.create(
+            title="Target Corpus",
+            creator=self.forker,
+            parent=self.source_corpus,
+        )
+
+    def test_all_forked_objects_owned_by_forker(self):
+        """Test that all forked objects are owned by the forking user."""
+        ctx = ForkContext(
+            source_corpus_id=self.source_corpus.id,
+            target_corpus_id=self.target_corpus.id,
+            user_id=self.forker.id,
+        )
+
+        # Fork everything
+        new_label_set_id = fork_label_set(ctx, self.label_set.id)
+        fork_annotation_labels(ctx, self.label_set.id, new_label_set_id)
+        doc_ids = list(
+            self.source_corpus.get_documents().values_list("id", flat=True)
+        )
+        fork_documents(ctx, doc_ids)
+
+        # Verify label set ownership
+        new_label_set = LabelSet.objects.get(pk=new_label_set_id)
+        self.assertEqual(
+            new_label_set.creator_id,
+            self.forker.id,
+            "LabelSet should be owned by forker",
+        )
+
+        # Verify label ownership
+        for old_id, new_id in ctx.label_map.items():
+            new_label = AnnotationLabel.objects.get(pk=new_id)
+            self.assertEqual(
+                new_label.creator_id,
+                self.forker.id,
+                "AnnotationLabel should be owned by forker",
+            )
+
+        # Verify document ownership
+        for old_id, new_id in ctx.doc_map.items():
+            new_doc = Document.objects.get(pk=new_id)
+            self.assertEqual(
+                new_doc.creator_id,
+                self.forker.id,
+                "Document should be owned by forker",
+            )

--- a/opencontractserver/utils/fork_handlers.py
+++ b/opencontractserver/utils/fork_handlers.py
@@ -1,0 +1,934 @@
+"""
+Fork handlers for individual model types.
+
+Each handler is responsible for forking a specific model type and updating
+the ForkContext with ID mappings.
+"""
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+from django.contrib.auth import get_user_model
+from django.core.files.base import ContentFile
+from django.core.files.storage import default_storage
+from django.db import transaction
+
+from opencontractserver.types.enums import PermissionTypes
+from opencontractserver.utils.fork_utils import ForkContext
+from opencontractserver.utils.permissioning import set_permissions_for_obj_to_user
+
+logger = logging.getLogger(__name__)
+User = get_user_model()
+
+
+def fork_label_set(
+    ctx: ForkContext,
+    source_label_set_id: Optional[int],
+) -> Optional[int]:
+    """
+    Fork a LabelSet and return the new LabelSet ID.
+
+    Args:
+        ctx: Fork context with user_id and target corpus
+        source_label_set_id: ID of the LabelSet to fork (can be None)
+
+    Returns:
+        New LabelSet ID or None if no label set to fork
+    """
+    if not source_label_set_id:
+        logger.info("No label set to fork")
+        return None
+
+    from opencontractserver.annotations.models import LabelSet
+    from opencontractserver.corpuses.models import Corpus
+
+    try:
+        old_label_set = LabelSet.objects.get(pk=source_label_set_id)
+    except LabelSet.DoesNotExist:
+        logger.warning(f"LabelSet {source_label_set_id} not found")
+        return None
+
+    # Create new label set
+    new_label_set = LabelSet(
+        creator_id=ctx.user_id,
+        title=f"[FORK] {old_label_set.title}",
+        description=old_label_set.description,
+    )
+    new_label_set.save()
+    logger.info(f"Created forked LabelSet: {new_label_set.id}")
+
+    # Copy icon file if present
+    if old_label_set.icon and old_label_set.icon.name:
+        try:
+            icon_obj = default_storage.open(old_label_set.icon.name)
+            icon_file = ContentFile(icon_obj.read())
+            new_label_set.icon.save(Path(old_label_set.icon.name).name, icon_file)
+            new_label_set.save()
+            logger.info("Copied label set icon")
+        except Exception as e:
+            logger.warning(f"Could not copy label set icon: {e}")
+
+    # Update target corpus to use new label set
+    target_corpus = Corpus.objects.get(pk=ctx.target_corpus_id)
+    target_corpus.label_set = new_label_set
+    target_corpus.save(update_fields=["label_set", "modified"])
+
+    return new_label_set.id
+
+
+def fork_annotation_labels(
+    ctx: ForkContext,
+    source_label_set_id: Optional[int],
+    new_label_set_id: Optional[int],
+) -> int:
+    """
+    Fork all AnnotationLabels from a LabelSet.
+
+    Updates ctx.label_map with old_id -> new_id mappings.
+
+    Args:
+        ctx: Fork context
+        source_label_set_id: Original LabelSet ID
+        new_label_set_id: New LabelSet ID to add labels to
+
+    Returns:
+        Number of labels forked
+    """
+    if not source_label_set_id or not new_label_set_id:
+        return 0
+
+    from opencontractserver.annotations.models import AnnotationLabel, LabelSet
+
+    try:
+        old_label_set = LabelSet.objects.get(pk=source_label_set_id)
+        new_label_set = LabelSet.objects.get(pk=new_label_set_id)
+    except LabelSet.DoesNotExist:
+        return 0
+
+    old_labels = list(old_label_set.annotation_labels.all())
+    count = 0
+
+    for old_label in old_labels:
+        try:
+            new_label = AnnotationLabel(
+                creator_id=ctx.user_id,
+                label_type=old_label.label_type,
+                color=old_label.color,
+                description=old_label.description,
+                icon=old_label.icon,
+                text=old_label.text,
+            )
+            new_label.save()
+
+            # Store mapping
+            ctx.label_map[old_label.id] = new_label.id
+
+            # Add to new label set
+            new_label_set.annotation_labels.add(new_label)
+            count += 1
+
+        except Exception as e:
+            logger.error(f"Error forking label {old_label.id}: {e}")
+
+    logger.info(f"Forked {count} annotation labels")
+    return count
+
+
+def fork_corpus_folders(ctx: ForkContext) -> int:
+    """
+    Fork all CorpusFolders from source corpus to target corpus.
+
+    Preserves folder hierarchy by processing root folders first, then children.
+    Updates ctx.folder_map with old_id -> new_id mappings.
+
+    Args:
+        ctx: Fork context
+
+    Returns:
+        Number of folders forked
+    """
+    from opencontractserver.corpuses.models import Corpus, CorpusFolder
+
+    source_corpus = Corpus.objects.get(pk=ctx.source_corpus_id)
+    target_corpus = Corpus.objects.get(pk=ctx.target_corpus_id)
+
+    # Get all folders - we'll process them in dependency order
+    all_folders = list(CorpusFolder.objects.filter(corpus=source_corpus))
+
+    # Build a map of folder_id -> folder and parent_id -> children
+    folder_by_id = {f.id: f for f in all_folders}
+    children_by_parent = {}
+    root_folders = []
+
+    for folder in all_folders:
+        if folder.parent_id is None:
+            root_folders.append(folder)
+        else:
+            if folder.parent_id not in children_by_parent:
+                children_by_parent[folder.parent_id] = []
+            children_by_parent[folder.parent_id].append(folder)
+
+    count = 0
+
+    def fork_folder_recursive(old_folder, new_parent_id):
+        """Fork a folder and its children recursively."""
+        nonlocal count
+
+        try:
+            new_folder = CorpusFolder(
+                name=old_folder.name,
+                corpus=target_corpus,
+                parent_id=new_parent_id,
+                description=old_folder.description,
+                color=old_folder.color,
+                icon=old_folder.icon,
+                tags=old_folder.tags.copy() if old_folder.tags else [],
+                is_public=old_folder.is_public,
+                creator_id=ctx.user_id,
+            )
+            new_folder.save()
+
+            ctx.folder_map[old_folder.id] = new_folder.id
+            count += 1
+
+            # Fork children
+            children = children_by_parent.get(old_folder.id, [])
+            for child in children:
+                fork_folder_recursive(child, new_folder.id)
+
+        except Exception as e:
+            logger.error(f"Error forking folder {old_folder.id}: {e}")
+
+    # Start with root folders
+    for root_folder in root_folders:
+        fork_folder_recursive(root_folder, None)
+
+    logger.info(f"Forked {count} corpus folders")
+    return count
+
+
+def fork_documents(
+    ctx: ForkContext,
+    doc_ids: list[int],
+) -> int:
+    """
+    Fork documents from source corpus to target corpus.
+
+    Uses the Corpus.add_document() method which handles corpus isolation.
+    Updates ctx.doc_map with old_id -> new_id mappings.
+
+    Args:
+        ctx: Fork context
+        doc_ids: List of document IDs to fork
+
+    Returns:
+        Number of documents forked
+    """
+    from opencontractserver.corpuses.models import Corpus
+    from opencontractserver.documents.models import Document, DocumentPath
+
+    target_corpus = Corpus.objects.get(pk=ctx.target_corpus_id)
+    user = User.objects.get(pk=ctx.user_id)
+
+    count = 0
+    for doc_id in doc_ids:
+        try:
+            old_doc = Document.objects.get(pk=doc_id)
+
+            # Get the folder mapping if document was in a folder
+            old_path = DocumentPath.objects.filter(
+                corpus_id=ctx.source_corpus_id,
+                document_id=doc_id,
+                is_current=True,
+                is_deleted=False,
+            ).first()
+
+            new_folder = None
+            if old_path and old_path.folder_id:
+                new_folder_id = ctx.folder_map.get(old_path.folder_id)
+                if new_folder_id:
+                    from opencontractserver.corpuses.models import CorpusFolder
+
+                    new_folder = CorpusFolder.objects.get(pk=new_folder_id)
+
+            # Use add_document which handles corpus isolation properly
+            new_doc, status, new_path = target_corpus.add_document(
+                document=old_doc,
+                user=user,
+                folder=new_folder,
+                title=f"[FORK] {old_doc.title}",
+            )
+
+            # Store mapping
+            ctx.doc_map[doc_id] = new_doc.id
+            count += 1
+
+            logger.debug(f"Forked document {doc_id} -> {new_doc.id}")
+
+        except Exception as e:
+            logger.error(f"Error forking document {doc_id}: {e}")
+            raise
+
+    ctx.documents_forked = count
+    logger.info(f"Forked {count} documents")
+    return count
+
+
+def fork_annotations(
+    ctx: ForkContext,
+    annotation_ids: list[int],
+) -> int:
+    """
+    Fork annotations to target corpus.
+
+    Updates ctx.annotation_map with old_id -> new_id mappings.
+    Note: Per permission guide, annotations inherit permissions from doc+corpus,
+    so we don't set explicit permissions.
+
+    Args:
+        ctx: Fork context
+        annotation_ids: List of annotation IDs to fork
+
+    Returns:
+        Number of annotations forked
+    """
+    from opencontractserver.annotations.models import Annotation
+
+    # Process in batches to avoid memory issues
+    batch_size = 1000
+    count = 0
+    new_annotations = []
+
+    for i in range(0, len(annotation_ids), batch_size):
+        batch_ids = annotation_ids[i : i + batch_size]
+        old_annotations = Annotation.objects.filter(pk__in=batch_ids).select_related(
+            "annotation_label", "document"
+        )
+
+        for old_ann in old_annotations:
+            # Skip if we don't have the document mapping
+            new_doc_id = ctx.doc_map.get(old_ann.document_id)
+            if not new_doc_id:
+                logger.warning(
+                    f"Skipping annotation {old_ann.id}: document {old_ann.document_id} not forked"
+                )
+                continue
+
+            # Skip if we don't have the label mapping (for labeled annotations)
+            new_label_id = None
+            if old_ann.annotation_label_id:
+                new_label_id = ctx.label_map.get(old_ann.annotation_label_id)
+                if not new_label_id:
+                    logger.warning(
+                        f"Skipping annotation {old_ann.id}: label {old_ann.annotation_label_id} not forked"
+                    )
+                    continue
+
+            try:
+                # Create new annotation
+                new_ann = Annotation(
+                    page=old_ann.page,
+                    raw_text=old_ann.raw_text,
+                    tokens_jsons=old_ann.tokens_jsons,
+                    bounding_box=old_ann.bounding_box,
+                    json=old_ann.json,
+                    annotation_type=old_ann.annotation_type,
+                    annotation_label_id=new_label_id,
+                    document_id=new_doc_id,
+                    corpus_id=ctx.target_corpus_id,
+                    structural=old_ann.structural,
+                    is_public=old_ann.is_public,
+                    creator_id=ctx.user_id,
+                )
+                new_annotations.append((old_ann.id, new_ann))
+
+            except Exception as e:
+                logger.error(f"Error preparing annotation {old_ann.id}: {e}")
+
+        # Bulk create annotations in this batch
+        if new_annotations:
+            # Can't use bulk_create because we need IDs for mapping
+            for old_id, new_ann in new_annotations:
+                new_ann.save()
+                ctx.annotation_map[old_id] = new_ann.id
+                count += 1
+
+            new_annotations = []
+
+    ctx.annotations_forked = count
+    logger.info(f"Forked {count} annotations")
+    return count
+
+
+def fork_relationships(ctx: ForkContext) -> int:
+    """
+    Fork relationships between annotations.
+
+    Relationships link source and target annotations. We need to remap
+    both the source and target annotation IDs.
+
+    Args:
+        ctx: Fork context
+
+    Returns:
+        Number of relationships forked
+    """
+    from opencontractserver.annotations.models import Relationship
+
+    # Get relationships from source corpus where analysis is null
+    old_relationships = Relationship.objects.filter(
+        corpus_id=ctx.source_corpus_id,
+        analysis__isnull=True,
+    ).prefetch_related("source_annotations", "target_annotations")
+
+    count = 0
+    for old_rel in old_relationships:
+        try:
+            # Get new document ID
+            new_doc_id = ctx.doc_map.get(old_rel.document_id)
+            if not new_doc_id and old_rel.document_id:
+                logger.warning(
+                    f"Skipping relationship {old_rel.id}: document not forked"
+                )
+                continue
+
+            # Get new label ID
+            new_label_id = None
+            if old_rel.relationship_label_id:
+                new_label_id = ctx.label_map.get(old_rel.relationship_label_id)
+                if not new_label_id:
+                    logger.warning(
+                        f"Skipping relationship {old_rel.id}: label not forked"
+                    )
+                    continue
+
+            # Create new relationship
+            new_rel = Relationship(
+                relationship_label_id=new_label_id,
+                corpus_id=ctx.target_corpus_id,
+                document_id=new_doc_id,
+                structural=old_rel.structural,
+                is_public=old_rel.is_public,
+                creator_id=ctx.user_id,
+            )
+            new_rel.save()
+
+            # Map source annotations
+            source_ann_ids = []
+            for old_source in old_rel.source_annotations.all():
+                new_source_id = ctx.annotation_map.get(old_source.id)
+                if new_source_id:
+                    source_ann_ids.append(new_source_id)
+            if source_ann_ids:
+                new_rel.source_annotations.set(source_ann_ids)
+
+            # Map target annotations
+            target_ann_ids = []
+            for old_target in old_rel.target_annotations.all():
+                new_target_id = ctx.annotation_map.get(old_target.id)
+                if new_target_id:
+                    target_ann_ids.append(new_target_id)
+            if target_ann_ids:
+                new_rel.target_annotations.set(target_ann_ids)
+
+            count += 1
+
+        except Exception as e:
+            logger.error(f"Error forking relationship {old_rel.id}: {e}")
+
+    ctx.relationships_forked = count
+    logger.info(f"Forked {count} relationships")
+    return count
+
+
+def fork_fieldsets(ctx: ForkContext) -> int:
+    """
+    Fork fieldsets (extraction schemas) from source corpus.
+
+    Only forks fieldsets that are linked to the source corpus as metadata_schema.
+    Updates ctx.fieldset_map with old_id -> new_id mappings.
+
+    Args:
+        ctx: Fork context
+
+    Returns:
+        Number of fieldsets forked
+    """
+    from opencontractserver.corpuses.models import Corpus
+    from opencontractserver.extracts.models import Fieldset
+
+    source_corpus = Corpus.objects.get(pk=ctx.source_corpus_id)
+    target_corpus = Corpus.objects.get(pk=ctx.target_corpus_id)
+
+    # Check if source corpus has a metadata schema
+    if not hasattr(source_corpus, "metadata_schema") or not source_corpus.metadata_schema:
+        logger.info("No metadata schema to fork")
+        return 0
+
+    old_fieldset = source_corpus.metadata_schema
+
+    # Create new fieldset for target corpus
+    new_fieldset = Fieldset(
+        name=f"[FORK] {old_fieldset.name}",
+        description=old_fieldset.description,
+        corpus=target_corpus,  # Link to new corpus
+        creator_id=ctx.user_id,
+        is_public=old_fieldset.is_public,
+    )
+    new_fieldset.save()
+
+    # Set permissions
+    set_permissions_for_obj_to_user(ctx.user_id, new_fieldset, [PermissionTypes.CRUD])
+
+    ctx.fieldset_map[old_fieldset.id] = new_fieldset.id
+    logger.info(f"Forked fieldset {old_fieldset.id} -> {new_fieldset.id}")
+    return 1
+
+
+def fork_columns(ctx: ForkContext) -> int:
+    """
+    Fork columns from forked fieldsets.
+
+    Updates ctx.column_map with old_id -> new_id mappings.
+
+    Args:
+        ctx: Fork context
+
+    Returns:
+        Number of columns forked
+    """
+    from opencontractserver.extracts.models import Column, Fieldset
+
+    if not ctx.fieldset_map:
+        return 0
+
+    count = 0
+    for old_fieldset_id, new_fieldset_id in ctx.fieldset_map.items():
+        old_columns = Column.objects.filter(fieldset_id=old_fieldset_id).order_by(
+            "display_order"
+        )
+
+        for old_col in old_columns:
+            try:
+                new_col = Column(
+                    name=old_col.name,
+                    fieldset_id=new_fieldset_id,
+                    query=old_col.query,
+                    match_text=old_col.match_text,
+                    must_contain_text=old_col.must_contain_text,
+                    output_type=old_col.output_type,
+                    limit_to_label=old_col.limit_to_label,
+                    instructions=old_col.instructions,
+                    extract_is_list=old_col.extract_is_list,
+                    task_name=old_col.task_name,
+                    data_type=old_col.data_type,
+                    validation_config=old_col.validation_config,
+                    is_manual_entry=old_col.is_manual_entry,
+                    default_value=old_col.default_value,
+                    help_text=old_col.help_text,
+                    display_order=old_col.display_order,
+                    creator_id=ctx.user_id,
+                    is_public=old_col.is_public,
+                )
+                new_col.save()
+
+                ctx.column_map[old_col.id] = new_col.id
+                count += 1
+
+            except Exception as e:
+                logger.error(f"Error forking column {old_col.id}: {e}")
+
+    logger.info(f"Forked {count} columns")
+    return count
+
+
+def fork_extracts(ctx: ForkContext) -> int:
+    """
+    Fork extracts from source corpus.
+
+    Updates ctx.extract_map with old_id -> new_id mappings.
+
+    Args:
+        ctx: Fork context
+
+    Returns:
+        Number of extracts forked
+    """
+    from opencontractserver.corpuses.models import Corpus
+    from opencontractserver.extracts.models import Extract
+
+    source_corpus = Corpus.objects.get(pk=ctx.source_corpus_id)
+
+    # Get extracts for source corpus
+    old_extracts = Extract.objects.filter(corpus=source_corpus).prefetch_related(
+        "documents"
+    )
+
+    count = 0
+    for old_extract in old_extracts:
+        # Check if we have the fieldset mapping
+        new_fieldset_id = ctx.fieldset_map.get(old_extract.fieldset_id)
+        if not new_fieldset_id:
+            logger.warning(
+                f"Skipping extract {old_extract.id}: fieldset not forked"
+            )
+            continue
+
+        try:
+            new_extract = Extract(
+                corpus_id=ctx.target_corpus_id,
+                name=f"[FORK] {old_extract.name}",
+                fieldset_id=new_fieldset_id,
+                started=old_extract.started,
+                finished=old_extract.finished,
+                error=old_extract.error,
+                creator_id=ctx.user_id,
+                is_public=old_extract.is_public,
+            )
+            new_extract.save()
+
+            # Set permissions
+            set_permissions_for_obj_to_user(
+                ctx.user_id, new_extract, [PermissionTypes.CRUD]
+            )
+
+            # Map documents M2M
+            new_doc_ids = []
+            for old_doc in old_extract.documents.all():
+                new_doc_id = ctx.doc_map.get(old_doc.id)
+                if new_doc_id:
+                    new_doc_ids.append(new_doc_id)
+            if new_doc_ids:
+                new_extract.documents.set(new_doc_ids)
+
+            ctx.extract_map[old_extract.id] = new_extract.id
+            count += 1
+
+        except Exception as e:
+            logger.error(f"Error forking extract {old_extract.id}: {e}")
+
+    ctx.extracts_forked = count
+    logger.info(f"Forked {count} extracts")
+    return count
+
+
+def fork_datacells(ctx: ForkContext) -> int:
+    """
+    Fork datacells from forked extracts.
+
+    Args:
+        ctx: Fork context
+
+    Returns:
+        Number of datacells forked
+    """
+    from opencontractserver.extracts.models import Datacell
+
+    if not ctx.extract_map:
+        return 0
+
+    count = 0
+    for old_extract_id, new_extract_id in ctx.extract_map.items():
+        old_datacells = Datacell.objects.filter(
+            extract_id=old_extract_id
+        ).prefetch_related("sources")
+
+        for old_cell in old_datacells:
+            # Get new document ID
+            new_doc_id = ctx.doc_map.get(old_cell.document_id)
+            if not new_doc_id:
+                continue
+
+            # Get new column ID
+            new_col_id = ctx.column_map.get(old_cell.column_id)
+            if not new_col_id:
+                continue
+
+            try:
+                new_cell = Datacell(
+                    extract_id=new_extract_id,
+                    column_id=new_col_id,
+                    document_id=new_doc_id,
+                    data=old_cell.data,
+                    data_definition=old_cell.data_definition,
+                    started=old_cell.started,
+                    completed=old_cell.completed,
+                    failed=old_cell.failed,
+                    stacktrace=old_cell.stacktrace,
+                    corrected_data=old_cell.corrected_data,
+                    creator_id=ctx.user_id,
+                    is_public=old_cell.is_public,
+                )
+                new_cell.save()
+
+                # Map sources M2M (annotations)
+                new_source_ids = []
+                for old_source in old_cell.sources.all():
+                    new_source_id = ctx.annotation_map.get(old_source.id)
+                    if new_source_id:
+                        new_source_ids.append(new_source_id)
+                if new_source_ids:
+                    new_cell.sources.set(new_source_ids)
+
+                count += 1
+
+            except Exception as e:
+                logger.error(f"Error forking datacell {old_cell.id}: {e}")
+
+    logger.info(f"Forked {count} datacells")
+    return count
+
+
+def fork_conversations(ctx: ForkContext) -> int:
+    """
+    Fork conversations (chats) from source corpus.
+
+    Only forks CHAT type conversations (agent chats), not THREAD (discussions).
+    Updates ctx.conversation_map with old_id -> new_id mappings.
+
+    Args:
+        ctx: Fork context
+
+    Returns:
+        Number of conversations forked
+    """
+    from opencontractserver.conversations.models import Conversation
+
+    # Get chat-type conversations for source corpus or its documents
+    old_conversations = Conversation.objects.filter(
+        conversation_type="chat",
+    ).filter(
+        # Corpus-level chats OR document-level chats for forked documents
+        chat_with_corpus_id=ctx.source_corpus_id
+    ) | Conversation.objects.filter(
+        conversation_type="chat",
+        chat_with_document_id__in=list(ctx.doc_map.keys()),
+    )
+
+    count = 0
+    for old_conv in old_conversations.distinct():
+        try:
+            # Determine new corpus/document references
+            new_corpus_id = None
+            new_doc_id = None
+
+            if old_conv.chat_with_corpus_id == ctx.source_corpus_id:
+                new_corpus_id = ctx.target_corpus_id
+
+            if old_conv.chat_with_document_id:
+                new_doc_id = ctx.doc_map.get(old_conv.chat_with_document_id)
+                if not new_doc_id:
+                    logger.warning(
+                        f"Skipping conversation {old_conv.id}: document not forked"
+                    )
+                    continue
+
+            new_conv = Conversation(
+                title=f"[FORK] {old_conv.title}" if old_conv.title else "",
+                description=old_conv.description,
+                conversation_type=old_conv.conversation_type,
+                chat_with_corpus_id=new_corpus_id,
+                chat_with_document_id=new_doc_id,
+                is_public=old_conv.is_public,
+                creator_id=ctx.user_id,
+            )
+            new_conv.save()
+
+            # Set permissions
+            set_permissions_for_obj_to_user(
+                ctx.user_id, new_conv, [PermissionTypes.CRUD]
+            )
+
+            ctx.conversation_map[old_conv.id] = new_conv.id
+            count += 1
+
+        except Exception as e:
+            logger.error(f"Error forking conversation {old_conv.id}: {e}")
+
+    ctx.conversations_forked = count
+    logger.info(f"Forked {count} conversations")
+    return count
+
+
+def fork_chat_messages(ctx: ForkContext) -> int:
+    """
+    Fork chat messages from forked conversations.
+
+    Maintains message hierarchy (parent_message relationships).
+
+    Args:
+        ctx: Fork context
+
+    Returns:
+        Number of messages forked
+    """
+    from opencontractserver.conversations.models import ChatMessage
+
+    if not ctx.conversation_map:
+        return 0
+
+    count = 0
+    message_map = {}  # old_id -> new_id for parent references
+
+    for old_conv_id, new_conv_id in ctx.conversation_map.items():
+        # Get messages ordered by creation time (parents first)
+        old_messages = ChatMessage.objects.filter(
+            conversation_id=old_conv_id
+        ).order_by("created_at")
+
+        for old_msg in old_messages:
+            try:
+                # Get new parent message ID
+                new_parent_id = None
+                if old_msg.parent_message_id:
+                    new_parent_id = message_map.get(old_msg.parent_message_id)
+
+                # Get new source document ID
+                new_source_doc_id = None
+                if old_msg.source_document_id:
+                    new_source_doc_id = ctx.doc_map.get(old_msg.source_document_id)
+
+                new_msg = ChatMessage(
+                    conversation_id=new_conv_id,
+                    msg_type=old_msg.msg_type,
+                    agent_type=old_msg.agent_type,
+                    parent_message_id=new_parent_id,
+                    content=old_msg.content,
+                    data=old_msg.data,
+                    source_document_id=new_source_doc_id,
+                    state=old_msg.state,
+                    creator_id=ctx.user_id,
+                )
+                new_msg.save()
+
+                # Map source_annotations M2M
+                new_source_ann_ids = []
+                for old_ann in old_msg.source_annotations.all():
+                    new_ann_id = ctx.annotation_map.get(old_ann.id)
+                    if new_ann_id:
+                        new_source_ann_ids.append(new_ann_id)
+                if new_source_ann_ids:
+                    new_msg.source_annotations.set(new_source_ann_ids)
+
+                # Map created_annotations M2M
+                new_created_ann_ids = []
+                for old_ann in old_msg.created_annotations.all():
+                    new_ann_id = ctx.annotation_map.get(old_ann.id)
+                    if new_ann_id:
+                        new_created_ann_ids.append(new_ann_id)
+                if new_created_ann_ids:
+                    new_msg.created_annotations.set(new_created_ann_ids)
+
+                message_map[old_msg.id] = new_msg.id
+                count += 1
+
+            except Exception as e:
+                logger.error(f"Error forking message {old_msg.id}: {e}")
+
+    logger.info(f"Forked {count} chat messages")
+    return count
+
+
+def fork_notes(ctx: ForkContext) -> int:
+    """
+    Fork notes from source corpus documents.
+
+    Maintains note hierarchy (parent relationships).
+    Updates ctx.note_map with old_id -> new_id mappings.
+
+    Args:
+        ctx: Fork context
+
+    Returns:
+        Number of notes forked
+    """
+    from opencontractserver.annotations.models import Note
+
+    # Get notes for documents in the source corpus
+    old_notes = Note.objects.filter(
+        document_id__in=list(ctx.doc_map.keys())
+    ).order_by("created")  # Process parents first
+
+    count = 0
+    for old_note in old_notes:
+        try:
+            # Get new document ID
+            new_doc_id = ctx.doc_map.get(old_note.document_id)
+            if not new_doc_id:
+                continue
+
+            # Get new parent note ID
+            new_parent_id = None
+            if old_note.parent_id:
+                new_parent_id = ctx.note_map.get(old_note.parent_id)
+
+            # Get new annotation ID
+            new_ann_id = None
+            if old_note.annotation_id:
+                new_ann_id = ctx.annotation_map.get(old_note.annotation_id)
+
+            new_note = Note(
+                title=f"[FORK] {old_note.title}",
+                content=old_note.content,
+                parent_id=new_parent_id,
+                corpus_id=ctx.target_corpus_id,
+                document_id=new_doc_id,
+                annotation_id=new_ann_id,
+                is_public=old_note.is_public,
+                creator_id=ctx.user_id,
+            )
+            # Use skip_revision to avoid creating revision during fork
+            new_note.save(skip_revision=True)
+
+            ctx.note_map[old_note.id] = new_note.id
+            count += 1
+
+        except Exception as e:
+            logger.error(f"Error forking note {old_note.id}: {e}")
+
+    ctx.notes_forked = count
+    logger.info(f"Forked {count} notes")
+    return count
+
+
+def fork_note_revisions(ctx: ForkContext) -> int:
+    """
+    Fork note revisions from forked notes.
+
+    Args:
+        ctx: Fork context
+
+    Returns:
+        Number of note revisions forked
+    """
+    from opencontractserver.annotations.models import NoteRevision
+
+    if not ctx.note_map:
+        return 0
+
+    count = 0
+    for old_note_id, new_note_id in ctx.note_map.items():
+        old_revisions = NoteRevision.objects.filter(note_id=old_note_id).order_by(
+            "version"
+        )
+
+        for old_rev in old_revisions:
+            try:
+                new_rev = NoteRevision(
+                    note_id=new_note_id,
+                    author_id=ctx.user_id,
+                    version=old_rev.version,
+                    diff=old_rev.diff,
+                    snapshot=old_rev.snapshot,
+                    checksum_base=old_rev.checksum_base,
+                    checksum_full=old_rev.checksum_full,
+                )
+                new_rev.save()
+                count += 1
+
+            except Exception as e:
+                logger.error(f"Error forking note revision {old_rev.id}: {e}")
+
+    logger.info(f"Forked {count} note revisions")
+    return count

--- a/opencontractserver/utils/fork_utils.py
+++ b/opencontractserver/utils/fork_utils.py
@@ -1,0 +1,361 @@
+"""
+Forking utilities and configuration for corpus forking.
+
+This module provides an enumerable, configuration-driven forking system that
+allows easy updates to what gets forked when creating a corpus copy.
+
+Usage:
+    from opencontractserver.utils.fork_utils import (
+        ForkableModelType,
+        ForkContext,
+        get_default_fork_config,
+    )
+
+    # Get models to fork
+    config = get_default_fork_config()
+
+    # Create a fork context for tracking ID mappings
+    ctx = ForkContext(
+        source_corpus_id=123,
+        target_corpus_id=456,
+        user_id=1,
+    )
+
+    # Fork documents
+    fork_documents(ctx, doc_ids)
+"""
+
+import logging
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+class ForkableModelType(Enum):
+    """
+    Enumeration of all model types that can be forked.
+
+    This enum serves as a registry of forkable models and their ordering.
+    The order matters - models with dependencies must be forked after
+    their dependencies.
+    """
+
+    # ========== Core Organization Models (Fork First) ==========
+    LABEL_SET = "label_set"
+    ANNOTATION_LABEL = "annotation_label"
+    CORPUS_FOLDER = "corpus_folder"
+
+    # ========== Content Models ==========
+    DOCUMENT = "document"
+    ANNOTATION = "annotation"
+    RELATIONSHIP = "relationship"
+
+    # ========== Extract-related Models ==========
+    FIELDSET = "fieldset"
+    COLUMN = "column"
+    EXTRACT = "extract"
+    DATACELL = "datacell"
+
+    # ========== Conversation Models ==========
+    CONVERSATION = "conversation"
+    CHAT_MESSAGE = "chat_message"
+
+    # ========== Notes Models ==========
+    NOTE = "note"
+    NOTE_REVISION = "note_revision"
+
+    # ========== Models NOT to Fork (excluded by default) ==========
+    # These are listed for documentation but excluded from DEFAULT_FORK_CONFIG
+    # ANALYSIS = "analysis"  # Excluded - created by analyzers
+    # ANALYZER = "analyzer"  # Excluded - system config
+    # AGENT_CONFIG = "agent_config"  # Excluded - system config
+    # CORPUS_ACTION = "corpus_action"  # Excluded - system config
+    # MODERATION_ACTION = "moderation_action"  # Excluded - audit trail
+    # USER_REPUTATION = "user_reputation"  # Excluded - user-specific
+    # CORPUS_MODERATOR = "corpus_moderator"  # Excluded - permissions
+
+
+@dataclass
+class ForkModelConfig:
+    """
+    Configuration for forking a specific model type.
+
+    Attributes:
+        model_type: The type of model this config applies to
+        enabled: Whether this model type should be forked
+        requires_permission_grant: Whether to call set_permissions_for_obj_to_user()
+                                   Per permission guide, inherited models don't need this
+        has_file_fields: List of FileField names that need file copying
+        id_mapping_key: Key name for storing ID mappings (old_id -> new_id)
+        depends_on: List of model types that must be forked first
+        filter_kwargs: Filter criteria for selecting objects to fork
+        batch_size: Number of objects to process in each batch (for bulk operations)
+        use_bulk_create: Whether to use bulk_create for performance
+    """
+
+    model_type: ForkableModelType
+    enabled: bool = True
+    requires_permission_grant: bool = False
+    has_file_fields: list[str] = field(default_factory=list)
+    id_mapping_key: Optional[str] = None
+    depends_on: list[ForkableModelType] = field(default_factory=list)
+    filter_kwargs: dict = field(default_factory=dict)
+    batch_size: int = 500
+    use_bulk_create: bool = True
+
+
+@dataclass
+class ForkContext:
+    """
+    Context object for tracking state during a fork operation.
+
+    This is passed between fork handlers to share ID mappings and state.
+    """
+
+    source_corpus_id: int
+    target_corpus_id: int
+    user_id: int
+
+    # ID mappings: old_id -> new_id
+    doc_map: dict[int, int] = field(default_factory=dict)
+    label_map: dict[int, int] = field(default_factory=dict)
+    annotation_map: dict[int, int] = field(default_factory=dict)
+    folder_map: dict[int, int] = field(default_factory=dict)
+    fieldset_map: dict[int, int] = field(default_factory=dict)
+    column_map: dict[int, int] = field(default_factory=dict)
+    extract_map: dict[int, int] = field(default_factory=dict)
+    conversation_map: dict[int, int] = field(default_factory=dict)
+    note_map: dict[int, int] = field(default_factory=dict)
+
+    # Statistics
+    documents_forked: int = 0
+    annotations_forked: int = 0
+    relationships_forked: int = 0
+    extracts_forked: int = 0
+    conversations_forked: int = 0
+    notes_forked: int = 0
+
+
+@dataclass
+class ForkResult:
+    """
+    Result of a fork operation.
+    """
+
+    success: bool
+    new_corpus_id: Optional[int] = None
+    error_message: Optional[str] = None
+    context: Optional[ForkContext] = None
+
+    # Statistics
+    documents_forked: int = 0
+    annotations_forked: int = 0
+    relationships_forked: int = 0
+    fieldsets_forked: int = 0
+    extracts_forked: int = 0
+    datacells_forked: int = 0
+    conversations_forked: int = 0
+    messages_forked: int = 0
+    notes_forked: int = 0
+    folders_forked: int = 0
+
+
+def get_default_fork_config() -> dict[ForkableModelType, ForkModelConfig]:
+    """
+    Get the default fork configuration.
+
+    This defines what models get forked and how. Modify this to change
+    default forking behavior.
+
+    Returns:
+        Dictionary mapping model types to their fork configurations.
+    """
+    return {
+        # ========== Organization Models ==========
+        ForkableModelType.LABEL_SET: ForkModelConfig(
+            model_type=ForkableModelType.LABEL_SET,
+            enabled=True,
+            requires_permission_grant=False,  # Permissions via corpus
+            has_file_fields=["icon"],
+            batch_size=1,  # Only one per corpus
+            use_bulk_create=False,
+        ),
+        ForkableModelType.ANNOTATION_LABEL: ForkModelConfig(
+            model_type=ForkableModelType.ANNOTATION_LABEL,
+            enabled=True,
+            requires_permission_grant=False,
+            id_mapping_key="label_map",
+            depends_on=[ForkableModelType.LABEL_SET],
+            batch_size=100,
+            use_bulk_create=True,
+        ),
+        ForkableModelType.CORPUS_FOLDER: ForkModelConfig(
+            model_type=ForkableModelType.CORPUS_FOLDER,
+            enabled=True,
+            requires_permission_grant=False,  # Permissions via corpus
+            id_mapping_key="folder_map",
+            batch_size=100,
+            use_bulk_create=False,  # Need to preserve hierarchy
+        ),
+        # ========== Content Models ==========
+        ForkableModelType.DOCUMENT: ForkModelConfig(
+            model_type=ForkableModelType.DOCUMENT,
+            enabled=True,
+            requires_permission_grant=True,  # Direct permission model
+            has_file_fields=["txt_extract_file", "pawls_parse_file"],
+            id_mapping_key="doc_map",
+            depends_on=[ForkableModelType.CORPUS_FOLDER],
+            batch_size=50,  # Lower due to file operations
+            use_bulk_create=False,  # Files need individual handling
+        ),
+        ForkableModelType.ANNOTATION: ForkModelConfig(
+            model_type=ForkableModelType.ANNOTATION,
+            enabled=True,
+            requires_permission_grant=False,  # Inherited from doc+corpus
+            id_mapping_key="annotation_map",
+            depends_on=[
+                ForkableModelType.DOCUMENT,
+                ForkableModelType.ANNOTATION_LABEL,
+            ],
+            filter_kwargs={"analysis__isnull": True},  # Only non-analysis annotations
+            batch_size=1000,
+            use_bulk_create=True,
+        ),
+        ForkableModelType.RELATIONSHIP: ForkModelConfig(
+            model_type=ForkableModelType.RELATIONSHIP,
+            enabled=True,
+            requires_permission_grant=False,  # Inherited from doc+corpus
+            depends_on=[ForkableModelType.ANNOTATION],
+            filter_kwargs={"analysis__isnull": True},  # Only non-analysis relationships
+            batch_size=1000,
+            use_bulk_create=False,  # M2M fields need individual handling
+        ),
+        # ========== Extract Models ==========
+        ForkableModelType.FIELDSET: ForkModelConfig(
+            model_type=ForkableModelType.FIELDSET,
+            enabled=True,
+            requires_permission_grant=True,  # Direct permission model
+            id_mapping_key="fieldset_map",
+            batch_size=10,
+            use_bulk_create=False,
+        ),
+        ForkableModelType.COLUMN: ForkModelConfig(
+            model_type=ForkableModelType.COLUMN,
+            enabled=True,
+            requires_permission_grant=False,  # Via fieldset
+            id_mapping_key="column_map",
+            depends_on=[ForkableModelType.FIELDSET],
+            batch_size=100,
+            use_bulk_create=True,
+        ),
+        ForkableModelType.EXTRACT: ForkModelConfig(
+            model_type=ForkableModelType.EXTRACT,
+            enabled=True,
+            requires_permission_grant=True,  # Hybrid permission model
+            id_mapping_key="extract_map",
+            depends_on=[ForkableModelType.FIELDSET, ForkableModelType.DOCUMENT],
+            batch_size=50,
+            use_bulk_create=False,  # M2M documents field
+        ),
+        ForkableModelType.DATACELL: ForkModelConfig(
+            model_type=ForkableModelType.DATACELL,
+            enabled=True,
+            requires_permission_grant=False,  # Via extract
+            depends_on=[
+                ForkableModelType.EXTRACT,
+                ForkableModelType.COLUMN,
+                ForkableModelType.DOCUMENT,
+            ],
+            batch_size=1000,
+            use_bulk_create=True,
+        ),
+        # ========== Conversation Models ==========
+        ForkableModelType.CONVERSATION: ForkModelConfig(
+            model_type=ForkableModelType.CONVERSATION,
+            enabled=True,
+            requires_permission_grant=True,
+            id_mapping_key="conversation_map",
+            depends_on=[ForkableModelType.DOCUMENT],
+            # Only fork CHAT type (agent conversations), not THREAD (discussions)
+            filter_kwargs={"conversation_type": "chat"},
+            batch_size=100,
+            use_bulk_create=False,
+        ),
+        ForkableModelType.CHAT_MESSAGE: ForkModelConfig(
+            model_type=ForkableModelType.CHAT_MESSAGE,
+            enabled=True,
+            requires_permission_grant=False,  # Via conversation
+            depends_on=[
+                ForkableModelType.CONVERSATION,
+                ForkableModelType.DOCUMENT,
+                ForkableModelType.ANNOTATION,
+            ],
+            batch_size=500,
+            use_bulk_create=True,
+        ),
+        # ========== Notes Models ==========
+        ForkableModelType.NOTE: ForkModelConfig(
+            model_type=ForkableModelType.NOTE,
+            enabled=True,
+            requires_permission_grant=False,  # Inherited via document
+            id_mapping_key="note_map",
+            depends_on=[ForkableModelType.DOCUMENT, ForkableModelType.ANNOTATION],
+            batch_size=500,
+            use_bulk_create=False,  # Hierarchy needs ordering
+        ),
+        ForkableModelType.NOTE_REVISION: ForkModelConfig(
+            model_type=ForkableModelType.NOTE_REVISION,
+            enabled=True,
+            requires_permission_grant=False,
+            depends_on=[ForkableModelType.NOTE],
+            batch_size=1000,
+            use_bulk_create=True,
+        ),
+    }
+
+
+def get_fork_order(
+    config: dict[ForkableModelType, ForkModelConfig],
+) -> list[ForkableModelType]:
+    """
+    Get the ordered list of model types to fork based on dependencies.
+
+    Uses topological sort to ensure dependencies are forked first.
+
+    Args:
+        config: Fork configuration dictionary
+
+    Returns:
+        Ordered list of model types to fork
+    """
+    # Build dependency graph
+    enabled_types = {t for t, c in config.items() if c.enabled}
+    result = []
+    visited = set()
+    temp_visited = set()
+
+    def visit(model_type: ForkableModelType):
+        if model_type in temp_visited:
+            raise ValueError(f"Circular dependency detected for {model_type}")
+        if model_type in visited:
+            return
+
+        temp_visited.add(model_type)
+
+        model_config = config.get(model_type)
+        if model_config:
+            for dep in model_config.depends_on:
+                if dep in enabled_types:
+                    visit(dep)
+
+        temp_visited.remove(model_type)
+        visited.add(model_type)
+        result.append(model_type)
+
+    for model_type in enabled_types:
+        if model_type not in visited:
+            visit(model_type)
+
+    return result


### PR DESCRIPTION
This commit introduces a comprehensive, configuration-driven forking system that addresses gaps in the original implementation:

New Features:
- Fork all relevant models: documents, annotations, relationships, extracts, fieldsets, columns, datacells, conversations, notes, and folder structure
- Enumerable ForkableModelType enum for easy addition/removal of forkable models
- ForkModelConfig dataclass for configuring fork behavior per model type
- Proper permission handling per consolidated_permissioning_guide.md
- Optional flags for fork_extracts, fork_conversations, fork_notes

Architecture:
- opencontractserver/utils/fork_utils.py: Config and context classes
- opencontractserver/utils/fork_handlers.py: Individual handlers per model
- opencontractserver/tasks/fork_tasks_v2.py: Orchestrating Celery task
- Updated StartCorpusFork mutation to use fork_corpus_v2

What is NOT forked (by design):
- Analyses and analyzer-created annotations
- Discussion threads (only chat conversations are forked)
- Moderation actions, user reputation, moderator assignments
- CorpusActions (automation configurations)

Permission Model Alignment:
- Documents: Direct permissions (set via set_permissions_for_obj_to_user)
- Annotations/Relationships: Inherited from doc+corpus (no explicit perms)
- Extracts/Fieldsets: Direct permissions required
- Conversations: Direct permissions required

Includes comprehensive test coverage in test_fork_v2.py.