### PR TITLE
Fix sensitive data exposure in logs and error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Structural annotations now correctly load images for embedding generation
   - Files: `opencontractserver/utils/multimodal_embeddings.py:136-166`
 
+### Security
+- **JWT authentication error message hardening** (CWE-209: Information Exposure Through Error Messages)
+  - JWT errors now return generic messages (`"Invalid token"`) instead of exposing exception details
+  - Detailed errors logged server-side only for debugging
+  - Files: `config/rest_jwt_auth.py:80-90`
+- **Sensitive data redaction in logs** (CWE-532: Insertion of Sensitive Information into Log File)
+  - New `redact_sensitive_kwargs()` utility recursively redacts API keys, secrets, passwords, tokens, credentials
+  - Applied to parser, embedder, and post-processor kwargs logging
+  - Files: `opencontractserver/utils/logging.py`, `opencontractserver/tasks/doc_tasks.py`,
+    `opencontractserver/pipeline/base/embedder.py`, `opencontractserver/pipeline/base/post_processor.py`,
+    `opencontractserver/pipeline/parsers/llamaparse_parser.py`, `opencontractserver/pipeline/post_processors/pdf_redactor.py`
+
 ### Changed
 - **Image retrieval uses fast path**: Both REST API and embedding tasks check `image_content_file` first
   - Falls back to PAWLs loading only for legacy annotations without pre-extracted images

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,6 +231,44 @@ docker compose -f production.yml up
 
 ## Testing Patterns
 
+### Manual Test Scripts
+
+**Location**: `docs/test_scripts/`
+
+When performing manual testing (e.g., testing migrations, verifying database state, testing API endpoints interactively), **always document the test steps** in a markdown file under `docs/test_scripts/`. These scripts will later be used to build automated integration tests.
+
+**Format**:
+```markdown
+# Test: [Brief description]
+
+## Purpose
+What this test verifies.
+
+## Prerequisites
+- Required state (e.g., "migration at 0058")
+- Required data (e.g., "at least one document exists")
+
+## Steps
+1. Step one with exact command
+   ```bash
+   docker compose -f local.yml run --rm django python manage.py shell -c "..."
+   ```
+2. Step two...
+
+## Expected Results
+- What should happen after each step
+- Success criteria
+
+## Cleanup
+Commands to restore original state if needed.
+```
+
+**When to document**:
+- Migration testing (rollback, create test data, migrate forward)
+- Database constraint validation
+- Race condition verification
+- Any manual verification requested during code review
+
 ### Backend Tests
 
 **Location**: `opencontractserver/tests/`

--- a/config/rest_jwt_auth.py
+++ b/config/rest_jwt_auth.py
@@ -78,7 +78,8 @@ class GraphQLJWTAuthentication(authentication.BaseAuthentication):
             raise exceptions.AuthenticationFailed("Token has expired")
 
         except JSONWebTokenError as e:
-            raise exceptions.AuthenticationFailed(f"Invalid token: {e}")
+            logger.warning(f"JWT validation failed: {e}")
+            raise exceptions.AuthenticationFailed("Invalid token")
 
         except Exception as e:
             logger.error(f"JWT authentication error: {e}")

--- a/config/rest_jwt_auth.py
+++ b/config/rest_jwt_auth.py
@@ -78,10 +78,14 @@ class GraphQLJWTAuthentication(authentication.BaseAuthentication):
             raise exceptions.AuthenticationFailed("Token has expired")
 
         except JSONWebTokenError as e:
+            # Security: Log detailed error server-side but return generic message
+            # to prevent information disclosure to potential attackers
             logger.warning(f"JWT validation failed: {e}")
             raise exceptions.AuthenticationFailed("Invalid token")
 
         except Exception as e:
+            # Security: Log detailed error server-side but return generic message
+            # to prevent information disclosure to potential attackers
             logger.error(f"JWT authentication error: {e}")
             raise exceptions.AuthenticationFailed("Authentication error")
 

--- a/opencontractserver/pipeline/base/embedder.py
+++ b/opencontractserver/pipeline/base/embedder.py
@@ -5,6 +5,7 @@ from typing import Optional
 
 from opencontractserver.pipeline.base.file_types import FileTypeEnum
 from opencontractserver.types.enums import ContentModality
+from opencontractserver.utils.logging import redact_sensitive_kwargs
 
 from .base_component import PipelineComponentBase
 
@@ -160,7 +161,10 @@ class BaseEmbedder(PipelineComponentBase, ABC):
             )
             return None
         merged_kwargs = {**self.get_component_settings(), **direct_kwargs}
-        logger.info(f"Calling _embed_text_impl with merged kwargs: {merged_kwargs}")
+        logger.info(
+            f"Calling _embed_text_impl with merged kwargs: "
+            f"{redact_sensitive_kwargs(merged_kwargs)}"
+        )
         return self._embed_text_impl(text, **merged_kwargs)
 
     def embed_image(
@@ -187,7 +191,10 @@ class BaseEmbedder(PipelineComponentBase, ABC):
             )
             return None
         merged_kwargs = {**self.get_component_settings(), **direct_kwargs}
-        logger.info(f"Calling _embed_image_impl with merged kwargs: {merged_kwargs}")
+        logger.info(
+            f"Calling _embed_image_impl with merged kwargs: "
+            f"{redact_sensitive_kwargs(merged_kwargs)}"
+        )
         return self._embed_image_impl(image_base64, image_format, **merged_kwargs)
 
     def embed_text_and_image(

--- a/opencontractserver/pipeline/base/post_processor.py
+++ b/opencontractserver/pipeline/base/post_processor.py
@@ -5,6 +5,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Mapping
 
 from opencontractserver.types.dicts import OpenContractsExportDataJsonPythonType
+from opencontractserver.utils.logging import redact_sensitive_kwargs
 
 from .base_component import PipelineComponentBase
 
@@ -79,5 +80,8 @@ class BasePostProcessor(PipelineComponentBase, ABC):
                 - Modified export data dictionary
         """
         merged_kwargs = {**self.get_component_settings(), **direct_kwargs}
-        logger.info(f"Calling _process_export_impl with merged kwargs: {merged_kwargs}")
+        logger.info(
+            f"Calling _process_export_impl with merged kwargs: "
+            f"{redact_sensitive_kwargs(merged_kwargs)}"
+        )
         return self._process_export_impl(zip_bytes, export_data, **merged_kwargs)

--- a/opencontractserver/pipeline/parsers/llamaparse_parser.py
+++ b/opencontractserver/pipeline/parsers/llamaparse_parser.py
@@ -135,13 +135,11 @@ class LlamaParseParser(BaseParser):
         Returns:
             OpenContractDocExport with the parsed document data, or None if parsing failed.
         """
-        # Redact sensitive keys before logging
-        safe_kwargs = {
-            k: ("***" if k == "api_key" else v) for k, v in all_kwargs.items()
-        }
+        from opencontractserver.utils.logging import redact_sensitive_kwargs
+
         logger.info(
             f"LlamaParseParser - Parsing doc {doc_id} for user {user_id} "
-            f"with effective kwargs: {safe_kwargs}"
+            f"with effective kwargs: {redact_sensitive_kwargs(all_kwargs)}"
         )
 
         # Override settings with kwargs if provided

--- a/opencontractserver/pipeline/post_processors/pdf_redactor.py
+++ b/opencontractserver/pipeline/post_processors/pdf_redactor.py
@@ -13,6 +13,7 @@ from opencontractserver.types.dicts import (
     OpenContractsExportDataJsonPythonType,
     OpenContractsSinglePageAnnotationType,
 )
+from opencontractserver.utils.logging import redact_sensitive_kwargs
 
 logger = logging.getLogger(__name__)
 
@@ -53,7 +54,10 @@ class PDFRedactor(BasePostProcessor):
         with redacted PDFs.
         Settings (like 'labels_to_redact') are sourced from all_kwargs.
         """
-        logger.debug(f"PDFRedactor processing export. Effective kwargs: {all_kwargs}")
+        logger.debug(
+            f"PDFRedactor processing export. Effective kwargs: "
+            f"{redact_sensitive_kwargs(all_kwargs)}"
+        )
         try:
             labels_to_redact = all_kwargs.get("labels_to_redact", [])
 

--- a/opencontractserver/tasks/doc_tasks.py
+++ b/opencontractserver/tasks/doc_tasks.py
@@ -227,9 +227,14 @@ def ingest_doc(self, user_id: int, doc_id: int) -> None:
     # Attempt to load parser kwargs
     parser_kwargs = {}
     if hasattr(settings, "PARSER_KWARGS"):
+        from opencontractserver.utils.logging import redact_sensitive_kwargs
+
         kwargs = getattr(settings, "PARSER_KWARGS", {})
         parser_kwargs = kwargs.get(parser_name, {})
-        logger.debug(f"Resolved parser kwargs for '{parser_name}': {parser_kwargs}")
+        logger.debug(
+            f"Resolved parser kwargs for '{parser_name}': "
+            f"{redact_sensitive_kwargs(parser_kwargs)}"
+        )
 
     # Get the parser class using get_component_by_name
     try:

--- a/opencontractserver/tests/test_logging_utils.py
+++ b/opencontractserver/tests/test_logging_utils.py
@@ -52,7 +52,9 @@ class TestRedactSensitiveKwargs(TestCase):
 
     def test_no_false_positives_keyboard(self):
         """Test that 'keyboard' is NOT redacted (no false positive on 'key')."""
-        result = redact_sensitive_kwargs({"keyboard": "qwerty", "keyboard_layout": "us"})
+        result = redact_sensitive_kwargs(
+            {"keyboard": "qwerty", "keyboard_layout": "us"}
+        )
         self.assertEqual(result, {"keyboard": "qwerty", "keyboard_layout": "us"})
 
     def test_no_false_positives_monkey(self):

--- a/opencontractserver/tests/test_logging_utils.py
+++ b/opencontractserver/tests/test_logging_utils.py
@@ -1,0 +1,162 @@
+"""
+Tests for opencontractserver/utils/logging.py
+"""
+
+from django.test import TestCase
+
+from opencontractserver.utils.logging import redact_sensitive_kwargs
+
+
+class TestRedactSensitiveKwargs(TestCase):
+    """Tests for the redact_sensitive_kwargs utility function."""
+
+    def test_redacts_api_key(self):
+        """Test that api_key is redacted."""
+        result = redact_sensitive_kwargs({"api_key": "sk-123", "verbose": True})
+        self.assertEqual(result, {"api_key": "***", "verbose": True})
+
+    def test_redacts_apikey_no_underscore(self):
+        """Test that apikey (no underscore) is redacted."""
+        result = redact_sensitive_kwargs({"apikey": "sk-123"})
+        self.assertEqual(result, {"apikey": "***"})
+
+    def test_case_insensitive_matching(self):
+        """Test that matching is case-insensitive."""
+        result = redact_sensitive_kwargs({"API_KEY": "sk-123", "ApiKey": "sk-456"})
+        self.assertEqual(result, {"API_KEY": "***", "ApiKey": "***"})
+
+    def test_multiple_sensitive_patterns(self):
+        """Test that multiple sensitive patterns are all redacted."""
+        result = redact_sensitive_kwargs(
+            {
+                "password": "pass123",
+                "access_token": "token456",
+                "client_secret": "secret789",
+                "safe_value": "not_sensitive",
+            }
+        )
+        self.assertEqual(
+            result,
+            {
+                "password": "***",
+                "access_token": "***",
+                "client_secret": "***",
+                "safe_value": "not_sensitive",
+            },
+        )
+
+    def test_empty_dict(self):
+        """Test that empty dict returns empty dict."""
+        result = redact_sensitive_kwargs({})
+        self.assertEqual(result, {})
+
+    def test_no_false_positives_keyboard(self):
+        """Test that 'keyboard' is NOT redacted (no false positive on 'key')."""
+        result = redact_sensitive_kwargs({"keyboard": "qwerty", "keyboard_layout": "us"})
+        self.assertEqual(result, {"keyboard": "qwerty", "keyboard_layout": "us"})
+
+    def test_no_false_positives_monkey(self):
+        """Test that 'monkey' is NOT redacted (no false positive on 'key')."""
+        result = redact_sensitive_kwargs({"monkey": "banana"})
+        self.assertEqual(result, {"monkey": "banana"})
+
+    def test_nested_dict_redaction(self):
+        """Test that nested dictionaries are recursively redacted."""
+        result = redact_sensitive_kwargs(
+            {
+                "provider_config": {
+                    "api_key": "secret123",
+                    "endpoint": "https://api.example.com",
+                },
+                "verbose": True,
+            }
+        )
+        self.assertEqual(
+            result,
+            {
+                "provider_config": {
+                    "api_key": "***",
+                    "endpoint": "https://api.example.com",
+                },
+                "verbose": True,
+            },
+        )
+
+    def test_deeply_nested_dict_redaction(self):
+        """Test that deeply nested dictionaries are recursively redacted."""
+        result = redact_sensitive_kwargs(
+            {
+                "level1": {
+                    "level2": {
+                        "level3": {
+                            "api_key": "deep_secret",
+                        }
+                    }
+                }
+            }
+        )
+        self.assertEqual(
+            result,
+            {"level1": {"level2": {"level3": {"api_key": "***"}}}},
+        )
+
+    def test_list_of_dicts_redaction(self):
+        """Test that lists of dictionaries are redacted."""
+        result = redact_sensitive_kwargs(
+            {
+                "providers": [
+                    {"name": "openai", "api_key": "sk-123"},
+                    {"name": "anthropic", "api_key": "sk-456"},
+                ]
+            }
+        )
+        self.assertEqual(
+            result,
+            {
+                "providers": [
+                    {"name": "openai", "api_key": "***"},
+                    {"name": "anthropic", "api_key": "***"},
+                ]
+            },
+        )
+
+    def test_list_of_non_dicts_unchanged(self):
+        """Test that lists of non-dict values are unchanged."""
+        result = redact_sensitive_kwargs(
+            {"items": [1, 2, 3], "names": ["alice", "bob"]}
+        )
+        self.assertEqual(result, {"items": [1, 2, 3], "names": ["alice", "bob"]})
+
+    def test_mixed_list_redaction(self):
+        """Test that mixed lists (dicts and non-dicts) are handled correctly."""
+        result = redact_sensitive_kwargs(
+            {"mixed": [{"api_key": "secret"}, "string", 123, {"safe": "value"}]}
+        )
+        self.assertEqual(
+            result,
+            {"mixed": [{"api_key": "***"}, "string", 123, {"safe": "value"}]},
+        )
+
+    def test_authorization_header_redacted(self):
+        """Test that authorization-related keys are redacted."""
+        result = redact_sensitive_kwargs(
+            {"authorization": "Bearer xyz", "authorization_header": "token"}
+        )
+        self.assertEqual(
+            result, {"authorization": "***", "authorization_header": "***"}
+        )
+
+    def test_bearer_token_redacted(self):
+        """Test that bearer-related keys are redacted."""
+        result = redact_sensitive_kwargs({"bearer_token": "xyz123"})
+        self.assertEqual(result, {"bearer_token": "***"})
+
+    def test_credential_redacted(self):
+        """Test that credential-related keys are redacted."""
+        result = redact_sensitive_kwargs(
+            {"credential": "abc", "user_credential": "def", "credentials_file": "/path"}
+        )
+        self.assertEqual(
+            result,
+            {"credential": "***", "user_credential": "***", "credentials_file": "***"},
+        )

--- a/opencontractserver/utils/logging.py
+++ b/opencontractserver/utils/logging.py
@@ -7,15 +7,28 @@ Provides helper functions for safe logging that avoid exposing sensitive data.
 from typing import Any
 
 # Keys that should be redacted in logs (case-insensitive partial match)
-SENSITIVE_KEY_PATTERNS = ("key", "secret", "password", "token", "credential")
+# Using specific patterns to avoid false positives (e.g., "keyboard", "hockey")
+SENSITIVE_KEY_PATTERNS = (
+    "_key",  # Matches api_key, secret_key, but not keyboard
+    "apikey",  # Matches apikey, ApiKey (no underscore variant)
+    "_secret",  # Matches client_secret, app_secret
+    "secret_",  # Matches secret_key, secret_id
+    "password",
+    "_token",  # Matches access_token, auth_token
+    "token_",  # Matches token_secret, token_id
+    "credential",
+    "authorization",
+    "bearer",  # Common auth header value prefix
+)
 
 
 def redact_sensitive_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
     """
-    Redact sensitive values from a kwargs dict before logging.
+    Recursively redact sensitive values from a kwargs dict before logging.
 
     Matches keys containing common sensitive patterns like 'api_key', 'secret',
-    'password', 'token', etc. (case-insensitive).
+    'password', 'token', etc. (case-insensitive). Handles nested dictionaries
+    and lists of dictionaries.
 
     Args:
         kwargs: Dictionary of keyword arguments that may contain sensitive values.
@@ -26,12 +39,21 @@ def redact_sensitive_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
     Example:
         >>> redact_sensitive_kwargs({"api_key": "sk-123", "verbose": True})
         {"api_key": "***", "verbose": True}
+
+        >>> redact_sensitive_kwargs({"config": {"api_key": "sk-123"}})
+        {"config": {"api_key": "***"}}
     """
-    return {
-        k: (
-            "***"
-            if any(pattern in k.lower() for pattern in SENSITIVE_KEY_PATTERNS)
-            else v
-        )
-        for k, v in kwargs.items()
-    }
+    result = {}
+    for k, v in kwargs.items():
+        if any(pattern in k.lower() for pattern in SENSITIVE_KEY_PATTERNS):
+            result[k] = "***"
+        elif isinstance(v, dict):
+            result[k] = redact_sensitive_kwargs(v)
+        elif isinstance(v, list):
+            result[k] = [
+                redact_sensitive_kwargs(item) if isinstance(item, dict) else item
+                for item in v
+            ]
+        else:
+            result[k] = v
+    return result

--- a/opencontractserver/utils/logging.py
+++ b/opencontractserver/utils/logging.py
@@ -1,0 +1,37 @@
+"""
+Logging utilities for OpenContracts.
+
+Provides helper functions for safe logging that avoid exposing sensitive data.
+"""
+
+from typing import Any
+
+# Keys that should be redacted in logs (case-insensitive partial match)
+SENSITIVE_KEY_PATTERNS = ("key", "secret", "password", "token", "credential")
+
+
+def redact_sensitive_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
+    """
+    Redact sensitive values from a kwargs dict before logging.
+
+    Matches keys containing common sensitive patterns like 'api_key', 'secret',
+    'password', 'token', etc. (case-insensitive).
+
+    Args:
+        kwargs: Dictionary of keyword arguments that may contain sensitive values.
+
+    Returns:
+        A new dictionary with sensitive values replaced with '***'.
+
+    Example:
+        >>> redact_sensitive_kwargs({"api_key": "sk-123", "verbose": True})
+        {"api_key": "***", "verbose": True}
+    """
+    return {
+        k: (
+            "***"
+            if any(pattern in k.lower() for pattern in SENSITIVE_KEY_PATTERNS)
+            else v
+        )
+        for k, v in kwargs.items()
+    }


### PR DESCRIPTION
## Summary
- Fix JWT authentication to return generic error messages instead of exposing exception details (CodeQL py/stack-trace-exposure)
- Add `redact_sensitive_kwargs()` utility to filter sensitive data from log output
- Apply redaction across parser, embedder, and post-processor kwargs logging

## Security Issues Addressed
1. **JWT error message exposure**: `JSONWebTokenError` details were returned to users, potentially exposing internal information
2. **API key logging**: Parser and embedder kwargs containing `api_key` and similar sensitive keys were logged in plaintext

## Changes
| File | Change |
|------|--------|
| `config/rest_jwt_auth.py` | Return generic "Invalid token" message, log details server-side |
| `opencontractserver/utils/logging.py` | New `redact_sensitive_kwargs()` utility |
| `opencontractserver/tasks/doc_tasks.py` | Redact parser kwargs before logging |
| `opencontractserver/pipeline/base/embedder.py` | Redact embedder kwargs before logging |
| `opencontractserver/pipeline/base/post_processor.py` | Redact post-processor kwargs before logging |
| `opencontractserver/pipeline/parsers/llamaparse_parser.py` | Use shared redaction utility |

## Sensitive Key Patterns Redacted
- `key` (matches `api_key`, `API_KEY`, etc.)
- `secret`
- `password`
- `token`
- `credential`

## Test plan
- [ ] Verify JWT errors return generic message to client
- [ ] Verify sensitive kwargs are redacted in logs
- [ ] Run existing tests to ensure no regressions