### PR TITLE
Enforce documents must belong to at least one corpus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+#### Documents Must Belong to Corpus Constraint
+- **Enforces that all documents must belong to at least one corpus**
+  - Documents can no longer exist without a corpus association
+  - Upload mutations now require `add_to_corpus_id` parameter
+  - Removal from last corpus is prevented
+  - System corpuses cannot be deleted
+  - Files: `config/graphql/mutations.py` (lines 1567-1571, 950-1002, 3593-3624)
+- **`is_system_corpus` field on Corpus model**
+  - Identifies system-managed corpuses like "My Documents" and "Shared With Me"
+  - Prevents accidental deletion of system corpuses
+  - Files: `opencontractserver/corpuses/models.py` (lines 197-201)
+  - Migration: `opencontractserver/corpuses/migrations/0037_add_is_system_corpus_field.py`
+- **`migrate_orphaned_documents` management command**
+  - Migrates orphaned documents to per-user system corpuses
+  - Creates "My Documents" corpus for users with edit access
+  - Creates "Shared With Me" corpus for users with read-only access
+  - Cleans up non-default embeddings during migration
+  - Usage: `python manage.py migrate_orphaned_documents [--dry-run] [--verbose]`
+  - Files: `opencontractserver/documents/management/commands/migrate_orphaned_documents.py`
+- **Tests for document-corpus constraints**
+  - Tests for orphan migration, removal constraints, deletion constraints
+  - Files: `opencontractserver/tests/test_orphan_document_migration.py`
+
+### Changed
+- **Frontend UploadModal now requires corpus selection**
+  - Removed "Skip Corpus" button from upload flow
+  - Corpus selection step subtitle changed to "Select a corpus for your documents"
+  - Upload button disabled until corpus is selected
+  - Files: `frontend/src/components/widgets/modals/UploadModal/UploadModal.tsx`
+
 #### Unified Upload Modal with @os-legal/ui Design System
 - **Consolidated `BulkUploadModal` and `DocumentUploadModal`** into single `UploadModal` component
   - Auto-detects upload mode: ZIP files → bulk mode, PDFs → single mode

--- a/config/graphql/mutations.py
+++ b/config/graphql/mutations.py
@@ -950,6 +950,7 @@ class RemoveDocumentsFromCorpus(graphene.Mutation):
     @login_required
     def mutate(root, info, corpus_id, document_ids_to_remove):
         from opencontractserver.corpuses.folder_service import DocumentFolderService
+        from opencontractserver.documents.models import DocumentPath
 
         try:
             user = info.context.user
@@ -957,6 +958,28 @@ class RemoveDocumentsFromCorpus(graphene.Mutation):
                 int(from_global_id(doc_id)[1]) for doc_id in document_ids_to_remove
             ]
             corpus = Corpus.objects.get(pk=from_global_id(corpus_id)[1])
+
+            # Check if any document would become orphaned (no longer in any corpus)
+            for doc_pk in doc_pks:
+                # Count active corpuses for this document, excluding the current corpus
+                other_corpus_count = (
+                    DocumentPath.objects.filter(
+                        document_id=doc_pk,
+                        is_current=True,
+                        is_deleted=False,
+                    )
+                    .exclude(corpus=corpus)
+                    .values("corpus")
+                    .distinct()
+                    .count()
+                )
+
+                if other_corpus_count == 0:
+                    return RemoveDocumentsFromCorpus(
+                        message="Cannot remove document from its last corpus. "
+                        "Documents must belong to at least one corpus.",
+                        ok=False,
+                    )
 
             # Delegate to service - handles permission checks, soft-delete, audit trail
             removed_count, error = DocumentFolderService.remove_documents_from_corpus(
@@ -1565,9 +1588,9 @@ class UploadDocument(graphene.Mutation):
         )
         custom_meta = GenericScalar(required=False, description="")
         add_to_corpus_id = graphene.ID(
-            required=False,
-            description="If provided, successfully uploaded document will "
-            "be uploaded to corpus with specified id",
+            required=True,
+            description="Corpus to add the uploaded document to. "
+            "Documents must always belong to at least one corpus.",
         )
         add_to_extract_id = graphene.ID(
             required=False,
@@ -1600,17 +1623,13 @@ class UploadDocument(graphene.Mutation):
         description,
         custom_meta,
         make_public,
-        add_to_corpus_id=None,
+        add_to_corpus_id,
         add_to_extract_id=None,
         add_to_folder_id=None,
         slug=None,
     ):
-        if add_to_corpus_id is not None and add_to_extract_id is not None:
-            return UploadDocument(
-                message="Cannot simultaneously add document to both corpus and extract",
-                ok=False,
-                document=None,
-            )
+        # Note: add_to_extract_id is deprecated but kept for backwards compatibility
+        # Documents must always belong to a corpus
 
         ok = False
         document = None
@@ -1652,28 +1671,29 @@ class UploadDocument(graphene.Mutation):
 
             user = info.context.user
 
-            # If uploading directly to a corpus, use import_content() for deduplication
-            if add_to_corpus_id is not None and kind in [
-                "application/pdf",
-                "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-                "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-            ]:
-                try:
-                    corpus = Corpus.objects.get(id=from_global_id(add_to_corpus_id)[1])
+            # All documents must belong to a corpus
+            try:
+                corpus = Corpus.objects.get(id=from_global_id(add_to_corpus_id)[1])
 
-                    # Resolve folder if provided
-                    folder = None
-                    if add_to_folder_id is not None:
-                        folder_pk = from_global_id(add_to_folder_id)[1]
-                        folder = CorpusFolder.objects.get(pk=folder_pk, corpus=corpus)
+                # Resolve folder if provided
+                folder = None
+                if add_to_folder_id is not None:
+                    folder_pk = from_global_id(add_to_folder_id)[1]
+                    folder = CorpusFolder.objects.get(pk=folder_pk, corpus=corpus)
 
-                    # Generate path from filename
-                    safe_filename = "".join(
-                        c if c.isalnum() or c in "-_." else "_" for c in filename[:100]
-                    )
-                    doc_path = f"/documents/{safe_filename}"
+                # Generate path from filename
+                safe_filename = "".join(
+                    c if c.isalnum() or c in "-_." else "_" for c in filename[:100]
+                )
+                doc_path = f"/documents/{safe_filename}"
 
+                # For binary document types, use import_content for deduplication
+                if kind in [
+                    "application/pdf",
+                    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+                    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                ]:
                     # Use import_content for content-based deduplication
                     document, status, path_record = corpus.import_content(
                         content=file_bytes,
@@ -1689,11 +1709,6 @@ class UploadDocument(graphene.Mutation):
                         slug=slug,
                     )
 
-                    # Set permissions on the document (may be new or reused)
-                    set_permissions_for_obj_to_user(
-                        user, document, [PermissionTypes.CRUD]
-                    )
-
                     if status == "created":
                         logger.info(
                             f"[UPLOAD] Created new document {document.id} in corpus {corpus.id}"
@@ -1707,35 +1722,8 @@ class UploadDocument(graphene.Mutation):
                             f"[UPLOAD] Document {document.id} status: {status} in corpus {corpus.id}"
                         )
 
-                    # Note: folder assignment is already handled by corpus.import_content()
-                    # which passes folder to import_document() -> DocumentPath creation
-
-                except Exception as e:
-                    logger.error(f"[UPLOAD] Error importing to corpus: {e}")
-                    message = f"Importing to corpus failed due to error: {e}"
-                    return UploadDocument(message=message, ok=False, document=None)
-            else:
-                # Standalone document upload (no corpus) - create directly
-                if kind in [
-                    "application/pdf",
-                    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-                    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-                    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-                ]:
-                    pdf_file = ContentFile(file_bytes, name=filename)
-                    document = Document(
-                        creator=user,
-                        title=title,
-                        description=description,
-                        custom_meta=custom_meta,
-                        pdf_file=pdf_file,
-                        backend_lock=True,
-                        is_public=make_public,
-                        file_type=kind,
-                        slug=slug,
-                    )
-                    document.save()
                 elif kind in ["text/plain", "application/txt"]:
+                    # For text files, create document and add to corpus via DocumentPath
                     txt_extract_file = ContentFile(file_bytes, name=filename)
                     document = Document(
                         creator=user,
@@ -1750,22 +1738,45 @@ class UploadDocument(graphene.Mutation):
                     )
                     document.save()
 
-                set_permissions_for_obj_to_user(user, document, [PermissionTypes.CRUD])
+                    # Create DocumentPath to link document to corpus
+                    from opencontractserver.documents.models import DocumentPath
 
-                # Handle linking to extract (corpus case already handled above)
-                if add_to_extract_id is not None:
-                    try:
-                        extract = Extract.objects.get(
-                            Q(pk=from_global_id(add_to_extract_id)[1])
-                            & (Q(creator=user) | Q(is_public=True))
-                        )
-                        if extract.finished is not None:
-                            raise ValueError(
-                                "Cannot add document to a finished extract"
-                            )
-                        transaction.on_commit(lambda: extract.documents.add(document))
-                    except Exception as e:
-                        message = f"Adding to extract failed due to error: {e}"
+                    DocumentPath.objects.create(
+                        document=document,
+                        corpus=corpus,
+                        folder=folder,
+                        path=doc_path,
+                        version_number=1,
+                        is_current=True,
+                        is_deleted=False,
+                        creator=user,
+                    )
+                    logger.info(
+                        f"[UPLOAD] Created text document {document.id} in corpus {corpus.id}"
+                    )
+
+                else:
+                    return UploadDocument(
+                        message=f"Unsupported file type: {kind}",
+                        ok=False,
+                        document=None,
+                    )
+
+                # Set permissions on the document (may be new or reused)
+                set_permissions_for_obj_to_user(
+                    user, document, [PermissionTypes.CRUD]
+                )
+
+            except Corpus.DoesNotExist:
+                return UploadDocument(
+                    message="Specified corpus not found",
+                    ok=False,
+                    document=None,
+                )
+            except Exception as e:
+                logger.error(f"[UPLOAD] Error importing to corpus: {e}")
+                message = f"Importing to corpus failed due to error: {e}"
+                return UploadDocument(message=message, ok=False, document=None)
 
             ok = True
 
@@ -1799,8 +1810,9 @@ class UploadDocumentsZip(graphene.Mutation):
             required=False, description="Optional metadata to apply to all documents"
         )
         add_to_corpus_id = graphene.ID(
-            required=False,
-            description="If provided, successfully uploaded documents will be added to corpus with specified id",
+            required=True,
+            description="Corpus to add the uploaded documents to. "
+            "Documents must always belong to at least one corpus.",
         )
         make_public = graphene.Boolean(
             required=True,
@@ -1818,10 +1830,10 @@ class UploadDocumentsZip(graphene.Mutation):
         info,
         base64_file_string,
         make_public,
+        add_to_corpus_id,
         title_prefix=None,
         description=None,
         custom_meta=None,
-        add_to_corpus_id=None,
     ):
         # Was going to user a user_passes_test decorator, but I wanted a custom error message
         # that could be easily reflected to user in the GUI.
@@ -3585,6 +3597,31 @@ class DeleteCorpusMutation(DRFDeletion):
 
     class Arguments:
         id = graphene.String(required=True)
+
+    @classmethod
+    @login_required
+    @graphql_ratelimit(rate=RateLimits.WRITE_LIGHT)
+    def mutate(cls, root, info, id):
+        """Override to add system corpus and document checks."""
+        corpus_pk = from_global_id(id)[1]
+        corpus = Corpus.objects.get(pk=corpus_pk)
+
+        # Prevent deletion of system corpuses
+        if corpus.is_system_corpus:
+            raise PermissionError(
+                "System corpuses cannot be deleted. "
+                "These are auto-managed corpuses like 'My Documents'."
+            )
+
+        # Prevent deletion if corpus has documents
+        if corpus.document_count() > 0:
+            raise PermissionError(
+                "Cannot delete corpus containing documents. "
+                "Remove or reassign all documents first."
+            )
+
+        # Delegate to parent class for standard deletion logic
+        return super().mutate(root, info, id=id)
 
 
 class CreateLabelMutation(DRFMutation):

--- a/frontend/src/components/widgets/modals/UploadModal/UploadModal.tsx
+++ b/frontend/src/components/widgets/modals/UploadModal/UploadModal.tsx
@@ -316,12 +316,6 @@ export const UploadModal: React.FC<UploadModalProps> = ({
     onClose,
   ]);
 
-  // Handle skip corpus
-  const handleSkipCorpus = useCallback(() => {
-    setStep("uploading");
-    uploadMutations.uploadFiles(uploadState.files, null);
-  }, [uploadState.files, uploadMutations]);
-
   // Get header content
   const getHeaderTitle = () => {
     if (mode === "bulk") {
@@ -354,7 +348,7 @@ export const UploadModal: React.FC<UploadModalProps> = ({
       case "details":
         return "Review and edit document details";
       case "corpus":
-        return "Optionally add to a corpus";
+        return "Select a corpus for your documents";
       case "uploading":
         return "Processing your uploads...";
       default:
@@ -609,25 +603,16 @@ export const UploadModal: React.FC<UploadModalProps> = ({
                       Upload
                     </Button>
                   ) : (
-                    <>
-                      <Button
-                        variant="secondary"
-                        onClick={handleSkipCorpus}
-                        disabled={!isFormValid()}
-                      >
-                        Skip Corpus
-                      </Button>
-                      <Button
-                        variant="primary"
-                        onClick={handleContinue}
-                        disabled={!isFormValid()}
-                      >
-                        Continue
-                        <ArrowRight
-                          style={{ width: 16, height: 16, marginLeft: 8 }}
-                        />
-                      </Button>
-                    </>
+                    <Button
+                      variant="primary"
+                      onClick={handleContinue}
+                      disabled={!isFormValid()}
+                    >
+                      Continue
+                      <ArrowRight
+                        style={{ width: 16, height: 16, marginLeft: 8 }}
+                      />
+                    </Button>
                   )}
                 </>
               )}
@@ -640,10 +625,11 @@ export const UploadModal: React.FC<UploadModalProps> = ({
                     />
                     Back
                   </Button>
-                  <Button variant="secondary" onClick={handleSkipCorpus}>
-                    Skip
-                  </Button>
-                  <Button variant="primary" onClick={handleContinue}>
+                  <Button
+                    variant="primary"
+                    onClick={handleContinue}
+                    disabled={!selectedCorpus}
+                  >
                     <Upload style={{ width: 16, height: 16, marginRight: 8 }} />
                     Upload
                   </Button>

--- a/opencontractserver/corpuses/migrations/0037_add_is_system_corpus_field.py
+++ b/opencontractserver/corpuses/migrations/0037_add_is_system_corpus_field.py
@@ -1,0 +1,21 @@
+# Generated manually
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("corpuses", "0036_alter_corpusquerygroupobjectpermission_unique_together_and_more"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="corpus",
+            name="is_system_corpus",
+            field=models.BooleanField(
+                default=False,
+                help_text="System-managed corpus (e.g., 'My Documents'). Cannot be deleted by users.",
+            ),
+        ),
+    ]

--- a/opencontractserver/corpuses/models.py
+++ b/opencontractserver/corpuses/models.py
@@ -194,6 +194,12 @@ class Corpus(TreeNode):
     # Error status
     error = django.db.models.BooleanField(default=False)
 
+    # System corpus flag - used for auto-created corpuses like "My Documents"
+    is_system_corpus = django.db.models.BooleanField(
+        default=False,
+        help_text="System-managed corpus (e.g., 'My Documents'). Cannot be deleted by users.",
+    )
+
     # Timing variables
     created = django.db.models.DateTimeField(default=timezone.now)
     modified = django.db.models.DateTimeField(default=timezone.now, blank=True)

--- a/opencontractserver/documents/management/commands/migrate_orphaned_documents.py
+++ b/opencontractserver/documents/management/commands/migrate_orphaned_documents.py
@@ -1,0 +1,460 @@
+"""
+Management command to migrate orphaned documents (documents without any corpus) to
+per-user system corpuses.
+
+This command is part of the "documents must always belong to a corpus" constraint.
+It creates "My Documents" corpuses for document creators and users with edit permissions,
+and "Shared With Me" corpuses for users with read-only permissions.
+
+Usage:
+    python manage.py migrate_orphaned_documents [--dry-run] [--user-id ID] [--verbose]
+"""
+
+import logging
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+from opencontractserver.corpuses.models import Corpus
+from opencontractserver.documents.models import (
+    Document,
+    DocumentPath,
+    DocumentUserObjectPermission,
+)
+from opencontractserver.types.enums import PermissionTypes
+from opencontractserver.utils.permissioning import set_permissions_for_obj_to_user
+
+logger = logging.getLogger(__name__)
+User = get_user_model()
+
+# Permission codenames that grant edit access
+EDIT_PERMISSION_CODENAMES = {
+    "change_document",
+    "update_document",
+    "remove_document",
+    "delete_document",
+}
+
+# Permission codenames that grant read-only access
+READ_PERMISSION_CODENAMES = {
+    "view_document",
+    "read_document",
+}
+
+
+class Command(BaseCommand):
+    """
+    Migrate orphaned documents to per-user system corpuses.
+
+    This command:
+    1. Identifies documents with no active DocumentPath records (orphaned)
+    2. For each orphan, determines who has access via creator and guardian permissions
+    3. Creates "My Documents" corpus for users with edit access
+    4. Creates "Shared With Me" corpus for users with read-only access
+    5. Creates DocumentPath records linking documents to appropriate corpuses
+    6. Drops non-default embeddings (they'll be regenerated with corpus embedder)
+    """
+
+    help = "Migrate orphaned documents to per-user system corpuses"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Run in dry-run mode (no database changes)",
+        )
+        parser.add_argument(
+            "--user-id",
+            type=int,
+            help="Process only orphaned documents for a specific user by ID",
+        )
+        parser.add_argument(
+            "--batch-size",
+            type=int,
+            default=100,
+            help="Number of documents to process in each batch (default: 100)",
+        )
+        parser.add_argument(
+            "--verbose",
+            action="store_true",
+            help="Show detailed progress information",
+        )
+        parser.add_argument(
+            "--skip-embedding-cleanup",
+            action="store_true",
+            help="Skip deletion of non-default embeddings",
+        )
+
+    def handle(self, *args, **options):
+        """Execute the migration command."""
+        dry_run = options["dry_run"]
+        user_id = options.get("user_id")
+        batch_size = options["batch_size"]
+        verbose = options["verbose"]
+        skip_embedding_cleanup = options["skip_embedding_cleanup"]
+
+        if dry_run:
+            self.stdout.write(
+                self.style.WARNING("Running in DRY-RUN mode - no changes will be made")
+            )
+
+        # Find all orphaned documents
+        orphaned_docs = self._find_orphaned_documents(user_id)
+        total_orphans = orphaned_docs.count()
+
+        if total_orphans == 0:
+            self.stdout.write(
+                self.style.SUCCESS("No orphaned documents found. Nothing to migrate.")
+            )
+            return
+
+        self.stdout.write(f"Found {total_orphans} orphaned document(s) to process\n")
+
+        # Track statistics
+        stats = {
+            "documents_processed": 0,
+            "my_documents_corpuses_created": 0,
+            "shared_with_me_corpuses_created": 0,
+            "document_paths_created": 0,
+            "embeddings_deleted": 0,
+            "errors": [],
+        }
+
+        # Process documents in batches
+        processed = 0
+        for doc in orphaned_docs.iterator():
+            try:
+                doc_stats = self._process_orphaned_document(
+                    document=doc,
+                    dry_run=dry_run,
+                    verbose=verbose,
+                    skip_embedding_cleanup=skip_embedding_cleanup,
+                )
+
+                stats["documents_processed"] += 1
+                stats["my_documents_corpuses_created"] += doc_stats[
+                    "my_documents_created"
+                ]
+                stats["shared_with_me_corpuses_created"] += doc_stats[
+                    "shared_with_me_created"
+                ]
+                stats["document_paths_created"] += doc_stats["paths_created"]
+                stats["embeddings_deleted"] += doc_stats["embeddings_deleted"]
+
+                processed += 1
+                if processed % batch_size == 0:
+                    self.stdout.write(f"  Processed {processed}/{total_orphans}...")
+
+            except Exception as e:
+                error_msg = f"Error processing document {doc.pk}: {e}"
+                stats["errors"].append(error_msg)
+                self.stdout.write(self.style.ERROR(error_msg))
+                if verbose:
+                    import traceback
+
+                    self.stdout.write(traceback.format_exc())
+
+        # Print summary
+        self._print_summary(stats, dry_run)
+
+    def _find_orphaned_documents(self, user_id=None):
+        """Find documents with no active DocumentPath records."""
+        # Get IDs of documents that have active paths
+        docs_with_paths = DocumentPath.objects.filter(
+            is_current=True, is_deleted=False
+        ).values_list("document_id", flat=True)
+
+        # Find documents NOT in that set
+        orphaned = Document.objects.exclude(id__in=docs_with_paths)
+
+        if user_id:
+            orphaned = orphaned.filter(creator_id=user_id)
+
+        return orphaned.order_by("id")
+
+    def _process_orphaned_document(
+        self, document, dry_run, verbose, skip_embedding_cleanup
+    ):
+        """Process a single orphaned document."""
+        stats = {
+            "my_documents_created": 0,
+            "shared_with_me_created": 0,
+            "paths_created": 0,
+            "embeddings_deleted": 0,
+        }
+
+        if verbose:
+            self.stdout.write(
+                f"\nProcessing document {document.pk}: {document.title or '(untitled)'}"
+            )
+
+        # Determine who has access to this document
+        users_with_edit = set()
+        users_with_read_only = set()
+
+        # Creator always has edit access
+        if document.creator:
+            users_with_edit.add(document.creator)
+
+        # Check guardian permissions
+        perms = DocumentUserObjectPermission.objects.filter(
+            content_object=document
+        ).select_related("user", "permission")
+
+        for perm in perms:
+            user = perm.user
+            if user == document.creator:
+                continue  # Already handled
+
+            codename = perm.permission.codename
+            if codename in EDIT_PERMISSION_CODENAMES:
+                users_with_edit.add(user)
+                # Remove from read-only if they have edit
+                users_with_read_only.discard(user)
+            elif codename in READ_PERMISSION_CODENAMES:
+                # Only add to read-only if they don't have edit
+                if user not in users_with_edit:
+                    users_with_read_only.add(user)
+
+        if verbose:
+            self.stdout.write(
+                f"  Users with edit access: {[u.username for u in users_with_edit]}"
+            )
+            self.stdout.write(
+                f"  Users with read-only access: {[u.username for u in users_with_read_only]}"
+            )
+
+        # Create corpus assignments for users with edit access
+        for user in users_with_edit:
+            corpus, created = self._get_or_create_my_documents_corpus(user, dry_run)
+            if created:
+                stats["my_documents_created"] += 1
+
+            if self._create_document_path(document, corpus, user, dry_run, verbose):
+                stats["paths_created"] += 1
+
+        # Create corpus assignments for users with read-only access
+        for user in users_with_read_only:
+            corpus, created = self._get_or_create_shared_with_me_corpus(user, dry_run)
+            if created:
+                stats["shared_with_me_created"] += 1
+
+            if self._create_document_path(document, corpus, user, dry_run, verbose):
+                stats["paths_created"] += 1
+
+        # Clean up non-default embeddings
+        if not skip_embedding_cleanup:
+            deleted_count = self._cleanup_embeddings(document, dry_run, verbose)
+            stats["embeddings_deleted"] = deleted_count
+
+        return stats
+
+    def _get_or_create_my_documents_corpus(self, user, dry_run):
+        """Get or create user's editable 'My Documents' corpus."""
+        try:
+            corpus = Corpus.objects.get(
+                creator=user, title="My Documents", is_system_corpus=True
+            )
+            return corpus, False
+        except Corpus.DoesNotExist:
+            if dry_run:
+                # Return a fake corpus for dry run
+                return None, True
+
+            with transaction.atomic():
+                corpus = Corpus.objects.create(
+                    creator=user,
+                    title="My Documents",
+                    description="Auto-created corpus for your documents",
+                    is_public=False,
+                    is_system_corpus=True,
+                )
+                set_permissions_for_obj_to_user(user, corpus, [PermissionTypes.CRUD])
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        f"  Created 'My Documents' corpus for user {user.username}"
+                    )
+                )
+                return corpus, True
+
+    def _get_or_create_shared_with_me_corpus(self, user, dry_run):
+        """Get or create user's read-only 'Shared With Me' corpus."""
+        try:
+            corpus = Corpus.objects.get(
+                creator=user, title="Shared With Me", is_system_corpus=True
+            )
+            return corpus, False
+        except Corpus.DoesNotExist:
+            if dry_run:
+                # Return a fake corpus for dry run
+                return None, True
+
+            with transaction.atomic():
+                corpus = Corpus.objects.create(
+                    creator=user,
+                    title="Shared With Me",
+                    description="Documents shared with you (read-only)",
+                    is_public=False,
+                    is_system_corpus=True,
+                )
+                # User only gets read permission on this corpus
+                set_permissions_for_obj_to_user(user, corpus, [PermissionTypes.READ])
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        f"  Created 'Shared With Me' corpus for user {user.username}"
+                    )
+                )
+                return corpus, True
+
+    def _create_document_path(self, document, corpus, user, dry_run, verbose):
+        """Create DocumentPath linking document to corpus."""
+        if dry_run:
+            if verbose:
+                corpus_title = corpus.title if corpus else "(new corpus)"
+                self.stdout.write(
+                    f"    Would create DocumentPath: {document.title} -> {corpus_title}"
+                )
+            return True
+
+        # Check if path already exists (shouldn't happen but be safe)
+        existing = DocumentPath.objects.filter(
+            document=document, corpus=corpus, is_current=True, is_deleted=False
+        ).exists()
+
+        if existing:
+            if verbose:
+                self.stdout.write(
+                    f"    DocumentPath already exists for document {document.pk} in corpus {corpus.pk}"
+                )
+            return False
+
+        # Generate unique path
+        base_path = self._generate_path(document)
+        path = base_path
+        counter = 1
+
+        while DocumentPath.objects.filter(
+            corpus=corpus, path=path, is_current=True, is_deleted=False
+        ).exists():
+            path = f"{base_path}_{counter}"
+            counter += 1
+
+        with transaction.atomic():
+            DocumentPath.objects.create(
+                document=document,
+                corpus=corpus,
+                folder=None,
+                path=path,
+                version_number=1,
+                parent=None,
+                is_current=True,
+                is_deleted=False,
+                creator=user,
+            )
+
+        if verbose:
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"    Created DocumentPath: {path} in corpus '{corpus.title}'"
+                )
+            )
+
+        return True
+
+    def _generate_path(self, document):
+        """Generate a filesystem path for a document."""
+        if document.title:
+            safe_title = "".join(
+                c if c.isalnum() or c in "-_." else "_" for c in document.title[:100]
+            ).strip("_")
+            if safe_title:
+                return f"/migrated/{safe_title}"
+
+        return f"/migrated/document_{document.pk}"
+
+    def _cleanup_embeddings(self, document, dry_run, verbose):
+        """Delete non-default embeddings for the document."""
+        from opencontractserver.annotations.models import Embedding
+
+        default_embedder = getattr(settings, "DEFAULT_EMBEDDER", None)
+
+        if not default_embedder:
+            if verbose:
+                self.stdout.write(
+                    "    Skipping embedding cleanup - DEFAULT_EMBEDDER not configured"
+                )
+            return 0
+
+        # Find embeddings to delete (non-default)
+        embeddings_to_delete = Embedding.objects.filter(document=document).exclude(
+            embedder_path=default_embedder
+        )
+
+        count = embeddings_to_delete.count()
+
+        if count == 0:
+            return 0
+
+        if dry_run:
+            if verbose:
+                self.stdout.write(
+                    f"    Would delete {count} non-default embedding(s)"
+                )
+            return count
+
+        embeddings_to_delete.delete()
+
+        if verbose:
+            self.stdout.write(
+                self.style.SUCCESS(f"    Deleted {count} non-default embedding(s)")
+            )
+
+        return count
+
+    def _print_summary(self, stats, dry_run):
+        """Print command execution summary."""
+        self.stdout.write("\n" + "=" * 60)
+        self.stdout.write(
+            self.style.SUCCESS("MIGRATION SUMMARY")
+            if not stats["errors"]
+            else self.style.WARNING("MIGRATION SUMMARY (WITH ERRORS)")
+        )
+        self.stdout.write("=" * 60)
+
+        if dry_run:
+            self.stdout.write(self.style.WARNING("DRY-RUN MODE - No changes were made"))
+
+        self.stdout.write(f"Documents processed: {stats['documents_processed']}")
+        self.stdout.write(
+            f"'My Documents' corpuses created: {stats['my_documents_corpuses_created']}"
+        )
+        self.stdout.write(
+            f"'Shared With Me' corpuses created: {stats['shared_with_me_corpuses_created']}"
+        )
+        self.stdout.write(f"DocumentPaths created: {stats['document_paths_created']}")
+        self.stdout.write(f"Embeddings deleted: {stats['embeddings_deleted']}")
+
+        if stats["errors"]:
+            self.stdout.write(
+                "\n" + self.style.ERROR(f"Errors ({len(stats['errors'])}):")
+            )
+            for error in stats["errors"]:
+                self.stdout.write(f"  - {error}")
+
+        self.stdout.write("=" * 60)
+
+        if not dry_run and stats["documents_processed"] > 0:
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"\nSuccessfully migrated {stats['documents_processed']} orphaned document(s)"
+                )
+            )
+        elif dry_run and stats["documents_processed"] > 0:
+            self.stdout.write(
+                self.style.WARNING(
+                    f"\nWould migrate {stats['documents_processed']} orphaned document(s)"
+                )
+            )
+            self.stdout.write("  Run without --dry-run to apply changes")

--- a/opencontractserver/tests/test_orphan_document_migration.py
+++ b/opencontractserver/tests/test_orphan_document_migration.py
@@ -1,0 +1,685 @@
+"""
+Tests for orphaned document migration command.
+
+This test file covers the migrate_orphaned_documents management command which:
+1. Finds documents with no active DocumentPath records (orphans)
+2. Creates "My Documents" corpuses for users with edit access
+3. Creates "Shared With Me" corpuses for users with read-only access
+4. Links orphaned documents to appropriate corpuses via DocumentPath
+5. Cleans up non-default embeddings
+"""
+
+from io import StringIO
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.core.files.base import ContentFile
+from django.core.management import call_command
+from django.test import TestCase, TransactionTestCase, override_settings
+from guardian.shortcuts import assign_perm
+
+from opencontractserver.corpuses.models import Corpus
+from opencontractserver.documents.models import (
+    Document,
+    DocumentPath,
+    DocumentUserObjectPermission,
+)
+
+User = get_user_model()
+
+
+class TestFindOrphanedDocuments(TestCase):
+    """Test finding orphaned documents."""
+
+    def setUp(self):
+        """Set up test data."""
+        self.user = User.objects.create_user(
+            username="testuser", email="test@example.com", password="testpass123"
+        )
+
+        # Create a document with a corpus (not orphaned)
+        self.corpus = Corpus.objects.create(
+            title="Test Corpus", description="Test corpus", creator=self.user
+        )
+
+        self.doc_with_corpus = Document.objects.create(
+            title="Document With Corpus",
+            description="Has a corpus",
+            creator=self.user,
+        )
+        self.doc_with_corpus.pdf_file.save(
+            "test.pdf", ContentFile(b"Test PDF content")
+        )
+
+        # Create DocumentPath for doc_with_corpus
+        DocumentPath.objects.create(
+            document=self.doc_with_corpus,
+            corpus=self.corpus,
+            path="/test/document.pdf",
+            version_number=1,
+            is_current=True,
+            is_deleted=False,
+            creator=self.user,
+        )
+
+        # Create orphaned document (no DocumentPath)
+        self.orphan_doc = Document.objects.create(
+            title="Orphaned Document",
+            description="No corpus",
+            creator=self.user,
+        )
+        self.orphan_doc.pdf_file.save("orphan.pdf", ContentFile(b"Orphan PDF content"))
+
+    def test_find_orphaned_documents(self):
+        """Test that orphaned documents are correctly identified."""
+        # Import the command to use its internal method
+        from opencontractserver.documents.management.commands.migrate_orphaned_documents import (
+            Command,
+        )
+
+        cmd = Command()
+        orphans = cmd._find_orphaned_documents()
+
+        self.assertEqual(orphans.count(), 1)
+        self.assertEqual(orphans.first(), self.orphan_doc)
+
+    def test_document_with_deleted_path_is_orphan(self):
+        """Test that document with only deleted paths is considered orphan."""
+        # Create another document
+        doc_deleted_path = Document.objects.create(
+            title="Document With Deleted Path",
+            description="Path was deleted",
+            creator=self.user,
+        )
+
+        # Create a deleted DocumentPath
+        DocumentPath.objects.create(
+            document=doc_deleted_path,
+            corpus=self.corpus,
+            path="/deleted/document.pdf",
+            version_number=1,
+            is_current=True,
+            is_deleted=True,  # Deleted!
+            creator=self.user,
+        )
+
+        from opencontractserver.documents.management.commands.migrate_orphaned_documents import (
+            Command,
+        )
+
+        cmd = Command()
+        orphans = cmd._find_orphaned_documents()
+
+        # Should find both orphans
+        self.assertEqual(orphans.count(), 2)
+        orphan_ids = set(orphans.values_list("id", flat=True))
+        self.assertIn(self.orphan_doc.id, orphan_ids)
+        self.assertIn(doc_deleted_path.id, orphan_ids)
+
+
+class TestOrphanMigrationCreatesMyDocuments(TransactionTestCase):
+    """Test migration creates 'My Documents' corpus for document creators."""
+
+    def setUp(self):
+        """Set up test data with orphaned document."""
+        self.user_a = User.objects.create_user(
+            username="user_a", email="usera@example.com", password="testpass123"
+        )
+
+        # Create orphaned document owned by user_a
+        self.orphan_doc = Document.objects.create(
+            title="Orphan Owned by A",
+            description="No corpus",
+            creator=self.user_a,
+        )
+        self.orphan_doc.pdf_file.save("orphan.pdf", ContentFile(b"Orphan PDF content"))
+
+    def test_migration_creates_my_documents_corpus(self):
+        """Test that migration creates 'My Documents' corpus for creator."""
+        out = StringIO()
+        call_command("migrate_orphaned_documents", stdout=out)
+
+        # Verify 'My Documents' corpus was created
+        my_docs = Corpus.objects.filter(
+            creator=self.user_a, title="My Documents", is_system_corpus=True
+        )
+        self.assertEqual(my_docs.count(), 1)
+
+        corpus = my_docs.first()
+        self.assertTrue(corpus.is_system_corpus)
+        self.assertFalse(corpus.is_public)
+
+    def test_migration_creates_document_path(self):
+        """Test that migration creates DocumentPath linking doc to corpus."""
+        call_command("migrate_orphaned_documents")
+
+        # Find the created corpus
+        my_docs = Corpus.objects.get(
+            creator=self.user_a, title="My Documents", is_system_corpus=True
+        )
+
+        # Verify DocumentPath was created
+        path = DocumentPath.objects.filter(
+            document=self.orphan_doc, corpus=my_docs, is_current=True, is_deleted=False
+        )
+        self.assertEqual(path.count(), 1)
+
+    def test_migration_dry_run_makes_no_changes(self):
+        """Test that dry-run mode doesn't create anything."""
+        out = StringIO()
+        call_command("migrate_orphaned_documents", "--dry-run", stdout=out)
+
+        # Verify no corpus was created
+        my_docs = Corpus.objects.filter(
+            creator=self.user_a, title="My Documents", is_system_corpus=True
+        )
+        self.assertEqual(my_docs.count(), 0)
+
+        # Verify no DocumentPath was created
+        paths = DocumentPath.objects.filter(document=self.orphan_doc)
+        self.assertEqual(paths.count(), 0)
+
+        # Check output mentions dry run
+        output = out.getvalue()
+        self.assertIn("DRY-RUN", output)
+
+    def test_migration_idempotent(self):
+        """Test that running migration twice doesn't create duplicates."""
+        call_command("migrate_orphaned_documents")
+        call_command("migrate_orphaned_documents")
+
+        # Should still have only one corpus
+        my_docs = Corpus.objects.filter(
+            creator=self.user_a, title="My Documents", is_system_corpus=True
+        )
+        self.assertEqual(my_docs.count(), 1)
+
+        # Should still have only one path
+        corpus = my_docs.first()
+        paths = DocumentPath.objects.filter(
+            document=self.orphan_doc, corpus=corpus, is_current=True, is_deleted=False
+        )
+        self.assertEqual(paths.count(), 1)
+
+
+class TestOrphanMigrationWithSharedDocuments(TransactionTestCase):
+    """Test migration handles shared documents correctly."""
+
+    def setUp(self):
+        """Set up test data with shared orphaned documents."""
+        self.user_a = User.objects.create_user(
+            username="user_a", email="usera@example.com", password="testpass123"
+        )
+        self.user_b = User.objects.create_user(
+            username="user_b", email="userb@example.com", password="testpass123"
+        )
+        self.user_c = User.objects.create_user(
+            username="user_c", email="userc@example.com", password="testpass123"
+        )
+
+        # Create orphaned document owned by user_a, shared read-only with user_b
+        self.orphan_shared_readonly = Document.objects.create(
+            title="Orphan Shared Read-Only",
+            description="Shared with B read-only",
+            creator=self.user_a,
+        )
+        self.orphan_shared_readonly.pdf_file.save(
+            "shared_ro.pdf", ContentFile(b"Shared RO content")
+        )
+        assign_perm("view_document", self.user_b, self.orphan_shared_readonly)
+
+        # Create orphaned document owned by user_a, shared with edit to user_c
+        self.orphan_shared_edit = Document.objects.create(
+            title="Orphan Shared Edit",
+            description="Shared with C for edit",
+            creator=self.user_a,
+        )
+        self.orphan_shared_edit.pdf_file.save(
+            "shared_edit.pdf", ContentFile(b"Shared Edit content")
+        )
+        assign_perm("change_document", self.user_c, self.orphan_shared_edit)
+
+    def test_migration_creates_shared_with_me_for_readonly(self):
+        """Test that read-only shared docs go to 'Shared With Me' corpus."""
+        call_command("migrate_orphaned_documents")
+
+        # User B should have 'Shared With Me' corpus
+        shared_corpus = Corpus.objects.filter(
+            creator=self.user_b, title="Shared With Me", is_system_corpus=True
+        )
+        self.assertEqual(shared_corpus.count(), 1)
+
+        corpus = shared_corpus.first()
+        self.assertTrue(corpus.is_system_corpus)
+
+        # Document should be linked to it
+        path = DocumentPath.objects.filter(
+            document=self.orphan_shared_readonly,
+            corpus=corpus,
+            is_current=True,
+            is_deleted=False,
+        )
+        self.assertEqual(path.count(), 1)
+
+    def test_migration_creates_my_documents_for_edit_shared(self):
+        """Test that edit-shared docs go to 'My Documents' corpus."""
+        call_command("migrate_orphaned_documents")
+
+        # User C should have 'My Documents' corpus (has edit rights)
+        my_docs = Corpus.objects.filter(
+            creator=self.user_c, title="My Documents", is_system_corpus=True
+        )
+        self.assertEqual(my_docs.count(), 1)
+
+        corpus = my_docs.first()
+
+        # Document should be linked to it
+        path = DocumentPath.objects.filter(
+            document=self.orphan_shared_edit,
+            corpus=corpus,
+            is_current=True,
+            is_deleted=False,
+        )
+        self.assertEqual(path.count(), 1)
+
+    def test_creator_also_gets_document(self):
+        """Test that creator also gets the document in their 'My Documents'."""
+        call_command("migrate_orphaned_documents")
+
+        # User A (creator) should have both docs in 'My Documents'
+        my_docs = Corpus.objects.get(
+            creator=self.user_a, title="My Documents", is_system_corpus=True
+        )
+
+        paths = DocumentPath.objects.filter(
+            corpus=my_docs, is_current=True, is_deleted=False
+        )
+        doc_ids = set(paths.values_list("document_id", flat=True))
+
+        self.assertIn(self.orphan_shared_readonly.id, doc_ids)
+        self.assertIn(self.orphan_shared_edit.id, doc_ids)
+
+    def test_user_with_both_permissions_gets_my_documents_only(self):
+        """Test that user with both view and change gets 'My Documents' only."""
+        # Give user_b both view and change permissions
+        assign_perm("change_document", self.user_b, self.orphan_shared_readonly)
+
+        call_command("migrate_orphaned_documents")
+
+        # User B should have 'My Documents' (edit trumps read-only)
+        my_docs = Corpus.objects.filter(
+            creator=self.user_b, title="My Documents", is_system_corpus=True
+        )
+        self.assertEqual(my_docs.count(), 1)
+
+        # User B should NOT have 'Shared With Me' for this document
+        # (they have edit access, so it goes to My Documents)
+        my_docs_corpus = my_docs.first()
+        path_in_my_docs = DocumentPath.objects.filter(
+            document=self.orphan_shared_readonly,
+            corpus=my_docs_corpus,
+            is_current=True,
+            is_deleted=False,
+        )
+        self.assertEqual(path_in_my_docs.count(), 1)
+
+
+class TestOrphanMigrationEmbeddingCleanup(TransactionTestCase):
+    """Test migration cleans up non-default embeddings."""
+
+    def setUp(self):
+        """Set up test data with orphaned document and embeddings."""
+        self.user = User.objects.create_user(
+            username="testuser", email="test@example.com", password="testpass123"
+        )
+
+        self.orphan_doc = Document.objects.create(
+            title="Orphan With Embeddings",
+            description="Has embeddings",
+            creator=self.user,
+        )
+        self.orphan_doc.pdf_file.save("orphan.pdf", ContentFile(b"Orphan PDF content"))
+
+    @override_settings(
+        DEFAULT_EMBEDDER="opencontractserver.pipeline.embedders.default.DefaultEmbedder"
+    )
+    def test_migration_deletes_non_default_embeddings(self):
+        """Test that non-default embeddings are deleted."""
+        from opencontractserver.annotations.models import Embedding
+
+        # Create embeddings - one default, one non-default
+        Embedding.objects.create(
+            document=self.orphan_doc,
+            embedder_path="opencontractserver.pipeline.embedders.default.DefaultEmbedder",
+            vector_384=[0.1] * 384,
+        )
+        Embedding.objects.create(
+            document=self.orphan_doc,
+            embedder_path="some.other.Embedder",
+            vector_384=[0.2] * 384,
+        )
+
+        self.assertEqual(Embedding.objects.filter(document=self.orphan_doc).count(), 2)
+
+        call_command("migrate_orphaned_documents")
+
+        # Only default embedding should remain
+        embeddings = Embedding.objects.filter(document=self.orphan_doc)
+        self.assertEqual(embeddings.count(), 1)
+        self.assertEqual(
+            embeddings.first().embedder_path,
+            "opencontractserver.pipeline.embedders.default.DefaultEmbedder",
+        )
+
+    def test_migration_skip_embedding_cleanup_flag(self):
+        """Test --skip-embedding-cleanup flag works."""
+        from opencontractserver.annotations.models import Embedding
+
+        # Create non-default embedding
+        Embedding.objects.create(
+            document=self.orphan_doc,
+            embedder_path="some.other.Embedder",
+            vector_384=[0.2] * 384,
+        )
+
+        call_command("migrate_orphaned_documents", "--skip-embedding-cleanup")
+
+        # Embedding should still exist
+        embeddings = Embedding.objects.filter(document=self.orphan_doc)
+        self.assertEqual(embeddings.count(), 1)
+
+
+class TestOrphanMigrationPathGeneration(TransactionTestCase):
+    """Test DocumentPath generation during migration."""
+
+    def setUp(self):
+        """Set up test data."""
+        self.user = User.objects.create_user(
+            username="testuser", email="test@example.com", password="testpass123"
+        )
+
+    def test_path_generated_from_title(self):
+        """Test that path is generated from document title."""
+        doc = Document.objects.create(
+            title="My Important Document",
+            description="Test",
+            creator=self.user,
+        )
+        doc.pdf_file.save("test.pdf", ContentFile(b"content"))
+
+        call_command("migrate_orphaned_documents")
+
+        corpus = Corpus.objects.get(
+            creator=self.user, title="My Documents", is_system_corpus=True
+        )
+        path = DocumentPath.objects.get(
+            document=doc, corpus=corpus, is_current=True, is_deleted=False
+        )
+
+        self.assertIn("My_Important_Document", path.path)
+        self.assertTrue(path.path.startswith("/migrated/"))
+
+    def test_path_uses_id_when_no_title(self):
+        """Test that path uses document ID when title is empty."""
+        doc = Document.objects.create(
+            title="",
+            description="No title",
+            creator=self.user,
+        )
+        doc.pdf_file.save("test.pdf", ContentFile(b"content"))
+
+        call_command("migrate_orphaned_documents")
+
+        corpus = Corpus.objects.get(
+            creator=self.user, title="My Documents", is_system_corpus=True
+        )
+        path = DocumentPath.objects.get(
+            document=doc, corpus=corpus, is_current=True, is_deleted=False
+        )
+
+        self.assertIn(f"document_{doc.pk}", path.path)
+
+    def test_path_conflict_resolution(self):
+        """Test that conflicting paths are resolved with suffix."""
+        # Create two documents with same title
+        doc1 = Document.objects.create(
+            title="Same Title",
+            description="First",
+            creator=self.user,
+        )
+        doc1.pdf_file.save("test1.pdf", ContentFile(b"content1"))
+
+        doc2 = Document.objects.create(
+            title="Same Title",
+            description="Second",
+            creator=self.user,
+        )
+        doc2.pdf_file.save("test2.pdf", ContentFile(b"content2"))
+
+        call_command("migrate_orphaned_documents")
+
+        corpus = Corpus.objects.get(
+            creator=self.user, title="My Documents", is_system_corpus=True
+        )
+        paths = DocumentPath.objects.filter(
+            corpus=corpus, is_current=True, is_deleted=False
+        )
+
+        # Both should have paths
+        self.assertEqual(paths.count(), 2)
+
+        # Paths should be different
+        path_values = list(paths.values_list("path", flat=True))
+        self.assertNotEqual(path_values[0], path_values[1])
+
+
+class TestOrphanMigrationNoOrphans(TestCase):
+    """Test migration behavior when there are no orphans."""
+
+    def setUp(self):
+        """Set up test data with no orphans."""
+        self.user = User.objects.create_user(
+            username="testuser", email="test@example.com", password="testpass123"
+        )
+
+        # Create a document WITH a corpus
+        self.corpus = Corpus.objects.create(
+            title="Test Corpus", description="Test", creator=self.user
+        )
+
+        self.doc = Document.objects.create(
+            title="Non-Orphan Document",
+            description="Has corpus",
+            creator=self.user,
+        )
+        self.doc.pdf_file.save("test.pdf", ContentFile(b"content"))
+
+        DocumentPath.objects.create(
+            document=self.doc,
+            corpus=self.corpus,
+            path="/test/doc.pdf",
+            version_number=1,
+            is_current=True,
+            is_deleted=False,
+            creator=self.user,
+        )
+
+    def test_migration_with_no_orphans(self):
+        """Test that migration handles no orphans gracefully."""
+        out = StringIO()
+        call_command("migrate_orphaned_documents", stdout=out)
+
+        output = out.getvalue()
+        self.assertIn("No orphaned documents found", output)
+
+        # No system corpuses should be created
+        system_corpuses = Corpus.objects.filter(is_system_corpus=True)
+        self.assertEqual(system_corpuses.count(), 0)
+
+
+class TestDocumentCorpusConstraints(TransactionTestCase):
+    """Test the document-corpus constraints enforced by GraphQL mutations."""
+
+    def setUp(self):
+        """Set up test data."""
+        self.user = User.objects.create_user(
+            username="testuser", email="test@example.com", password="testpass123"
+        )
+
+        # Create a corpus with a document
+        self.corpus = Corpus.objects.create(
+            title="Test Corpus", description="Test", creator=self.user
+        )
+
+        self.doc = Document.objects.create(
+            title="Test Document",
+            description="Has corpus",
+            creator=self.user,
+        )
+        self.doc.pdf_file.save("test.pdf", ContentFile(b"content"))
+
+        DocumentPath.objects.create(
+            document=self.doc,
+            corpus=self.corpus,
+            path="/test/doc.pdf",
+            version_number=1,
+            is_current=True,
+            is_deleted=False,
+            creator=self.user,
+        )
+
+    def test_cannot_delete_system_corpus(self):
+        """Test that system corpuses cannot be deleted."""
+        # Create a system corpus
+        system_corpus = Corpus.objects.create(
+            title="My Documents",
+            description="System corpus",
+            creator=self.user,
+            is_system_corpus=True,
+        )
+
+        # Attempting to delete should raise PermissionError
+        from config.graphql.mutations import DeleteCorpusMutation
+        from graphql_relay import to_global_id
+        from unittest.mock import MagicMock
+
+        info = MagicMock()
+        info.context.user = self.user
+
+        with self.assertRaises(PermissionError) as context:
+            DeleteCorpusMutation.mutate(
+                None, info, id=to_global_id("CorpusType", system_corpus.pk)
+            )
+
+        self.assertIn("System corpuses cannot be deleted", str(context.exception))
+
+    def test_cannot_delete_corpus_with_documents(self):
+        """Test that corpuses with documents cannot be deleted."""
+        from config.graphql.mutations import DeleteCorpusMutation
+        from graphql_relay import to_global_id
+        from unittest.mock import MagicMock
+        from opencontractserver.utils.permissioning import set_permissions_for_obj_to_user
+        from opencontractserver.types.enums import PermissionTypes
+
+        # Give user delete permission
+        set_permissions_for_obj_to_user(self.user, self.corpus, [PermissionTypes.CRUD])
+
+        info = MagicMock()
+        info.context.user = self.user
+
+        with self.assertRaises(PermissionError) as context:
+            DeleteCorpusMutation.mutate(
+                None, info, id=to_global_id("CorpusType", self.corpus.pk)
+            )
+
+        self.assertIn("Cannot delete corpus containing documents", str(context.exception))
+
+
+class TestRemoveFromLastCorpusConstraint(TransactionTestCase):
+    """Test that documents cannot be removed from their last corpus."""
+
+    def setUp(self):
+        """Set up test data with document in only one corpus."""
+        self.user = User.objects.create_user(
+            username="testuser", email="test@example.com", password="testpass123"
+        )
+
+        self.corpus = Corpus.objects.create(
+            title="Only Corpus", description="Test", creator=self.user
+        )
+
+        self.doc = Document.objects.create(
+            title="Test Document",
+            description="In only one corpus",
+            creator=self.user,
+        )
+        self.doc.pdf_file.save("test.pdf", ContentFile(b"content"))
+
+        DocumentPath.objects.create(
+            document=self.doc,
+            corpus=self.corpus,
+            path="/test/doc.pdf",
+            version_number=1,
+            is_current=True,
+            is_deleted=False,
+            creator=self.user,
+        )
+
+    def test_cannot_remove_from_last_corpus(self):
+        """Test that removing document from last corpus fails."""
+        from config.graphql.mutations import RemoveDocumentsFromCorpus
+        from graphql_relay import to_global_id
+        from unittest.mock import MagicMock
+
+        info = MagicMock()
+        info.context.user = self.user
+
+        result = RemoveDocumentsFromCorpus.mutate(
+            None,
+            info,
+            corpus_id=to_global_id("CorpusType", self.corpus.pk),
+            document_ids_to_remove=[to_global_id("DocumentType", self.doc.pk)],
+        )
+
+        self.assertFalse(result.ok)
+        self.assertIn("Cannot remove document from its last corpus", result.message)
+
+    def test_can_remove_from_corpus_if_in_multiple(self):
+        """Test that document can be removed if it's in multiple corpuses."""
+        from opencontractserver.corpuses.folder_service import DocumentFolderService
+        from opencontractserver.utils.permissioning import set_permissions_for_obj_to_user
+        from opencontractserver.types.enums import PermissionTypes
+
+        # Create second corpus and add document
+        corpus2 = Corpus.objects.create(
+            title="Second Corpus", description="Test", creator=self.user
+        )
+        set_permissions_for_obj_to_user(self.user, corpus2, [PermissionTypes.CRUD])
+        set_permissions_for_obj_to_user(self.user, self.corpus, [PermissionTypes.CRUD])
+
+        DocumentPath.objects.create(
+            document=self.doc,
+            corpus=corpus2,
+            path="/test/doc.pdf",
+            version_number=1,
+            is_current=True,
+            is_deleted=False,
+            creator=self.user,
+        )
+
+        from config.graphql.mutations import RemoveDocumentsFromCorpus
+        from graphql_relay import to_global_id
+        from unittest.mock import MagicMock
+
+        info = MagicMock()
+        info.context.user = self.user
+
+        # Should succeed since doc is in corpus2 as well
+        result = RemoveDocumentsFromCorpus.mutate(
+            None,
+            info,
+            corpus_id=to_global_id("CorpusType", self.corpus.pk),
+            document_ids_to_remove=[to_global_id("DocumentType", self.doc.pk)],
+        )
+
+        self.assertTrue(result.ok)


### PR DESCRIPTION
This change ensures that all documents in the system must belong to at least
one corpus. Corpuses have critical settings like embedding configuration that
are difficult to manage for corpus-less documents.

Backend changes:
- Add is_system_corpus field to Corpus model to identify auto-created corpuses
- Make add_to_corpus_id required in UploadDocument and UploadDocumentsZip mutations
- Add validation to RemoveDocumentsFromCorpus to prevent removal from last corpus
- Add validation to DeleteCorpusMutation to prevent deletion of system corpuses
  and corpuses containing documents

Frontend changes:
- Remove "Skip Corpus" option from UploadModal
- Require corpus selection before upload can proceed
- Update corpus step subtitle to "Select a corpus for your documents"

Migration support:
- Add migrate_orphaned_documents management command to handle existing orphans
- Creates "My Documents" corpus for users with edit access to orphaned docs
- Creates "Shared With Me" corpus for users with read-only access
- Cleans up non-default embeddings during migration

Tests:
- Add comprehensive tests for orphan migration scenarios
- Add tests for document-corpus constraint enforcement