### PR TITLE
Replace annotation search with semantic search in Annotations view

### DIFF
--- a/frontend/src/components/annotations/ModernAnnotationCard.tsx
+++ b/frontend/src/components/annotations/ModernAnnotationCard.tsx
@@ -13,6 +13,7 @@ import {
   Users,
   Lock,
   AlignLeft,
+  Sparkles,
 } from "lucide-react";
 
 import { ServerAnnotationType } from "../../types/graphql-api";
@@ -33,6 +34,8 @@ export interface ModernAnnotationCardProps {
   annotation: ServerAnnotationType;
   onClick?: () => void;
   isSelected?: boolean;
+  /** Similarity score from semantic search (0.0-1.0, higher is more similar) */
+  similarityScore?: number;
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -139,6 +142,27 @@ const TypeBadge = styled.div<{ $type: "doc" | "text" }>`
   border-radius: 4px;
   background: ${(props) => (props.$type === "doc" ? "#dbeafe" : "#f0fdfa")};
   color: ${(props) => (props.$type === "doc" ? "#2563eb" : "#0f766e")};
+`;
+
+const SimilarityBadge = styled.div<{ $score: number }>`
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
+  font-size: 11px;
+  font-weight: 600;
+  border-radius: 4px;
+  background: ${(props) => {
+    // Color gradient based on score: green for high, yellow for medium, gray for low
+    if (props.$score >= 0.8) return "#dcfce7"; // green
+    if (props.$score >= 0.6) return "#fef9c3"; // yellow
+    return "#f1f5f9"; // gray
+  }};
+  color: ${(props) => {
+    if (props.$score >= 0.8) return "#166534"; // green
+    if (props.$score >= 0.6) return "#854d0e"; // yellow
+    return "#64748b"; // gray
+  }};
 `;
 
 const LabelsetTag = styled.div`
@@ -413,6 +437,7 @@ export const ModernAnnotationCard: React.FC<ModernAnnotationCardProps> = ({
   annotation,
   onClick,
   isSelected = false,
+  similarityScore,
 }) => {
   const source = getAnnotationSource(annotation);
   const labelType = getAnnotationLabelType(annotation);
@@ -451,6 +476,15 @@ export const ModernAnnotationCard: React.FC<ModernAnnotationCardProps> = ({
           <LabelName>{labelName}</LabelName>
         </LabelContainer>
         <BadgesContainer>
+          {similarityScore !== undefined && (
+            <SimilarityBadge
+              $score={similarityScore}
+              title={`${Math.round(similarityScore * 100)}% semantic match`}
+            >
+              <Sparkles size={12} />
+              {Math.round(similarityScore * 100)}%
+            </SimilarityBadge>
+          )}
           <SourceBadgeComponent source={source} />
           <ModalityBadge modalities={contentModalities} />
           <TypeBadge $type={labelType}>

--- a/frontend/src/graphql/queries.ts
+++ b/frontend/src/graphql/queries.ts
@@ -925,6 +925,145 @@ export const GET_ANNOTATIONS = gql`
   }
 `;
 
+// ═══════════════════════════════════════════════════════════════════════════════
+// SEMANTIC SEARCH QUERY
+// ═══════════════════════════════════════════════════════════════════════════════
+
+export interface SemanticSearchInput {
+  query: string;
+  corpusId?: string;
+  documentId?: string;
+  modalities?: string[];
+  labelText?: string;
+  rawTextContains?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export interface SemanticSearchResult {
+  annotation: ServerAnnotationType;
+  similarityScore: number;
+  document: DocumentType | null;
+  corpus: RawCorpusType | null;
+}
+
+export interface SemanticSearchOutput {
+  semanticSearch: SemanticSearchResult[];
+}
+
+export const SEMANTIC_SEARCH_ANNOTATIONS = gql`
+  query SemanticSearchAnnotations(
+    $query: String!
+    $corpusId: ID
+    $documentId: ID
+    $modalities: [String]
+    $labelText: String
+    $rawTextContains: String
+    $limit: Int
+    $offset: Int
+  ) {
+    semanticSearch(
+      query: $query
+      corpusId: $corpusId
+      documentId: $documentId
+      modalities: $modalities
+      labelText: $labelText
+      rawTextContains: $rawTextContains
+      limit: $limit
+      offset: $offset
+    ) {
+      annotation {
+        id
+        tokensJsons
+        json
+        page
+        created
+        creator {
+          id
+          email
+          username
+          slug
+          __typename
+        }
+        corpus {
+          id
+          slug
+          icon
+          title
+          description
+          preferredEmbedder
+          creator {
+            id
+            slug
+            __typename
+          }
+          labelSet {
+            id
+            title
+            __typename
+          }
+          __typename
+        }
+        document {
+          id
+          slug
+          title
+          description
+          backendLock
+          pdfFile
+          txtExtractFile
+          pawlsParseFile
+          icon
+          fileType
+          creator {
+            id
+            slug
+            __typename
+          }
+          __typename
+        }
+        analysis {
+          id
+          analyzer {
+            analyzerId
+            __typename
+          }
+          __typename
+        }
+        annotationLabel {
+          id
+          text
+          color
+          icon
+          description
+          labelType
+          __typename
+        }
+        annotationType
+        structural
+        rawText
+        isPublic
+        myPermissions
+        contentModalities
+        __typename
+      }
+      similarityScore
+      document {
+        id
+        slug
+        title
+        __typename
+      }
+      corpus {
+        id
+        slug
+        title
+        __typename
+      }
+    }
+  }
+`;
+
 export interface GetAnnotationLabelsInput {
   corpusId?: string;
   labelsetId?: string;

--- a/frontend/src/views/Annotations.tsx
+++ b/frontend/src/views/Annotations.tsx
@@ -10,7 +10,7 @@ import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
 import _ from "lodash";
 
-import { useQuery, useReactiveVar } from "@apollo/client";
+import { useQuery, useLazyQuery, useReactiveVar } from "@apollo/client";
 import {
   SearchBox,
   FilterTabs,
@@ -31,6 +31,7 @@ import {
   Users,
   Lock,
   PenLine,
+  Sparkles,
 } from "lucide-react";
 
 import {
@@ -50,6 +51,10 @@ import {
   GetCorpusLabelsetAndLabelsOutputs,
   GET_ANNOTATIONS,
   GET_CORPUS_LABELSET_AND_LABELS,
+  SemanticSearchInput,
+  SemanticSearchOutput,
+  SemanticSearchResult,
+  SEMANTIC_SEARCH_ANNOTATIONS,
 } from "../graphql/queries";
 import { ServerAnnotationType, PageInfo } from "../types/graphql-api";
 import { FetchMoreOnVisible } from "../components/widgets/infinite_scroll/FetchMoreOnVisible";
@@ -366,6 +371,14 @@ export const Annotations = () => {
   const [searchValue, setSearchValue] = useState("");
   const [showAdvancedFilters, setShowAdvancedFilters] = useState(false);
 
+  // Semantic search state
+  const [semanticSearchOffset, setSemanticSearchOffset] = useState(0);
+  const [semanticSearchResults, setSemanticSearchResults] = useState<
+    SemanticSearchResult[]
+  >([]);
+  const [hasMoreSemanticResults, setHasMoreSemanticResults] = useState(true);
+  const SEMANTIC_SEARCH_LIMIT = 20;
+
   // Build query variables
   let annotation_variables: LooseObject = {
     label_Type: "TEXT_LABEL",
@@ -418,6 +431,37 @@ export const Annotations = () => {
     notifyOnNetworkStatusChange: true,
   });
 
+  // Semantic search query (lazy - triggered when user searches)
+  const [
+    executeSemanticSearch,
+    { loading: semanticSearchLoading, error: semanticSearchError },
+  ] = useLazyQuery<SemanticSearchOutput, SemanticSearchInput>(
+    SEMANTIC_SEARCH_ANNOTATIONS,
+    {
+      fetchPolicy: "network-only",
+      notifyOnNetworkStatusChange: true,
+      onCompleted: (data) => {
+        if (data?.semanticSearch) {
+          const newResults = data.semanticSearch;
+          if (semanticSearchOffset === 0) {
+            // Fresh search - replace results
+            setSemanticSearchResults(newResults);
+          } else {
+            // Load more - append results
+            setSemanticSearchResults((prev) => [...prev, ...newResults]);
+          }
+          // Check if there are more results
+          setHasMoreSemanticResults(
+            newResults.length === SEMANTIC_SEARCH_LIMIT
+          );
+        }
+      },
+    }
+  );
+
+  // Determine if we're in semantic search mode (user has entered a search query)
+  const isSemanticSearchActive = searchValue.trim().length > 0;
+
   // Consolidated effect for refetching annotations on filter changes
   // This prevents race conditions from multiple simultaneous filter changes
   useEffect(() => {
@@ -458,13 +502,29 @@ export const Annotations = () => {
     }
   }, [sourceFilter]);
 
-  // Get raw items from query
+  // Get raw items from query - handles both browse mode and semantic search
   const rawItems: ServerAnnotationType[] = useMemo(() => {
+    if (isSemanticSearchActive) {
+      // In semantic search mode, extract annotations from search results
+      return semanticSearchResults.map((result) => result.annotation);
+    }
+    // In browse mode, use the regular annotations query
     if (annotation_data?.annotations) {
       return annotation_data.annotations.edges.map((edge) => edge.node);
     }
     return [];
-  }, [annotation_data]);
+  }, [annotation_data, isSemanticSearchActive, semanticSearchResults]);
+
+  // Create a map of annotation ID to similarity score for display
+  const similarityScoreMap = useMemo(() => {
+    const map = new Map<string, number>();
+    if (isSemanticSearchActive) {
+      semanticSearchResults.forEach((result) => {
+        map.set(result.annotation.id, result.similarityScore);
+      });
+    }
+    return map;
+  }, [isSemanticSearchActive, semanticSearchResults]);
 
   // Apply local filters (type and source)
   const filteredItems = useMemo(() => {
@@ -506,34 +566,114 @@ export const Annotations = () => {
     return { total, docLabels, textLabels, humanAnnotated };
   }, [rawItems, annotation_data?.annotations?.totalCount]);
 
-  // Debounced search
-  const debouncedSearch = useRef(
-    _.debounce((searchTerm: string) => {
-      annotationContentSearchTerm(searchTerm);
-    }, 1000)
+  // Execute semantic search with current filters
+  const performSemanticSearch = useCallback(
+    (query: string, offset: number = 0) => {
+      if (!query.trim()) return;
+
+      const variables: SemanticSearchInput = {
+        query: query.trim(),
+        limit: SEMANTIC_SEARCH_LIMIT,
+        offset,
+      };
+
+      // Add corpus filter if set
+      if (filtered_to_corpus?.id) {
+        variables.corpusId = filtered_to_corpus.id;
+      }
+
+      // Add modalities filter based on source filter (semantic search uses modalities)
+      // Note: structural filtering is handled server-side differently
+      if (sourceFilter === "structural") {
+        // For structural, we don't filter by modalities as structural annotations
+        // can have any modality
+      }
+
+      executeSemanticSearch({ variables });
+    },
+    [executeSemanticSearch, filtered_to_corpus, sourceFilter]
   );
 
-  const handleSearchChange = useCallback((value: string) => {
-    setSearchValue(value);
-    debouncedSearch.current(value);
-  }, []);
+  // Debounced semantic search
+  const debouncedSearch = useRef(
+    _.debounce((searchTerm: string) => {
+      if (searchTerm.trim()) {
+        // Reset pagination for new search
+        setSemanticSearchOffset(0);
+        setSemanticSearchResults([]);
+        setHasMoreSemanticResults(true);
+        performSemanticSearch(searchTerm, 0);
+      } else {
+        // Clear search - return to browse mode
+        setSemanticSearchResults([]);
+        setSemanticSearchOffset(0);
+        setHasMoreSemanticResults(true);
+      }
+    }, 500)
+  );
 
-  const handleSearchSubmit = useCallback((value: string) => {
-    annotationContentSearchTerm(value);
-  }, []);
+  const handleSearchChange = useCallback(
+    (value: string) => {
+      setSearchValue(value);
+      debouncedSearch.current(value);
+    },
+    [debouncedSearch]
+  );
 
-  // Handle infinite scroll
+  const handleSearchSubmit = useCallback(
+    (value: string) => {
+      // Cancel any pending debounced search
+      debouncedSearch.current.cancel();
+      setSearchValue(value);
+
+      if (value.trim()) {
+        // Reset pagination and execute search immediately
+        setSemanticSearchOffset(0);
+        setSemanticSearchResults([]);
+        setHasMoreSemanticResults(true);
+        performSemanticSearch(value, 0);
+      } else {
+        // Clear search - return to browse mode
+        setSemanticSearchResults([]);
+        setSemanticSearchOffset(0);
+        setHasMoreSemanticResults(true);
+      }
+    },
+    [performSemanticSearch, debouncedSearch]
+  );
+
+  // Handle infinite scroll - supports both browse mode and semantic search
   const handleFetchMore = useCallback(() => {
-    const pageInfo = annotation_data?.annotations?.pageInfo;
-    if (!annotation_loading && pageInfo?.hasNextPage) {
-      fetchMoreAnnotations({
-        variables: {
-          limit: 20,
-          cursor: pageInfo.endCursor,
-        },
-      });
+    if (isSemanticSearchActive) {
+      // Semantic search pagination (offset-based)
+      if (!semanticSearchLoading && hasMoreSemanticResults) {
+        const newOffset = semanticSearchOffset + SEMANTIC_SEARCH_LIMIT;
+        setSemanticSearchOffset(newOffset);
+        performSemanticSearch(searchValue, newOffset);
+      }
+    } else {
+      // Browse mode pagination (cursor-based)
+      const pageInfo = annotation_data?.annotations?.pageInfo;
+      if (!annotation_loading && pageInfo?.hasNextPage) {
+        fetchMoreAnnotations({
+          variables: {
+            limit: 20,
+            cursor: pageInfo.endCursor,
+          },
+        });
+      }
     }
-  }, [annotation_loading, annotation_data, fetchMoreAnnotations]);
+  }, [
+    isSemanticSearchActive,
+    semanticSearchLoading,
+    hasMoreSemanticResults,
+    semanticSearchOffset,
+    searchValue,
+    performSemanticSearch,
+    annotation_loading,
+    annotation_data,
+    fetchMoreAnnotations,
+  ]);
 
   // Handle annotation click - navigate to document
   // Supports both corpus-linked and standalone documents (e.g., structural annotations)
@@ -738,10 +878,18 @@ export const Annotations = () => {
         {/* Annotations Grid */}
         <AnnotationsListContainer>
           <LoadingOverlay
-            active={annotation_loading}
+            active={
+              isSemanticSearchActive
+                ? semanticSearchLoading
+                : annotation_loading
+            }
             inverted
             size="large"
-            content="Loading Annotations..."
+            content={
+              isSemanticSearchActive
+                ? "Searching annotations..."
+                : "Loading Annotations..."
+            }
           />
 
           <AnnotationsGrid>
@@ -752,12 +900,19 @@ export const Annotations = () => {
                   annotation={annotation}
                   onClick={() => handleAnnotationClick(annotation)}
                   isSelected={selected_annotation_ids.includes(annotation.id)}
+                  similarityScore={similarityScoreMap.get(annotation.id)}
                 />
               ))
-            ) : !annotation_loading ? (
+            ) : !(isSemanticSearchActive
+                ? semanticSearchLoading
+                : annotation_loading) ? (
               <EmptyStateWrapper>
                 <AnnotationIconWrapper>
-                  <PenLine size={32} />
+                  {isSemanticSearchActive ? (
+                    <Sparkles size={32} />
+                  ) : (
+                    <PenLine size={32} />
+                  )}
                 </AnnotationIconWrapper>
                 <h3
                   style={{
@@ -767,7 +922,9 @@ export const Annotations = () => {
                     margin: "24px 0 8px",
                   }}
                 >
-                  No annotations found
+                  {isSemanticSearchActive
+                    ? "No matching annotations found"
+                    : "No annotations found"}
                 </h3>
                 <p
                   style={{
@@ -777,8 +934,9 @@ export const Annotations = () => {
                     maxWidth: "300px",
                   }}
                 >
-                  Try adjusting your filters or search query to find what you're
-                  looking for.
+                  {isSemanticSearchActive
+                    ? "Try a different search query or adjust your filters to find semantically similar annotations."
+                    : "Try adjusting your filters or search query to find what you're looking for."}
                 </p>
               </EmptyStateWrapper>
             ) : null}

--- a/frontend/src/views/Annotations.tsx
+++ b/frontend/src/views/Annotations.tsx
@@ -502,6 +502,23 @@ export const Annotations = () => {
     }
   }, [sourceFilter]);
 
+  // Re-execute semantic search when filters change (fixes race condition)
+  // This ensures search results stay in sync with filter selections
+  useEffect(() => {
+    if (searchValue.trim()) {
+      // Reset pagination and re-search with new filters
+      setSemanticSearchOffset(0);
+      setSemanticSearchResults([]);
+      setHasMoreSemanticResults(true);
+      // Use a small delay to let state settle before searching
+      const timeoutId = setTimeout(() => {
+        performSemanticSearch(searchValue, 0);
+      }, 100);
+      return () => clearTimeout(timeoutId);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filtered_to_corpus?.id, sourceFilter, typeFilter]);
+
   // Get raw items from query - handles both browse mode and semantic search
   const rawItems: ServerAnnotationType[] = useMemo(() => {
     if (isSemanticSearchActive) {
@@ -611,6 +628,13 @@ export const Annotations = () => {
       }
     }, 500)
   );
+
+  // Cleanup debounce on unmount to prevent memory leaks
+  useEffect(() => {
+    return () => {
+      debouncedSearch.current.cancel();
+    };
+  }, []);
 
   const handleSearchChange = useCallback(
     (value: string) => {
@@ -891,6 +915,25 @@ export const Annotations = () => {
                 : "Loading Annotations..."
             }
           />
+
+          {/* Error display for semantic search failures */}
+          {semanticSearchError && (
+            <div
+              style={{
+                padding: "16px 24px",
+                marginBottom: "16px",
+                backgroundColor: "#fef2f2",
+                border: "1px solid #fecaca",
+                borderRadius: "8px",
+                color: "#dc2626",
+                fontSize: "14px",
+              }}
+            >
+              <strong>Search failed:</strong>{" "}
+              {semanticSearchError.message ||
+                "An error occurred while searching. Please try again."}
+            </div>
+          )}
 
           <AnnotationsGrid>
             {filteredItems.length > 0 ? (

--- a/frontend/tests/AnnotationsSemanticSearch.ct.tsx
+++ b/frontend/tests/AnnotationsSemanticSearch.ct.tsx
@@ -210,9 +210,10 @@ test.describe("Annotations Semantic Search", () => {
       />
     );
 
-    // Verify the hero section renders
-    await expect(page.getByText("Browse")).toBeVisible({ timeout: 10000 });
-    await expect(page.getByText("annotations")).toBeVisible({ timeout: 5000 });
+    // Verify the hero section renders - use heading role for specificity
+    await expect(
+      page.getByRole("heading", { name: /Browse.*annotations/ })
+    ).toBeVisible({ timeout: 10000 });
 
     await component.unmount();
   });
@@ -225,14 +226,29 @@ test.describe("Annotations Semantic Search", () => {
       />
     );
 
-    // Verify filter tabs are visible
-    await expect(page.getByText("All Types")).toBeVisible({ timeout: 10000 });
-    await expect(page.getByText("Doc Labels")).toBeVisible({ timeout: 5000 });
-    await expect(page.getByText("Text Labels")).toBeVisible({ timeout: 5000 });
-    await expect(page.getByText("All Sources")).toBeVisible({ timeout: 5000 });
-    await expect(page.getByText("Human")).toBeVisible({ timeout: 5000 });
-    await expect(page.getByText("AI Agent")).toBeVisible({ timeout: 5000 });
-    await expect(page.getByText("Structural")).toBeVisible({ timeout: 5000 });
+    // Verify filter tabs are visible - use role="tab" for specificity
+    // This distinguishes tabs from stats labels with the same text
+    await expect(page.getByRole("tab", { name: "All Types" })).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(page.getByRole("tab", { name: "Doc Labels" })).toBeVisible({
+      timeout: 5000,
+    });
+    await expect(page.getByRole("tab", { name: "Text Labels" })).toBeVisible({
+      timeout: 5000,
+    });
+    await expect(page.getByRole("tab", { name: "All Sources" })).toBeVisible({
+      timeout: 5000,
+    });
+    await expect(page.getByRole("tab", { name: "Human" })).toBeVisible({
+      timeout: 5000,
+    });
+    await expect(page.getByRole("tab", { name: "AI Agent" })).toBeVisible({
+      timeout: 5000,
+    });
+    await expect(page.getByRole("tab", { name: "Structural" })).toBeVisible({
+      timeout: 5000,
+    });
 
     await component.unmount();
   });
@@ -248,15 +264,19 @@ test.describe("Annotations Semantic Search", () => {
       />
     );
 
-    // Verify stats section elements
+    // Verify stats section elements - these are NOT tabs, just stat labels
+    // Stats have a specific structure: value + label
     await expect(page.getByText("Total Annotations")).toBeVisible({
       timeout: 10000,
     });
-    await expect(page.getByText("Doc Labels")).toBeVisible({ timeout: 5000 });
-    await expect(page.getByText("Text Labels")).toBeVisible({ timeout: 5000 });
     await expect(page.getByText("Human Annotated")).toBeVisible({
       timeout: 5000,
     });
+
+    // Verify the stats show zero counts - look for "0" text that appears
+    // multiple times (once for each stat)
+    const zeroValues = page.getByText("0", { exact: true });
+    await expect(zeroValues.first()).toBeVisible({ timeout: 5000 });
 
     await component.unmount();
   });
@@ -271,7 +291,7 @@ test.describe("Annotations Filter Tabs", () => {
       ...mockAnnotation,
       annotationLabel: {
         ...mockAnnotation.annotationLabel,
-        text: "Text Label",
+        text: "Text Annotation Label",
         labelType: "TOKEN_LABEL",
       },
     };
@@ -282,7 +302,7 @@ test.describe("Annotations Filter Tabs", () => {
       annotationLabel: {
         ...mockAnnotation.annotationLabel,
         id: "QW5ub3RhdGlvbkxhYmVsVHlwZToy",
-        text: "Doc Label",
+        text: "Doc Annotation Label",
         labelType: "DOC_TYPE_LABEL",
       },
     };
@@ -294,11 +314,14 @@ test.describe("Annotations Filter Tabs", () => {
       />
     );
 
-    // Initially both should be visible
-    await expect(page.getByText("Text Label")).toBeVisible({ timeout: 15000 });
-    await expect(
-      page.locator('[class*="Card"]').filter({ hasText: "Doc Label" })
-    ).toBeVisible({ timeout: 5000 });
+    // Initially both should be visible - use unique label names that don't
+    // conflict with tab labels
+    await expect(page.getByText("Text Annotation Label")).toBeVisible({
+      timeout: 15000,
+    });
+    await expect(page.getByText("Doc Annotation Label")).toBeVisible({
+      timeout: 5000,
+    });
 
     await component.unmount();
   });

--- a/frontend/tests/AnnotationsSemanticSearch.ct.tsx
+++ b/frontend/tests/AnnotationsSemanticSearch.ct.tsx
@@ -1,0 +1,346 @@
+/**
+ * Component tests for semantic search functionality in Annotations view.
+ *
+ * Tests cover:
+ * - Basic semantic search execution
+ * - Error handling display
+ * - Filter changes re-triggering search
+ * - Empty state handling
+ */
+import React from "react";
+import { test, expect } from "@playwright/experimental-ct-react";
+import { AnnotationsSemanticSearchTestWrapper } from "./AnnotationsSemanticSearchTestWrapper";
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// MOCK DATA
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const mockAnnotation = {
+  id: "QW5ub3RhdGlvblR5cGU6MQ==",
+  tokensJsons: null,
+  json: {},
+  page: 0,
+  created: "2024-01-15T10:30:00Z",
+  creator: {
+    id: "VXNlclR5cGU6MQ==",
+    email: "user@example.com",
+    username: "testuser",
+    slug: "testuser",
+    __typename: "UserType",
+  },
+  corpus: {
+    id: "Q29ycHVzVHlwZTox",
+    slug: "test-corpus",
+    icon: null,
+    title: "Test Corpus",
+    description: "A test corpus",
+    preferredEmbedder: null,
+    creator: {
+      id: "VXNlclR5cGU6MQ==",
+      slug: "testuser",
+      __typename: "UserType",
+    },
+    labelSet: {
+      id: "TGFiZWxTZXRUeXBlOjE=",
+      title: "Test Labelset",
+      __typename: "LabelSetType",
+    },
+    __typename: "CorpusType",
+  },
+  document: {
+    id: "RG9jdW1lbnRUeXBlOjE=",
+    slug: "test-document",
+    title: "Test Document",
+    description: "A test document",
+    backendLock: false,
+    pdfFile: "/media/documents/test.pdf",
+    txtExtractFile: null,
+    pawlsParseFile: null,
+    icon: null,
+    fileType: "application/pdf",
+    creator: {
+      id: "VXNlclR5cGU6MQ==",
+      slug: "testuser",
+      __typename: "UserType",
+    },
+    __typename: "DocumentType",
+  },
+  analysis: null,
+  annotationLabel: {
+    id: "QW5ub3RhdGlvbkxhYmVsVHlwZTox",
+    text: "Contract Term",
+    color: "#FF5722",
+    icon: "FileText",
+    description: "A contract term annotation",
+    labelType: "TOKEN_LABEL",
+    __typename: "AnnotationLabelType",
+  },
+  annotationType: "TOKEN_LABEL",
+  structural: false,
+  rawText: "This is a sample annotation text for testing purposes.",
+  isPublic: false,
+  myPermissions: ["read", "update"],
+  contentModalities: ["TEXT"],
+  __typename: "AnnotationType",
+};
+
+const mockSemanticSearchResult = {
+  annotation: mockAnnotation,
+  similarityScore: 0.85,
+  document: {
+    id: "RG9jdW1lbnRUeXBlOjE=",
+    slug: "test-document",
+    title: "Test Document",
+    __typename: "DocumentType",
+  },
+  corpus: {
+    id: "Q29ycHVzVHlwZTox",
+    slug: "test-corpus",
+    title: "Test Corpus",
+    __typename: "CorpusType",
+  },
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TESTS
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test.describe("Annotations Semantic Search", () => {
+  test("should show empty state with appropriate message for semantic search", async ({
+    mount,
+    page,
+  }) => {
+    const component = await mount(
+      <AnnotationsSemanticSearchTestWrapper
+        semanticSearchResults={[]}
+        browseAnnotations={[]}
+      />
+    );
+
+    // Verify the page loads with search box
+    const searchInput = page.getByPlaceholder(
+      "Search annotations by label, text, or document..."
+    );
+    await expect(searchInput).toBeVisible({ timeout: 10000 });
+
+    // Type in the search box
+    await searchInput.fill("nonexistent query");
+
+    // Wait for debounce (500ms) + some buffer
+    await page.waitForTimeout(800);
+
+    // Verify semantic search empty state message
+    await expect(page.getByText("No matching annotations found")).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(page.getByText(/Try a different search query/)).toBeVisible({
+      timeout: 5000,
+    });
+
+    await component.unmount();
+  });
+
+  test("should show browse mode annotations initially", async ({
+    mount,
+    page,
+  }) => {
+    const browseAnnotation = {
+      ...mockAnnotation,
+      id: "QW5ub3RhdGlvblR5cGU6Mg==",
+      rawText: "Browse mode annotation text",
+      annotationLabel: {
+        ...mockAnnotation.annotationLabel,
+        text: "Browse Label",
+      },
+    };
+
+    const component = await mount(
+      <AnnotationsSemanticSearchTestWrapper
+        semanticSearchResults={[]}
+        browseAnnotations={[browseAnnotation]}
+      />
+    );
+
+    // In browse mode, should show browse annotation
+    await expect(page.getByText("Browse Label")).toBeVisible({
+      timeout: 15000,
+    });
+
+    await component.unmount();
+  });
+
+  test("should display error message when semantic search fails", async ({
+    mount,
+    page,
+  }) => {
+    const component = await mount(
+      <AnnotationsSemanticSearchTestWrapper
+        semanticSearchResults={[]}
+        browseAnnotations={[]}
+        simulateSearchError="Network error: Failed to fetch"
+      />
+    );
+
+    // Type in the search box
+    const searchInput = page.getByPlaceholder(
+      "Search annotations by label, text, or document..."
+    );
+    await expect(searchInput).toBeVisible({ timeout: 10000 });
+    await searchInput.fill("contract terms");
+
+    // Wait for debounce + network response
+    await page.waitForTimeout(1000);
+
+    // Verify error message is displayed
+    await expect(page.getByText("Search failed:")).toBeVisible({
+      timeout: 10000,
+    });
+
+    await component.unmount();
+  });
+
+  test("should show 'Browse annotations' title in hero section", async ({
+    mount,
+    page,
+  }) => {
+    const component = await mount(
+      <AnnotationsSemanticSearchTestWrapper
+        semanticSearchResults={[]}
+        browseAnnotations={[]}
+      />
+    );
+
+    // Verify the hero section renders
+    await expect(page.getByText("Browse")).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText("annotations")).toBeVisible({ timeout: 5000 });
+
+    await component.unmount();
+  });
+
+  test("should display filter tabs", async ({ mount, page }) => {
+    const component = await mount(
+      <AnnotationsSemanticSearchTestWrapper
+        semanticSearchResults={[]}
+        browseAnnotations={[]}
+      />
+    );
+
+    // Verify filter tabs are visible
+    await expect(page.getByText("All Types")).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText("Doc Labels")).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText("Text Labels")).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText("All Sources")).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText("Human")).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText("AI Agent")).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText("Structural")).toBeVisible({ timeout: 5000 });
+
+    await component.unmount();
+  });
+
+  test("should display stats section with zero counts when no annotations", async ({
+    mount,
+    page,
+  }) => {
+    const component = await mount(
+      <AnnotationsSemanticSearchTestWrapper
+        semanticSearchResults={[]}
+        browseAnnotations={[]}
+      />
+    );
+
+    // Verify stats section elements
+    await expect(page.getByText("Total Annotations")).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(page.getByText("Doc Labels")).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText("Text Labels")).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText("Human Annotated")).toBeVisible({
+      timeout: 5000,
+    });
+
+    await component.unmount();
+  });
+});
+
+test.describe("Annotations Filter Tabs", () => {
+  test("should filter annotations by type (doc/text labels)", async ({
+    mount,
+    page,
+  }) => {
+    const textAnnotation = {
+      ...mockAnnotation,
+      annotationLabel: {
+        ...mockAnnotation.annotationLabel,
+        text: "Text Label",
+        labelType: "TOKEN_LABEL",
+      },
+    };
+
+    const docAnnotation = {
+      ...mockAnnotation,
+      id: "QW5ub3RhdGlvblR5cGU6Mw==",
+      annotationLabel: {
+        ...mockAnnotation.annotationLabel,
+        id: "QW5ub3RhdGlvbkxhYmVsVHlwZToy",
+        text: "Doc Label",
+        labelType: "DOC_TYPE_LABEL",
+      },
+    };
+
+    const component = await mount(
+      <AnnotationsSemanticSearchTestWrapper
+        semanticSearchResults={[]}
+        browseAnnotations={[textAnnotation, docAnnotation]}
+      />
+    );
+
+    // Initially both should be visible
+    await expect(page.getByText("Text Label")).toBeVisible({ timeout: 15000 });
+    await expect(
+      page.locator('[class*="Card"]').filter({ hasText: "Doc Label" })
+    ).toBeVisible({ timeout: 5000 });
+
+    await component.unmount();
+  });
+
+  test("should filter annotations by source (human/agent/structural)", async ({
+    mount,
+    page,
+  }) => {
+    const humanAnnotation = {
+      ...mockAnnotation,
+      structural: false,
+      analysis: null,
+      annotationLabel: {
+        ...mockAnnotation.annotationLabel,
+        text: "Human Label",
+      },
+    };
+
+    const structuralAnnotation = {
+      ...mockAnnotation,
+      id: "QW5ub3RhdGlvblR5cGU6NA==",
+      structural: true,
+      annotationLabel: {
+        ...mockAnnotation.annotationLabel,
+        id: "QW5ub3RhdGlvbkxhYmVsVHlwZToz",
+        text: "Structural Label",
+      },
+    };
+
+    const component = await mount(
+      <AnnotationsSemanticSearchTestWrapper
+        semanticSearchResults={[]}
+        browseAnnotations={[humanAnnotation, structuralAnnotation]}
+      />
+    );
+
+    // Initially both should be visible (All Sources)
+    await expect(page.getByText("Human Label")).toBeVisible({ timeout: 15000 });
+    await expect(page.getByText("Structural Label")).toBeVisible({
+      timeout: 5000,
+    });
+
+    await component.unmount();
+  });
+});

--- a/frontend/tests/AnnotationsSemanticSearchTestWrapper.tsx
+++ b/frontend/tests/AnnotationsSemanticSearchTestWrapper.tsx
@@ -2,13 +2,14 @@
  * Test wrapper for Annotations semantic search component tests.
  *
  * Provides:
- * - MockedProvider with configurable GraphQL responses
+ * - MockedProvider with wildcard link for flexible query matching
  * - Proper cache configuration
  * - React Router context
- * - Authentication state setup
+ * - Authentication state setup (synchronous, before render)
  */
 import React, { useEffect } from "react";
-import { MockedProvider, MockedResponse } from "@apollo/client/testing";
+import { MockedProvider, MockLink } from "@apollo/client/testing";
+import { ApolloLink, Observable } from "@apollo/client";
 import { MemoryRouter } from "react-router-dom";
 import { GraphQLError } from "graphql";
 import { Annotations } from "../src/views/Annotations";
@@ -51,30 +52,13 @@ interface AnnotationsSemanticSearchTestWrapperProps {
 }
 
 /**
- * Inner component that handles reactive var setup.
+ * Inner component that handles reactive var cleanup on unmount.
  */
 const InnerWrapper: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
   useEffect(() => {
-    // Initialize authentication state
-    authStatusVar("AUTHENTICATED");
-    authToken("test-token");
-    userObj({
-      id: "VXNlclR5cGU6MQ==",
-      email: "test@example.com",
-      username: "testuser",
-    });
-
-    // Initialize filter state
-    filterToCorpus(null);
-    filterToLabelsetId("");
-    filterToLabelId("");
-    openedCorpus(null);
-    filterToStructuralAnnotations("INCLUDE");
-    selectedAnnotationIds([]);
-
-    // Cleanup
+    // Cleanup on unmount
     return () => {
       filterToCorpus(null);
       filterToLabelsetId("");
@@ -89,49 +73,31 @@ const InnerWrapper: React.FC<{ children: React.ReactNode }> = ({
 };
 
 /**
- * Creates semantic search mocks that match any query variables.
- * We need to create multiple mocks since each mock can only be used once.
+ * Creates a wildcard ApolloLink that responds to queries regardless of variables.
+ * This approach is more flexible than exact mock matching and handles:
+ * - Repeated queries (Apollo MockLink consumes mocks on first use)
+ * - Variable variations (different filter combinations)
+ * - Refetches triggered by reactive var changes
  */
-const createSemanticSearchMock = (
+const createAnnotationsWildcardLink = (
+  browseAnnotations: any[],
   semanticSearchResults: SemanticSearchResult[],
   simulateSearchError?: string,
   simulateSearchDelay: number = 0
-): MockedResponse => ({
-  request: {
-    query: SEMANTIC_SEARCH_ANNOTATIONS,
-  },
-  variableMatcher: () => true,
-  delay: simulateSearchDelay,
-  result: simulateSearchError
-    ? {
-        errors: [new GraphQLError(simulateSearchError)],
-      }
-    : {
-        data: {
-          semanticSearch: semanticSearchResults,
-        },
-      },
-});
-
-/**
- * Creates browse mode mocks for GET_ANNOTATIONS query.
- */
-const createBrowseMock = (browseAnnotations: any[]): MockedResponse => ({
-  request: {
-    query: GET_ANNOTATIONS,
-    variables: {
-      label_Type: "TEXT_LABEL",
-    },
-  },
-  result: {
+) => {
+  // Build the response for GET_ANNOTATIONS
+  const annotationsResponse = {
     data: {
       annotations: {
+        __typename: "AnnotationTypeConnection",
         totalCount: browseAnnotations.length,
         edges: browseAnnotations.map((annotation) => ({
+          __typename: "AnnotationTypeEdge",
           node: annotation,
           cursor: annotation.id,
         })),
         pageInfo: {
+          __typename: "PageInfo",
           hasNextPage: false,
           hasPreviousPage: false,
           startCursor: browseAnnotations[0]?.id || null,
@@ -140,8 +106,63 @@ const createBrowseMock = (browseAnnotations: any[]): MockedResponse => ({
         },
       },
     },
-  },
-});
+  };
+
+  // Build the response for SEMANTIC_SEARCH_ANNOTATIONS
+  const semanticSearchResponse = simulateSearchError
+    ? { errors: [new GraphQLError(simulateSearchError)] }
+    : { data: { semanticSearch: semanticSearchResults } };
+
+  // Build the response for GET_CORPUS_LABELSET_AND_LABELS (returns null when no corpus)
+  const corpusLabelsetResponse = {
+    data: {
+      corpus: null,
+    },
+  };
+
+  return new ApolloLink((operation) => {
+    const opName = operation.operationName;
+    const query = operation.query;
+
+    console.log(`[MOCK] Processing: ${opName}`, operation.variables);
+
+    // Match GET_ANNOTATIONS query (any variables)
+    if (query === GET_ANNOTATIONS || opName === "GetAnnotations") {
+      console.log("[MOCK] Returning annotations response");
+      return Observable.of(annotationsResponse);
+    }
+
+    // Match SEMANTIC_SEARCH_ANNOTATIONS query (any variables)
+    if (
+      query === SEMANTIC_SEARCH_ANNOTATIONS ||
+      opName === "SemanticSearchAnnotations"
+    ) {
+      console.log("[MOCK] Returning semantic search response");
+      if (simulateSearchDelay > 0) {
+        return new Observable((observer) => {
+          setTimeout(() => {
+            observer.next(semanticSearchResponse);
+            observer.complete();
+          }, simulateSearchDelay);
+        });
+      }
+      return Observable.of(semanticSearchResponse);
+    }
+
+    // Match GET_CORPUS_LABELSET_AND_LABELS query (any variables)
+    if (
+      query === GET_CORPUS_LABELSET_AND_LABELS ||
+      opName === "GetCorpusLabelsetAndLabels"
+    ) {
+      console.log("[MOCK] Returning corpus labelset response");
+      return Observable.of(corpusLabelsetResponse);
+    }
+
+    // For any unhandled queries, return null data to prevent errors
+    console.log(`[MOCK] Unhandled query: ${opName}`);
+    return Observable.of({ data: null });
+  });
+};
 
 /**
  * Test wrapper for Annotations component with semantic search mocks.
@@ -154,61 +175,35 @@ export const AnnotationsSemanticSearchTestWrapper: React.FC<
   simulateSearchError,
   simulateSearchDelay = 0,
 }) => {
-  // Create mocks array - each mock can only be consumed once
-  const mocks: MockedResponse[] = [
-    // Browse mode queries (multiple for refetches)
-    createBrowseMock(browseAnnotations),
-    createBrowseMock(browseAnnotations),
-    createBrowseMock(browseAnnotations),
-    createBrowseMock(browseAnnotations),
+  // Set up authentication state SYNCHRONOUSLY before render
+  // This ensures auth is available when components first render
+  authToken("test-token");
+  userObj({
+    id: "VXNlclR5cGU6MQ==",
+    email: "test@example.com",
+    username: "testuser",
+  } as any);
+  authStatusVar("AUTHENTICATED");
 
-    // Semantic search queries (multiple for repeat searches)
-    createSemanticSearchMock(
-      semanticSearchResults,
-      simulateSearchError,
-      simulateSearchDelay
-    ),
-    createSemanticSearchMock(
-      semanticSearchResults,
-      simulateSearchError,
-      simulateSearchDelay
-    ),
-    createSemanticSearchMock(
-      semanticSearchResults,
-      simulateSearchError,
-      simulateSearchDelay
-    ),
-    createSemanticSearchMock(
-      semanticSearchResults,
-      simulateSearchError,
-      simulateSearchDelay
-    ),
-    createSemanticSearchMock(
-      semanticSearchResults,
-      simulateSearchError,
-      simulateSearchDelay
-    ),
+  // Initialize filter state synchronously
+  filterToCorpus(null);
+  filterToLabelsetId("");
+  filterToLabelId("");
+  openedCorpus(null);
+  filterToStructuralAnnotations("INCLUDE");
+  selectedAnnotationIds([]);
 
-    // Corpus labelset query (skipped when no corpus selected)
-    {
-      request: {
-        query: GET_CORPUS_LABELSET_AND_LABELS,
-        variables: {
-          corpusId: "",
-        },
-      },
-      result: {
-        data: {
-          corpus: null,
-        },
-      },
-    },
-  ];
+  const link = createAnnotationsWildcardLink(
+    browseAnnotations,
+    semanticSearchResults,
+    simulateSearchError,
+    simulateSearchDelay
+  );
 
   const cache = createTestCache();
 
   return (
-    <MockedProvider mocks={mocks} addTypename={false} cache={cache}>
+    <MockedProvider link={link} cache={cache} addTypename={false}>
       <MemoryRouter initialEntries={["/annotations"]}>
         <InnerWrapper>
           <Annotations />

--- a/frontend/tests/AnnotationsSemanticSearchTestWrapper.tsx
+++ b/frontend/tests/AnnotationsSemanticSearchTestWrapper.tsx
@@ -1,0 +1,219 @@
+/**
+ * Test wrapper for Annotations semantic search component tests.
+ *
+ * Provides:
+ * - MockedProvider with configurable GraphQL responses
+ * - Proper cache configuration
+ * - React Router context
+ * - Authentication state setup
+ */
+import React, { useEffect } from "react";
+import { MockedProvider, MockedResponse } from "@apollo/client/testing";
+import { MemoryRouter } from "react-router-dom";
+import { GraphQLError } from "graphql";
+import { Annotations } from "../src/views/Annotations";
+import {
+  GET_ANNOTATIONS,
+  SEMANTIC_SEARCH_ANNOTATIONS,
+  GET_CORPUS_LABELSET_AND_LABELS,
+} from "../src/graphql/queries";
+import { createTestCache } from "./testUtils";
+import {
+  authStatusVar,
+  authToken,
+  userObj,
+  filterToCorpus,
+  filterToLabelsetId,
+  filterToLabelId,
+  openedCorpus,
+  filterToStructuralAnnotations,
+  selectedAnnotationIds,
+} from "../src/graphql/cache";
+
+interface SemanticSearchResult {
+  annotation: any;
+  similarityScore: number;
+  document: any;
+  corpus: any;
+}
+
+interface AnnotationsSemanticSearchTestWrapperProps {
+  /** Results to return for semantic search queries */
+  semanticSearchResults?: SemanticSearchResult[];
+  /** Annotations to return for browse mode (GET_ANNOTATIONS) */
+  browseAnnotations?: any[];
+  /** Simulate a search error with this message */
+  simulateSearchError?: string;
+  /** Simulate delay in search response (ms) */
+  simulateSearchDelay?: number;
+  /** Optional corpus ID for filtering */
+  corpusId?: string;
+}
+
+/**
+ * Inner component that handles reactive var setup.
+ */
+const InnerWrapper: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  useEffect(() => {
+    // Initialize authentication state
+    authStatusVar("AUTHENTICATED");
+    authToken("test-token");
+    userObj({
+      id: "VXNlclR5cGU6MQ==",
+      email: "test@example.com",
+      username: "testuser",
+    });
+
+    // Initialize filter state
+    filterToCorpus(null);
+    filterToLabelsetId("");
+    filterToLabelId("");
+    openedCorpus(null);
+    filterToStructuralAnnotations("INCLUDE");
+    selectedAnnotationIds([]);
+
+    // Cleanup
+    return () => {
+      filterToCorpus(null);
+      filterToLabelsetId("");
+      filterToLabelId("");
+      openedCorpus(null);
+      filterToStructuralAnnotations("INCLUDE");
+      selectedAnnotationIds([]);
+    };
+  }, []);
+
+  return <>{children}</>;
+};
+
+/**
+ * Creates semantic search mocks that match any query variables.
+ * We need to create multiple mocks since each mock can only be used once.
+ */
+const createSemanticSearchMock = (
+  semanticSearchResults: SemanticSearchResult[],
+  simulateSearchError?: string,
+  simulateSearchDelay: number = 0
+): MockedResponse => ({
+  request: {
+    query: SEMANTIC_SEARCH_ANNOTATIONS,
+  },
+  variableMatcher: () => true,
+  delay: simulateSearchDelay,
+  result: simulateSearchError
+    ? {
+        errors: [new GraphQLError(simulateSearchError)],
+      }
+    : {
+        data: {
+          semanticSearch: semanticSearchResults,
+        },
+      },
+});
+
+/**
+ * Creates browse mode mocks for GET_ANNOTATIONS query.
+ */
+const createBrowseMock = (browseAnnotations: any[]): MockedResponse => ({
+  request: {
+    query: GET_ANNOTATIONS,
+    variables: {
+      label_Type: "TEXT_LABEL",
+    },
+  },
+  result: {
+    data: {
+      annotations: {
+        totalCount: browseAnnotations.length,
+        edges: browseAnnotations.map((annotation) => ({
+          node: annotation,
+          cursor: annotation.id,
+        })),
+        pageInfo: {
+          hasNextPage: false,
+          hasPreviousPage: false,
+          startCursor: browseAnnotations[0]?.id || null,
+          endCursor:
+            browseAnnotations[browseAnnotations.length - 1]?.id || null,
+        },
+      },
+    },
+  },
+});
+
+/**
+ * Test wrapper for Annotations component with semantic search mocks.
+ */
+export const AnnotationsSemanticSearchTestWrapper: React.FC<
+  AnnotationsSemanticSearchTestWrapperProps
+> = ({
+  semanticSearchResults = [],
+  browseAnnotations = [],
+  simulateSearchError,
+  simulateSearchDelay = 0,
+}) => {
+  // Create mocks array - each mock can only be consumed once
+  const mocks: MockedResponse[] = [
+    // Browse mode queries (multiple for refetches)
+    createBrowseMock(browseAnnotations),
+    createBrowseMock(browseAnnotations),
+    createBrowseMock(browseAnnotations),
+    createBrowseMock(browseAnnotations),
+
+    // Semantic search queries (multiple for repeat searches)
+    createSemanticSearchMock(
+      semanticSearchResults,
+      simulateSearchError,
+      simulateSearchDelay
+    ),
+    createSemanticSearchMock(
+      semanticSearchResults,
+      simulateSearchError,
+      simulateSearchDelay
+    ),
+    createSemanticSearchMock(
+      semanticSearchResults,
+      simulateSearchError,
+      simulateSearchDelay
+    ),
+    createSemanticSearchMock(
+      semanticSearchResults,
+      simulateSearchError,
+      simulateSearchDelay
+    ),
+    createSemanticSearchMock(
+      semanticSearchResults,
+      simulateSearchError,
+      simulateSearchDelay
+    ),
+
+    // Corpus labelset query (skipped when no corpus selected)
+    {
+      request: {
+        query: GET_CORPUS_LABELSET_AND_LABELS,
+        variables: {
+          corpusId: "",
+        },
+      },
+      result: {
+        data: {
+          corpus: null,
+        },
+      },
+    },
+  ];
+
+  const cache = createTestCache();
+
+  return (
+    <MockedProvider mocks={mocks} addTypename={false} cache={cache}>
+      <MemoryRouter initialEntries={["/annotations"]}>
+        <InnerWrapper>
+          <Annotations />
+        </InnerWrapper>
+      </MemoryRouter>
+    </MockedProvider>
+  );
+};


### PR DESCRIPTION
- Add SEMANTIC_SEARCH_ANNOTATIONS GraphQL query with TypeScript types
  for calling the new semanticSearch backend endpoint

- Update Annotations.tsx to use semantic search when users enter a
  search query, falling back to browse mode (GET_ANNOTATIONS) when
  the search box is empty

- Add similarity score display to ModernAnnotationCard with color-coded
  badges (green for high match, yellow for medium, gray for low)

- Support offset-based pagination for semantic search results alongside
  existing cursor-based pagination for browse mode

- Update loading states and empty state messages to reflect semantic
  search context when active