### PR TITLE
Add bulk document selection and removal actions to folder toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,31 @@ All notable changes to OpenContracts will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2026-01-24
+## [Unreleased] - 2026-01-25
+
+### Added
+
+#### Bulk Document Selection and Removal
+- **Bulk document selection in folder toolbar**: New Select All / Deselect All functionality for corpus documents
+  - Selection count display showing "X of Y" documents selected
+  - Clear selection button to deselect all
+  - Selection state persists across folder navigation for building cross-folder selections
+  - Files: `frontend/src/components/corpuses/folders/FolderToolbar.tsx:780-827`
+- **Bulk remove from corpus action**: Remove multiple selected documents from corpus in one operation
+  - Dedicated danger button with document count indicator
+  - Proper confirmation modal (replaces browser `window.confirm`)
+  - Files: `frontend/src/components/corpuses/folders/RemoveDocumentsModal.tsx`, `frontend/src/components/corpuses/folders/FolderDocumentBrowser.tsx:367-371`
+- **Mobile-responsive bulk actions**: Kebab menu includes selection controls for tablet/mobile viewports
+  - Files: `frontend/src/components/corpuses/folders/FolderToolbar.tsx:976-993`
+- **Loading state handling**: Select All button disabled while documents are loading to prevent incomplete selections
+  - New `documentsLoading` reactive var syncs loading state from CorpusDocumentCards to FolderToolbar
+  - Files: `frontend/src/graphql/cache.ts:379-384`, `frontend/src/components/documents/CorpusDocumentCards.tsx:193-201`
 
 ### Fixed
+
+#### Cache Eviction Consistency
+- **Fixed folder document counts not updating after bulk removal**: Added `corpusFolders` cache eviction to `REMOVE_DOCUMENTS_FROM_CORPUS` mutation to match the pattern used by `MOVE_DOCUMENT_TO_FOLDER`
+  - Files: `frontend/src/components/corpuses/folders/RemoveDocumentsModal.tsx:109-112`
 
 #### Duplicate Tool Registration and Caller Tool Precedence
 - **Fixed duplicate tool registration error in PydanticAI agent**: Resolved `pydantic_ai.exceptions.UserError` when caller-provided tools have the same name as default tools

--- a/frontend/src/assets/configurations/osLegalStyles.ts
+++ b/frontend/src/assets/configurations/osLegalStyles.ts
@@ -98,6 +98,16 @@ export const OS_LEGAL_COLORS = {
   dangerHover: "#b91c1c",
   /** Danger background - light red tint. */
   dangerLight: "rgba(220, 38, 38, 0.1)",
+  /** Danger surface background - very light red for panels/modals. */
+  dangerSurface: "#fef2f2",
+  /** Danger surface hover state - slightly darker. */
+  dangerSurfaceHover: "#fee2e2",
+  /** Danger border color - light red for subtle borders. */
+  dangerBorder: "#fecaca",
+  /** Danger border hover state - more prominent red. */
+  dangerBorderHover: "#f87171",
+  /** Danger text color - dark red for text on danger surfaces. */
+  dangerText: "#991b1b",
 
   /** Success color - green. Use for confirmations and positive feedback. */
   success: "#16a34a",

--- a/frontend/src/atoms/folderAtoms.ts
+++ b/frontend/src/atoms/folderAtoms.ts
@@ -391,3 +391,36 @@ export const closeAllFolderModalsAtom = atom(null, (_get, set) => {
   set(activeFolderModalIdAtom, null);
   set(createFolderParentIdAtom, null);
 });
+
+// ============================================================================
+// REMOVE DOCUMENTS MODAL STATE
+// ============================================================================
+
+/**
+ * Show/hide remove documents confirmation modal
+ */
+export const showRemoveDocumentsModalAtom = atom<boolean>(false);
+
+/**
+ * Document IDs to be removed (set when opening the modal)
+ */
+export const removeDocumentsIdsAtom = atom<string[]>([]);
+
+/**
+ * Open remove documents confirmation modal
+ */
+export const openRemoveDocumentsModalAtom = atom(
+  null,
+  (_get, set, documentIds: string[]) => {
+    set(removeDocumentsIdsAtom, documentIds);
+    set(showRemoveDocumentsModalAtom, true);
+  }
+);
+
+/**
+ * Close remove documents modal
+ */
+export const closeRemoveDocumentsModalAtom = atom(null, (_get, set) => {
+  set(showRemoveDocumentsModalAtom, false);
+  set(removeDocumentsIdsAtom, []);
+});

--- a/frontend/src/components/corpuses/folders/FolderDocumentBrowser.tsx
+++ b/frontend/src/components/corpuses/folders/FolderDocumentBrowser.tsx
@@ -28,6 +28,7 @@ import {
   linkDocumentsModalState,
   openedCorpus,
   currentViewDocumentIds,
+  documentsLoading,
 } from "../../../graphql/cache";
 import { FolderTreeSidebar } from "./FolderTreeSidebar";
 import { FolderToolbar } from "./FolderToolbar";
@@ -37,6 +38,7 @@ import { BulkImportModal } from "../../widgets/modals/BulkImportModal";
 import { EditFolderModal } from "./EditFolderModal";
 import { MoveFolderModal } from "./MoveFolderModal";
 import { DeleteFolderModal } from "./DeleteFolderModal";
+import { RemoveDocumentsModal } from "./RemoveDocumentsModal";
 import { TrashFolderView } from "./TrashFolderView";
 import {
   folderCorpusIdAtom,
@@ -45,6 +47,7 @@ import {
   openCreateFolderModalAtom,
   folderListAtom,
   corpusPermissionsAtom,
+  openRemoveDocumentsModalAtom,
 } from "../../../atoms/folderAtoms";
 import {
   MOVE_DOCUMENT_TO_FOLDER,
@@ -55,11 +58,6 @@ import {
   MoveCorpusFolderOutputs,
   GET_CORPUS_FOLDERS,
 } from "../../../graphql/queries/folders";
-import {
-  REMOVE_DOCUMENTS_FROM_CORPUS,
-  RemoveDocumentsFromCorpusInputs,
-  RemoveDocumentsFromCorpusOutputs,
-} from "../../../graphql/mutations";
 import { TABLET_BREAKPOINT } from "../../../assets/configurations/constants";
 import {
   OS_LEGAL_COLORS,
@@ -318,6 +316,7 @@ export const FolderDocumentBrowser: React.FC<FolderDocumentBrowserProps> = ({
   const selectedFolderId = useReactiveVar(selectedFolderIdReactiveVar);
   const [sidebarCollapsed, setSidebarCollapsed] = useAtom(sidebarCollapsedAtom);
   const openCreateModal = useSetAtom(openCreateFolderModalAtom);
+  const openRemoveDocumentsModal = useSetAtom(openRemoveDocumentsModalAtom);
   const folderList = useAtomValue(folderListAtom);
   const location = useLocation();
   const navigate = useNavigate();
@@ -344,23 +343,12 @@ export const FolderDocumentBrowser: React.FC<FolderDocumentBrowserProps> = ({
   const linkModalState = useReactiveVar(linkDocumentsModalState);
   const selectedDocumentIds = useReactiveVar(selectedDocumentIdsReactiveVar);
   const viewDocumentIds = useReactiveVar(currentViewDocumentIds);
+  const isDocumentsLoading = useReactiveVar(documentsLoading);
 
   // Compute selection state
   const allSelected =
     viewDocumentIds.length > 0 &&
     viewDocumentIds.every((id) => selectedDocumentIds.includes(id));
-
-  // Remove documents from corpus mutation
-  const [removeDocumentsFromCorpus] = useMutation<
-    RemoveDocumentsFromCorpusOutputs,
-    RemoveDocumentsFromCorpusInputs
-  >(REMOVE_DOCUMENTS_FROM_CORPUS, {
-    // Evict documents from cache to force refetch
-    update(cache) {
-      cache.evict({ fieldName: "documents" });
-      cache.gc();
-    },
-  });
 
   // Handler for Select All / Deselect All
   const handleSelectAll = useCallback(() => {
@@ -378,35 +366,11 @@ export const FolderDocumentBrowser: React.FC<FolderDocumentBrowserProps> = ({
     selectedDocumentIdsReactiveVar([]);
   }, []);
 
-  // Handler for Remove from Corpus (bulk action)
+  // Handler for Remove from Corpus (bulk action) - opens confirmation modal
   const handleRemoveFromCorpus = useCallback(() => {
     if (selectedDocumentIds.length === 0) return;
-
-    const count = selectedDocumentIds.length;
-    const confirmMessage = `Remove ${count} document${
-      count !== 1 ? "s" : ""
-    } from this corpus?`;
-
-    if (window.confirm(confirmMessage)) {
-      removeDocumentsFromCorpus({
-        variables: {
-          corpusId,
-          documentIdsToRemove: selectedDocumentIds,
-        },
-      })
-        .then(() => {
-          toast.success(
-            `Successfully removed ${count} document${
-              count !== 1 ? "s" : ""
-            } from corpus`
-          );
-          selectedDocumentIdsReactiveVar([]);
-        })
-        .catch((error) => {
-          toast.error(`Error removing documents: ${error.message}`);
-        });
-    }
-  }, [selectedDocumentIds, corpusId, removeDocumentsFromCorpus]);
+    openRemoveDocumentsModal(selectedDocumentIds);
+  }, [selectedDocumentIds, openRemoveDocumentsModal]);
 
   // Helper to open the link modal
   const openLinkModal = (sourceIds: string[], targetIds: string[] = []) => {
@@ -773,6 +737,7 @@ export const FolderDocumentBrowser: React.FC<FolderDocumentBrowserProps> = ({
               onClearSelection={handleClearSelection}
               onRemoveFromCorpus={handleRemoveFromCorpus}
               allSelected={allSelected}
+              isLoading={isDocumentsLoading}
             />
           )}
 
@@ -829,6 +794,7 @@ export const FolderDocumentBrowser: React.FC<FolderDocumentBrowserProps> = ({
       <EditFolderModal />
       <MoveFolderModal />
       <DeleteFolderModal />
+      <RemoveDocumentsModal />
 
       {/* Bulk Import Modal */}
       <BulkImportModal />

--- a/frontend/src/components/corpuses/folders/FolderDocumentBrowser.tsx
+++ b/frontend/src/components/corpuses/folders/FolderDocumentBrowser.tsx
@@ -27,6 +27,7 @@ import {
   selectedDocumentIds as selectedDocumentIdsReactiveVar,
   linkDocumentsModalState,
   openedCorpus,
+  currentViewDocumentIds,
 } from "../../../graphql/cache";
 import { FolderTreeSidebar } from "./FolderTreeSidebar";
 import { FolderToolbar } from "./FolderToolbar";
@@ -54,6 +55,11 @@ import {
   MoveCorpusFolderOutputs,
   GET_CORPUS_FOLDERS,
 } from "../../../graphql/queries/folders";
+import {
+  REMOVE_DOCUMENTS_FROM_CORPUS,
+  RemoveDocumentsFromCorpusInputs,
+  RemoveDocumentsFromCorpusOutputs,
+} from "../../../graphql/mutations";
 import { TABLET_BREAKPOINT } from "../../../assets/configurations/constants";
 import {
   OS_LEGAL_COLORS,
@@ -337,6 +343,70 @@ export const FolderDocumentBrowser: React.FC<FolderDocumentBrowserProps> = ({
   // Document relationship modal state (from reactive var for cross-component access)
   const linkModalState = useReactiveVar(linkDocumentsModalState);
   const selectedDocumentIds = useReactiveVar(selectedDocumentIdsReactiveVar);
+  const viewDocumentIds = useReactiveVar(currentViewDocumentIds);
+
+  // Compute selection state
+  const allSelected =
+    viewDocumentIds.length > 0 &&
+    viewDocumentIds.every((id) => selectedDocumentIds.includes(id));
+
+  // Remove documents from corpus mutation
+  const [removeDocumentsFromCorpus] = useMutation<
+    RemoveDocumentsFromCorpusOutputs,
+    RemoveDocumentsFromCorpusInputs
+  >(REMOVE_DOCUMENTS_FROM_CORPUS, {
+    // Evict documents from cache to force refetch
+    update(cache) {
+      cache.evict({ fieldName: "documents" });
+      cache.gc();
+    },
+  });
+
+  // Handler for Select All / Deselect All
+  const handleSelectAll = useCallback(() => {
+    if (allSelected) {
+      // Deselect all
+      selectedDocumentIdsReactiveVar([]);
+    } else {
+      // Select all visible documents
+      selectedDocumentIdsReactiveVar([...viewDocumentIds]);
+    }
+  }, [allSelected, viewDocumentIds]);
+
+  // Handler for Clear Selection
+  const handleClearSelection = useCallback(() => {
+    selectedDocumentIdsReactiveVar([]);
+  }, []);
+
+  // Handler for Remove from Corpus (bulk action)
+  const handleRemoveFromCorpus = useCallback(() => {
+    if (selectedDocumentIds.length === 0) return;
+
+    const count = selectedDocumentIds.length;
+    const confirmMessage = `Remove ${count} document${
+      count !== 1 ? "s" : ""
+    } from this corpus?`;
+
+    if (window.confirm(confirmMessage)) {
+      removeDocumentsFromCorpus({
+        variables: {
+          corpusId,
+          documentIdsToRemove: selectedDocumentIds,
+        },
+      })
+        .then(() => {
+          toast.success(
+            `Successfully removed ${count} document${
+              count !== 1 ? "s" : ""
+            } from corpus`
+          );
+          selectedDocumentIdsReactiveVar([]);
+        })
+        .catch((error) => {
+          toast.error(`Error removing documents: ${error.message}`);
+        });
+    }
+  }, [selectedDocumentIds, corpusId, removeDocumentsFromCorpus]);
 
   // Helper to open the link modal
   const openLinkModal = (sourceIds: string[], targetIds: string[] = []) => {
@@ -697,7 +767,12 @@ export const FolderDocumentBrowser: React.FC<FolderDocumentBrowserProps> = ({
               onUpload={handleUpload}
               onBulkImport={handleBulkImport}
               selectedDocumentCount={selectedDocumentIds.length}
+              totalDocumentCount={viewDocumentIds.length}
               onLinkDocuments={() => openLinkModal(selectedDocumentIds)}
+              onSelectAll={handleSelectAll}
+              onClearSelection={handleClearSelection}
+              onRemoveFromCorpus={handleRemoveFromCorpus}
+              allSelected={allSelected}
             />
           )}
 

--- a/frontend/src/components/corpuses/folders/FolderToolbar.tsx
+++ b/frontend/src/components/corpuses/folders/FolderToolbar.tsx
@@ -14,6 +14,10 @@ import {
   Link2,
   ChevronDown,
   FileArchive,
+  CheckSquare,
+  Square,
+  X,
+  Trash2,
 } from "lucide-react";
 import { FolderBreadcrumb } from "./FolderBreadcrumb";
 import {
@@ -61,8 +65,18 @@ interface FolderToolbarProps {
   onBulkImport?: () => void;
   /** Number of currently selected documents (for multi-select actions) */
   selectedDocumentCount?: number;
+  /** Total number of documents in current view (for Select All) */
+  totalDocumentCount?: number;
   /** Callback when user clicks Link Documents button */
   onLinkDocuments?: () => void;
+  /** Callback when user clicks Select All */
+  onSelectAll?: () => void;
+  /** Callback when user clicks Clear Selection */
+  onClearSelection?: () => void;
+  /** Callback when user clicks Remove from Corpus (bulk action) */
+  onRemoveFromCorpus?: () => void;
+  /** Whether all visible documents are selected */
+  allSelected?: boolean;
 }
 
 // ===============================================
@@ -256,6 +270,121 @@ const ViewToggleButton = styled.button<{ $active: boolean }>`
   svg {
     width: 16px;
     height: 16px;
+  }
+`;
+
+// Selection controls group - shown when documents exist
+const SelectionGroup = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  background: ${OS_LEGAL_COLORS.surfaceHover};
+  border-radius: ${OS_LEGAL_SPACING.borderRadiusButton};
+  border: 1px solid ${OS_LEGAL_COLORS.border};
+
+  @media (max-width: ${TABLET_BREAKPOINT}px) {
+    display: none;
+  }
+`;
+
+const SelectAllButton = styled.button<{ $allSelected?: boolean }>`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  background: ${(props) =>
+    props.$allSelected ? OS_LEGAL_COLORS.accent : "transparent"};
+  border: none;
+  border-radius: 4px;
+  font-size: 12px;
+  font-weight: 500;
+  color: ${(props) =>
+    props.$allSelected ? "white" : OS_LEGAL_COLORS.textSecondary};
+  cursor: pointer;
+  transition: all 0.15s ease;
+
+  &:hover {
+    background: ${(props) =>
+      props.$allSelected
+        ? OS_LEGAL_COLORS.accentHover
+        : OS_LEGAL_COLORS.border};
+    color: ${(props) =>
+      props.$allSelected ? "white" : OS_LEGAL_COLORS.textPrimary};
+  }
+
+  svg {
+    width: 14px;
+    height: 14px;
+  }
+`;
+
+const SelectionCount = styled.span`
+  font-size: 12px;
+  font-weight: 500;
+  color: ${OS_LEGAL_COLORS.textSecondary};
+  padding: 0 4px;
+`;
+
+const SelectionDivider = styled.div`
+  width: 1px;
+  height: 16px;
+  background: ${OS_LEGAL_COLORS.border};
+`;
+
+const ClearSelectionButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px;
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  color: ${OS_LEGAL_COLORS.textMuted};
+  cursor: pointer;
+  transition: all 0.15s ease;
+
+  &:hover {
+    background: ${OS_LEGAL_COLORS.border};
+    color: ${OS_LEGAL_COLORS.textPrimary};
+  }
+
+  svg {
+    width: 14px;
+    height: 14px;
+  }
+`;
+
+const DangerButton = styled.button`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  border-radius: ${OS_LEGAL_SPACING.borderRadiusButton};
+  font-size: 13px;
+  font-weight: 500;
+  color: #dc2626;
+  cursor: pointer;
+  transition: all 0.15s ease;
+
+  &:hover {
+    background: #fee2e2;
+    border-color: #f87171;
+  }
+
+  svg {
+    width: 16px;
+    height: 16px;
+  }
+
+  @media (max-width: ${TABLET_BREAKPOINT}px) {
+    padding: 8px;
+
+    span {
+      display: none;
+    }
   }
 `;
 
@@ -520,7 +649,12 @@ export const FolderToolbar: React.FC<FolderToolbarProps> = ({
   onUpload,
   onBulkImport,
   selectedDocumentCount = 0,
+  totalDocumentCount = 0,
   onLinkDocuments,
+  onSelectAll,
+  onClearSelection,
+  onRemoveFromCorpus,
+  allSelected = false,
 }) => {
   const [sidebarCollapsed, setSidebarCollapsed] = useAtom(sidebarCollapsedAtom);
   const canCreateFolders = useAtomValue(canCreateFoldersAtom);
@@ -639,6 +773,51 @@ export const FolderToolbar: React.FC<FolderToolbarProps> = ({
         >
           <ChevronUp />
         </NavButton>
+
+        {/* Selection controls - shown when documents exist */}
+        {totalDocumentCount > 0 && onSelectAll && (
+          <SelectionGroup>
+            <SelectAllButton
+              onClick={onSelectAll}
+              $allSelected={allSelected}
+              title={allSelected ? "Deselect all" : "Select all"}
+              aria-label={allSelected ? "Deselect all" : "Select all"}
+            >
+              {allSelected ? <CheckSquare /> : <Square />}
+              {allSelected ? "All" : "Select All"}
+            </SelectAllButton>
+            {selectedDocumentCount > 0 && (
+              <>
+                <SelectionDivider />
+                <SelectionCount>
+                  {selectedDocumentCount} of {totalDocumentCount}
+                </SelectionCount>
+                {onClearSelection && (
+                  <ClearSelectionButton
+                    onClick={onClearSelection}
+                    title="Clear selection"
+                    aria-label="Clear selection"
+                  >
+                    <X />
+                  </ClearSelectionButton>
+                )}
+              </>
+            )}
+          </SelectionGroup>
+        )}
+
+        {/* Remove from Corpus button - visible when 1+ documents selected */}
+        {selectedDocumentCount >= 1 && onRemoveFromCorpus && (
+          <DangerButton
+            onClick={onRemoveFromCorpus}
+            title={`Remove ${selectedDocumentCount} document${
+              selectedDocumentCount !== 1 ? "s" : ""
+            } from corpus`}
+          >
+            <Trash2 />
+            <span>Remove ({selectedDocumentCount})</span>
+          </DangerButton>
+        )}
 
         {/* Link Documents button - visible when 1+ documents selected */}
         {selectedDocumentCount >= 1 && onLinkDocuments && (
@@ -773,6 +952,44 @@ export const FolderToolbar: React.FC<FolderToolbarProps> = ({
           <PanelLeftOpen />
           Show Folders
         </MobileMenuItem>
+        {/* Selection controls for mobile */}
+        {totalDocumentCount > 0 && onSelectAll && (
+          <MobileMenuItem
+            role="menuitem"
+            onClick={() => {
+              onSelectAll();
+              closeMobileMenu();
+            }}
+          >
+            {allSelected ? <CheckSquare /> : <Square />}
+            {allSelected ? "Deselect All" : "Select All"} ({totalDocumentCount})
+          </MobileMenuItem>
+        )}
+        {selectedDocumentCount > 0 && onClearSelection && (
+          <MobileMenuItem
+            role="menuitem"
+            onClick={() => {
+              onClearSelection();
+              closeMobileMenu();
+            }}
+          >
+            <X />
+            Clear Selection ({selectedDocumentCount})
+          </MobileMenuItem>
+        )}
+        {selectedDocumentCount >= 1 && onRemoveFromCorpus && (
+          <MobileMenuItem
+            role="menuitem"
+            onClick={() => {
+              onRemoveFromCorpus();
+              closeMobileMenu();
+            }}
+            style={{ color: "#dc2626" }}
+          >
+            <Trash2 />
+            Remove from Corpus ({selectedDocumentCount})
+          </MobileMenuItem>
+        )}
         {selectedDocumentCount >= 1 && onLinkDocuments && (
           <MobileMenuItem
             role="menuitem"

--- a/frontend/src/components/corpuses/folders/FolderToolbar.tsx
+++ b/frontend/src/components/corpuses/folders/FolderToolbar.tsx
@@ -367,18 +367,18 @@ const DangerButton = styled.button`
   align-items: center;
   gap: 6px;
   padding: 8px 12px;
-  background: #fef2f2;
-  border: 1px solid #fecaca;
+  background: ${OS_LEGAL_COLORS.dangerSurface};
+  border: 1px solid ${OS_LEGAL_COLORS.dangerBorder};
   border-radius: ${OS_LEGAL_SPACING.borderRadiusButton};
   font-size: 13px;
   font-weight: 500;
-  color: #dc2626;
+  color: ${OS_LEGAL_COLORS.danger};
   cursor: pointer;
   transition: all 0.15s ease;
 
   &:hover {
-    background: #fee2e2;
-    border-color: #f87171;
+    background: ${OS_LEGAL_COLORS.dangerSurfaceHover};
+    border-color: ${OS_LEGAL_COLORS.dangerBorderHover};
   }
 
   svg {
@@ -681,13 +681,7 @@ export const FolderToolbar: React.FC<FolderToolbarProps> = ({
   // Memoized view mode change handler to prevent unnecessary re-renders
   const handleViewModeChange = useCallback(
     (mode: ViewMode) => {
-      console.log("[FolderToolbar] View mode change requested:", mode);
-      if (onViewModeChange) {
-        console.log("[FolderToolbar] Calling onViewModeChange with:", mode);
-        onViewModeChange(mode);
-      } else {
-        console.log("[FolderToolbar] onViewModeChange is not defined!");
-      }
+      onViewModeChange?.(mode);
     },
     [onViewModeChange]
   );
@@ -1013,7 +1007,7 @@ export const FolderToolbar: React.FC<FolderToolbarProps> = ({
               onRemoveFromCorpus();
               closeMobileMenu();
             }}
-            style={{ color: "#dc2626" }}
+            style={{ color: OS_LEGAL_COLORS.danger }}
           >
             <Trash2 />
             Remove from Corpus ({selectedDocumentCount})

--- a/frontend/src/components/corpuses/folders/FolderToolbar.tsx
+++ b/frontend/src/components/corpuses/folders/FolderToolbar.tsx
@@ -77,6 +77,8 @@ interface FolderToolbarProps {
   onRemoveFromCorpus?: () => void;
   /** Whether all visible documents are selected */
   allSelected?: boolean;
+  /** Whether documents are currently loading (disables Select All) */
+  isLoading?: boolean;
 }
 
 // ===============================================
@@ -304,13 +306,18 @@ const SelectAllButton = styled.button<{ $allSelected?: boolean }>`
   cursor: pointer;
   transition: all 0.15s ease;
 
-  &:hover {
+  &:hover:not(:disabled) {
     background: ${(props) =>
       props.$allSelected
         ? OS_LEGAL_COLORS.accentHover
         : OS_LEGAL_COLORS.border};
     color: ${(props) =>
       props.$allSelected ? "white" : OS_LEGAL_COLORS.textPrimary};
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
   }
 
   svg {
@@ -655,6 +662,7 @@ export const FolderToolbar: React.FC<FolderToolbarProps> = ({
   onClearSelection,
   onRemoveFromCorpus,
   allSelected = false,
+  isLoading = false,
 }) => {
   const [sidebarCollapsed, setSidebarCollapsed] = useAtom(sidebarCollapsedAtom);
   const canCreateFolders = useAtomValue(canCreateFoldersAtom);
@@ -780,8 +788,21 @@ export const FolderToolbar: React.FC<FolderToolbarProps> = ({
             <SelectAllButton
               onClick={onSelectAll}
               $allSelected={allSelected}
-              title={allSelected ? "Deselect all" : "Select all"}
-              aria-label={allSelected ? "Deselect all" : "Select all"}
+              disabled={isLoading}
+              title={
+                isLoading
+                  ? "Loading documents..."
+                  : allSelected
+                  ? "Deselect all"
+                  : "Select all"
+              }
+              aria-label={
+                isLoading
+                  ? "Loading documents"
+                  : allSelected
+                  ? "Deselect all"
+                  : "Select all"
+              }
             >
               {allSelected ? <CheckSquare /> : <Square />}
               {allSelected ? "All" : "Select All"}
@@ -956,13 +977,21 @@ export const FolderToolbar: React.FC<FolderToolbarProps> = ({
         {totalDocumentCount > 0 && onSelectAll && (
           <MobileMenuItem
             role="menuitem"
+            disabled={isLoading}
             onClick={() => {
-              onSelectAll();
-              closeMobileMenu();
+              if (!isLoading) {
+                onSelectAll();
+                closeMobileMenu();
+              }
             }}
+            style={isLoading ? { opacity: 0.5, cursor: "not-allowed" } : {}}
           >
             {allSelected ? <CheckSquare /> : <Square />}
-            {allSelected ? "Deselect All" : "Select All"} ({totalDocumentCount})
+            {isLoading
+              ? "Loading..."
+              : `${
+                  allSelected ? "Deselect All" : "Select All"
+                } (${totalDocumentCount})`}
           </MobileMenuItem>
         )}
         {selectedDocumentCount > 0 && onClearSelection && (

--- a/frontend/src/components/corpuses/folders/RemoveDocumentsModal.tsx
+++ b/frontend/src/components/corpuses/folders/RemoveDocumentsModal.tsx
@@ -1,0 +1,228 @@
+import React, { useCallback } from "react";
+import { useAtomValue, useSetAtom } from "jotai";
+import { useMutation } from "@apollo/client";
+import { Modal, Button, Message } from "semantic-ui-react";
+import styled from "styled-components";
+import { X, AlertTriangle } from "lucide-react";
+import { toast } from "react-toastify";
+import {
+  showRemoveDocumentsModalAtom,
+  removeDocumentsIdsAtom,
+  closeRemoveDocumentsModalAtom,
+  folderCorpusIdAtom,
+} from "../../../atoms/folderAtoms";
+import {
+  REMOVE_DOCUMENTS_FROM_CORPUS,
+  RemoveDocumentsFromCorpusInputs,
+  RemoveDocumentsFromCorpusOutputs,
+} from "../../../graphql/mutations";
+import { selectedDocumentIds as selectedDocumentIdsReactiveVar } from "../../../graphql/cache";
+
+/**
+ * RemoveDocumentsModal - Confirmation modal for bulk removing documents from corpus
+ *
+ * Features:
+ * - Shows count of documents to be removed
+ * - Requires explicit confirmation
+ * - Clears selection after successful removal
+ * - Shows loading and error states
+ */
+
+const StyledModal = styled(Modal)`
+  &.ui.modal {
+    max-width: 500px;
+  }
+`;
+
+const ModalHeader = styled(Modal.Header)`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: #fef2f2;
+  border-bottom: 2px solid #fecaca;
+  color: #991b1b;
+`;
+
+const CloseButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  background: none;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  color: #dc2626;
+  transition: all 0.15s ease;
+
+  &:hover {
+    background: #fecaca;
+    color: #991b1b;
+  }
+`;
+
+const WarningBox = styled.div`
+  display: flex;
+  gap: 12px;
+  padding: 16px;
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  border-radius: 8px;
+  margin-bottom: 16px;
+  color: #991b1b;
+`;
+
+const WarningIcon = styled(AlertTriangle)`
+  flex-shrink: 0;
+  margin-top: 2px;
+`;
+
+const WarningContent = styled.div`
+  flex: 1;
+
+  h4 {
+    margin: 0 0 8px 0;
+    font-size: 16px;
+    font-weight: 600;
+  }
+
+  p {
+    margin: 0;
+    font-size: 14px;
+    line-height: 1.5;
+  }
+`;
+
+const InfoBox = styled.div`
+  padding: 12px;
+  background: #f8fafc;
+  border-radius: 6px;
+  font-size: 14px;
+  color: #475569;
+
+  strong {
+    color: #1e293b;
+    font-weight: 600;
+  }
+`;
+
+export const RemoveDocumentsModal: React.FC = () => {
+  const showModal = useAtomValue(showRemoveDocumentsModalAtom);
+  const documentIds = useAtomValue(removeDocumentsIdsAtom);
+  const corpusId = useAtomValue(folderCorpusIdAtom);
+  const closeModal = useSetAtom(closeRemoveDocumentsModalAtom);
+
+  const [removeDocuments, { loading, error }] = useMutation<
+    RemoveDocumentsFromCorpusOutputs,
+    RemoveDocumentsFromCorpusInputs
+  >(REMOVE_DOCUMENTS_FROM_CORPUS, {
+    // Evict documents and folders from cache to force refetch
+    // This ensures both the document list and folder tree (with doc counts) update
+    update(cache) {
+      cache.evict({ fieldName: "documents" });
+      cache.evict({ fieldName: "corpusFolders" });
+      cache.gc();
+    },
+    onCompleted: (data) => {
+      if (data.removeDocumentsFromCorpus.ok) {
+        const count = documentIds.length;
+        toast.success(
+          `Successfully removed ${count} document${
+            count !== 1 ? "s" : ""
+          } from corpus`
+        );
+        // Clear selection after successful removal
+        selectedDocumentIdsReactiveVar([]);
+        closeModal();
+      } else {
+        toast.error(
+          data.removeDocumentsFromCorpus.message ||
+            "Failed to remove documents from corpus"
+        );
+      }
+    },
+    onError: (error) => {
+      toast.error(`Error removing documents: ${error.message}`);
+    },
+  });
+
+  const handleClose = useCallback(() => {
+    if (!loading) {
+      closeModal();
+    }
+  }, [closeModal, loading]);
+
+  const handleConfirmRemove = useCallback(() => {
+    if (!corpusId || documentIds.length === 0) return;
+
+    removeDocuments({
+      variables: {
+        corpusId,
+        documentIdsToRemove: documentIds,
+      },
+    });
+  }, [corpusId, documentIds, removeDocuments]);
+
+  if (!showModal || documentIds.length === 0) return null;
+
+  const count = documentIds.length;
+
+  return (
+    <StyledModal open={showModal} onClose={handleClose} size="small">
+      <ModalHeader>
+        <span>Remove Documents from Corpus</span>
+        <CloseButton
+          onClick={handleClose}
+          aria-label="Close"
+          disabled={loading}
+        >
+          <X size={20} />
+        </CloseButton>
+      </ModalHeader>
+
+      <Modal.Content>
+        <WarningBox>
+          <WarningIcon size={24} />
+          <WarningContent>
+            <h4>Confirm Removal</h4>
+            <p>
+              You are about to remove{" "}
+              <strong>
+                {count} document{count !== 1 ? "s" : ""}
+              </strong>{" "}
+              from this corpus. The documents will remain in your library but
+              will no longer be associated with this corpus.
+            </p>
+          </WarningContent>
+        </WarningBox>
+
+        <InfoBox>
+          <strong>Documents to remove:</strong> {count}
+        </InfoBox>
+
+        {error && (
+          <Message error style={{ marginTop: "16px" }}>
+            <Message.Header>Error Removing Documents</Message.Header>
+            <p>{error.message}</p>
+          </Message>
+        )}
+      </Modal.Content>
+
+      <Modal.Actions>
+        <Button onClick={handleClose} disabled={loading}>
+          Cancel
+        </Button>
+        <Button
+          negative
+          onClick={handleConfirmRemove}
+          loading={loading}
+          disabled={loading}
+        >
+          Remove {count} Document{count !== 1 ? "s" : ""}
+        </Button>
+      </Modal.Actions>
+    </StyledModal>
+  );
+};

--- a/frontend/src/components/corpuses/folders/RemoveDocumentsModal.tsx
+++ b/frontend/src/components/corpuses/folders/RemoveDocumentsModal.tsx
@@ -5,6 +5,7 @@ import { Modal, Button, Message } from "semantic-ui-react";
 import styled from "styled-components";
 import { X, AlertTriangle } from "lucide-react";
 import { toast } from "react-toastify";
+import { OS_LEGAL_COLORS } from "../../../assets/configurations/osLegalStyles";
 import {
   showRemoveDocumentsModalAtom,
   removeDocumentsIdsAtom,
@@ -38,9 +39,9 @@ const ModalHeader = styled(Modal.Header)`
   display: flex;
   align-items: center;
   justify-content: space-between;
-  background: #fef2f2;
-  border-bottom: 2px solid #fecaca;
-  color: #991b1b;
+  background: ${OS_LEGAL_COLORS.dangerSurface};
+  border-bottom: 2px solid ${OS_LEGAL_COLORS.dangerBorder};
+  color: ${OS_LEGAL_COLORS.dangerText};
 `;
 
 const CloseButton = styled.button`
@@ -54,12 +55,12 @@ const CloseButton = styled.button`
   border: none;
   border-radius: 6px;
   cursor: pointer;
-  color: #dc2626;
+  color: ${OS_LEGAL_COLORS.danger};
   transition: all 0.15s ease;
 
   &:hover {
-    background: #fecaca;
-    color: #991b1b;
+    background: ${OS_LEGAL_COLORS.dangerBorder};
+    color: ${OS_LEGAL_COLORS.dangerText};
   }
 `;
 
@@ -67,11 +68,11 @@ const WarningBox = styled.div`
   display: flex;
   gap: 12px;
   padding: 16px;
-  background: #fef2f2;
-  border: 1px solid #fecaca;
+  background: ${OS_LEGAL_COLORS.dangerSurface};
+  border: 1px solid ${OS_LEGAL_COLORS.dangerBorder};
   border-radius: 8px;
   margin-bottom: 16px;
-  color: #991b1b;
+  color: ${OS_LEGAL_COLORS.dangerText};
 `;
 
 const WarningIcon = styled(AlertTriangle)`

--- a/frontend/src/components/documents/CorpusDocumentCards.tsx
+++ b/frontend/src/components/documents/CorpusDocumentCards.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useEffect } from "react";
 import { toast } from "react-toastify";
 import { useMutation, useQuery, useReactiveVar } from "@apollo/client";
 import { useNavigate } from "react-router-dom";
@@ -20,6 +20,7 @@ import {
   openedCorpus,
   selectedFolderId,
   linkDocumentsModalState,
+  currentViewDocumentIds,
 } from "../../graphql/cache";
 import {
   GET_CORPUS_FOLDERS,
@@ -176,6 +177,17 @@ export const CorpusDocumentCards = ({
     "documents for folderId:",
     selected_folder_id
   );
+
+  // Update the global reactive var with current view document IDs for toolbar's Select All functionality
+  useEffect(() => {
+    const ids = document_items.map((doc) => doc.id);
+    currentViewDocumentIds(ids);
+
+    // Clear on unmount
+    return () => {
+      currentViewDocumentIds([]);
+    };
+  }, [document_items]);
 
   const handleRemoveContracts = (delete_ids: string[]) => {
     removeDocumentsFromCorpus({

--- a/frontend/src/components/documents/CorpusDocumentCards.tsx
+++ b/frontend/src/components/documents/CorpusDocumentCards.tsx
@@ -21,6 +21,7 @@ import {
   selectedFolderId,
   linkDocumentsModalState,
   currentViewDocumentIds,
+  documentsLoading as documentsLoadingVar,
 } from "../../graphql/cache";
 import {
   GET_CORPUS_FOLDERS,
@@ -188,6 +189,16 @@ export const CorpusDocumentCards = ({
       currentViewDocumentIds([]);
     };
   }, [document_items]);
+
+  // Sync loading state to reactive var for toolbar to disable Select All while loading
+  useEffect(() => {
+    documentsLoadingVar(documents_loading);
+
+    // Clear on unmount
+    return () => {
+      documentsLoadingVar(false);
+    };
+  }, [documents_loading]);
 
   const handleRemoveContracts = (delete_ids: string[]) => {
     removeDocumentsFromCorpus({

--- a/frontend/src/components/documents/CorpusDocumentCards.tsx
+++ b/frontend/src/components/documents/CorpusDocumentCards.tsx
@@ -57,8 +57,6 @@ export const CorpusDocumentCards = ({
    * If the corpus_id is passed in, it will query and display the documents for
    * that corpus and let you browse them.
    */
-  console.log("[CorpusDocumentCards] Rendering with viewMode:", viewMode);
-
   const selected_document_ids = useReactiveVar(selectedDocumentIds);
   const document_search_term = useReactiveVar(documentSearchTerm);
   const selected_metadata_id_to_filter_on = useReactiveVar(
@@ -96,8 +94,6 @@ export const CorpusDocumentCards = ({
     ...(filter_to_label_id ? { hasLabelWithId: filter_to_label_id } : {}),
     ...(document_search_term ? { textSearch: document_search_term } : {}),
   };
-
-  console.log("[QUERY] GET_DOCUMENTS variables:", queryVariables);
 
   const {
     refetch: refetchDocuments,
@@ -171,13 +167,6 @@ export const CorpusDocumentCards = ({
   const document_items = document_data
     .map((edge) => (edge?.node ? edge.node : undefined))
     .filter((item): item is DocumentType => !!item);
-
-  console.log(
-    "[QUERY] GET_DOCUMENTS returned",
-    document_items.length,
-    "documents for folderId:",
-    selected_folder_id
-  );
 
   // Update the global reactive var with current view document IDs for toolbar's Select All functionality
   useEffect(() => {

--- a/frontend/src/graphql/cache.ts
+++ b/frontend/src/graphql/cache.ts
@@ -369,6 +369,12 @@ export const openedDocument = makeVar<DocumentType | null>(null);
 export const selectedDocumentIds = makeVar<string[]>([]);
 export const viewingDocument = makeVar<DocumentType | null>(null);
 export const editingDocument = makeVar<DocumentType | null>(null);
+/**
+ * Tracks document IDs currently visible in the folder/corpus view.
+ * Used by FolderToolbar to enable Select All functionality.
+ * Set by CorpusDocumentCards when documents load.
+ */
+export const currentViewDocumentIds = makeVar<string[]>([]);
 
 /**
  * Document relationship modal state.

--- a/frontend/src/graphql/cache.ts
+++ b/frontend/src/graphql/cache.ts
@@ -377,6 +377,13 @@ export const editingDocument = makeVar<DocumentType | null>(null);
 export const currentViewDocumentIds = makeVar<string[]>([]);
 
 /**
+ * Tracks whether documents are currently loading in the folder/corpus view.
+ * Used by FolderToolbar to disable Select All while loading.
+ * Set by CorpusDocumentCards during query loading state.
+ */
+export const documentsLoading = makeVar<boolean>(false);
+
+/**
  * Document relationship modal state.
  * Used to trigger the link documents modal from various entry points:
  * - Right-click context menu on a single document

--- a/frontend/src/graphql/mutations.ts
+++ b/frontend/src/graphql/mutations.ts
@@ -795,8 +795,10 @@ export interface RemoveDocumentsFromCorpusInputs {
 }
 
 export interface RemoveDocumentsFromCorpusOutputs {
-  ok?: boolean;
-  message?: string;
+  removeDocumentsFromCorpus: {
+    ok?: boolean;
+    message?: string;
+  };
 }
 
 export const REMOVE_DOCUMENTS_FROM_CORPUS = gql`

--- a/frontend/tests/folders/FolderToolbar.ct.tsx
+++ b/frontend/tests/folders/FolderToolbar.ct.tsx
@@ -292,4 +292,250 @@ test.describe("FolderToolbar", () => {
       await expect(tableButton).toHaveAttribute("aria-label", "Table view");
     });
   });
+
+  test.describe("Selection Controls", () => {
+    test("shows selection group when documents exist and onSelectAll is provided", async ({
+      mount,
+    }) => {
+      const component = await mount(
+        <FolderTestWrapper>
+          <ToolbarFixture
+            totalDocumentCount={10}
+            selectedDocumentCount={0}
+            onSelectAll={() => {}}
+          />
+        </FolderTestWrapper>
+      );
+
+      // Selection group should be visible with Select All button
+      const selectAllButton = component.getByRole("button", {
+        name: "Select all",
+      });
+      await expect(selectAllButton).toBeVisible();
+    });
+
+    test("hides selection group when no documents exist", async ({ mount }) => {
+      const component = await mount(
+        <FolderTestWrapper>
+          <ToolbarFixture
+            totalDocumentCount={0}
+            selectedDocumentCount={0}
+            onSelectAll={() => {}}
+          />
+        </FolderTestWrapper>
+      );
+
+      // Selection group should not be visible
+      const selectAllButtons = component.locator(
+        'button:has-text("Select All")'
+      );
+      await expect(selectAllButtons).toHaveCount(0);
+    });
+
+    test("shows selection count when documents are selected", async ({
+      mount,
+    }) => {
+      const component = await mount(
+        <FolderTestWrapper>
+          <ToolbarFixture
+            totalDocumentCount={10}
+            selectedDocumentCount={3}
+            onSelectAll={() => {}}
+            onClearSelection={() => {}}
+          />
+        </FolderTestWrapper>
+      );
+
+      // Should show "3 of 10" text
+      await expect(component.locator("text=3 of 10")).toBeVisible();
+    });
+
+    test("shows clear selection button when documents are selected", async ({
+      mount,
+    }) => {
+      const component = await mount(
+        <FolderTestWrapper>
+          <ToolbarFixture
+            totalDocumentCount={10}
+            selectedDocumentCount={3}
+            onSelectAll={() => {}}
+            onClearSelection={() => {}}
+          />
+        </FolderTestWrapper>
+      );
+
+      const clearButton = component.getByRole("button", {
+        name: "Clear selection",
+      });
+      await expect(clearButton).toBeVisible();
+    });
+
+    test("calls onSelectAll when Select All button is clicked", async ({
+      mount,
+    }) => {
+      let selectAllCalled = false;
+      const component = await mount(
+        <FolderTestWrapper>
+          <ToolbarFixture
+            totalDocumentCount={10}
+            selectedDocumentCount={0}
+            onSelectAll={() => {
+              selectAllCalled = true;
+            }}
+          />
+        </FolderTestWrapper>
+      );
+
+      const selectAllButton = component.getByRole("button", {
+        name: "Select all",
+      });
+      await selectAllButton.click();
+
+      expect(selectAllCalled).toBe(true);
+    });
+
+    test("calls onClearSelection when clear button is clicked", async ({
+      mount,
+    }) => {
+      let clearCalled = false;
+      const component = await mount(
+        <FolderTestWrapper>
+          <ToolbarFixture
+            totalDocumentCount={10}
+            selectedDocumentCount={3}
+            onSelectAll={() => {}}
+            onClearSelection={() => {
+              clearCalled = true;
+            }}
+          />
+        </FolderTestWrapper>
+      );
+
+      const clearButton = component.getByRole("button", {
+        name: "Clear selection",
+      });
+      await clearButton.click();
+
+      expect(clearCalled).toBe(true);
+    });
+
+    test("Select All button is disabled when loading", async ({ mount }) => {
+      const component = await mount(
+        <FolderTestWrapper>
+          <ToolbarFixture
+            totalDocumentCount={10}
+            selectedDocumentCount={0}
+            onSelectAll={() => {}}
+            isLoading={true}
+          />
+        </FolderTestWrapper>
+      );
+
+      const selectAllButton = component.getByRole("button", {
+        name: "Loading documents",
+      });
+      await expect(selectAllButton).toBeDisabled();
+    });
+
+    test("shows checkmark icon when all documents are selected", async ({
+      mount,
+    }) => {
+      const component = await mount(
+        <FolderTestWrapper>
+          <ToolbarFixture
+            totalDocumentCount={10}
+            selectedDocumentCount={10}
+            onSelectAll={() => {}}
+            allSelected={true}
+          />
+        </FolderTestWrapper>
+      );
+
+      // When all selected, button should say "Deselect all"
+      const deselectButton = component.getByRole("button", {
+        name: "Deselect all",
+      });
+      await expect(deselectButton).toBeVisible();
+    });
+  });
+
+  test.describe("Remove from Corpus Button", () => {
+    test("shows Remove button when documents are selected", async ({
+      mount,
+    }) => {
+      const component = await mount(
+        <FolderTestWrapper>
+          <ToolbarFixture
+            totalDocumentCount={10}
+            selectedDocumentCount={3}
+            onSelectAll={() => {}}
+            onRemoveFromCorpus={() => {}}
+          />
+        </FolderTestWrapper>
+      );
+
+      // Remove button should show count
+      const removeButton = component.locator('button:has-text("Remove (3)")');
+      await expect(removeButton).toBeVisible();
+    });
+
+    test("hides Remove button when no documents are selected", async ({
+      mount,
+    }) => {
+      const component = await mount(
+        <FolderTestWrapper>
+          <ToolbarFixture
+            totalDocumentCount={10}
+            selectedDocumentCount={0}
+            onSelectAll={() => {}}
+            onRemoveFromCorpus={() => {}}
+          />
+        </FolderTestWrapper>
+      );
+
+      const removeButtons = component.locator('button:has-text("Remove")');
+      await expect(removeButtons).toHaveCount(0);
+    });
+
+    test("calls onRemoveFromCorpus when Remove button is clicked", async ({
+      mount,
+    }) => {
+      let removeCalled = false;
+      const component = await mount(
+        <FolderTestWrapper>
+          <ToolbarFixture
+            totalDocumentCount={10}
+            selectedDocumentCount={3}
+            onSelectAll={() => {}}
+            onRemoveFromCorpus={() => {
+              removeCalled = true;
+            }}
+          />
+        </FolderTestWrapper>
+      );
+
+      const removeButton = component.locator('button:has-text("Remove (3)")');
+      await removeButton.click();
+
+      expect(removeCalled).toBe(true);
+    });
+
+    test("Remove button shows correct singular text for 1 document", async ({
+      mount,
+    }) => {
+      const component = await mount(
+        <FolderTestWrapper>
+          <ToolbarFixture
+            totalDocumentCount={10}
+            selectedDocumentCount={1}
+            onSelectAll={() => {}}
+            onRemoveFromCorpus={() => {}}
+          />
+        </FolderTestWrapper>
+      );
+
+      const removeButton = component.locator('button:has-text("Remove (1)")');
+      await expect(removeButton).toBeVisible();
+    });
+  });
 });

--- a/frontend/tests/folders/RemoveDocumentsModal.ct.tsx
+++ b/frontend/tests/folders/RemoveDocumentsModal.ct.tsx
@@ -1,0 +1,202 @@
+import { test, expect } from "@playwright/experimental-ct-react";
+import { FolderTestWrapper } from "./utils/FolderTestWrapper";
+import { RemoveDocumentsModalFixture } from "./utils/testFixtures";
+
+test.describe("RemoveDocumentsModal", () => {
+  test.describe("Modal Visibility", () => {
+    test("renders when showModal is true and documentIds has items", async ({
+      mount,
+      page,
+    }) => {
+      const component = await mount(
+        <FolderTestWrapper>
+          <RemoveDocumentsModalFixture
+            showModal={true}
+            documentIds={["doc-1", "doc-2"]}
+          />
+        </FolderTestWrapper>
+      );
+
+      // Modal renders to document.body (portal), so check page not component
+      await expect(page.getByText("Remove Documents from Corpus")).toBeVisible({
+        timeout: 5000,
+      });
+    });
+
+    test("does not render when showModal is false", async ({ mount, page }) => {
+      const component = await mount(
+        <FolderTestWrapper>
+          <RemoveDocumentsModalFixture
+            showModal={false}
+            documentIds={["doc-1"]}
+          />
+        </FolderTestWrapper>
+      );
+
+      // Modal should not be visible
+      await expect(
+        page.getByText("Remove Documents from Corpus")
+      ).not.toBeVisible();
+    });
+
+    test("does not render when documentIds is empty", async ({
+      mount,
+      page,
+    }) => {
+      const component = await mount(
+        <FolderTestWrapper>
+          <RemoveDocumentsModalFixture showModal={true} documentIds={[]} />
+        </FolderTestWrapper>
+      );
+
+      // Modal should not be visible
+      await expect(
+        page.getByText("Remove Documents from Corpus")
+      ).not.toBeVisible();
+    });
+  });
+
+  test.describe("Document Count Display", () => {
+    test("shows correct count for multiple documents", async ({
+      mount,
+      page,
+    }) => {
+      const component = await mount(
+        <FolderTestWrapper>
+          <RemoveDocumentsModalFixture
+            showModal={true}
+            documentIds={["doc-1", "doc-2", "doc-3"]}
+          />
+        </FolderTestWrapper>
+      );
+
+      // Should show "3 documents" in the strong tag within warning text
+      await expect(
+        page.locator("strong", { hasText: "3 documents" })
+      ).toBeVisible({
+        timeout: 5000,
+      });
+      // Info box should show count
+      await expect(page.getByText("Documents to remove:")).toBeVisible();
+    });
+
+    test("shows correct singular text for 1 document", async ({
+      mount,
+      page,
+    }) => {
+      const component = await mount(
+        <FolderTestWrapper>
+          <RemoveDocumentsModalFixture
+            showModal={true}
+            documentIds={["doc-1"]}
+          />
+        </FolderTestWrapper>
+      );
+
+      // Should show "1 document" (singular) in the strong tag
+      await expect(
+        page.locator("strong", { hasText: "1 document" })
+      ).toBeVisible({
+        timeout: 5000,
+      });
+    });
+
+    test("remove button shows correct count", async ({ mount, page }) => {
+      const component = await mount(
+        <FolderTestWrapper>
+          <RemoveDocumentsModalFixture
+            showModal={true}
+            documentIds={["doc-1", "doc-2"]}
+          />
+        </FolderTestWrapper>
+      );
+
+      // Remove button should show "Remove 2 Documents"
+      const removeButton = page.getByRole("button", {
+        name: "Remove 2 Documents",
+      });
+      await expect(removeButton).toBeVisible({
+        timeout: 5000,
+      });
+    });
+  });
+
+  test.describe("Modal Actions", () => {
+    test("has Cancel button", async ({ mount, page }) => {
+      const component = await mount(
+        <FolderTestWrapper>
+          <RemoveDocumentsModalFixture
+            showModal={true}
+            documentIds={["doc-1"]}
+          />
+        </FolderTestWrapper>
+      );
+
+      await expect(page.getByText("Cancel")).toBeVisible({ timeout: 5000 });
+    });
+
+    test("has Remove button with negative styling", async ({ mount, page }) => {
+      const component = await mount(
+        <FolderTestWrapper>
+          <RemoveDocumentsModalFixture
+            showModal={true}
+            documentIds={["doc-1"]}
+          />
+        </FolderTestWrapper>
+      );
+
+      // Remove button should have "negative" class from Semantic UI
+      const removeButton = page.locator('button.negative:has-text("Remove")');
+      await expect(removeButton).toBeVisible({ timeout: 5000 });
+    });
+
+    test("has close button in header", async ({ mount, page }) => {
+      const component = await mount(
+        <FolderTestWrapper>
+          <RemoveDocumentsModalFixture
+            showModal={true}
+            documentIds={["doc-1"]}
+          />
+        </FolderTestWrapper>
+      );
+
+      const closeButton = page.getByRole("button", { name: "Close" });
+      await expect(closeButton).toBeVisible({ timeout: 5000 });
+    });
+  });
+
+  test.describe("Warning Content", () => {
+    test("displays warning about removal", async ({ mount, page }) => {
+      const component = await mount(
+        <FolderTestWrapper>
+          <RemoveDocumentsModalFixture
+            showModal={true}
+            documentIds={["doc-1"]}
+          />
+        </FolderTestWrapper>
+      );
+
+      // Should explain what happens
+      await expect(page.getByText("Confirm Removal")).toBeVisible({
+        timeout: 5000,
+      });
+      await expect(page.getByText("will remain in your library")).toBeVisible();
+    });
+  });
+
+  test.describe("Accessibility", () => {
+    test("close button has aria-label", async ({ mount, page }) => {
+      const component = await mount(
+        <FolderTestWrapper>
+          <RemoveDocumentsModalFixture
+            showModal={true}
+            documentIds={["doc-1"]}
+          />
+        </FolderTestWrapper>
+      );
+
+      const closeButton = page.getByRole("button", { name: "Close" });
+      await expect(closeButton).toHaveAttribute("aria-label", "Close");
+    });
+  });
+});

--- a/frontend/tests/folders/utils/testFixtures.tsx
+++ b/frontend/tests/folders/utils/testFixtures.tsx
@@ -6,6 +6,7 @@ import {
   FolderToolbar,
   ViewMode,
 } from "../../../src/components/corpuses/folders/FolderToolbar";
+import { RemoveDocumentsModal } from "../../../src/components/corpuses/folders/RemoveDocumentsModal";
 import {
   selectedFolderIdAtom,
   folderListAtom,
@@ -14,6 +15,8 @@ import {
   folderCorpusIdAtom,
   sidebarCollapsedAtom,
   corpusPermissionsAtom,
+  showRemoveDocumentsModalAtom,
+  removeDocumentsIdsAtom,
 } from "../../../src/atoms/folderAtoms";
 
 /**
@@ -74,6 +77,14 @@ interface ToolbarFixtureProps {
   onGoUp?: () => void;
   onNewFolder?: () => void;
   onUpload?: () => void;
+  // Selection-related props
+  selectedDocumentCount?: number;
+  totalDocumentCount?: number;
+  onSelectAll?: () => void;
+  onClearSelection?: () => void;
+  onRemoveFromCorpus?: () => void;
+  allSelected?: boolean;
+  isLoading?: boolean;
 }
 
 export function ToolbarFixture({
@@ -88,6 +99,14 @@ export function ToolbarFixture({
   onGoUp = () => {},
   onNewFolder = () => {},
   onUpload = () => {},
+  // Selection props with defaults
+  selectedDocumentCount = 0,
+  totalDocumentCount = 0,
+  onSelectAll,
+  onClearSelection,
+  onRemoveFromCorpus,
+  allSelected = false,
+  isLoading = false,
 }: ToolbarFixtureProps) {
   // canCreateFoldersAtom now reads from corpusPermissionsAtom
   // which checks for "update_corpus" permission on the corpus
@@ -117,7 +136,38 @@ export function ToolbarFixture({
         onGoUp={onGoUp}
         onNewFolder={onNewFolder}
         onUpload={onUpload}
+        selectedDocumentCount={selectedDocumentCount}
+        totalDocumentCount={totalDocumentCount}
+        onSelectAll={onSelectAll}
+        onClearSelection={onClearSelection}
+        onRemoveFromCorpus={onRemoveFromCorpus}
+        allSelected={allSelected}
+        isLoading={isLoading}
       />
     </div>
   );
+}
+
+// ============================================================================
+// Remove Documents Modal Fixture
+// ============================================================================
+
+interface RemoveDocumentsModalFixtureProps {
+  showModal?: boolean;
+  documentIds?: string[];
+  corpusId?: string;
+}
+
+export function RemoveDocumentsModalFixture({
+  showModal = true,
+  documentIds = [],
+  corpusId = "corpus-1",
+}: RemoveDocumentsModalFixtureProps) {
+  useHydrateAtoms([
+    [showRemoveDocumentsModalAtom, showModal],
+    [removeDocumentsIdsAtom, documentIds],
+    [folderCorpusIdAtom, corpusId],
+  ] as const);
+
+  return <RemoveDocumentsModal />;
 }


### PR DESCRIPTION
## Summary
- Add **Select All / Deselect All** button to toggle selection of all visible documents in folder view
- Add **selection count display** showing "X of Y" when documents are selected  
- Add **Clear Selection** button (X) to quickly deselect all documents
- Add **Remove from Corpus** bulk action button with confirmation dialog
- All actions available in mobile kebab menu for responsive support

## Test plan
- [ ] Navigate to a corpus with documents
- [ ] Verify "Select All" button appears when documents are present
- [ ] Click Select All and verify all documents become selected
- [ ] Verify selection count shows correct "X of Y" 
- [ ] Click the X button to clear selection
- [ ] Select multiple documents and click "Remove" button
- [ ] Verify confirmation dialog appears
- [ ] Confirm removal and verify documents are removed from corpus
- [ ] Test on mobile viewport using kebab menu