### PR TITLE
Fix bulk upload documents not showing backend_lock processing state

### DIFF
--- a/opencontractserver/tasks/import_tasks.py
+++ b/opencontractserver/tasks/import_tasks.py
@@ -20,7 +20,7 @@ from opencontractserver.annotations.models import (
     Annotation,
 )
 from opencontractserver.corpuses.models import Corpus, TemporaryFileHandle
-from opencontractserver.documents.models import Document
+from opencontractserver.documents.models import Document, DocumentPath
 from opencontractserver.types.dicts import (
     OpenContractsAnnotatedDocumentImportType,
     OpenContractsExportDataJsonPythonType,
@@ -317,36 +317,39 @@ def import_document_to_corpus(
 
         # Link to corpus using proper versioning method
         # This creates a corpus-isolated copy with DocumentPath
-        corpus_obj.add_document(document=doc_obj, user=user_obj)
+        # IMPORTANT: Use the corpus copy for all subsequent operations
+        corpus_doc, _status, _doc_path = corpus_obj.add_document(
+            document=doc_obj, user=user_obj
+        )
         logger.info(f"Linked document to corpus: {corpus_obj.title}")
 
-        # Import text annotations
+        # Import text annotations - use corpus_doc (the corpus copy)
         doc_annotations_data = document_import_data["doc_data"]["labelled_text"]
         logger.info(f"Importing {len(doc_annotations_data)} text annotations")
         import_annotations(
             user_id,
-            doc_obj,
+            corpus_doc,
             corpus_obj,
             doc_annotations_data,
             label_lookup,
             label_type=TOKEN_LABEL,
         )
 
-        # Import document-level annotations
+        # Import document-level annotations - use corpus_doc (the corpus copy)
         doc_labels = document_import_data["doc_data"]["doc_labels"]
         logger.info(f"Importing {len(doc_labels)} doc labels")
         for doc_label in doc_labels:
             label_obj = existing_doc_labels[doc_label]
             annot_obj = Annotation.objects.create(
                 annotation_label=label_obj,
-                document=doc_obj,
+                document=corpus_doc,
                 corpus=corpus_obj,
                 creator_id=user_id,
             )
             set_permissions_for_obj_to_user(user_id, annot_obj, [PermissionTypes.ALL])
 
         logger.info("Document import completed successfully")
-        return doc_obj.id
+        return corpus_doc.id
 
     except Exception as e:
         logger.error(f"Exception encountered in document import: {e}")
@@ -492,6 +495,13 @@ def process_documents_zip(
                             or f"Uploaded as part of batch upload (job: {job_id})"
                         )
 
+                        # Generate path for corpus document
+                        safe_filename = "".join(
+                            c if c.isalnum() or c in "-_." else "_"
+                            for c in base_filename[:100]
+                        )
+                        doc_path = f"/documents/{safe_filename}"
+
                         # Create the document based on file type
                         document = None
 
@@ -501,18 +511,39 @@ def process_documents_zip(
                             "application/vnd.openxmlformats-officedocument.presentationml.presentation",
                             "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
                         ]:
-                            pdf_file = ContentFile(file_bytes, name=filename)
-                            document = Document(
-                                creator=user_obj,
-                                title=doc_title,
-                                description=doc_description,
-                                custom_meta=custom_meta,
-                                pdf_file=pdf_file,
-                                backend_lock=True,
-                                is_public=make_public,
-                                file_type=kind,
-                            )
-                            document.save()
+                            if corpus_obj:
+                                # Use import_content to create document directly in corpus
+                                # This avoids creating orphan standalone documents
+                                document, status, path_record = (
+                                    corpus_obj.import_content(
+                                        content=file_bytes,
+                                        path=doc_path,
+                                        user=user_obj,
+                                        title=doc_title,
+                                        description=doc_description,
+                                        custom_meta=custom_meta,
+                                        is_public=make_public,
+                                        file_type=kind,
+                                    )
+                                )
+                                logger.info(
+                                    f"process_documents_zip() - Created document {document.id} "
+                                    f"in corpus {corpus_obj.id} (status: {status})"
+                                )
+                            else:
+                                # Standalone upload (no corpus) - legacy path
+                                pdf_file = ContentFile(file_bytes, name=filename)
+                                document = Document(
+                                    creator=user_obj,
+                                    title=doc_title,
+                                    description=doc_description,
+                                    custom_meta=custom_meta,
+                                    pdf_file=pdf_file,
+                                    backend_lock=True,
+                                    is_public=make_public,
+                                    file_type=kind,
+                                )
+                                document.save()
                         elif kind in ["text/plain", "application/txt"]:
                             txt_extract_file = ContentFile(file_bytes, name=filename)
                             document = Document(
@@ -527,20 +558,28 @@ def process_documents_zip(
                             )
                             document.save()
 
+                            # For text files with corpus, create DocumentPath directly
+                            if corpus_obj:
+                                DocumentPath.objects.create(
+                                    document=document,
+                                    corpus=corpus_obj,
+                                    folder=None,
+                                    path=doc_path,
+                                    version_number=1,
+                                    is_current=True,
+                                    is_deleted=False,
+                                    creator=user_obj,
+                                )
+                                logger.info(
+                                    f"process_documents_zip() - Created text document {document.id} "
+                                    f"in corpus {corpus_obj.id}"
+                                )
+
                         if document:
                             # Set permissions for the document
                             set_permissions_for_obj_to_user(
                                 user_obj, document, [PermissionTypes.CRUD]
                             )
-
-                            # Add to corpus if needed
-                            if corpus_obj:
-                                # Use the new versioning system to create proper DocumentPath
-                                added_doc, status, doc_path = corpus_obj.add_document(
-                                    document=document, user=user_obj
-                                )
-                                # Update document reference in case versioning returned a different doc
-                                document = added_doc
 
                             # Update results
                             results["processed_files"] += 1
@@ -1003,65 +1042,84 @@ def import_zip_with_folder_structure(
                         doc_path_str = f"/{entry.sanitized_path}"
 
                     # Create document based on file type
-                    document = None
+                    # Use import_content to create document directly in corpus
+                    # This avoids creating orphan standalone documents
+                    added_doc = None
+                    doc_path = None
 
-                    if mime_type in [
-                        "application/pdf",
-                        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-                        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-                        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-                    ]:
-                        pdf_file = ContentFile(file_bytes, name=entry.filename)
-                        document = Document(
-                            creator=user_obj,
-                            title=doc_title,
-                            description=doc_description,
-                            custom_meta=custom_meta,
-                            pdf_file=pdf_file,
-                            backend_lock=True,
-                            is_public=make_public,
-                            file_type=mime_type,
-                        )
-                        document.save()
-                    elif mime_type in ["text/plain", "application/txt"]:
-                        txt_extract_file = ContentFile(file_bytes, name=entry.filename)
-                        document = Document(
-                            creator=user_obj,
-                            title=doc_title,
-                            description=doc_description,
-                            custom_meta=custom_meta,
-                            txt_extract_file=txt_extract_file,
-                            backend_lock=True,
-                            is_public=make_public,
-                            file_type=mime_type,
-                        )
-                        document.save()
-
-                    if document:
-                        # Set permissions for the document
-                        set_permissions_for_obj_to_user(
-                            user_obj, document, [PermissionTypes.CRUD]
-                        )
-
-                        # Add to corpus with folder assignment and path for versioning
-                        # If a document already exists at this path, it will be upversioned
-                        try:
-                            added_doc, status, doc_path = corpus_obj.add_document(
-                                document=document,
+                    try:
+                        if mime_type in [
+                            "application/pdf",
+                            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                            "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+                            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                        ]:
+                            # Use import_content to create document directly in corpus
+                            added_doc, status, doc_path = corpus_obj.import_content(
+                                content=file_bytes,
+                                path=doc_path_str,
                                 user=user_obj,
                                 folder=doc_folder,
-                                path=doc_path_str,
+                                title=doc_title,
+                                description=doc_description,
+                                custom_meta=custom_meta,
+                                is_public=make_public,
+                                file_type=mime_type,
                             )
-                        except PermissionError as e:
-                            logger.warning(
-                                f"Permission error adding document at {doc_path_str}: {e}"
+                            logger.info(
+                                f"import_zip_with_folder_structure() - Created document "
+                                f"{added_doc.id} in corpus {corpus_obj.id} (status: {status})"
                             )
-                            results["files_errored"] += 1
-                            results["errors"].append(
-                                f"Permission error for {entry.sanitized_path}: {str(e)}"
+                        elif mime_type in ["text/plain", "application/txt"]:
+                            # For text files, create document and link to corpus
+                            txt_extract_file = ContentFile(
+                                file_bytes, name=entry.filename
                             )
-                            continue
+                            added_doc = Document(
+                                creator=user_obj,
+                                title=doc_title,
+                                description=doc_description,
+                                custom_meta=custom_meta,
+                                txt_extract_file=txt_extract_file,
+                                backend_lock=True,
+                                is_public=make_public,
+                                file_type=mime_type,
+                            )
+                            added_doc.save()
 
+                            # Create DocumentPath to link document to corpus
+                            doc_path = DocumentPath.objects.create(
+                                document=added_doc,
+                                corpus=corpus_obj,
+                                folder=doc_folder,
+                                path=doc_path_str,
+                                version_number=1,
+                                is_current=True,
+                                is_deleted=False,
+                                creator=user_obj,
+                            )
+                            logger.info(
+                                f"import_zip_with_folder_structure() - Created text document "
+                                f"{added_doc.id} in corpus {corpus_obj.id}"
+                            )
+
+                        if added_doc:
+                            # Set permissions for the document
+                            set_permissions_for_obj_to_user(
+                                user_obj, added_doc, [PermissionTypes.CRUD]
+                            )
+
+                    except PermissionError as e:
+                        logger.warning(
+                            f"Permission error adding document at {doc_path_str}: {e}"
+                        )
+                        results["files_errored"] += 1
+                        results["errors"].append(
+                            f"Permission error for {entry.sanitized_path}: {str(e)}"
+                        )
+                        continue
+
+                    if added_doc:
                         results["files_processed"] += 1
                         results["document_ids"].append(str(added_doc.id))
 

--- a/opencontractserver/tasks/import_tasks.py
+++ b/opencontractserver/tasks/import_tasks.py
@@ -514,6 +514,7 @@ def process_documents_zip(
                             if corpus_obj:
                                 # Use import_content to create document directly in corpus
                                 # This avoids creating orphan standalone documents
+                                # backend_lock=True ensures document shows as processing
                                 document, status, path_record = (
                                     corpus_obj.import_content(
                                         content=file_bytes,
@@ -524,6 +525,7 @@ def process_documents_zip(
                                         custom_meta=custom_meta,
                                         is_public=make_public,
                                         file_type=kind,
+                                        backend_lock=True,
                                     )
                                 )
                                 logger.info(
@@ -1055,6 +1057,7 @@ def import_zip_with_folder_structure(
                             "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
                         ]:
                             # Use import_content to create document directly in corpus
+                            # backend_lock=True ensures document shows as processing
                             added_doc, status, doc_path = corpus_obj.import_content(
                                 content=file_bytes,
                                 path=doc_path_str,
@@ -1065,6 +1068,7 @@ def import_zip_with_folder_structure(
                                 custom_meta=custom_meta,
                                 is_public=make_public,
                                 file_type=mime_type,
+                                backend_lock=True,
                             )
                             logger.info(
                                 f"import_zip_with_folder_structure() - Created document "

--- a/opencontractserver/tasks/import_tasks_v2.py
+++ b/opencontractserver/tasks/import_tasks_v2.py
@@ -200,31 +200,35 @@ def _import_corpus_v1(
                     )
 
                     # Add to corpus using new versioned system
-                    corpus_obj.add_document(doc_obj, user=user_obj)
+                    # IMPORTANT: Use the corpus copy for all subsequent operations
+                    corpus_doc, _status, _doc_path = corpus_obj.add_document(
+                        doc_obj, user=user_obj
+                    )
 
-                    # Import doc-level annotations
+                    # Import doc-level annotations - use corpus_doc (the corpus copy)
                     for doc_label_name in doc_data.get("doc_labels", []):
                         label_obj = doc_label_lookup.get(doc_label_name)
                         if label_obj:
                             Annotation.objects.create(
                                 annotation_label=label_obj,
-                                document=doc_obj,
+                                document=corpus_doc,
                                 corpus=corpus_obj,
                                 creator=user_obj,
                             )
 
-                    # Import text annotations
+                    # Import text annotations - use corpus_doc (the corpus copy)
                     import_annotations(
                         user_id=user_obj.id,
-                        doc_obj=doc_obj,
+                        doc_obj=corpus_doc,
                         corpus_obj=corpus_obj,
                         annotations_data=doc_data.get("labelled_text", []),
                         label_lookup=label_lookup,
                         label_type=TOKEN_LABEL,
                     )
 
-                    doc_obj.backend_lock = False
-                    doc_obj.save()
+                    # Unlock the corpus copy (not the original)
+                    corpus_doc.backend_lock = False
+                    corpus_doc.save()
 
             except Exception as e:
                 logger.error(f"Error importing document {doc_filename}: {e}")

--- a/opencontractserver/tests/test_zip_import_integration.py
+++ b/opencontractserver/tests/test_zip_import_integration.py
@@ -1710,3 +1710,194 @@ file.pdf,Custom Title
         self.assertTrue(result["success"])
         self.assertTrue(result["metadata_file_found"])
         self.assertEqual(result["metadata_applied"], 1)
+
+
+class TestBackendLockBehavior(TestCase):
+    """
+    Tests for backend_lock=True behavior during bulk document import.
+
+    Documents created via bulk import should have backend_lock=True immediately
+    after creation to indicate they are being processed. This ensures the frontend
+    shows them as "processing" until the Celery pipeline completes.
+
+    Related: Fix for bulk upload documents not showing backend_lock processing state.
+    """
+
+    def setUp(self):
+        """Set up test user, corpus, and sample data."""
+        with transaction.atomic():
+            self.user = User.objects.create_user(
+                username="testuser", password="testpass"
+            )
+
+        with transaction.atomic():
+            self.corpus = Corpus.objects.create(
+                title="Test Corpus",
+                description="Corpus for testing",
+                creator=self.user,
+            )
+            set_permissions_for_obj_to_user(
+                self.user, self.corpus, [PermissionTypes.ALL]
+            )
+
+        # Sample PDF bytes
+        self.pdf_bytes = SAMPLE_PDF_FILE_ONE_PATH.read_bytes()
+
+    def _create_test_zip(self, files: dict[str, bytes]) -> io.BytesIO:
+        """Create an in-memory zip file for testing."""
+        buffer = io.BytesIO()
+        with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as zf:
+            for name, content in files.items():
+                zf.writestr(name, content)
+        buffer.seek(0)
+        return buffer
+
+    def _create_temp_file_handle(self, zip_buffer: io.BytesIO) -> TemporaryFileHandle:
+        """Create a TemporaryFileHandle from a zip buffer."""
+        zip_content = ContentFile(zip_buffer.read(), name="test_import.zip")
+        handle = TemporaryFileHandle.objects.create(
+            file=zip_content,
+        )
+        return handle
+
+    def test_import_zip_sets_backend_lock_true(self):
+        """
+        Documents created via import_zip_with_folder_structure have backend_lock=True.
+
+        This ensures documents show as "processing" in the frontend immediately
+        after creation, before the Celery pipeline completes.
+        """
+        from opencontractserver.tasks.import_tasks import (
+            import_zip_with_folder_structure,
+        )
+
+        files = {
+            "file1.pdf": self.pdf_bytes,
+            "docs/file2.pdf": self.pdf_bytes,
+        }
+        zip_buffer = self._create_test_zip(files)
+        handle = self._create_temp_file_handle(zip_buffer)
+
+        result = import_zip_with_folder_structure.apply(
+            kwargs={
+                "temporary_file_handle_id": handle.id,
+                "user_id": self.user.id,
+                "job_id": "test-backend-lock",
+                "corpus_id": self.corpus.id,
+            }
+        ).get()
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["files_processed"], 2)
+
+        # Verify ALL created documents have backend_lock=True
+        for doc_id in result["document_ids"]:
+            doc = Document.objects.get(id=doc_id)
+            self.assertTrue(
+                doc.backend_lock,
+                f"Document {doc_id} should have backend_lock=True after import, "
+                f"but got backend_lock={doc.backend_lock}",
+            )
+
+    def test_process_documents_zip_sets_backend_lock_true(self):
+        """
+        Documents created via process_documents_zip have backend_lock=True.
+
+        This is the older zip import task that should also set backend_lock=True.
+        """
+        from opencontractserver.tasks.import_tasks import process_documents_zip
+
+        files = {
+            "contract.pdf": self.pdf_bytes,
+        }
+        zip_buffer = self._create_test_zip(files)
+        handle = self._create_temp_file_handle(zip_buffer)
+
+        result = process_documents_zip.apply(
+            kwargs={
+                "temporary_file_handle_id": handle.id,
+                "user_id": self.user.id,
+                "job_id": "test-backend-lock-old",
+                "corpus_id": self.corpus.id,
+            }
+        ).get()
+
+        self.assertEqual(result["processed_files"], 1)
+
+        # Verify document has backend_lock=True
+        for doc_id in result["document_ids"]:
+            doc = Document.objects.get(id=doc_id)
+            self.assertTrue(
+                doc.backend_lock,
+                f"Document {doc_id} should have backend_lock=True after import, "
+                f"but got backend_lock={doc.backend_lock}",
+            )
+
+    def test_text_file_import_sets_backend_lock_true(self):
+        """
+        Text files imported via zip also have backend_lock=True.
+
+        Text files follow a different code path but should still be locked.
+        """
+        from opencontractserver.tasks.import_tasks import (
+            import_zip_with_folder_structure,
+        )
+
+        files = {
+            "readme.txt": b"This is a plain text document.",
+        }
+        zip_buffer = self._create_test_zip(files)
+        handle = self._create_temp_file_handle(zip_buffer)
+
+        result = import_zip_with_folder_structure.apply(
+            kwargs={
+                "temporary_file_handle_id": handle.id,
+                "user_id": self.user.id,
+                "job_id": "test-backend-lock-text",
+                "corpus_id": self.corpus.id,
+            }
+        ).get()
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["files_processed"], 1)
+
+        # Verify text document has backend_lock=True
+        doc = Document.objects.get(id=result["document_ids"][0])
+        self.assertTrue(
+            doc.backend_lock,
+            f"Text document should have backend_lock=True, got {doc.backend_lock}",
+        )
+
+    def test_standalone_upload_without_corpus_sets_backend_lock_true(self):
+        """
+        Standalone document uploads (no corpus) also have backend_lock=True.
+
+        This is the legacy path for uploads without a corpus.
+        """
+        from opencontractserver.tasks.import_tasks import process_documents_zip
+
+        files = {
+            "standalone.pdf": self.pdf_bytes,
+        }
+        zip_buffer = self._create_test_zip(files)
+        handle = self._create_temp_file_handle(zip_buffer)
+
+        # Import WITHOUT corpus_id
+        result = process_documents_zip.apply(
+            kwargs={
+                "temporary_file_handle_id": handle.id,
+                "user_id": self.user.id,
+                "job_id": "test-backend-lock-standalone",
+                # No corpus_id - standalone upload
+            }
+        ).get()
+
+        self.assertEqual(result["processed_files"], 1)
+
+        # Verify standalone document has backend_lock=True
+        doc = Document.objects.get(id=result["document_ids"][0])
+        self.assertTrue(
+            doc.backend_lock,
+            f"Standalone document should have backend_lock=True, "
+            f"got {doc.backend_lock}",
+        )


### PR DESCRIPTION
## Summary

- Bulk uploaded documents were not showing as processing (`backend_lock=True`) on the frontend
- Root cause: Old pattern created orphan standalone documents that triggered processing, while returning corpus copies with `backend_lock=False` and empty parsing artifacts
- Fix: Use `corpus.import_content()` for bulk uploads, aligning with `UploadDocument` mutation behavior

## Changes

| File | Function | Fix |
|------|----------|-----|
| `import_tasks.py` | `process_documents_zip` | Use `import_content()` for PDFs instead of standalone doc + `add_document()` |
| `import_tasks.py` | `import_zip_with_folder_structure` | Same fix |
| `import_tasks.py` | `import_document_to_corpus` | Capture `add_document()` return value; use corpus copy for annotations |
| `import_tasks_v2.py` | V1 import handler | Same fix for `add_document()` return value |

## Test plan

- [ ] Upload a ZIP file with multiple PDFs to a corpus
- [ ] Verify documents show as processing (`backend_lock=True`) immediately after upload
- [ ] Verify documents unlock after processing completes
- [ ] Verify parsed content (PAWLS, text) is available on the corpus documents
- [ ] Verify annotations can be created on the processed documents