### PR TITLE
Improve agent tools: server-side search dropdown and deterministic parameter injection

### DIFF
--- a/frontend/src/components/corpuses/CreateCorpusActionModal.tsx
+++ b/frontend/src/components/corpuses/CreateCorpusActionModal.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { useMemo, useState, useCallback } from "react";
 import {
   Modal,
   Form,
@@ -16,6 +16,7 @@ import {
 } from "semantic-ui-react";
 import { useMutation, useQuery } from "@apollo/client";
 import { toast } from "react-toastify";
+import _ from "lodash";
 
 /**
  * Default moderation tools (fallback when backend query fails or returns no data).
@@ -129,6 +130,8 @@ export const CreateCorpusActionModal: React.FC<
   const [disabled, setDisabled] = React.useState(false);
   const [runOnAllCorpuses, setRunOnAllCorpuses] = React.useState(false);
   const [isSubmitting, setIsSubmitting] = React.useState(false);
+  // Agent search state for server-side filtering
+  const [agentSearchQuery, setAgentSearchQuery] = useState<string>("");
 
   const resetForm = () => {
     setName("");
@@ -147,6 +150,7 @@ export const CreateCorpusActionModal: React.FC<
     setSelectedModerationTools(DEFAULT_MODERATION_TOOLS.map((t) => t.name));
     setDisabled(false);
     setRunOnAllCorpuses(false);
+    setAgentSearchQuery("");
   };
 
   // Helper to normalize trigger value to lowercase format
@@ -261,12 +265,32 @@ export const CreateCorpusActionModal: React.FC<
     GetAnalyzersInputs
   >(GET_ANALYZERS);
 
-  const { data: agentConfigsData } = useQuery<
+  const { data: agentConfigsData, loading: agentConfigsLoading } = useQuery<
     GetAgentConfigurationsOutput,
     GetAgentConfigurationsInput
   >(GET_AGENT_CONFIGURATIONS, {
-    variables: { isActive: true },
+    variables: {
+      isActive: true,
+      name_Contains: agentSearchQuery || undefined,
+      first: 50, // Limit results for performance
+    },
+    fetchPolicy: "cache-and-network", // Refresh data on mount
   });
+
+  // Debounced search handler for agent dropdown
+  const debouncedSetAgentSearch = useCallback(
+    _.debounce((query: string) => {
+      setAgentSearchQuery(query);
+    }, 300),
+    []
+  );
+
+  const handleAgentSearchChange = (
+    _event: React.SyntheticEvent<HTMLElement>,
+    { searchQuery }: { searchQuery: string }
+  ) => {
+    debouncedSetAgentSearch(searchQuery);
+  };
 
   // Fetch moderation tools dynamically from backend
   // Only fetch when needed (thread/message triggers)
@@ -875,7 +899,10 @@ export const CreateCorpusActionModal: React.FC<
                             setSelectedAgentConfigId(data.value as string);
                             setPreAuthorizedTools([]);
                           }}
+                          onSearchChange={handleAgentSearchChange}
+                          loading={agentConfigsLoading}
                           placeholder="Select agent configuration"
+                          selectOnNavigation={false}
                         />
                       </Form.Field>
 
@@ -957,7 +984,10 @@ export const CreateCorpusActionModal: React.FC<
                         setSelectedAgentConfigId(data.value as string);
                         setPreAuthorizedTools([]);
                       }}
+                      onSearchChange={handleAgentSearchChange}
+                      loading={agentConfigsLoading}
                       placeholder="Select agent configuration"
+                      selectOnNavigation={false}
                     />
                   </Form.Field>
 

--- a/frontend/src/graphql/queries.ts
+++ b/frontend/src/graphql/queries.ts
@@ -4302,10 +4302,14 @@ export const SEARCH_AGENTS_FOR_MENTION = gql`
 /**
  * GET_AGENT_CONFIGURATIONS - Get available agent configurations for corpus actions
  * Used in CreateCorpusActionModal to allow selecting an agent for automated actions
+ *
+ * Supports server-side search via name_Contains and pagination via first parameter.
  */
 export interface GetAgentConfigurationsInput {
   corpusId?: string;
   isActive?: boolean;
+  name_Contains?: string;
+  first?: number;
 }
 
 export interface GetAgentConfigurationsOutput {
@@ -4330,8 +4334,18 @@ export interface GetAgentConfigurationsOutput {
 }
 
 export const GET_AGENT_CONFIGURATIONS = gql`
-  query GetAgentConfigurations($corpusId: String, $isActive: Boolean) {
-    agentConfigurations(corpusId: $corpusId, isActive: $isActive) {
+  query GetAgentConfigurations(
+    $corpusId: String
+    $isActive: Boolean
+    $name_Contains: String
+    $first: Int
+  ) {
+    agentConfigurations(
+      corpusId: $corpusId
+      isActive: $isActive
+      name_Contains: $name_Contains
+      first: $first
+    ) {
       edges {
         node {
           id

--- a/frontend/tests/create-corpus-action-modal.ct.tsx
+++ b/frontend/tests/create-corpus-action-modal.ct.tsx
@@ -102,7 +102,7 @@ const getAnalyzersMock = {
 const getAgentConfigsMock = {
   request: {
     query: GET_AGENT_CONFIGURATIONS,
-    variables: { isActive: true },
+    variables: { isActive: true, name_Contains: undefined, first: 50 },
   },
   result: {
     data: {

--- a/opencontractserver/llms/tools/pydantic_ai_tools.py
+++ b/opencontractserver/llms/tools/pydantic_ai_tools.py
@@ -223,13 +223,24 @@ class PydanticAIDependencies(BaseModel):
 class PydanticAIToolWrapper:
     """Modern Pydantic AI tool wrapper following latest patterns."""
 
-    def __init__(self, core_tool: CoreTool):
+    def __init__(
+        self,
+        core_tool: CoreTool,
+        inject_params: dict[str, Any] | None = None,
+    ):
         """Initialize the wrapper.
 
         Args:
             core_tool: The CoreTool instance to wrap
+            inject_params: Parameters to automatically inject at execution time,
+                hiding them from the LLM's view of the tool schema. This is used
+                for context-bound values like document_id or corpus_id that should
+                be deterministic (set by the system) rather than chosen by the LLM.
+                Maps parameter name -> value to inject.
+                Example: {"document_id": 123, "corpus_id": 456}
         """
         self.core_tool = core_tool
+        self.inject_params = inject_params or {}
         self._metadata = PydanticAIToolMetadata(
             name=core_tool.name,
             description=core_tool.description,
@@ -271,12 +282,17 @@ class PydanticAIToolWrapper:
             )
         ]
 
-        # Add original parameters (excluding 'self' if present)
+        # Add original parameters, EXCLUDING:
+        # - 'self'/'cls' (method artifacts)
+        # - Parameters in inject_params (hidden from LLM, auto-injected at runtime)
         for param_name, param in sig.parameters.items():
-            if param_name not in ["self", "cls"]:
+            if (
+                param_name not in ["self", "cls"]
+                and param_name not in self.inject_params
+            ):
                 new_params.append(param)
 
-        # Create new signature
+        # Create new signature (LLM will only see non-injected params)
         new_sig = sig.replace(parameters=new_params)
 
         # ------------------------------------------------------------------
@@ -328,12 +344,18 @@ class PydanticAIToolWrapper:
                 ctx: RunContext[PydanticAIDependencies], *args, **kwargs
             ):
                 """Async wrapper for PydanticAI tools."""
+                # Inject context-bound parameters before any other processing.
+                # These params are hidden from the LLM and set deterministically.
+                for param_name, value in self.inject_params.items():
+                    kwargs[param_name] = value
+
                 # Defense-in-depth: validate user permissions BEFORE any tool execution
                 # This prevents permission escalation via agents
                 await _check_user_permissions(ctx)
 
                 # Defense-in-depth: validate resource ID params match context
                 # This prevents prompt injection attacks that try to access other resources
+                # (Also validates injected params match deps as additional safety check)
                 _validate_resource_id_params(ctx, **kwargs)
 
                 # Trigger approval gate *before* attempting execution.
@@ -367,12 +389,18 @@ class PydanticAIToolWrapper:
                 ctx: RunContext[PydanticAIDependencies], *args, **kwargs
             ):
                 """Sync to async wrapper for PydanticAI tools."""
+                # Inject context-bound parameters before any other processing.
+                # These params are hidden from the LLM and set deterministically.
+                for param_name, value in self.inject_params.items():
+                    kwargs[param_name] = value
+
                 # Defense-in-depth: validate user permissions BEFORE any tool execution
                 # This prevents permission escalation via agents
                 await _check_user_permissions(ctx)
 
                 # Defense-in-depth: validate resource ID params match context
                 # This prevents prompt injection attacks that try to access other resources
+                # (Also validates injected params match deps as additional safety check)
                 _validate_resource_id_params(ctx, **kwargs)
 
                 _maybe_raise(ctx, *args, **kwargs)
@@ -452,16 +480,24 @@ class PydanticAIToolFactory:
         return [PydanticAIToolFactory.create_tool(tool) for tool in core_tools]
 
     @staticmethod
-    def create_tool(core_tool: CoreTool) -> Callable:
+    def create_tool(
+        core_tool: CoreTool,
+        inject_params: dict[str, Any] | None = None,
+    ) -> Callable:
         """Convert a single CoreTool to a modern Pydantic AI callable tool.
 
         Args:
             core_tool: CoreTool instance
+            inject_params: Parameters to auto-inject at execution time, hiding them
+                from the LLM. Used for context-bound values like document_id.
+                Example: {"document_id": 123}
 
         Returns:
             PydanticAI-compatible callable function
         """
-        return PydanticAIToolWrapper(core_tool).callable_function
+        return PydanticAIToolWrapper(
+            core_tool, inject_params=inject_params
+        ).callable_function
 
     @staticmethod
     def from_function(
@@ -473,6 +509,7 @@ class PydanticAIToolFactory:
         requires_approval: bool = False,
         requires_corpus: bool = False,
         requires_write_permission: bool = False,
+        inject_params: dict[str, Any] | None = None,
     ) -> Callable:
         """Create a PydanticAI-compatible callable tool directly from a Python function.
 
@@ -484,6 +521,10 @@ class PydanticAIToolFactory:
             requires_approval: Whether the tool requires approval
             requires_corpus: Whether the tool requires a corpus_id to function
             requires_write_permission: Whether the tool performs write operations
+            inject_params: Parameters to auto-inject at execution time, hiding them
+                from the LLM. Used for context-bound values like document_id that
+                should be deterministic. Maps param name -> value to inject.
+                Example: {"document_id": 123}
 
         Returns:
             PydanticAI-compatible callable function
@@ -497,7 +538,9 @@ class PydanticAIToolFactory:
             requires_corpus=requires_corpus,
             requires_write_permission=requires_write_permission,
         )
-        return PydanticAIToolWrapper(core_tool).callable_function
+        return PydanticAIToolWrapper(
+            core_tool, inject_params=inject_params
+        ).callable_function
 
     @staticmethod
     def create_tool_registry(core_tools: list[CoreTool]) -> dict[str, Callable]:

--- a/opencontractserver/tests/test_pydantic_ai_tools_module.py
+++ b/opencontractserver/tests/test_pydantic_ai_tools_module.py
@@ -320,3 +320,152 @@ class TestCheckUserPermissions(TestCase):
         with self.assertRaises(PermissionError) as context:
             await _check_user_permissions(ctx)
         self.assertIn("not found", str(context.exception))
+
+
+# ---------------------------------------------------------------------------
+# Tests for inject_params functionality
+# ---------------------------------------------------------------------------
+
+
+def tool_with_doc_id(document_id: int, text: str) -> dict:
+    """A tool that requires document_id and text."""
+    return {"document_id": document_id, "text": text, "processed": True}
+
+
+async def async_tool_with_ids(document_id: int, corpus_id: int, query: str) -> dict:
+    """An async tool that requires document_id, corpus_id, and a query."""
+    return {"document_id": document_id, "corpus_id": corpus_id, "query": query}
+
+
+@pytest.mark.django_db
+class TestInjectParams(TestCase):
+    """Test suite for inject_params functionality.
+
+    This tests the feature where context-bound parameters (like document_id)
+    can be automatically injected at execution time while being hidden from
+    the LLM's view of the tool schema.
+    """
+
+    def test_inject_params_filters_from_signature(self):
+        """Test that injected params are filtered from the function signature.
+
+        The LLM should not see document_id as a parameter - it should only
+        see 'text' as a required parameter.
+        """
+        wrapped = PydanticAIToolFactory.from_function(
+            tool_with_doc_id,
+            name="process_document",
+            inject_params={"document_id": 123},
+        )
+
+        sig = inspect.signature(wrapped)
+        param_names = list(sig.parameters.keys())
+
+        # ctx should be first param (for PydanticAI)
+        self.assertEqual(param_names[0], "ctx")
+
+        # document_id should NOT be in params (hidden from LLM)
+        self.assertNotIn("document_id", param_names)
+
+        # text should still be visible to LLM
+        self.assertIn("text", param_names)
+
+    def test_inject_params_multiple_params_filtered(self):
+        """Test that multiple injected params are all filtered from signature."""
+        wrapped = PydanticAIToolFactory.from_function(
+            async_tool_with_ids,
+            name="search_document",
+            inject_params={"document_id": 100, "corpus_id": 200},
+        )
+
+        sig = inspect.signature(wrapped)
+        param_names = list(sig.parameters.keys())
+
+        # Only ctx and query should be visible
+        self.assertEqual(param_names, ["ctx", "query"])
+
+        # document_id and corpus_id should be hidden
+        self.assertNotIn("document_id", param_names)
+        self.assertNotIn("corpus_id", param_names)
+
+
+@pytest.mark.django_db
+@pytest.mark.asyncio
+class TestInjectParamsExecution(TestCase):
+    """Async tests for inject_params execution behavior."""
+
+    async def test_sync_tool_injects_params_at_execution(self):
+        """Test that injected params are provided to sync function at execution."""
+        wrapped = PydanticAIToolFactory.from_function(
+            tool_with_doc_id,
+            name="process_document",
+            inject_params={"document_id": 42},
+        )
+
+        # Call without providing document_id - it should be injected
+        ctx = MagicMock(deps=None)
+        result = await wrapped(ctx, text="hello world")
+
+        # Verify injected value was used
+        self.assertEqual(result["document_id"], 42)
+        self.assertEqual(result["text"], "hello world")
+        self.assertTrue(result["processed"])
+
+    async def test_async_tool_injects_params_at_execution(self):
+        """Test that injected params are provided to async function at execution."""
+        wrapped = PydanticAIToolFactory.from_function(
+            async_tool_with_ids,
+            name="search_document",
+            inject_params={"document_id": 100, "corpus_id": 200},
+        )
+
+        # Call with only query - document_id and corpus_id should be injected
+        ctx = MagicMock(deps=None)
+        result = await wrapped(ctx, query="find contracts")
+
+        # Verify all injected values were used
+        self.assertEqual(result["document_id"], 100)
+        self.assertEqual(result["corpus_id"], 200)
+        self.assertEqual(result["query"], "find contracts")
+
+    async def test_wrapper_constructor_accepts_inject_params(self):
+        """Test that PydanticAIToolWrapper constructor accepts inject_params."""
+        core_tool = CoreTool.from_function(tool_with_doc_id)
+        wrapper = PydanticAIToolWrapper(core_tool, inject_params={"document_id": 999})
+
+        # Verify inject_params is stored
+        self.assertEqual(wrapper.inject_params, {"document_id": 999})
+
+        # Verify it works at execution
+        ctx = MagicMock(deps=None)
+        result = await wrapper.callable_function(ctx, text="test")
+        self.assertEqual(result["document_id"], 999)
+
+    async def test_create_tool_accepts_inject_params(self):
+        """Test that PydanticAIToolFactory.create_tool accepts inject_params."""
+        core_tool = CoreTool.from_function(tool_with_doc_id)
+        wrapped = PydanticAIToolFactory.create_tool(
+            core_tool, inject_params={"document_id": 777}
+        )
+
+        ctx = MagicMock(deps=None)
+        result = await wrapped(ctx, text="factory test")
+
+        self.assertEqual(result["document_id"], 777)
+        self.assertEqual(result["text"], "factory test")
+
+    async def test_no_inject_params_preserves_original_signature(self):
+        """Test that without inject_params, all original params are preserved."""
+        wrapped = PydanticAIToolFactory.from_function(
+            tool_with_doc_id,
+            name="process_document",
+            # No inject_params
+        )
+
+        sig = inspect.signature(wrapped)
+        param_names = list(sig.parameters.keys())
+
+        # All params should be visible (ctx + original params)
+        self.assertIn("ctx", param_names)
+        self.assertIn("document_id", param_names)
+        self.assertIn("text", param_names)

--- a/opencontractserver/utils/permissioning.py
+++ b/opencontractserver/utils/permissioning.py
@@ -206,17 +206,17 @@ def get_users_permissions_for_obj(
 ) -> set[str]:
 
     model_name = instance._meta.model_name
-    logger.info(
+    logger.debug(
         f"get_users_permissions_for_obj() - Starting check for {user.username} with model type {model_name}"
     )
 
     app_label = instance._meta.app_label
-    logger.info(f"get_users_permissions_for_obj - App name: {app_label}")
+    logger.debug(f"get_users_permissions_for_obj - App name: {app_label}")
 
     # Check if the model has django-guardian permission tables
     # Some models (like AnnotationLabel) use creator-based permissions instead
     if not hasattr(instance, f"{model_name}userobjectpermission_set"):
-        logger.info(
+        logger.debug(
             f"Model {model_name} does not have guardian permissions, using creator-based permissions"
         )
         # For models without guardian permissions, use creator-based permissions
@@ -242,16 +242,16 @@ def get_users_permissions_for_obj(
         elif hasattr(instance, "is_public") and instance.is_public:
             model_permissions_for_user.add(f"read_{model_name}")
 
-        logger.info(f"Creator-based permissions: {model_permissions_for_user}")
+        logger.debug(f"Creator-based permissions: {model_permissions_for_user}")
         return model_permissions_for_user
 
     this_user_perms = getattr(instance, f"{model_name}userobjectpermission_set")
 
-    logger.info(f"get_users_permissions_for_obj - this_user_perms: {this_user_perms}")
+    logger.debug(f"get_users_permissions_for_obj - this_user_perms: {this_user_perms}")
     permission_id_to_name_map = get_permission_id_to_name_map_for_model(
         instance=instance
     )
-    logger.info(
+    logger.debug(
         f"get_users_permissions_for_obj - permission_id_to_name_map: {permission_id_to_name_map}"
     )
 
@@ -270,7 +270,7 @@ def get_users_permissions_for_obj(
         this_users_group_perms = getattr(
             instance, f"{model_name}groupobjectpermission_set"
         ).filter(group_id__in=get_users_group_ids(user_instance=user))
-        logger.info(
+        logger.debug(
             f"get_users_permissions_for_obj - this_users_group_perms: {this_users_group_perms}"
         )
         for perm in this_users_group_perms:
@@ -278,7 +278,7 @@ def get_users_permissions_for_obj(
                 permission_id_to_name_map[perm.permission_id]
             )
 
-    logger.info(f"Final permissions: {model_permissions_for_user}")
+    logger.debug(f"Final permissions: {model_permissions_for_user}")
 
     return model_permissions_for_user
 


### PR DESCRIPTION
## Summary

- Add server-side search and pagination to agent configuration dropdown in Create Corpus Action modal
- Add `inject_params` mechanism to hide context-bound parameters (like `document_id`) from LLM tool schemas
- Reduce logging verbosity in permission checking

## Changes

### Agent Dropdown Improvements
- Add `fetchPolicy: "cache-and-network"` to refresh agent configs on mount
- Add server-side search via `name_Contains` filter with 300ms debounce
- Add pagination limit (`first: 50`) for performance
- Add loading state indicator to dropdowns

### Tool Parameter Injection (Security Enhancement)
- Add `inject_params` to `PydanticAIToolWrapper` for auto-injecting context-bound values
- Filter injected params from function signature so LLM cannot see or modify them
- Prevents LLMs from choosing arbitrary document/corpus IDs via prompt injection
- Existing `_validate_resource_id_params` defense-in-depth still validates injected values

### Logging
- Change `get_users_permissions_for_obj` logging from INFO to DEBUG level

## Test plan
- [x] Existing pydantic_ai_tools tests pass (16 tests)
- [x] New inject_params tests pass (7 tests)
- [x] Tool approval gate tests pass (4 tests)
- [ ] Manual test: Open Create Corpus Action modal, verify agent dropdown refreshes and search works