### PR TITLE
Refactor Corpus landing page with two-view architecture

### DIFF
--- a/frontend/src/components/corpuses/CorpusAbout/CorpusAbout.tsx
+++ b/frontend/src/components/corpuses/CorpusAbout/CorpusAbout.tsx
@@ -29,6 +29,8 @@ export interface CorpusAboutProps {
   canEdit: boolean;
   /** Callback when edit/add description button is clicked */
   onEditDescription: () => void;
+  /** Hide the header (useful when embedded with external header) */
+  hideHeader?: boolean;
   /** Test ID for the component */
   testId?: string;
 }
@@ -50,6 +52,7 @@ export const CorpusAbout: React.FC<CorpusAboutProps> = ({
   isLoading,
   canEdit,
   onEditDescription,
+  hideHeader = false,
   testId = "corpus-about",
 }) => {
   const hasContent = mdContent || corpus.description;
@@ -58,48 +61,54 @@ export const CorpusAbout: React.FC<CorpusAboutProps> = ({
     <AboutCard
       id={testId}
       data-testid={testId}
+      $minimal={hideHeader}
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.4 }}
       style={{ minHeight: 0 }}
     >
-      <AboutHeader>
-        <AboutTitle>
-          <BookOpen size={22} />
-          About this Corpus
-        </AboutTitle>
-        <ActionButtons>
-          {hasContent && (
-            <HistoryButton
-              onClick={onEditDescription}
-              aria-label="View version history"
-            >
-              <Activity size={14} />
-              Version History
-            </HistoryButton>
-          )}
-          {canEdit && (
-            <EditButton
-              onClick={onEditDescription}
-              aria-label={hasContent ? "Edit description" : "Add description"}
-            >
-              {hasContent ? (
-                <>
-                  <Edit size={14} />
-                  Edit
-                </>
-              ) : (
-                <>
-                  <Plus size={14} />
-                  Add Description
-                </>
-              )}
-            </EditButton>
-          )}
-        </ActionButtons>
-      </AboutHeader>
+      {!hideHeader && (
+        <AboutHeader>
+          <AboutTitle>
+            <BookOpen size={22} />
+            About this Corpus
+          </AboutTitle>
+          <ActionButtons>
+            {hasContent && (
+              <HistoryButton
+                onClick={onEditDescription}
+                aria-label="View version history"
+              >
+                <Activity size={14} />
+                Version History
+              </HistoryButton>
+            )}
+            {canEdit && (
+              <EditButton
+                onClick={onEditDescription}
+                aria-label={hasContent ? "Edit description" : "Add description"}
+              >
+                {hasContent ? (
+                  <>
+                    <Edit size={14} />
+                    Edit
+                  </>
+                ) : (
+                  <>
+                    <Plus size={14} />
+                    Add Description
+                  </>
+                )}
+              </EditButton>
+            )}
+          </ActionButtons>
+        </AboutHeader>
+      )}
 
-      <AboutContent className={!hasContent && !isLoading ? "empty" : ""}>
+      <AboutContent
+        className={!hasContent && !isLoading ? "empty" : ""}
+        $minimal={hideHeader}
+      >
         {isLoading ? (
           <LoadingPlaceholder>
             <div className="title-skeleton" />

--- a/frontend/src/components/corpuses/CorpusAbout/styles.ts
+++ b/frontend/src/components/corpuses/CorpusAbout/styles.ts
@@ -9,12 +9,14 @@ import {
   mediaQuery,
 } from "../styles/corpusDesignTokens";
 
-export const AboutCard = styled(motion.div)`
-  background: ${CORPUS_COLORS.white};
-  border-radius: ${CORPUS_RADII.lg};
-  box-shadow: ${CORPUS_SHADOWS.card};
+export const AboutCard = styled(motion.div)<{ $minimal?: boolean }>`
+  background: ${(props) =>
+    props.$minimal ? "transparent" : CORPUS_COLORS.white};
+  border-radius: ${(props) => (props.$minimal ? "0" : CORPUS_RADII.lg)};
+  box-shadow: ${(props) => (props.$minimal ? "none" : CORPUS_SHADOWS.card)};
   overflow: hidden;
-  border: 1px solid ${CORPUS_COLORS.slate[200]};
+  border: ${(props) =>
+    props.$minimal ? "none" : `1px solid ${CORPUS_COLORS.slate[200]}`};
   display: flex;
   flex-direction: column;
   position: relative;
@@ -128,22 +130,22 @@ export const EditButton = styled.button`
   }
 `;
 
-export const AboutContent = styled.div`
-  padding: 2rem;
-  padding-bottom: 4rem;
+export const AboutContent = styled.div<{ $minimal?: boolean }>`
+  padding: ${(props) => (props.$minimal ? "0" : "2rem")};
+  padding-bottom: ${(props) => (props.$minimal ? "0" : "4rem")};
   color: ${CORPUS_COLORS.slate[600]};
   line-height: 1.8;
   font-size: 1.0625rem;
   flex: 1;
-  overflow-y: auto;
+  overflow-y: ${(props) => (props.$minimal ? "visible" : "auto")};
   overflow-x: hidden;
   position: relative;
   min-height: 0;
   max-height: 100%;
 
   ${mediaQuery.tablet} {
-    padding: 1.25rem;
-    padding-bottom: 3rem;
+    padding: ${(props) => (props.$minimal ? "0" : "1.25rem")};
+    padding-bottom: ${(props) => (props.$minimal ? "0" : "3rem")};
     font-size: 0.9375rem;
     line-height: 1.65;
   }

--- a/frontend/src/components/corpuses/CorpusHome.tsx
+++ b/frontend/src/components/corpuses/CorpusHome.tsx
@@ -1,214 +1,14 @@
-import React, { useEffect, useMemo } from "react";
-import styled from "styled-components";
-import { useQuery, useReactiveVar } from "@apollo/client";
+import React from "react";
+import { useReactiveVar } from "@apollo/client";
 import { useLocation, useNavigate } from "react-router-dom";
-import {
-  BookOpen,
-  ListTree,
-  ChevronsUpDown,
-  ChevronsDownUp,
-} from "lucide-react";
-import {
-  corpusHomeView,
-  CorpusHomeViewType,
-  tocExpandAll,
-} from "../../graphql/cache";
-import {
-  updateHomeViewParam,
-  updateTocExpandedParam,
-} from "../../utils/navigationUtils";
 
-import {
-  GET_CORPUS_WITH_HISTORY,
-  GetCorpusWithHistoryQuery,
-  GetCorpusWithHistoryQueryVariables,
-} from "../../graphql/queries";
+import { corpusDetailView } from "../../graphql/cache";
+import { updateDetailViewParam } from "../../utils/navigationUtils";
 import { CorpusType } from "../../types/graphql-api";
-import { PermissionTypes } from "../types";
-import { getPermissions } from "../../utils/transform";
-import { CorpusAbout } from "./CorpusAbout";
-import { CorpusHero } from "./CorpusHero";
-import { DocumentTableOfContents } from "./DocumentTableOfContents";
-import {
-  OS_LEGAL_COLORS,
-  OS_LEGAL_SPACING,
-} from "../../assets/configurations/osLegalStyles";
+import { CorpusLandingView } from "./CorpusHome/CorpusLandingView";
+import { CorpusDetailsView } from "./CorpusHome/CorpusDetailsView";
 
-// Styled Components
-const Container = styled.div`
-  display: flex;
-  flex-direction: column;
-  flex: 1;
-  background: #f8fafc;
-  overflow: hidden;
-  position: relative;
-  height: 100%;
-  max-height: 100%;
-  min-height: 0;
-`;
-
-const MainContent = styled.div`
-  flex: 1;
-  overflow-y: auto;
-  overflow-x: hidden;
-  padding: 1rem 0.25rem;
-  display: flex;
-  flex-direction: column;
-  min-height: 0;
-  max-height: 100%;
-
-  @media (max-width: 768px) {
-    padding: clamp(0.5rem, 1.5vh, 0.75rem) clamp(0.5rem, 2vw, 0.75rem);
-  }
-`;
-
-const StretchWrapper = styled.div`
-  flex: 1;
-  display: flex;
-  justify-content: center;
-  align-items: stretch;
-  width: 100%;
-  min-height: 0;
-  max-height: 100%;
-  overflow: hidden;
-`;
-
-const ContentWrapper = styled.div`
-  width: 100%;
-  max-width: 1200px;
-  display: flex;
-  flex-direction: column;
-  min-height: 0;
-  max-height: 100%;
-  overflow: hidden;
-`;
-
-const TabContainer = styled.div`
-  background: ${OS_LEGAL_COLORS.surface};
-  border: 1px solid ${OS_LEGAL_COLORS.border};
-  border-radius: ${OS_LEGAL_SPACING.borderRadiusCard};
-  box-shadow: ${OS_LEGAL_SPACING.shadowCard};
-  display: flex;
-  flex-direction: column;
-  min-height: 0;
-  flex: 1;
-  overflow: hidden;
-`;
-
-const TabHeader = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  border-bottom: 1px solid ${OS_LEGAL_COLORS.border};
-  background: ${OS_LEGAL_COLORS.surfaceHover};
-  border-radius: ${OS_LEGAL_SPACING.borderRadiusCard}
-    ${OS_LEGAL_SPACING.borderRadiusCard} 0 0;
-`;
-
-const TabList = styled.div`
-  display: flex;
-`;
-
-const TabActions = styled.div`
-  display: flex;
-  align-items: center;
-  padding-right: 16px;
-`;
-
-const ExpandToggleButton = styled.button`
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 8px 14px;
-  border: 1px solid ${OS_LEGAL_COLORS.border};
-  border-radius: 6px;
-  background: ${OS_LEGAL_COLORS.surface};
-  color: ${OS_LEGAL_COLORS.textSecondary};
-  font-size: 0.8125rem;
-  font-weight: 500;
-  cursor: pointer;
-  transition: all 0.15s ease;
-
-  &:hover {
-    background: ${OS_LEGAL_COLORS.surfaceHover};
-    border-color: ${OS_LEGAL_COLORS.accent};
-    color: ${OS_LEGAL_COLORS.accent};
-  }
-
-  &:focus-visible {
-    outline: 2px solid ${OS_LEGAL_COLORS.accent};
-    outline-offset: 2px;
-  }
-`;
-
-const Tab = styled.button<{ $active: boolean }>`
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 16px 28px;
-  border: none;
-  background: ${(props) =>
-    props.$active ? OS_LEGAL_COLORS.surface : "transparent"};
-  color: ${(props) =>
-    props.$active ? OS_LEGAL_COLORS.accent : OS_LEGAL_COLORS.textSecondary};
-  font-size: 1rem;
-  font-weight: ${(props) => (props.$active ? "600" : "500")};
-  cursor: pointer;
-  transition: all 0.15s ease;
-  position: relative;
-
-  ${(props) =>
-    props.$active &&
-    `
-    &::after {
-      content: '';
-      position: absolute;
-      bottom: -1px;
-      left: 0;
-      right: 0;
-      height: 3px;
-      background: ${OS_LEGAL_COLORS.accent};
-    }
-  `}
-
-  &:hover {
-    color: ${(props) =>
-      props.$active ? OS_LEGAL_COLORS.accent : OS_LEGAL_COLORS.textPrimary};
-    background: ${(props) =>
-      props.$active ? OS_LEGAL_COLORS.surface : "rgba(0,0,0,0.02)"};
-  }
-
-  &:focus-visible {
-    outline: 2px solid ${OS_LEGAL_COLORS.accent};
-    outline-offset: -2px;
-  }
-
-  svg {
-    opacity: ${(props) => (props.$active ? 1 : 0.7)};
-  }
-`;
-
-const TabContent = styled.div`
-  flex: 1;
-  overflow-y: auto;
-  min-height: 0;
-
-  &::-webkit-scrollbar {
-    width: 8px;
-  }
-  &::-webkit-scrollbar-track {
-    background: ${OS_LEGAL_COLORS.surfaceHover};
-  }
-  &::-webkit-scrollbar-thumb {
-    background: ${OS_LEGAL_COLORS.border};
-    border-radius: 4px;
-    &:hover {
-      background: ${OS_LEGAL_COLORS.borderHover};
-    }
-  }
-`;
-
-interface CorpusHomeProps {
+export interface CorpusHomeProps {
   corpus: CorpusType;
   onEditDescription: () => void;
   onNavigate?: (tabIndex: number) => void;
@@ -231,6 +31,17 @@ interface CorpusHomeProps {
   onOpenMobileMenu?: () => void;
 }
 
+/**
+ * CorpusHome - Orchestrator component that switches between landing and details views
+ *
+ * Views:
+ * - Landing: Centered layout with description and "View Details" button
+ * - Details: Two-column layout (desktop) or tabbed (mobile) with TOC and About
+ *
+ * URL State:
+ * - /c/user/corpus → Landing view (default)
+ * - /c/user/corpus?view=details → Details view
+ */
 export const CorpusHome: React.FC<CorpusHomeProps> = ({
   corpus,
   onEditDescription,
@@ -239,161 +50,46 @@ export const CorpusHome: React.FC<CorpusHomeProps> = ({
   onChatSubmit,
   onViewChatHistory,
   onNavigateToCorpuses,
-  onOpenMobileMenu,
 }) => {
   const location = useLocation();
   const navigate = useNavigate();
-  const [mdContent, setMdContent] = React.useState<string | null>(null);
 
-  // Get active tab from URL-driven reactive var (default to "about")
-  const homeViewFromUrl = useReactiveVar(corpusHomeView);
-  const activeTab: CorpusHomeViewType = homeViewFromUrl ?? "about";
+  // Get current view from URL-driven reactive var (set by CentralRouteManager)
+  const currentView = useReactiveVar(corpusDetailView);
 
-  // Get TOC expand state from URL-driven reactive var
-  const isTocExpanded = useReactiveVar(tocExpandAll);
-
-  // Update tab via URL (CentralRouteManager Phase 2 will set the reactive var)
-  const setActiveTab = (tab: CorpusHomeViewType) => {
-    updateHomeViewParam(location, navigate, tab);
+  // Handle switching to details view
+  const handleViewDetails = () => {
+    updateDetailViewParam(location, navigate, "details");
   };
 
-  // Toggle TOC expand state via URL
-  const handleToggleExpandAll = () => {
-    updateTocExpandedParam(location, navigate, !isTocExpanded);
+  // Handle switching back to landing view
+  const handleBackToLanding = () => {
+    updateDetailViewParam(location, navigate, "landing");
   };
 
-  // CRITICAL: Memoize variables object to prevent Apollo refetch on every render
-  // Parent passes new corpus object reference on every render (reactive var issue)
-  // Apollo refetches queries when variables object changes, so we must stabilize it
-  // Note: corpus.id is already a primitive, so we only need to memoize the object
-  const historyVariables = useMemo(() => ({ id: corpus.id }), [corpus.id]);
-
-  // Fetch corpus with description history
-  const { data: corpusData, loading: corpusLoading } = useQuery<
-    GetCorpusWithHistoryQuery,
-    GetCorpusWithHistoryQueryVariables
-  >(GET_CORPUS_WITH_HISTORY, {
-    variables: historyVariables,
-  });
-
-  // Fetch markdown content from URL
-  useEffect(() => {
-    if (corpusData?.corpus?.mdDescription) {
-      fetch(corpusData.corpus.mdDescription)
-        .then((res) => {
-          if (!res.ok) {
-            throw new Error(`HTTP ${res.status}: ${res.statusText}`);
-          }
-          return res.text();
-        })
-        .then((text) => setMdContent(text))
-        .catch((err) => {
-          console.error("Error fetching corpus description:", err);
-          setMdContent(null);
-        });
-    }
-  }, [corpusData]);
-
-  // Use the fetched corpus data instead of the prop
-  const fullCorpus = corpusData?.corpus || corpus;
-
-  const canEdit = getPermissions(fullCorpus.myPermissions || []).includes(
-    PermissionTypes.CAN_UPDATE
-  );
+  // Render the appropriate view
+  if (currentView === "details") {
+    return (
+      <CorpusDetailsView
+        corpus={corpus}
+        onBack={handleBackToLanding}
+        onEditDescription={onEditDescription}
+        testId="corpus-home-details"
+      />
+    );
+  }
 
   return (
-    <Container id="corpus-home-container">
-      <CorpusHero
-        corpus={fullCorpus}
-        chatQuery={chatQuery}
-        onChatQueryChange={onChatQueryChange || (() => {})}
-        onChatSubmit={onChatSubmit || (() => {})}
-        onViewChatHistory={onViewChatHistory || (() => {})}
-        onNavigateToCorpuses={onNavigateToCorpuses}
-        onOpenMobileMenu={onOpenMobileMenu}
-        autoFocusChat={true}
-        showQuickActions={true}
-        testId="corpus-home-hero"
-      />
-
-      <MainContent id="corpus-home-main-content">
-        <StretchWrapper>
-          <ContentWrapper id="corpus-home-content">
-            <TabContainer>
-              <TabHeader>
-                <TabList role="tablist" aria-label="Corpus information tabs">
-                  <Tab
-                    role="tab"
-                    $active={activeTab === "about"}
-                    onClick={() => setActiveTab("about")}
-                    aria-selected={activeTab === "about"}
-                    aria-controls="about-panel"
-                    id="about-tab"
-                  >
-                    <BookOpen size={20} />
-                    About
-                  </Tab>
-                  <Tab
-                    role="tab"
-                    $active={activeTab === "toc"}
-                    onClick={() => setActiveTab("toc")}
-                    aria-selected={activeTab === "toc"}
-                    aria-controls="toc-panel"
-                    id="toc-tab"
-                  >
-                    <ListTree size={20} />
-                    Table of Contents
-                  </Tab>
-                </TabList>
-                {activeTab === "toc" && (
-                  <TabActions>
-                    <ExpandToggleButton
-                      onClick={handleToggleExpandAll}
-                      aria-label={isTocExpanded ? "Collapse all" : "Expand all"}
-                    >
-                      {isTocExpanded ? (
-                        <>
-                          <ChevronsDownUp size={16} />
-                          Collapse All
-                        </>
-                      ) : (
-                        <>
-                          <ChevronsUpDown size={16} />
-                          Expand All
-                        </>
-                      )}
-                    </ExpandToggleButton>
-                  </TabActions>
-                )}
-              </TabHeader>
-              <TabContent
-                role="tabpanel"
-                id={activeTab === "about" ? "about-panel" : "toc-panel"}
-                aria-labelledby={
-                  activeTab === "about" ? "about-tab" : "toc-tab"
-                }
-              >
-                {activeTab === "about" ? (
-                  <CorpusAbout
-                    corpus={fullCorpus}
-                    mdContent={mdContent}
-                    isLoading={corpusLoading}
-                    canEdit={canEdit}
-                    onEditDescription={onEditDescription}
-                    testId="corpus-home-description-card"
-                  />
-                ) : (
-                  <DocumentTableOfContents
-                    corpusId={corpus.id}
-                    maxDepth={4}
-                    embedded={true}
-                  />
-                )}
-              </TabContent>
-            </TabContainer>
-          </ContentWrapper>
-        </StretchWrapper>
-      </MainContent>
-    </Container>
+    <CorpusLandingView
+      corpus={corpus}
+      onViewDetails={handleViewDetails}
+      onEditDescription={onEditDescription}
+      onNavigateToCorpuses={onNavigateToCorpuses}
+      chatQuery={chatQuery}
+      onChatQueryChange={onChatQueryChange}
+      onChatSubmit={onChatSubmit}
+      onViewChatHistory={onViewChatHistory}
+      testId="corpus-home-landing"
+    />
   );
 };

--- a/frontend/src/components/corpuses/CorpusHome/CorpusDetailsView.tsx
+++ b/frontend/src/components/corpuses/CorpusHome/CorpusDetailsView.tsx
@@ -1,0 +1,367 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { useQuery, useReactiveVar } from "@apollo/client";
+import { useLocation, useNavigate } from "react-router-dom";
+import {
+  ArrowLeft,
+  Users,
+  Calendar,
+  Globe,
+  Shield,
+  FileText,
+  BookOpen,
+  ListTree,
+  ChevronsUpDown,
+  ChevronsDownUp,
+  Edit,
+  Activity,
+} from "lucide-react";
+import { formatDistanceToNow } from "date-fns";
+
+import {
+  GET_CORPUS_WITH_HISTORY,
+  GetCorpusWithHistoryQuery,
+  GetCorpusWithHistoryQueryVariables,
+} from "../../../graphql/queries";
+import { CorpusType } from "../../../types/graphql-api";
+import { PermissionTypes } from "../../types";
+import { getPermissions } from "../../../utils/transform";
+import { tocExpandAll } from "../../../graphql/cache";
+import { updateTocExpandedParam } from "../../../utils/navigationUtils";
+import { CorpusAbout } from "../CorpusAbout/CorpusAbout";
+import { DocumentTableOfContents } from "../DocumentTableOfContents";
+import { MCPShareButton } from "../../common/MCPShareButton";
+
+import {
+  DetailsContainer,
+  DetailsPage,
+  DetailsHeader,
+  BackButton,
+  DetailsTitleRow,
+  DetailsTitleSection,
+  DetailsTitle,
+  CenteredMetadataRow,
+  MetadataItem,
+  MetadataSeparator,
+  AccessBadge,
+  DetailsMainContent,
+  TwoColumnLayout,
+  DocumentsSidebar,
+  SidebarLabel,
+  SectionLabel,
+  SidebarContent,
+  AboutMainContent,
+  AboutHeader,
+  AboutActions,
+  TextButton,
+  TextButtonPrimary,
+  AboutBody,
+  ExpandButton,
+  MobileTabContainer,
+  MobileTabList,
+  MobileTab,
+  MobileTabContent,
+} from "./styles";
+
+type MobileTabType = "toc" | "about";
+
+export interface CorpusDetailsViewProps {
+  /** The corpus object */
+  corpus: CorpusType;
+  /** Callback when "< Overview" back button is clicked */
+  onBack: () => void;
+  /** Callback when edit description is clicked */
+  onEditDescription: () => void;
+  /** Test ID for the component */
+  testId?: string;
+}
+
+/**
+ * CorpusDetailsView - Minimalist two-column details layout
+ *
+ * Features:
+ * - Clean typography-first design
+ * - Narrow Documents sidebar (left)
+ * - Full About content (right)
+ * - No cards, just clean dividers
+ * - Mobile: Tabbed interface
+ */
+export const CorpusDetailsView: React.FC<CorpusDetailsViewProps> = ({
+  corpus,
+  onBack,
+  onEditDescription,
+  testId = "corpus-details",
+}) => {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const [mdContent, setMdContent] = React.useState<string | null>(null);
+  const [mobileTab, setMobileTab] = useState<MobileTabType>("about");
+
+  // Get TOC expand state from URL-driven reactive var (set by CentralRouteManager)
+  const isTocExpanded = useReactiveVar(tocExpandAll);
+
+  // Toggle TOC expand state via URL utility
+  // CentralRouteManager Phase 2 will detect URL change and set tocExpandAll reactive var
+  const handleToggleExpandAll = () => {
+    updateTocExpandedParam(location, navigate, !isTocExpanded);
+  };
+
+  // CRITICAL: Memoize variables object to prevent Apollo refetch on every render
+  const historyVariables = useMemo(() => ({ id: corpus.id }), [corpus.id]);
+
+  // Fetch corpus with description history
+  const { data: corpusData, loading: corpusLoading } = useQuery<
+    GetCorpusWithHistoryQuery,
+    GetCorpusWithHistoryQueryVariables
+  >(GET_CORPUS_WITH_HISTORY, {
+    variables: historyVariables,
+  });
+
+  // Fetch markdown content from URL
+  useEffect(() => {
+    if (corpusData?.corpus?.mdDescription) {
+      fetch(corpusData.corpus.mdDescription)
+        .then((res) => {
+          if (!res.ok) {
+            throw new Error(`HTTP ${res.status}: ${res.statusText}`);
+          }
+          return res.text();
+        })
+        .then((text) => setMdContent(text))
+        .catch((err) => {
+          console.error("Error fetching corpus description:", err);
+          setMdContent(null);
+        });
+    }
+  }, [corpusData]);
+
+  // Use the fetched corpus data instead of the prop for description/history
+  const fullCorpus = corpusData?.corpus || corpus;
+
+  const canEdit = getPermissions(fullCorpus.myPermissions || []).includes(
+    PermissionTypes.CAN_UPDATE
+  );
+
+  const creatorName = fullCorpus.creator?.email?.split("@")[0] || "Unknown";
+  const createdDate = fullCorpus.created
+    ? formatDistanceToNow(new Date(fullCorpus.created), { addSuffix: true })
+    : "recently";
+
+  // Get document count from original corpus prop (which has documents field)
+  const docCount = corpus.documents?.totalCount;
+
+  const hasContent = mdContent || fullCorpus.description;
+
+  return (
+    <DetailsContainer data-testid={testId}>
+      <DetailsPage>
+        {/* Header section - clean, minimal */}
+        <DetailsHeader>
+          <BackButton
+            onClick={onBack}
+            whileHover={{ scale: 1.01 }}
+            whileTap={{ scale: 0.99 }}
+            data-testid={`${testId}-back-btn`}
+          >
+            <ArrowLeft />
+            Overview
+          </BackButton>
+
+          <DetailsTitleRow>
+            <DetailsTitleSection>
+              <DetailsTitle data-testid={`${testId}-title`}>
+                {fullCorpus.title || "Untitled Corpus"}
+              </DetailsTitle>
+
+              {/* Metadata row - subtle, inline */}
+              <CenteredMetadataRow
+                style={{ justifyContent: "flex-start", marginTop: "0.75rem" }}
+                data-testid={`${testId}-metadata`}
+              >
+                <AccessBadge $isPublic={fullCorpus.isPublic}>
+                  {fullCorpus.isPublic ? (
+                    <>
+                      <Globe aria-hidden="true" />
+                      Public
+                    </>
+                  ) : (
+                    <>
+                      <Shield aria-hidden="true" />
+                      Private
+                    </>
+                  )}
+                </AccessBadge>
+
+                {fullCorpus.isPublic && fullCorpus.slug && (
+                  <>
+                    <MetadataSeparator />
+                    <MCPShareButton
+                      corpusSlug={fullCorpus.slug}
+                      size="sm"
+                      testId={`${testId}-mcp-share`}
+                    />
+                  </>
+                )}
+
+                <MetadataSeparator />
+
+                <MetadataItem>
+                  <Users aria-hidden="true" />
+                  <span>{creatorName}</span>
+                </MetadataItem>
+
+                <MetadataSeparator />
+
+                <MetadataItem>
+                  <Calendar aria-hidden="true" />
+                  <span>{createdDate}</span>
+                </MetadataItem>
+
+                {docCount != null && docCount > 0 && (
+                  <>
+                    <MetadataSeparator />
+                    <MetadataItem>
+                      <FileText aria-hidden="true" />
+                      <span>
+                        {docCount} {docCount === 1 ? "document" : "documents"}
+                      </span>
+                    </MetadataItem>
+                  </>
+                )}
+              </CenteredMetadataRow>
+            </DetailsTitleSection>
+          </DetailsTitleRow>
+        </DetailsHeader>
+
+        {/* Main content - two columns with vertical divider */}
+        <DetailsMainContent>
+          <TwoColumnLayout>
+            {/* Left: Documents sidebar */}
+            <DocumentsSidebar>
+              <SidebarLabel>
+                <SectionLabel>Documents</SectionLabel>
+                <ExpandButton
+                  onClick={handleToggleExpandAll}
+                  aria-label={isTocExpanded ? "Collapse all" : "Expand all"}
+                >
+                  {isTocExpanded ? (
+                    <>
+                      <ChevronsDownUp />
+                      Collapse
+                    </>
+                  ) : (
+                    <>
+                      <ChevronsUpDown />
+                      Expand
+                    </>
+                  )}
+                </ExpandButton>
+              </SidebarLabel>
+              <SidebarContent>
+                <DocumentTableOfContents
+                  corpusId={corpus.id}
+                  maxDepth={4}
+                  embedded={true}
+                />
+              </SidebarContent>
+            </DocumentsSidebar>
+
+            {/* Right: About content */}
+            <AboutMainContent>
+              <AboutHeader>
+                <SectionLabel>About</SectionLabel>
+                <AboutActions>
+                  {hasContent && (
+                    <TextButton
+                      onClick={onEditDescription}
+                      aria-label="View version history"
+                    >
+                      <Activity />
+                      History
+                    </TextButton>
+                  )}
+                  {canEdit && (
+                    <TextButtonPrimary
+                      onClick={onEditDescription}
+                      aria-label={
+                        hasContent ? "Edit description" : "Add description"
+                      }
+                    >
+                      <Edit />
+                      {hasContent ? "Edit" : "Add"}
+                    </TextButtonPrimary>
+                  )}
+                </AboutActions>
+              </AboutHeader>
+              <AboutBody>
+                <CorpusAbout
+                  corpus={fullCorpus}
+                  mdContent={mdContent}
+                  isLoading={corpusLoading}
+                  canEdit={canEdit}
+                  onEditDescription={onEditDescription}
+                  hideHeader={true}
+                  testId={`${testId}-about`}
+                />
+              </AboutBody>
+            </AboutMainContent>
+          </TwoColumnLayout>
+
+          {/* Mobile: Tabbed interface */}
+          <MobileTabContainer>
+            <MobileTabList role="tablist" aria-label="Corpus details tabs">
+              <MobileTab
+                role="tab"
+                $active={mobileTab === "about"}
+                onClick={() => setMobileTab("about")}
+                aria-selected={mobileTab === "about"}
+                aria-controls="mobile-about-panel"
+                id="mobile-about-tab"
+              >
+                <BookOpen size={16} />
+                About
+              </MobileTab>
+              <MobileTab
+                role="tab"
+                $active={mobileTab === "toc"}
+                onClick={() => setMobileTab("toc")}
+                aria-selected={mobileTab === "toc"}
+                aria-controls="mobile-toc-panel"
+                id="mobile-toc-tab"
+              >
+                <ListTree size={16} />
+                Documents
+              </MobileTab>
+            </MobileTabList>
+
+            <MobileTabContent
+              role="tabpanel"
+              id={
+                mobileTab === "toc" ? "mobile-toc-panel" : "mobile-about-panel"
+              }
+              aria-labelledby={
+                mobileTab === "toc" ? "mobile-toc-tab" : "mobile-about-tab"
+              }
+            >
+              {mobileTab === "toc" ? (
+                <DocumentTableOfContents
+                  corpusId={corpus.id}
+                  maxDepth={4}
+                  embedded={true}
+                />
+              ) : (
+                <CorpusAbout
+                  corpus={fullCorpus}
+                  mdContent={mdContent}
+                  isLoading={corpusLoading}
+                  canEdit={canEdit}
+                  onEditDescription={onEditDescription}
+                  testId={`${testId}-about-mobile`}
+                />
+              )}
+            </MobileTabContent>
+          </MobileTabContainer>
+        </DetailsMainContent>
+      </DetailsPage>
+    </DetailsContainer>
+  );
+};

--- a/frontend/src/components/corpuses/CorpusHome/CorpusLandingView.tsx
+++ b/frontend/src/components/corpuses/CorpusHome/CorpusLandingView.tsx
@@ -1,0 +1,274 @@
+import React, { useEffect, useMemo } from "react";
+import { useQuery } from "@apollo/client";
+import {
+  ChevronRight,
+  Users,
+  Calendar,
+  Globe,
+  Shield,
+  FileText,
+  ArrowRight,
+  Plus,
+} from "lucide-react";
+import { formatDistanceToNow } from "date-fns";
+
+import {
+  GET_CORPUS_WITH_HISTORY,
+  GetCorpusWithHistoryQuery,
+  GetCorpusWithHistoryQueryVariables,
+} from "../../../graphql/queries";
+import { CorpusType } from "../../../types/graphql-api";
+import { PermissionTypes } from "../../types";
+import { getPermissions } from "../../../utils/transform";
+import { InlineChatBar } from "../CorpusHero/InlineChatBar";
+import { MCPShareButton } from "../../common/MCPShareButton";
+
+import {
+  LandingContainer,
+  LandingContent,
+  LandingHero,
+  CenteredBreadcrumbs,
+  CorpusBadge,
+  LandingTitle,
+  LandingDescription,
+  NoDescriptionContainer,
+  NoDescriptionText,
+  AddDescriptionLink,
+  CenteredMetadataRow,
+  MetadataItem,
+  MetadataSeparator,
+  AccessBadge,
+  ChatSection,
+  ViewDetailsButton,
+} from "./styles";
+
+export interface CorpusLandingViewProps {
+  /** The corpus object */
+  corpus: CorpusType;
+  /** Callback when "View Details" is clicked */
+  onViewDetails: () => void;
+  /** Callback when edit description is clicked */
+  onEditDescription: () => void;
+  /** Callback to navigate back to corpus list */
+  onNavigateToCorpuses?: () => void;
+  /** Chat integration props */
+  chatQuery?: string;
+  onChatQueryChange?: (value: string) => void;
+  onChatSubmit?: (query: string) => void;
+  onViewChatHistory?: () => void;
+  /** Test ID for the component */
+  testId?: string;
+}
+
+/**
+ * CorpusLandingView - Centered landing page for corpus
+ *
+ * Features:
+ * - Centered layout with max-width constraint
+ * - CORPUS badge above title
+ * - Large serif title
+ * - Description as subtitle (or "no description" with add action)
+ * - Metadata row (access badge, creator, date, doc count)
+ * - InlineChatBar for querying
+ * - "View Details" button to switch to details view
+ */
+export const CorpusLandingView: React.FC<CorpusLandingViewProps> = ({
+  corpus,
+  onViewDetails,
+  onEditDescription,
+  onNavigateToCorpuses,
+  chatQuery = "",
+  onChatQueryChange,
+  onChatSubmit,
+  onViewChatHistory,
+  testId = "corpus-landing",
+}) => {
+  const [mdContent, setMdContent] = React.useState<string | null>(null);
+
+  // CRITICAL: Memoize variables object to prevent Apollo refetch on every render
+  const historyVariables = useMemo(() => ({ id: corpus.id }), [corpus.id]);
+
+  // Fetch corpus with description history
+  const { data: corpusData } = useQuery<
+    GetCorpusWithHistoryQuery,
+    GetCorpusWithHistoryQueryVariables
+  >(GET_CORPUS_WITH_HISTORY, {
+    variables: historyVariables,
+  });
+
+  // Fetch markdown content from URL
+  useEffect(() => {
+    if (corpusData?.corpus?.mdDescription) {
+      fetch(corpusData.corpus.mdDescription)
+        .then((res) => {
+          if (!res.ok) {
+            throw new Error(`HTTP ${res.status}: ${res.statusText}`);
+          }
+          return res.text();
+        })
+        .then((text) => setMdContent(text))
+        .catch((err) => {
+          console.error("Error fetching corpus description:", err);
+          setMdContent(null);
+        });
+    }
+  }, [corpusData]);
+
+  // Use the fetched corpus data instead of the prop for description/history
+  const fullCorpus = corpusData?.corpus || corpus;
+
+  const canEdit = getPermissions(fullCorpus.myPermissions || []).includes(
+    PermissionTypes.CAN_UPDATE
+  );
+
+  const creatorName = fullCorpus.creator?.email?.split("@")[0] || "Unknown";
+  const createdDate = fullCorpus.created
+    ? formatDistanceToNow(new Date(fullCorpus.created), { addSuffix: true })
+    : "recently";
+
+  // Get document count from original corpus prop (which has documents field)
+  const docCount = corpus.documents?.totalCount;
+
+  // Get plain text description - prefer markdown content, fallback to plain description
+  // For hero subtitle, we use plain text only (no markdown rendering)
+  const descriptionText = mdContent
+    ? mdContent.split("\n")[0].slice(0, 200) // First line, max 200 chars
+    : fullCorpus.description;
+
+  const hasDescription = Boolean(descriptionText);
+
+  return (
+    <LandingContainer data-testid={testId}>
+      <LandingContent>
+        <LandingHero>
+          {/* Centered breadcrumbs */}
+          <CenteredBreadcrumbs
+            aria-label="Breadcrumb navigation"
+            data-testid={`${testId}-breadcrumbs`}
+          >
+            <a
+              href="#"
+              onClick={(e) => {
+                e.preventDefault();
+                onNavigateToCorpuses?.();
+              }}
+            >
+              Corpuses
+            </a>
+            <ChevronRight aria-hidden="true" />
+            <span className="current">
+              {fullCorpus.title || "Untitled Corpus"}
+            </span>
+          </CenteredBreadcrumbs>
+
+          {/* Corpus badge */}
+          <CorpusBadge>CORPUS</CorpusBadge>
+
+          {/* Large title */}
+          <LandingTitle data-testid={`${testId}-title`}>
+            {fullCorpus.title || "Untitled Corpus"}
+          </LandingTitle>
+
+          {/* Description as subtitle or "no description" with action */}
+          {hasDescription ? (
+            <LandingDescription data-testid={`${testId}-description`}>
+              {descriptionText}
+            </LandingDescription>
+          ) : (
+            <NoDescriptionContainer data-testid={`${testId}-no-description`}>
+              <NoDescriptionText>No description yet.</NoDescriptionText>
+              {canEdit && (
+                <AddDescriptionLink
+                  onClick={onEditDescription}
+                  data-testid={`${testId}-add-description-btn`}
+                >
+                  <Plus size={14} />
+                  Add one now
+                </AddDescriptionLink>
+              )}
+            </NoDescriptionContainer>
+          )}
+
+          {/* Metadata row */}
+          <CenteredMetadataRow data-testid={`${testId}-metadata`}>
+            <AccessBadge $isPublic={fullCorpus.isPublic}>
+              {fullCorpus.isPublic ? (
+                <>
+                  <Globe aria-hidden="true" />
+                  Public
+                </>
+              ) : (
+                <>
+                  <Shield aria-hidden="true" />
+                  Private
+                </>
+              )}
+            </AccessBadge>
+
+            {/* MCP Share button - only shown for public corpuses */}
+            {fullCorpus.isPublic && fullCorpus.slug && (
+              <>
+                <MetadataSeparator />
+                <MCPShareButton
+                  corpusSlug={fullCorpus.slug}
+                  size="sm"
+                  testId={`${testId}-mcp-share`}
+                />
+              </>
+            )}
+
+            <MetadataSeparator />
+
+            <MetadataItem>
+              <Users aria-hidden="true" />
+              <span>{creatorName}</span>
+            </MetadataItem>
+
+            <MetadataSeparator />
+
+            <MetadataItem>
+              <Calendar aria-hidden="true" />
+              <span>{createdDate}</span>
+            </MetadataItem>
+
+            {docCount != null && docCount > 0 && (
+              <>
+                <MetadataSeparator />
+                <MetadataItem>
+                  <FileText aria-hidden="true" />
+                  <span>
+                    {docCount} {docCount === 1 ? "document" : "documents"}
+                  </span>
+                </MetadataItem>
+              </>
+            )}
+          </CenteredMetadataRow>
+        </LandingHero>
+
+        {/* Chat section */}
+        <ChatSection>
+          <InlineChatBar
+            value={chatQuery}
+            onChange={onChatQueryChange || (() => {})}
+            onSubmit={onChatSubmit || (() => {})}
+            onViewHistory={onViewChatHistory || (() => {})}
+            autoFocus={true}
+            showQuickActions={true}
+            testId={`${testId}-chat`}
+          />
+        </ChatSection>
+
+        {/* View Details button */}
+        <ViewDetailsButton
+          onClick={onViewDetails}
+          whileHover={{ scale: 1.02 }}
+          whileTap={{ scale: 0.98 }}
+          data-testid={`${testId}-view-details-btn`}
+        >
+          View Details
+          <ArrowRight />
+        </ViewDetailsButton>
+      </LandingContent>
+    </LandingContainer>
+  );
+};

--- a/frontend/src/components/corpuses/CorpusHome/index.ts
+++ b/frontend/src/components/corpuses/CorpusHome/index.ts
@@ -1,0 +1,12 @@
+/**
+ * CorpusHome module exports
+ *
+ * Main orchestrator is in parent directory (CorpusHome.tsx)
+ * This folder contains the sub-components for landing and details views
+ */
+
+export { CorpusLandingView } from "./CorpusLandingView";
+export type { CorpusLandingViewProps } from "./CorpusLandingView";
+
+export { CorpusDetailsView } from "./CorpusDetailsView";
+export type { CorpusDetailsViewProps } from "./CorpusDetailsView";

--- a/frontend/src/components/corpuses/CorpusHome/styles.ts
+++ b/frontend/src/components/corpuses/CorpusHome/styles.ts
@@ -1,0 +1,897 @@
+/**
+ * Shared styled components for CorpusHome views
+ * Supports both landing (centered) and details (two-column/tabbed) layouts
+ */
+
+import styled from "styled-components";
+import { motion } from "framer-motion";
+import {
+  CORPUS_COLORS,
+  CORPUS_FONTS,
+  CORPUS_RADII,
+  CORPUS_SHADOWS,
+  CORPUS_TRANSITIONS,
+  mediaQuery,
+} from "../styles/corpusDesignTokens";
+
+// ============================================================================
+// SHARED CONTAINERS
+// ============================================================================
+
+/** Base container shared by both views */
+export const BaseContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  background: #f8fafc;
+  overflow: hidden;
+  position: relative;
+  height: 100%;
+  max-height: 100%;
+  min-height: 0;
+`;
+
+// ============================================================================
+// LANDING VIEW STYLES
+// ============================================================================
+
+/** Landing page container - centered content */
+export const LandingContainer = styled(BaseContainer)`
+  align-items: center;
+`;
+
+/** Centered content wrapper for landing view */
+export const LandingContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+  max-width: 800px;
+  padding: 2rem 1.5rem;
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+
+  ${mediaQuery.tablet} {
+    padding: 1.25rem 1rem;
+  }
+`;
+
+/** Hero section for landing view - centered header content */
+export const LandingHero = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 1rem;
+  padding: 2rem 1rem;
+  width: 100%;
+
+  ${mediaQuery.tablet} {
+    padding: 1.25rem 0.75rem;
+    gap: 0.75rem;
+  }
+`;
+
+/** Centered breadcrumbs for landing view */
+export const CenteredBreadcrumbs = styled.nav`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  color: ${CORPUS_COLORS.slate[500]};
+
+  a {
+    color: ${CORPUS_COLORS.slate[500]};
+    text-decoration: none;
+    transition: color ${CORPUS_TRANSITIONS.fast};
+
+    &:hover {
+      color: ${CORPUS_COLORS.teal[700]};
+    }
+  }
+
+  svg {
+    width: 14px;
+    height: 14px;
+    color: ${CORPUS_COLORS.slate[300]};
+  }
+
+  .current {
+    color: ${CORPUS_COLORS.slate[700]};
+    font-weight: 500;
+  }
+`;
+
+/** Corpus badge - teal background, uppercase */
+export const CorpusBadge = styled.span`
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.375rem 0.875rem;
+  border-radius: ${CORPUS_RADII.full};
+  background: ${CORPUS_COLORS.teal[700]};
+  color: ${CORPUS_COLORS.white};
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+`;
+
+/** Large serif title for landing view */
+export const LandingTitle = styled.h1`
+  margin: 0;
+  font-family: ${CORPUS_FONTS.serif};
+  font-size: 2.75rem;
+  font-weight: 400;
+  color: ${CORPUS_COLORS.slate[800]};
+  letter-spacing: -0.02em;
+  line-height: 1.15;
+  text-align: center;
+
+  ${mediaQuery.tablet} {
+    font-size: 1.875rem;
+  }
+`;
+
+/** Description subtitle under the title - elegant typography */
+export const LandingDescription = styled.p`
+  margin: 0;
+  margin-top: 1rem;
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: 1.125rem;
+  font-weight: 400;
+  color: ${CORPUS_COLORS.slate[500]};
+  line-height: 1.65;
+  text-align: center;
+  max-width: 600px;
+
+  ${mediaQuery.tablet} {
+    font-size: 1rem;
+    margin-top: 0.75rem;
+  }
+`;
+
+/** No description placeholder with action */
+export const NoDescriptionContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 1rem;
+`;
+
+export const NoDescriptionText = styled.span`
+  font-size: 0.9375rem;
+  color: ${CORPUS_COLORS.slate[400]};
+  font-style: italic;
+`;
+
+export const AddDescriptionLink = styled.button`
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0;
+  background: none;
+  border: none;
+  color: ${CORPUS_COLORS.teal[700]};
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all ${CORPUS_TRANSITIONS.fast};
+
+  &:hover {
+    color: ${CORPUS_COLORS.teal[600]};
+    text-decoration: underline;
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${CORPUS_COLORS.teal[500]};
+    outline-offset: 2px;
+  }
+
+  svg {
+    width: 14px;
+    height: 14px;
+  }
+`;
+
+/** Centered metadata row for landing view */
+export const CenteredMetadataRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-top: 0.5rem;
+
+  ${mediaQuery.tablet} {
+    gap: 0.75rem;
+  }
+`;
+
+/** Metadata item with icon */
+export const MetadataItem = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: 0.8125rem;
+  color: ${CORPUS_COLORS.slate[500]};
+
+  svg {
+    width: 14px;
+    height: 14px;
+    color: ${CORPUS_COLORS.slate[400]};
+  }
+
+  ${mediaQuery.tablet} {
+    font-size: 0.75rem;
+
+    svg {
+      width: 12px;
+      height: 12px;
+    }
+  }
+`;
+
+/** Metadata separator */
+export const MetadataSeparator = styled.div`
+  width: 1px;
+  height: 16px;
+  background: ${CORPUS_COLORS.slate[200]};
+
+  ${mediaQuery.tablet} {
+    height: 12px;
+  }
+`;
+
+/** Access badge (Public/Private) */
+export const AccessBadge = styled.div<{ $isPublic?: boolean }>`
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem 0.625rem;
+  border-radius: ${CORPUS_RADII.sm};
+  font-size: 0.75rem;
+  font-weight: 500;
+  background: ${(props) =>
+    props.$isPublic ? CORPUS_COLORS.teal[50] : "#fef3c7"};
+  color: ${(props) => (props.$isPublic ? CORPUS_COLORS.teal[700] : "#92400e")};
+
+  svg {
+    width: 12px;
+    height: 12px;
+  }
+`;
+
+/** Chat section wrapper for landing view */
+export const ChatSection = styled.div`
+  width: 100%;
+  max-width: 600px;
+  margin-top: 1.5rem;
+
+  ${mediaQuery.tablet} {
+    margin-top: 1rem;
+  }
+`;
+
+/** About card wrapper for landing view - simpler styling */
+export const LandingAboutCard = styled(motion.div)`
+  background: ${CORPUS_COLORS.white};
+  border-radius: ${CORPUS_RADII.lg};
+  box-shadow: ${CORPUS_SHADOWS.card};
+  border: 1px solid ${CORPUS_COLORS.slate[200]};
+  width: 100%;
+  margin-top: 2rem;
+  overflow: hidden;
+
+  ${mediaQuery.tablet} {
+    margin-top: 1.5rem;
+  }
+`;
+
+/** View Details button */
+export const ViewDetailsButton = styled(motion.button)`
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.5rem;
+  margin-top: 2rem;
+  background: ${CORPUS_COLORS.white};
+  border: 1px solid ${CORPUS_COLORS.slate[200]};
+  border-radius: ${CORPUS_RADII.md};
+  color: ${CORPUS_COLORS.teal[700]};
+  font-size: 0.9375rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all ${CORPUS_TRANSITIONS.fast};
+
+  svg {
+    width: 18px;
+    height: 18px;
+    transition: transform ${CORPUS_TRANSITIONS.fast};
+  }
+
+  &:hover {
+    background: ${CORPUS_COLORS.teal[50]};
+    border-color: ${CORPUS_COLORS.teal[200]};
+
+    svg {
+      transform: translateX(4px);
+    }
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${CORPUS_COLORS.teal[500]};
+    outline-offset: 2px;
+  }
+
+  ${mediaQuery.tablet} {
+    margin-top: 1.5rem;
+    padding: 0.625rem 1.25rem;
+    font-size: 0.875rem;
+  }
+`;
+
+// ============================================================================
+// DETAILS VIEW STYLES - Minimalist Typography-First Design
+// ============================================================================
+
+/** Details view container - subtle background with padding for floating page effect */
+export const DetailsContainer = styled(BaseContainer)`
+  background: ${CORPUS_COLORS.slate[100]};
+  padding: 1.5rem;
+
+  ${mediaQuery.tablet} {
+    padding: 0;
+    background: ${CORPUS_COLORS.white};
+  }
+`;
+
+/** Unified page wrapper - contains header + content, max-width constrained */
+export const DetailsPage = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: 1200px;
+  height: 100%;
+  min-height: 0; /* Allow flex shrinking */
+  margin: 0 auto;
+  background: ${CORPUS_COLORS.white};
+  border-radius: ${CORPUS_RADII.lg};
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05),
+    0 0 0 1px ${CORPUS_COLORS.slate[200]};
+  overflow: hidden; /* Contain children */
+
+  ${mediaQuery.tablet} {
+    max-width: 100%;
+    border-radius: 0;
+    box-shadow: none;
+  }
+`;
+
+/** Header section for details view */
+export const DetailsHeader = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 2rem 2.5rem 1.5rem;
+  border-bottom: 1px solid ${CORPUS_COLORS.slate[100]};
+  flex-shrink: 0;
+
+  ${mediaQuery.tablet} {
+    padding: 1.5rem 1.25rem 1.25rem;
+  }
+`;
+
+/** Back button - minimal, text-like */
+export const BackButton = styled(motion.button)`
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0;
+  margin-bottom: 1rem;
+  background: transparent;
+  border: none;
+  color: ${CORPUS_COLORS.slate[400]};
+  font-size: 0.8125rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: color ${CORPUS_TRANSITIONS.fast};
+  align-self: flex-start;
+
+  svg {
+    width: 14px;
+    height: 14px;
+    transition: transform ${CORPUS_TRANSITIONS.fast};
+  }
+
+  &:hover {
+    color: ${CORPUS_COLORS.teal[700]};
+
+    svg {
+      transform: translateX(-3px);
+    }
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${CORPUS_COLORS.teal[500]};
+    outline-offset: 4px;
+  }
+
+  ${mediaQuery.tablet} {
+    margin-bottom: 0.75rem;
+  }
+`;
+
+/** Title row for details header */
+export const DetailsTitleRow = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+`;
+
+/** Title section for details header */
+export const DetailsTitleSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+`;
+
+/** Title for details view - bold typography */
+export const DetailsTitle = styled.h1`
+  margin: 0;
+  font-family: ${CORPUS_FONTS.serif};
+  font-size: 2.25rem;
+  font-weight: 400;
+  color: ${CORPUS_COLORS.slate[900]};
+  letter-spacing: -0.025em;
+  line-height: 1.2;
+
+  ${mediaQuery.tablet} {
+    font-size: 1.75rem;
+  }
+`;
+
+/** Main content area - fills remaining space */
+export const DetailsMainContent = styled.div`
+  flex: 1;
+  overflow: hidden;
+  display: flex;
+  min-height: 0;
+`;
+
+/** Two-column layout - Documents sidebar + About main content */
+export const TwoColumnLayout = styled.div`
+  display: flex;
+  width: 100%;
+  height: 100%;
+  min-height: 0; /* Allow flex shrinking */
+
+  ${mediaQuery.tablet} {
+    display: none;
+  }
+`;
+
+/** Documents sidebar - percentage-based with bounds */
+export const DocumentsSidebar = styled.div`
+  width: 40%;
+  min-width: 320px;
+  max-width: 480px;
+  border-right: 1px solid ${CORPUS_COLORS.slate[200]};
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  min-height: 0; /* Allow flex shrinking */
+`;
+
+/** Sidebar header - minimal label, aligned with content */
+export const SidebarLabel = styled.div`
+  padding: 1.5rem 1.5rem 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-shrink: 0;
+`;
+
+/** Section label - uppercase, readable, muted */
+export const SectionLabel = styled.span`
+  font-size: 0.875rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: ${CORPUS_COLORS.slate[400]};
+`;
+
+/** Sidebar content - scrollable document list */
+export const SidebarContent = styled.div`
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 0 0.5rem 1rem;
+
+  &::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: ${CORPUS_COLORS.slate[200]};
+    border-radius: 3px;
+
+    &:hover {
+      background: ${CORPUS_COLORS.slate[300]};
+    }
+  }
+`;
+
+/** About main content area */
+export const AboutMainContent = styled.div`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  min-width: 0;
+  min-height: 0; /* Allow flex shrinking */
+`;
+
+/** About header - label + actions */
+export const AboutHeader = styled.div`
+  padding: 1.5rem 2.5rem 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-shrink: 0;
+`;
+
+/** About actions - inline, minimal */
+export const AboutActions = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+`;
+
+/** Text button - minimal, link-like */
+export const TextButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0;
+  background: transparent;
+  border: none;
+  color: ${CORPUS_COLORS.slate[400]};
+  font-size: 0.8125rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: color ${CORPUS_TRANSITIONS.fast};
+
+  svg {
+    width: 14px;
+    height: 14px;
+  }
+
+  &:hover {
+    color: ${CORPUS_COLORS.teal[700]};
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${CORPUS_COLORS.teal[500]};
+    outline-offset: 4px;
+  }
+`;
+
+/** Primary text button */
+export const TextButtonPrimary = styled(TextButton)`
+  color: ${CORPUS_COLORS.teal[700]};
+
+  &:hover {
+    color: ${CORPUS_COLORS.teal[600]};
+  }
+`;
+
+/** About body - scrollable content, fills available width */
+export const AboutBody = styled.div`
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 0 2.5rem 2rem;
+
+  /* Typography for readable prose - human-sized for desktop */
+  font-size: 1.3125rem;
+  line-height: 1.9;
+  color: ${CORPUS_COLORS.slate[600]};
+
+  /* Paragraph spacing */
+  p {
+    margin-bottom: 1.5em;
+    /* Optimal reading width per paragraph */
+    max-width: 60ch;
+  }
+
+  /* First paragraph - lead-in */
+  p:first-of-type {
+    font-size: 1.4375rem;
+    color: ${CORPUS_COLORS.slate[700]};
+  }
+
+  &::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: ${CORPUS_COLORS.slate[200]};
+    border-radius: 3px;
+
+    &:hover {
+      background: ${CORPUS_COLORS.slate[300]};
+    }
+  }
+`;
+
+/** Expand button - minimal */
+export const ExpandButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0;
+  background: transparent;
+  border: none;
+  color: ${CORPUS_COLORS.slate[400]};
+  font-size: 0.75rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: color ${CORPUS_TRANSITIONS.fast};
+
+  svg {
+    width: 12px;
+    height: 12px;
+  }
+
+  &:hover {
+    color: ${CORPUS_COLORS.teal[700]};
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${CORPUS_COLORS.teal[500]};
+    outline-offset: 4px;
+  }
+`;
+
+// Keep old exports for backwards compatibility but mark as deprecated
+/** @deprecated Use DocumentsSidebar instead */
+export const ColumnWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+`;
+
+/** @deprecated Use SidebarLabel/AboutHeader instead */
+export const ColumnHeader = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.5rem;
+  flex-shrink: 0;
+`;
+
+/** @deprecated Use SectionLabel instead */
+export const ColumnTitle = styled.h2`
+  margin: 0;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: ${CORPUS_COLORS.slate[400]};
+`;
+
+/** @deprecated Use AboutActions instead */
+export const ColumnActions = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+`;
+
+/** @deprecated Use TextButton instead */
+export const ColumnActionButton = styled.button`
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: ${CORPUS_COLORS.slate[400]};
+  font-size: 0.8125rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: color ${CORPUS_TRANSITIONS.fast};
+
+  svg {
+    width: 14px;
+    height: 14px;
+  }
+
+  &:hover {
+    color: ${CORPUS_COLORS.teal[700]};
+  }
+`;
+
+/** @deprecated Use TextButtonPrimary instead */
+export const ColumnActionButtonPrimary = styled(ColumnActionButton)`
+  color: ${CORPUS_COLORS.teal[700]};
+
+  &:hover {
+    color: ${CORPUS_COLORS.teal[600]};
+  }
+`;
+
+/** @deprecated Use SidebarContent/AboutBody instead */
+export const ColumnContent = styled.div`
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+  min-height: 0;
+`;
+
+/** @deprecated No longer used */
+export const ColumnCard = styled.div`
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+`;
+
+// ============================================================================
+// MOBILE TAB STYLES
+// ============================================================================
+
+/** Mobile tab container - only visible on mobile */
+export const MobileTabContainer = styled.div`
+  display: none;
+
+  ${mediaQuery.tablet} {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    min-height: 0;
+  }
+`;
+
+/** Mobile tab list */
+export const MobileTabList = styled.div`
+  display: flex;
+  background: ${CORPUS_COLORS.white};
+  border: 1px solid ${CORPUS_COLORS.slate[200]};
+  border-radius: ${CORPUS_RADII.lg} ${CORPUS_RADII.lg} 0 0;
+  overflow: hidden;
+  flex-shrink: 0;
+`;
+
+/** Mobile tab button */
+export const MobileTab = styled.button<{ $active: boolean }>`
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.875rem 1rem;
+  border: none;
+  background: ${(props) =>
+    props.$active ? CORPUS_COLORS.white : CORPUS_COLORS.slate[50]};
+  color: ${(props) =>
+    props.$active ? CORPUS_COLORS.teal[700] : CORPUS_COLORS.slate[600]};
+  font-size: 0.875rem;
+  font-weight: ${(props) => (props.$active ? "600" : "500")};
+  cursor: pointer;
+  transition: all ${CORPUS_TRANSITIONS.fast};
+  position: relative;
+
+  ${(props) =>
+    props.$active &&
+    `
+    &::after {
+      content: '';
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      height: 2px;
+      background: ${CORPUS_COLORS.teal[700]};
+    }
+  `}
+
+  &:hover {
+    background: ${(props) =>
+      props.$active ? CORPUS_COLORS.white : CORPUS_COLORS.slate[100]};
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${CORPUS_COLORS.teal[500]};
+    outline-offset: -2px;
+  }
+
+  svg {
+    width: 16px;
+    height: 16px;
+  }
+
+  &:not(:last-child) {
+    border-right: 1px solid ${CORPUS_COLORS.slate[200]};
+  }
+`;
+
+/** Mobile tab content */
+export const MobileTabContent = styled.div`
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+  background: ${CORPUS_COLORS.white};
+  border: 1px solid ${CORPUS_COLORS.slate[200]};
+  border-top: none;
+  border-radius: 0 0 ${CORPUS_RADII.lg} ${CORPUS_RADII.lg};
+  min-height: 0;
+
+  &::-webkit-scrollbar {
+    width: 8px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: ${CORPUS_COLORS.slate[50]};
+    border-radius: 4px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: ${CORPUS_COLORS.slate[200]};
+    border-radius: 4px;
+
+    &:hover {
+      background: ${CORPUS_COLORS.slate[300]};
+    }
+  }
+`;
+
+// ============================================================================
+// EXPAND TOGGLE BUTTON
+// ============================================================================
+
+/** Expand/Collapse all toggle button */
+export const ExpandToggleButton = styled.button`
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.5rem 0.875rem;
+  border: 1px solid ${CORPUS_COLORS.slate[200]};
+  border-radius: ${CORPUS_RADII.sm};
+  background: ${CORPUS_COLORS.white};
+  color: ${CORPUS_COLORS.slate[600]};
+  font-size: 0.8125rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all ${CORPUS_TRANSITIONS.fast};
+
+  svg {
+    width: 14px;
+    height: 14px;
+  }
+
+  &:hover {
+    background: ${CORPUS_COLORS.slate[50]};
+    border-color: ${CORPUS_COLORS.teal[200]};
+    color: ${CORPUS_COLORS.teal[700]};
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${CORPUS_COLORS.teal[500]};
+    outline-offset: 2px;
+  }
+`;

--- a/frontend/src/components/corpuses/DocumentTableOfContents.tsx
+++ b/frontend/src/components/corpuses/DocumentTableOfContents.tsx
@@ -65,8 +65,8 @@ interface DocumentNode {
 // ============================================================================
 
 const Container = styled.div<{ $embedded?: boolean }>`
-  padding: ${(props) => (props.$embedded ? "20px 24px" : "16px")};
-  background: ${OS_LEGAL_COLORS.surface};
+  padding: ${(props) => (props.$embedded ? "0" : "16px")};
+  background: transparent;
   border: ${(props) =>
     props.$embedded ? "none" : `1px solid ${OS_LEGAL_COLORS.border}`};
   border-radius: ${(props) =>
@@ -154,29 +154,36 @@ const TreeContainer = styled.div`
 `;
 
 const TreeNode = styled.div<{ $depth: number }>`
-  margin-left: ${(props) => props.$depth * 24}px;
+  margin-left: ${(props) => props.$depth * 16}px;
+  ${(props) =>
+    props.$depth > 0 &&
+    `
+    border-left: 1px solid #e2e8f0;
+    margin-left: ${props.$depth * 16 - 1}px;
+    padding-left: 1px;
+  `}
 `;
 
-const NodeItem = styled.div<{ $hasChildren: boolean }>`
+const NodeItem = styled.div<{
+  $hasChildren: boolean;
+  $hasDescription: boolean;
+}>`
   display: flex;
-  align-items: flex-start;
-  gap: 14px;
-  padding: 14px 18px;
-  margin: 6px 0;
-  border-radius: 10px;
+  align-items: ${(props) => (props.$hasDescription ? "flex-start" : "center")};
+  gap: 12px;
+  padding: ${(props) => (props.$hasDescription ? "12px 14px" : "10px 14px")};
+  margin: 2px 0;
+  border-radius: 6px;
   cursor: pointer;
-  transition: all 0.15s ease;
-  border: 1px solid transparent;
+  transition: background 0.15s ease;
 
   &:hover {
-    background: ${OS_LEGAL_COLORS.surfaceHover};
-    border-color: ${OS_LEGAL_COLORS.border};
+    background: #f1f5f9;
   }
 
   &:focus {
     outline: 2px solid ${OS_LEGAL_COLORS.accent};
     outline-offset: -2px;
-    background: ${OS_LEGAL_COLORS.surfaceHover};
   }
 
   &:focus-visible {
@@ -189,18 +196,17 @@ const ChevronContainer = styled.span<{ $visible: boolean }>`
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 20px;
-  height: 20px;
+  width: 16px;
+  height: 16px;
   flex-shrink: 0;
-  color: ${OS_LEGAL_COLORS.textMuted};
+  color: #94a3b8;
   opacity: ${(props) => (props.$visible ? 1 : 0)};
   cursor: ${(props) => (props.$visible ? "pointer" : "default")};
-  border-radius: 4px;
-  margin-top: 2px;
+  border-radius: 3px;
 
   &:hover {
-    background: ${(props) =>
-      props.$visible ? OS_LEGAL_COLORS.border : "transparent"};
+    background: ${(props) => (props.$visible ? "#e2e8f0" : "transparent")};
+    color: ${(props) => (props.$visible ? "#0f766e" : "#94a3b8")};
   }
 `;
 
@@ -208,12 +214,10 @@ const IconContainer = styled.div<{ $fileType?: string }>`
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 44px;
-  height: 44px;
+  width: 22px;
+  height: 22px;
   flex-shrink: 0;
-  border-radius: 10px;
-  background: ${OS_LEGAL_COLORS.accentLight};
-  color: ${OS_LEGAL_COLORS.accent};
+  color: #64748b;
 `;
 
 const NodeContent = styled.div`
@@ -222,54 +226,42 @@ const NodeContent = styled.div`
 `;
 
 const NodeTitle = styled.div`
-  font-family: ${OS_LEGAL_TYPOGRAPHY.fontFamilySerif};
-  font-size: 1.0625rem;
-  font-weight: 600;
-  color: ${OS_LEGAL_COLORS.textPrimary};
-  line-height: 1.35;
-  margin-bottom: 6px;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-size: 1.1875rem;
+  font-weight: 500;
+  color: #1e293b;
+  line-height: 1.5;
 
-  /* Allow wrapping but limit to 2 lines */
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
+  /* Single line with ellipsis */
+  white-space: nowrap;
   overflow: hidden;
+  text-overflow: ellipsis;
+
+  /* Hover state shows teal */
+  ${NodeItem}:hover & {
+    color: #0f766e;
+  }
 `;
 
 const NodeDescription = styled.div`
-  font-size: 0.9375rem;
-  color: ${OS_LEGAL_COLORS.textSecondary};
-  line-height: 1.5;
-  max-height: calc(1.5em * 2); /* Exactly 2 lines */
+  font-size: 1.0625rem;
+  color: #64748b;
+  line-height: 1.55;
+  margin-top: 4px;
 
   /* Limit to 2 lines with ellipsis */
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
-  text-overflow: ellipsis;
 `;
 
 const NodeMeta = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin-top: 6px;
+  display: none; /* Hide by default - too chunky */
 `;
 
 const FileTypeBadge = styled.span`
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  padding: 3px 10px;
-  background: ${OS_LEGAL_COLORS.surfaceHover};
-  border: 1px solid ${OS_LEGAL_COLORS.border};
-  border-radius: 4px;
-  font-size: 0.75rem;
-  font-weight: 500;
-  color: ${OS_LEGAL_COLORS.textMuted};
-  text-transform: uppercase;
-  letter-spacing: 0.03em;
+  display: none; /* Hide file type badges for cleaner look */
 `;
 
 const LoadingState = styled.div`
@@ -721,12 +713,14 @@ export const DocumentTableOfContents: React.FC<
   const renderNode = (node: DocumentNode, depth: number) => {
     const isExpanded = expandedNodes.has(node.id);
     const hasChildren = node.children.length > 0;
+    const hasDescription = Boolean(node.description);
     const FileIcon = getFileIcon(node.fileType);
 
     return (
       <TreeNode key={node.id} $depth={depth}>
         <NodeItem
           $hasChildren={hasChildren}
+          $hasDescription={hasDescription}
           onClick={() => handleDocumentClick(node)}
           onKeyDown={(e) => handleKeyDown(e, node, hasChildren, isExpanded)}
           role="treeitem"
@@ -744,14 +738,14 @@ export const DocumentTableOfContents: React.FC<
           >
             {hasChildren &&
               (isExpanded ? (
-                <ChevronDown size={16} />
+                <ChevronDown size={14} />
               ) : (
-                <ChevronRight size={16} />
+                <ChevronRight size={14} />
               ))}
           </ChevronContainer>
 
           <IconContainer $fileType={node.fileType}>
-            <FileIcon size={22} />
+            <FileIcon size={20} />
           </IconContainer>
 
           <NodeContent>

--- a/frontend/src/graphql/cache.ts
+++ b/frontend/src/graphql/cache.ts
@@ -590,6 +590,20 @@ export const corpusHomeView = makeVar<CorpusHomeViewType | null>(null);
 export const tocExpandAll = makeVar<boolean>(false);
 
 /**
+ * Corpus detail view selection (URL-driven state - set by CentralRouteManager Phase 2)
+ *
+ * Controls whether the corpus home page shows the landing view (centered, focused)
+ * or the details view (two-column with TOC and About).
+ * Defaults to "landing" when not specified in URL.
+ *
+ * URL Examples:
+ *   /c/user/corpus                    → corpusDetailView("landing") = default landing
+ *   /c/user/corpus?view=details       → corpusDetailView("details")
+ */
+export type CorpusDetailViewType = "landing" | "details";
+export const corpusDetailView = makeVar<CorpusDetailViewType>("landing");
+
+/**
  * Auth-related global variables
  */
 export const userObj = makeVar<User | null>(null);

--- a/frontend/src/routing/CentralRouteManager.tsx
+++ b/frontend/src/routing/CentralRouteManager.tsx
@@ -31,6 +31,7 @@ import {
   selectedMessageId,
   corpusHomeView,
   tocExpandAll,
+  corpusDetailView,
   routeLoading,
   routeError,
   authStatusVar,
@@ -40,6 +41,7 @@ import {
   showAnnotationBoundingBoxes,
   showAnnotationLabels,
   CorpusHomeViewType,
+  CorpusDetailViewType,
 } from "../graphql/cache";
 import {
   RESOLVE_CORPUS_BY_SLUGS_FULL,
@@ -783,6 +785,7 @@ export function CentralRouteManager() {
     const messageId = searchParams.get("message");
     const homeViewParam = searchParams.get("homeView");
     const tocExpandedParam = searchParams.get("tocExpanded") === "true";
+    const detailViewParam = searchParams.get("view");
 
     // Visualization state (booleans and enums)
     const structural = searchParams.get("structural") === "true";
@@ -800,6 +803,7 @@ export function CentralRouteManager() {
       messageId,
       homeView: homeViewParam,
       tocExpanded: tocExpandedParam,
+      detailView: detailViewParam,
       structural,
       selectedOnly,
       boundingBoxes,
@@ -817,6 +821,7 @@ export function CentralRouteManager() {
     const currentMessageId = selectedMessageId();
     const currentHomeView = corpusHomeView();
     const currentTocExpandAll = tocExpandAll();
+    const currentDetailView = corpusDetailView();
     const currentStructural = showStructuralAnnotations();
     const currentSelectedOnly = showSelectedAnnotationOnly();
     const currentBoundingBoxes = showAnnotationBoundingBoxes();
@@ -835,6 +840,10 @@ export function CentralRouteManager() {
       homeViewParam === "toc" || homeViewParam === "about"
         ? homeViewParam
         : null;
+
+    // Parse detailView param (only valid value is "details", defaults to "landing")
+    const newDetailView: CorpusDetailViewType =
+      detailViewParam === "details" ? "details" : "landing";
 
     // Collect all reactive var updates into a batch
     // This prevents cascading re-renders - all updates happen in one React tick
@@ -866,6 +875,9 @@ export function CentralRouteManager() {
     }
     if (currentTocExpandAll !== tocExpandedParam) {
       updates.push(() => tocExpandAll(tocExpandedParam));
+    }
+    if (currentDetailView !== newDetailView) {
+      updates.push(() => corpusDetailView(newDetailView));
     }
     if (currentStructural !== structural) {
       updates.push(() => showStructuralAnnotations(structural));
@@ -1032,6 +1044,7 @@ export function CentralRouteManager() {
   const messageId = useReactiveVar(selectedMessageId);
   const homeView = useReactiveVar(corpusHomeView);
   const tocExpanded = useReactiveVar(tocExpandAll);
+  const detailView = useReactiveVar(corpusDetailView);
   const structural = useReactiveVar(showStructuralAnnotations);
   const selectedOnly = useReactiveVar(showSelectedAnnotationOnly);
   const boundingBoxes = useReactiveVar(showAnnotationBoundingBoxes);
@@ -1096,6 +1109,7 @@ export function CentralRouteManager() {
         messageId,
         homeView,
         tocExpanded,
+        detailView,
         structural,
         selectedOnly,
         boundingBoxes,
@@ -1113,6 +1127,7 @@ export function CentralRouteManager() {
       messageId,
       homeView,
       tocExpanded,
+      view: detailView,
       showStructural: structural,
       showSelectedOnly: selectedOnly,
       showBoundingBoxes: boundingBoxes,
@@ -1146,6 +1161,7 @@ export function CentralRouteManager() {
     messageId,
     homeView,
     tocExpanded,
+    detailView,
     structural,
     selectedOnly,
     boundingBoxes,

--- a/frontend/src/utils/navigationUtils.ts
+++ b/frontend/src/utils/navigationUtils.ts
@@ -45,6 +45,7 @@ export interface QueryParams {
   messageId?: string | null;
   homeView?: string | null; // "about" | "toc" - corpus home view selection
   tocExpanded?: boolean; // true to expand all TOC nodes
+  view?: string | null; // "landing" | "details" - corpus detail view selection
   showStructural?: boolean;
   showSelectedOnly?: boolean;
   showBoundingBoxes?: boolean;
@@ -235,6 +236,10 @@ export function buildQueryParams(params: QueryParams): string {
   }
   if (params.tocExpanded) {
     searchParams.set("tocExpanded", "true");
+  }
+  if (params.view && params.view !== "landing") {
+    // Only add to URL if not default value
+    searchParams.set("view", params.view);
   }
 
   // Visualization state - only add non-default values to keep URLs clean
@@ -860,6 +865,29 @@ export function updateTocExpandedParam(
     searchParams.set("tocExpanded", "true");
   } else {
     searchParams.delete("tocExpanded");
+  }
+  navigate({ search: searchParams.toString() }, { replace: true });
+}
+
+/**
+ * Update corpus detail view selection in URL
+ * Used for switching between landing view and details view on corpus home
+ * @param location - React Router location object
+ * @param navigate - React Router navigate function
+ * @param view - View identifier ("landing" or "details")
+ *               Pass "landing" or null to clear and use default (landing)
+ */
+export function updateDetailViewParam(
+  location: { search: string },
+  navigate: (to: { search: string }, options?: { replace?: boolean }) => void,
+  view: "landing" | "details" | null
+) {
+  const searchParams = new URLSearchParams(location.search);
+  if (view && view !== "landing") {
+    // Only add to URL if not default value
+    searchParams.set("view", view);
+  } else {
+    searchParams.delete("view");
   }
   navigate({ search: searchParams.toString() }, { replace: true });
 }

--- a/frontend/src/views/Corpuses.tsx
+++ b/frontend/src/views/Corpuses.tsx
@@ -620,7 +620,7 @@ const CorpusViewContainer = styled.div`
 
 const NavigationSidebar = styled(motion.div)<{ $isExpanded: boolean }>`
   position: relative;
-  width: ${(props) => (props.$isExpanded ? "280px" : "72px")};
+  width: ${(props) => (props.$isExpanded ? "280px" : "80px")};
   background: linear-gradient(180deg, #ffffff 0%, #fafbfc 50%, #f8f9fa 100%);
   backdrop-filter: blur(10px);
   border-right: 1px solid #e2e8f0;
@@ -1311,6 +1311,29 @@ const NotificationBadge = styled.div`
   }
 `;
 
+// Compact badge for collapsed sidebar - slight overlap at corner
+const CollapsedBadge = styled.div<{ $isZero: boolean }>`
+  position: absolute;
+  top: -4px;
+  right: -12px;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  background: ${(props) =>
+    props.$isZero
+      ? "linear-gradient(135deg, #94a3b8 0%, #64748b 100%)"
+      : "linear-gradient(135deg, #ef4444 0%, #dc2626 100%)"};
+  color: white;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.6rem;
+  font-weight: 700;
+  z-index: 2;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+`;
+
 // Split view container for extracts tab
 const ExtractsSplitView = styled.div`
   display: flex;
@@ -1532,9 +1555,7 @@ export const Corpuses = () => {
   const urlTab = useReactiveVar(selectedTab);
   const [showDescriptionEditor, setShowDescriptionEditor] =
     useState<boolean>(false);
-  const [sidebarExpanded, setSidebarExpanded] = useState<boolean>(
-    () => width > MOBILE_VIEW_BREAKPOINT
-  ); // Expanded by default on desktop
+  const [sidebarExpanded, setSidebarExpanded] = useState<boolean>(false); // Collapsed by default, opens on hover
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState<boolean>(false);
   const { REACT_APP_ALLOW_IMPORTS } = useEnv();
 
@@ -2581,7 +2602,7 @@ export const Corpuses = () => {
           data-testid="navigation-sidebar"
           $isExpanded={use_mobile_layout ? mobileSidebarOpen : sidebarExpanded}
           initial={{
-            width: use_mobile_layout ? "0" : sidebarExpanded ? "280px" : "72px",
+            width: use_mobile_layout ? "0" : sidebarExpanded ? "280px" : "80px",
           }}
           animate={{
             width: use_mobile_layout
@@ -2590,9 +2611,11 @@ export const Corpuses = () => {
                 : "0"
               : sidebarExpanded
               ? "280px"
-              : "72px",
+              : "80px",
           }}
           transition={{ duration: 0.3, ease: "easeInOut" }}
+          onMouseEnter={() => !use_mobile_layout && setSidebarExpanded(true)}
+          onMouseLeave={() => !use_mobile_layout && setSidebarExpanded(false)}
         >
           <BottomSheetHandle
             onClick={() => use_mobile_layout && setMobileSidebarOpen(false)}
@@ -2681,9 +2704,9 @@ export const Corpuses = () => {
                   {item.badge !== undefined &&
                     !sidebarExpanded &&
                     !use_mobile_layout && (
-                      <NotificationBadge>
+                      <CollapsedBadge $isZero={item.badge === 0}>
                         {item.badge > 0 ? item.badge : "–"}
-                      </NotificationBadge>
+                      </CollapsedBadge>
                     )}
                 </div>
                 {(use_mobile_layout ? mobileSidebarOpen : sidebarExpanded) && (

--- a/frontend/tests/CorpusHome.ct.tsx
+++ b/frontend/tests/CorpusHome.ct.tsx
@@ -63,6 +63,7 @@ const dummyCorpus: CorpusType = {
       endCursor: null,
     },
     edges: [],
+    totalCount: 2,
   },
   __typename: "CorpusType",
 };
@@ -180,6 +181,32 @@ const corpusDocumentsMock: MockedResponse = {
   },
 };
 
+const corpusHistoryMock: MockedResponse = {
+  request: {
+    query: GET_CORPUS_WITH_HISTORY,
+    variables: { id: dummyCorpus.id },
+  },
+  result: {
+    data: {
+      corpus: {
+        id: dummyCorpus.id,
+        slug: "test-corpus",
+        title: dummyCorpus.title,
+        description: dummyCorpus.description,
+        mdDescription: null,
+        created: dummyCorpus.created,
+        modified: dummyCorpus.modified,
+        isPublic: dummyCorpus.isPublic,
+        myPermissions: dummyCorpus.myPermissions,
+        creator: dummyCorpus.creator,
+        labelSet: dummyCorpus.labelSet,
+        descriptionRevisions: [],
+        __typename: "CorpusType",
+      },
+    },
+  },
+};
+
 const mocks: MockedResponse[] = [
   {
     request: {
@@ -202,37 +229,15 @@ const mocks: MockedResponse[] = [
       },
     },
   },
-  // Duplicate for cache-and-network fetch policy
+  // Duplicate mocks for cache-and-network fetch policy
   documentRelationshipsMock,
   { ...documentRelationshipsMock },
   // Documents mock for TOC
   corpusDocumentsMock,
   { ...corpusDocumentsMock },
-  {
-    request: {
-      query: GET_CORPUS_WITH_HISTORY,
-      variables: { id: dummyCorpus.id },
-    },
-    result: {
-      data: {
-        corpus: {
-          id: dummyCorpus.id,
-          slug: "test-corpus",
-          title: dummyCorpus.title,
-          description: dummyCorpus.description,
-          mdDescription: null,
-          created: dummyCorpus.created,
-          modified: dummyCorpus.modified,
-          isPublic: dummyCorpus.isPublic,
-          myPermissions: dummyCorpus.myPermissions,
-          creator: dummyCorpus.creator,
-          labelSet: dummyCorpus.labelSet,
-          descriptionRevisions: [],
-          __typename: "CorpusType",
-        },
-      },
-    },
-  },
+  // Corpus history mock
+  corpusHistoryMock,
+  { ...corpusHistoryMock },
 ];
 
 /**
@@ -243,105 +248,67 @@ function mountCorpusHome(mount: any) {
 }
 
 /* --------------------------------------------------------------------------
- * Tests
+ * Tests for Landing View
  * -------------------------------------------------------------------------- */
 
 test.use({ viewport: { width: 1200, height: 800 } });
 
-test("defaults to About tab when no homeView URL param", async ({
+test("defaults to landing view when no view URL param", async ({
   mount,
   page,
 }) => {
   await mountCorpusHome(mount);
 
-  // About tab should be active by default
-  const aboutTab = page.getByRole("tab", { name: "About" });
-  await expect(aboutTab).toHaveAttribute("aria-selected", "true");
+  // Landing view should be visible
+  const landingView = page.getByTestId("corpus-home-landing");
+  await expect(landingView).toBeVisible();
 
-  // TOC tab should not be selected
-  const tocTab = page.getByRole("tab", { name: "Table of Contents" });
-  await expect(tocTab).toHaveAttribute("aria-selected", "false");
-
-  // About content should be visible
-  const aboutPanel = page.locator("#about-panel");
-  await expect(aboutPanel).toBeVisible();
+  // Details view should not be visible
+  const detailsView = page.getByTestId("corpus-home-details");
+  await expect(detailsView).toBeHidden();
 });
 
-test("shows TOC tab when homeView=toc URL param is set", async ({
-  mount,
-  page,
-}) => {
-  // Mount with initialHomeView="toc"
-  await mount(
-    <CorpusHomeTestWrapper
-      mocks={mocks}
-      corpus={dummyCorpus}
-      initialHomeView="toc"
-    />
-  );
-
-  // TOC tab should be active
-  const tocTab = page.getByRole("tab", { name: "Table of Contents" });
-  await expect(tocTab).toHaveAttribute("aria-selected", "true");
-
-  // About tab should not be selected
-  const aboutTab = page.getByRole("tab", { name: "About" });
-  await expect(aboutTab).toHaveAttribute("aria-selected", "false");
-
-  // TOC panel should be visible
-  const tocPanel = page.locator("#toc-panel");
-  await expect(tocPanel).toBeVisible();
-});
-
-test("switching tabs updates URL (via click)", async ({ mount, page }) => {
-  await mountCorpusHome(mount);
-
-  // Initially on About tab
-  const aboutTab = page.getByRole("tab", { name: "About" });
-  await expect(aboutTab).toHaveAttribute("aria-selected", "true");
-
-  // Click TOC tab
-  const tocTab = page.getByRole("tab", { name: "Table of Contents" });
-  await tocTab.click();
-
-  // TOC tab should now be selected
-  await expect(tocTab).toHaveAttribute("aria-selected", "true");
-  await expect(aboutTab).toHaveAttribute("aria-selected", "false");
-
-  // TOC panel should be visible
-  const tocPanel = page.locator("#toc-panel");
-  await expect(tocPanel).toBeVisible();
-});
-
-test("renders corpus hero, chat bar and description controls", async ({
+test("renders landing view with corpus title and badge", async ({
   mount,
   page,
 }) => {
   await mountCorpusHome(mount);
 
-  /* ------------------------------------------------------------------
-   * Hero section (title, privacy badge, breadcrumbs)
-   * ------------------------------------------------------------------ */
-  const hero = page.getByTestId("corpus-home-hero");
-  await expect(hero).toBeVisible();
+  // CORPUS badge should be visible
+  await expect(page.locator("text=CORPUS")).toBeVisible();
 
-  // Breadcrumbs are rendered
-  await expect(hero.locator("text=Corpuses")).toBeVisible();
-
-  // Title contains corpus name with "Corpus" accent
-  const title = page.getByTestId("corpus-home-hero-title");
+  // Title should be visible
+  const title = page.getByTestId("corpus-home-landing-title");
   await expect(title).toBeVisible();
-  await expect(title.locator("text=Corpus")).toBeVisible();
   await expect(title).toContainText(dummyCorpus.title);
+});
+
+test("renders landing view with metadata and access badge", async ({
+  mount,
+  page,
+}) => {
+  await mountCorpusHome(mount);
+
+  // Metadata row should be visible
+  const metadata = page.getByTestId("corpus-home-landing-metadata");
+  await expect(metadata).toBeVisible();
 
   // Privacy badge reflects corpus.isPublic
   const privacyText = dummyCorpus.isPublic ? "Public" : "Private";
-  await expect(hero.locator(`text=${privacyText}`)).toBeVisible();
+  await expect(metadata.locator(`text=${privacyText}`)).toBeVisible();
 
-  /* ------------------------------------------------------------------
-   * Inline chat bar
-   * ------------------------------------------------------------------ */
-  const chatBar = page.getByTestId("corpus-home-hero-chat");
+  // Creator name
+  await expect(metadata.locator("text=tester")).toBeVisible();
+});
+
+test("renders landing view with chat bar and quick actions", async ({
+  mount,
+  page,
+}) => {
+  await mountCorpusHome(mount);
+
+  // Chat bar should be visible
+  const chatBar = page.getByTestId("corpus-home-landing-chat");
   await expect(chatBar).toBeVisible();
 
   // Chat input placeholder
@@ -353,32 +320,171 @@ test("renders corpus hero, chat bar and description controls", async ({
   await expect(chatBar.locator("text=Summarize")).toBeVisible();
   await expect(chatBar.locator("text=Search")).toBeVisible();
   await expect(chatBar.locator("text=Analyze")).toBeVisible();
+});
 
-  /* ------------------------------------------------------------------
-   * Description card
-   * ------------------------------------------------------------------ */
-  const descriptionCard = page.locator("#corpus-home-description-card");
-  await expect(descriptionCard).toBeVisible();
+test("renders landing view with description as subtitle", async ({
+  mount,
+  page,
+}) => {
+  await mountCorpusHome(mount);
 
-  // Section heading
-  await expect(descriptionCard.locator("text=About this Corpus")).toBeVisible();
+  // Description should be visible as subtitle in hero section
+  const description = page.getByTestId("corpus-home-landing-description");
+  await expect(description).toBeVisible();
 
-  // Description text
+  // Description text (first line of the description)
+  await expect(description).toContainText("Dummy corpus for component-testing");
+});
+
+test("renders View Details button in landing view", async ({ mount, page }) => {
+  await mountCorpusHome(mount);
+
+  // View Details button should be visible
+  const viewDetailsBtn = page.getByTestId(
+    "corpus-home-landing-view-details-btn"
+  );
+  await expect(viewDetailsBtn).toBeVisible();
+  await expect(viewDetailsBtn).toContainText("View Details");
+});
+
+test("clicking View Details switches to details view", async ({
+  mount,
+  page,
+}) => {
+  await mountCorpusHome(mount);
+
+  // Initially in landing view
+  await expect(page.getByTestId("corpus-home-landing")).toBeVisible();
+
+  // Click View Details button
+  const viewDetailsBtn = page.getByTestId(
+    "corpus-home-landing-view-details-btn"
+  );
+  await viewDetailsBtn.click();
+
+  // Should now show details view
+  await expect(page.getByTestId("corpus-home-details")).toBeVisible();
+  await expect(page.getByTestId("corpus-home-landing")).toBeHidden();
+});
+
+/* --------------------------------------------------------------------------
+ * Tests for Details View
+ * -------------------------------------------------------------------------- */
+
+test("shows details view when view=details URL param is set", async ({
+  mount,
+  page,
+}) => {
+  // Mount with initialView="details"
+  await mount(
+    <CorpusHomeTestWrapper
+      mocks={mocks}
+      corpus={dummyCorpus}
+      initialView="details"
+    />
+  );
+
+  // Details view should be visible
+  const detailsView = page.getByTestId("corpus-home-details");
+  await expect(detailsView).toBeVisible();
+
+  // Landing view should not be visible
+  const landingView = page.getByTestId("corpus-home-landing");
+  await expect(landingView).toBeHidden();
+});
+
+test("details view shows back button", async ({ mount, page }) => {
+  await mount(
+    <CorpusHomeTestWrapper
+      mocks={mocks}
+      corpus={dummyCorpus}
+      initialView="details"
+    />
+  );
+
+  // Back button should be visible
+  const backBtn = page.getByTestId("corpus-home-details-back-btn");
+  await expect(backBtn).toBeVisible();
+  await expect(backBtn).toContainText("Overview");
+});
+
+test("details view shows corpus title", async ({ mount, page }) => {
+  await mount(
+    <CorpusHomeTestWrapper
+      mocks={mocks}
+      corpus={dummyCorpus}
+      initialView="details"
+    />
+  );
+
+  // Title should be visible
+  const title = page.getByTestId("corpus-home-details-title");
+  await expect(title).toBeVisible();
+  await expect(title).toContainText(dummyCorpus.title);
+});
+
+test("clicking back button in details view returns to landing", async ({
+  mount,
+  page,
+}) => {
+  await mount(
+    <CorpusHomeTestWrapper
+      mocks={mocks}
+      corpus={dummyCorpus}
+      initialView="details"
+    />
+  );
+
+  // Initially in details view
+  await expect(page.getByTestId("corpus-home-details")).toBeVisible();
+
+  // Click back button
+  const backBtn = page.getByTestId("corpus-home-details-back-btn");
+  await backBtn.click();
+
+  // Should now show landing view
+  await expect(page.getByTestId("corpus-home-landing")).toBeVisible();
+  await expect(page.getByTestId("corpus-home-details")).toBeHidden();
+});
+
+test("details view shows two-column layout on desktop", async ({
+  mount,
+  page,
+}) => {
+  await mount(
+    <CorpusHomeTestWrapper
+      mocks={mocks}
+      corpus={dummyCorpus}
+      initialView="details"
+    />
+  );
+
+  // Both Documents and About sections should be visible (minimalist labels)
+  // Use specific selector to avoid matching metadata and mobile tabs
   await expect(
-    descriptionCard.locator(
-      "text=Dummy corpus for component-testing CorpusHome."
-    )
+    page.locator("span").filter({ hasText: /^Documents$/ })
   ).toBeVisible();
-
-  /* ------------------------------------------------------------------
-   * Action buttons (Version History + Edit Description)
-   * ------------------------------------------------------------------ */
   await expect(
-    page.getByRole("button", { name: "Version History" })
+    page.locator("span").filter({ hasText: /^About$/ })
   ).toBeVisible();
+});
 
-  // Either "Edit Description" or "Add Description" should be available depending on permissions
-  await expect(
-    page.getByRole("button", { name: /(?:Edit|Add)/i })
-  ).toBeVisible();
+/* --------------------------------------------------------------------------
+ * Tests for Breadcrumbs
+ * -------------------------------------------------------------------------- */
+
+test("landing view has centered breadcrumbs", async ({ mount, page }) => {
+  await mountCorpusHome(mount);
+
+  // Breadcrumbs should be visible
+  const breadcrumbs = page.getByTestId("corpus-home-landing-breadcrumbs");
+  await expect(breadcrumbs).toBeVisible();
+
+  // Should have Corpuses link
+  await expect(breadcrumbs.locator("text=Corpuses")).toBeVisible();
+
+  // Should have current corpus name
+  await expect(breadcrumbs.locator(".current")).toContainText(
+    dummyCorpus.title
+  );
 });

--- a/frontend/tests/CorpusHome.ct.tsx
+++ b/frontend/tests/CorpusHome.ct.tsx
@@ -274,8 +274,8 @@ test("renders landing view with corpus title and badge", async ({
 }) => {
   await mountCorpusHome(mount);
 
-  // CORPUS badge should be visible
-  await expect(page.locator("text=CORPUS")).toBeVisible();
+  // CORPUS badge should be visible (exact match to avoid matching "Corpuses" breadcrumb)
+  await expect(page.getByText("CORPUS", { exact: true })).toBeVisible();
 
   // Title should be visible
   const title = page.getByTestId("corpus-home-landing-title");
@@ -436,14 +436,19 @@ test("clicking back button in details view returns to landing", async ({
   );
 
   // Initially in details view
-  await expect(page.getByTestId("corpus-home-details")).toBeVisible();
+  await expect(page.getByTestId("corpus-home-details")).toBeVisible({
+    timeout: 10000,
+  });
 
   // Click back button
   const backBtn = page.getByTestId("corpus-home-details-back-btn");
   await backBtn.click();
 
+  // Wait for URL change to propagate to reactive var and re-render
   // Should now show landing view
-  await expect(page.getByTestId("corpus-home-landing")).toBeVisible();
+  await expect(page.getByTestId("corpus-home-landing")).toBeVisible({
+    timeout: 10000,
+  });
   await expect(page.getByTestId("corpus-home-details")).toBeHidden();
 });
 

--- a/frontend/tests/CorpusHomeTestWrapper.tsx
+++ b/frontend/tests/CorpusHomeTestWrapper.tsx
@@ -7,6 +7,8 @@ import { CorpusHome } from "../src/components/corpuses/CorpusHome";
 import { CorpusType } from "../src/types/graphql-api";
 import { relayStylePagination } from "@apollo/client/utilities";
 import {
+  corpusDetailView,
+  CorpusDetailViewType,
   corpusHomeView,
   CorpusHomeViewType,
   tocExpandAll,
@@ -45,23 +47,33 @@ const createTestCache = () =>
 interface Props {
   mocks: ReadonlyArray<MockedResponse>;
   corpus: CorpusType;
+  /** Initial view for landing/details switch */
+  initialView?: CorpusDetailViewType;
+  /** Initial home view for About/TOC switch (within details view) */
   initialHomeView?: CorpusHomeViewType | null;
   initialTocExpanded?: boolean;
 }
 
 /**
  * Helper component that simulates CentralRouteManager Phase 2 behavior
- * by setting the corpusHomeView and tocExpandAll reactive vars from URL params
+ * by setting the reactive vars from URL params
  */
 const RouteParamInitializer: React.FC<{
   children: React.ReactNode;
+  initialView?: CorpusDetailViewType;
   initialHomeView?: CorpusHomeViewType | null;
   initialTocExpanded?: boolean;
-}> = ({ children, initialHomeView, initialTocExpanded }) => {
+}> = ({ children, initialView, initialHomeView, initialTocExpanded }) => {
   const [searchParams] = useSearchParams();
 
   useEffect(() => {
-    // Simulate CentralRouteManager Phase 2: parse homeView from URL
+    // Simulate CentralRouteManager Phase 2: parse view from URL
+    const viewParam = searchParams.get("view");
+    const newView: CorpusDetailViewType =
+      viewParam === "details" ? "details" : initialView ?? "landing";
+    corpusDetailView(newView);
+
+    // Parse homeView from URL (for details view About/TOC tabs)
     const homeViewParam = searchParams.get("homeView");
     const newHomeView: CorpusHomeViewType | null =
       homeViewParam === "toc" || homeViewParam === "about"
@@ -75,10 +87,11 @@ const RouteParamInitializer: React.FC<{
 
     // Cleanup on unmount
     return () => {
+      corpusDetailView("landing");
       corpusHomeView(null);
       tocExpandAll(false);
     };
-  }, [searchParams, initialHomeView, initialTocExpanded]);
+  }, [searchParams, initialView, initialHomeView, initialTocExpanded]);
 
   return <>{children}</>;
 };
@@ -86,6 +99,7 @@ const RouteParamInitializer: React.FC<{
 export const CorpusHomeTestWrapper: React.FC<Props> = ({
   mocks,
   corpus,
+  initialView,
   initialHomeView,
   initialTocExpanded,
 }) => {
@@ -97,8 +111,11 @@ export const CorpusHomeTestWrapper: React.FC<Props> = ({
     totalExtracts: 0,
   };
 
-  // Build initial route with homeView and tocExpanded query params if specified
+  // Build initial route with query params if specified
   const params: string[] = [];
+  if (initialView === "details") {
+    params.push("view=details");
+  }
   if (initialHomeView) {
     params.push(`homeView=${initialHomeView}`);
   }
@@ -113,6 +130,7 @@ export const CorpusHomeTestWrapper: React.FC<Props> = ({
       <MemoryRouter initialEntries={[initialRoute]}>
         <MockedProvider mocks={mocks} cache={createTestCache()} addTypename>
           <RouteParamInitializer
+            initialView={initialView}
             initialHomeView={initialHomeView}
             initialTocExpanded={initialTocExpanded}
           >

--- a/frontend/tests/CorpusHomeTestWrapper.tsx
+++ b/frontend/tests/CorpusHomeTestWrapper.tsx
@@ -68,9 +68,17 @@ const RouteParamInitializer: React.FC<{
 
   useEffect(() => {
     // Simulate CentralRouteManager Phase 2: parse view from URL
+    // URL param takes precedence to support navigation
+    // When URL has no view param, that means "landing" (the default)
+    // initialView is only used for initial mount, not subsequent changes
     const viewParam = searchParams.get("view");
-    const newView: CorpusDetailViewType =
-      viewParam === "details" ? "details" : initialView ?? "landing";
+    let newView: CorpusDetailViewType;
+    if (viewParam === "details") {
+      newView = "details";
+    } else {
+      // "landing" param, no param, or any other value = landing
+      newView = "landing";
+    }
     corpusDetailView(newView);
 
     // Parse homeView from URL (for details view About/TOC tabs)
@@ -103,6 +111,13 @@ export const CorpusHomeTestWrapper: React.FC<Props> = ({
   initialHomeView,
   initialTocExpanded,
 }) => {
+  // CRITICAL: Initialize reactive vars synchronously BEFORE render
+  // This ensures the component sees the correct values on first paint
+  // (useEffect in RouteParamInitializer runs AFTER render, which is too late)
+  corpusDetailView(initialView ?? "landing");
+  corpusHomeView(initialHomeView ?? null);
+  tocExpandAll(initialTocExpanded ?? false);
+
   // Default stats matching the mock data in CorpusHome.ct.tsx
   const stats = {
     totalDocs: 3,

--- a/frontend/tests/CorpusTabs.ct.tsx
+++ b/frontend/tests/CorpusTabs.ct.tsx
@@ -649,19 +649,19 @@ test.describe("Corpus Tabs - Navigation", () => {
   test.use({ viewport: { width: 1200, height: 800 } });
   test.setTimeout(30000); // Increase timeout for complex component rendering
 
-  test("should render home tab by default with corpus hero", async ({
+  test("should render home tab by default with corpus landing view", async ({
     mount,
     page,
   }) => {
     const corpus = createMockCorpus();
     await mountCorpuses(mount, corpus);
 
-    // Wait for home tab content to render
-    const hero = page.getByTestId("corpus-home-hero");
-    await expect(hero).toBeVisible({ timeout: 10000 });
+    // Wait for home tab content to render (landing view)
+    const landing = page.getByTestId("corpus-home-landing");
+    await expect(landing).toBeVisible({ timeout: 10000 });
 
     // Should show corpus title - use specific testid to avoid strict mode violation
-    const title = page.getByTestId("corpus-home-hero-title");
+    const title = page.getByTestId("corpus-home-landing-title");
     await expect(title).toContainText(corpus.title);
 
     // Sidebar should be visible on desktop
@@ -791,9 +791,9 @@ test.describe("Corpus Tabs - Navigation", () => {
     // Click back button to go home
     await page.locator('[title="Back to Home"]').click();
 
-    // Should be back on home tab
-    const hero = page.getByTestId("corpus-home-hero");
-    await expect(hero).toBeVisible({ timeout: 5000 });
+    // Should be back on home tab (landing view)
+    const landing = page.getByTestId("corpus-home-landing");
+    await expect(landing).toBeVisible({ timeout: 5000 });
   });
 });
 
@@ -1233,9 +1233,9 @@ test.describe("Corpus Tabs - URL State Sync", () => {
     // No tab option = default to home
     await mountCorpuses(mount, corpus);
 
-    // Should show home content (hero)
-    const hero = page.getByTestId("corpus-home-hero");
-    await expect(hero).toBeVisible({ timeout: 10000 });
+    // Should show home content (landing view)
+    const landing = page.getByTestId("corpus-home-landing");
+    await expect(landing).toBeVisible({ timeout: 10000 });
   });
 });
 
@@ -1247,31 +1247,32 @@ test.describe("Corpus Tabs - Home Tab Content", () => {
   test.use({ viewport: { width: 1200, height: 800 } });
   test.setTimeout(30000);
 
-  test("should show corpus hero with title and privacy badge", async ({
+  test("should show corpus landing with title and privacy badge", async ({
     mount,
     page,
   }) => {
     const corpus = createMockCorpus();
     await mountCorpuses(mount, corpus);
 
-    const hero = page.getByTestId("corpus-home-hero");
-    await expect(hero).toBeVisible({ timeout: 10000 });
+    const landing = page.getByTestId("corpus-home-landing");
+    await expect(landing).toBeVisible({ timeout: 10000 });
 
-    // Title should contain corpus name - use testid for specificity
-    const title = page.getByTestId("corpus-home-hero-title");
+    // Title should contain corpus name - use specific testid to avoid strict mode violation
+    const title = page.getByTestId("corpus-home-landing-title");
     await expect(title).toBeVisible();
     await expect(title).toContainText(corpus.title);
 
-    // Privacy badge (Private for our mock) - check within hero
-    await expect(hero.locator("text=Private")).toBeVisible();
+    // Privacy badge (Private for our mock) - check within landing view metadata
+    const metadata = page.getByTestId("corpus-home-landing-metadata");
+    await expect(metadata.locator("text=Private")).toBeVisible();
   });
 
   test("should show inline chat bar on home", async ({ mount, page }) => {
     const corpus = createMockCorpus();
     await mountCorpuses(mount, corpus);
 
-    // Chat bar should be visible
-    const chatBar = page.getByTestId("corpus-home-hero-chat");
+    // Chat bar should be visible (in landing view)
+    const chatBar = page.getByTestId("corpus-home-landing-chat");
     await expect(chatBar).toBeVisible({ timeout: 10000 });
 
     // Quick action chips
@@ -1280,18 +1281,16 @@ test.describe("Corpus Tabs - Home Tab Content", () => {
     await expect(chatBar.locator("text=Analyze")).toBeVisible();
   });
 
-  test("should show About section with description", async ({
-    mount,
-    page,
-  }) => {
+  test("should show description in landing view", async ({ mount, page }) => {
     const corpus = createMockCorpus();
     await mountCorpuses(mount, corpus);
 
-    // Description card should be visible
-    const descCard = page.locator("#corpus-home-description-card");
-    await expect(descCard).toBeVisible({ timeout: 10000 });
+    // Landing view should be visible
+    const landing = page.getByTestId("corpus-home-landing");
+    await expect(landing).toBeVisible({ timeout: 10000 });
 
-    await expect(descCard.locator("text=About this Corpus")).toBeVisible();
+    // CORPUS badge should be visible (exact match to avoid matching "Corpuses" breadcrumb)
+    await expect(page.getByText("CORPUS", { exact: true })).toBeVisible();
   });
 });
 

--- a/frontend/tests/CorpusesTestWrapper.tsx
+++ b/frontend/tests/CorpusesTestWrapper.tsx
@@ -19,6 +19,7 @@ import {
   selectedTab,
   selectedFolderId,
   selectedExtractIds,
+  corpusDetailView,
 } from "../src/graphql/cache";
 import { mergeArrayByIdFieldPolicy } from "../src/graphql/cache";
 import {
@@ -286,6 +287,11 @@ export const CorpusesTestWrapper: React.FC<WrapperProps> = ({
     } as any);
   }
 
+  // CRITICAL: Initialize corpusDetailView synchronously BEFORE render
+  // This ensures CorpusHome sees "landing" view on first paint
+  // (prevents stale values from previous tests)
+  corpusDetailView("landing");
+
   // Mark authentication as done immediately for tests
   // Component tests set reactive vars directly (pragmatic exception to The ONE PLACE TO RULE THEM ALL)
   React.useEffect(() => {
@@ -309,6 +315,7 @@ export const CorpusesTestWrapper: React.FC<WrapperProps> = ({
       selectedTab(null);
       selectedFolderId(null);
       selectedExtractIds([]);
+      corpusDetailView("landing");
     };
   }, []);
 


### PR DESCRIPTION
## Summary

- Refactors CorpusHome into a clean two-view architecture with Landing View and Details View
- Implements modern, typography-first minimalist design
- Adds proper URL-driven state management via CentralRouteManager for view switching
- Makes navigation sidebar collapsed by default with hover-to-expand behavior

## Changes

### Architecture
- Split `CorpusHome` into orchestrator pattern with `CorpusLandingView` and `CorpusDetailsView` components
- Added `corpusDetailView` reactive var to `CentralRouteManager` for proper URL state management
- URL params (`?view=details`, `?tocExpanded=true`) now follow routing convention

### Design
- **Landing View**: Centered layout with corpus title, description as subtitle, and "View Details" button
- **Details View**: Floating page design with two-column layout (Documents sidebar + About content)
- Subtle gray background with rounded corners and shadow for the content "page"
- Larger typography sized for desktop readability (body text 21px, titles 19px)
- Percentage-based Documents sidebar (40%) with min/max bounds (320px-480px)

### Fixes
- Fixed expand/collapse button navigating back to overview (was stripping `view` param)
- Fixed overflow clipping with `min-height: 0` on flex containers
- Navigation sidebar now collapsed by default

## Test plan

- [ ] Navigate to a corpus and verify landing view displays correctly
- [ ] Click "View Details" and verify two-column layout appears
- [ ] Click Expand/Collapse in Documents sidebar - should not change view
- [ ] Refresh page on details view - should stay on details view
- [ ] Test on mobile viewport - should show tabbed interface
- [ ] Verify navigation sidebar is collapsed by default and expands on hover