### PR TITLE
Add inline thread view with corpus context sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+#### Inline Thread View with Corpus Context Sidebar
+- **Added inline thread viewing**: Users can now view thread details inline within the Discussions tab instead of navigating away
+  - Click a thread to view details in-place with a "Back" button to return to the list
+  - Thread state tracked via `inlineSelectedThreadIdAtom` Jotai atom
+  - Files: `frontend/src/components/discussions/CorpusDiscussionsView.tsx`, `frontend/src/atoms/threadAtoms.ts`
+- **Added corpus context sidebar**: Displays corpus context alongside thread details
+  - About section with corpus description (markdown rendered)
+  - Documents section with collapsible table of contents
+  - Quick stats grid (documents, threads, annotations, comments)
+  - Collapsible sections with smooth animations via Framer Motion
+  - Responsive behavior: hidden < 1024px, collapsible 1024-1200px, always expanded > 1200px
+  - Sidebar expanded state persisted to localStorage via `threadContextSidebarExpandedAtom`
+  - Files: `frontend/src/components/threads/CorpusContextSidebar.tsx`, `frontend/src/components/threads/ThreadDetailWithContext.tsx`
+  - New styled components: `frontend/src/components/threads/styles/contextSidebarStyles.ts`
+- **Added modernized discussion thread UI**: Comprehensive redesign following OS-Legal-Style design system
+  - Typography-first design: Serif headings (Georgia), sans-serif body (Inter)
+  - Teal accent color scheme (#0f766e) for interactive elements
+  - Improved message cards, vote buttons, badges, and metadata displays
+  - Mobile-responsive with proper breakpoints
+  - Files: `frontend/src/components/threads/styles/discussionStyles.ts` (950+ lines)
+- **Added agent mention rendering**: Discussion messages render styled agent mentions with custom colors
+  - Runtime validation of badge configuration from GenericScalar fields
+  - Hex color validation with fallback to default agent color
+  - Tooltip display for agent mentions
+  - Files: `frontend/src/components/threads/MarkdownMessageRenderer.tsx`
+- **Added component tests for new features**:
+  - Mention badge rendering tests: `frontend/tests/MentionRendering.ct.tsx`
+  - Compact vote button tests: `frontend/tests/VoteButtonsCompact.ct.tsx`
+
 #### AnnotationsPanel Shared Component
 - **Created `AnnotationsPanel` reusable component**: Extracts shared filtering/display logic from annotations views
   - Provides filter tabs for type (All/Doc/Text) and source (All/Human/Agent/Structural)
@@ -59,6 +88,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Files: `frontend/src/graphql/queries.ts:752`
 
 ### Changed
+
+#### Window Resize Performance
+- **Added debounce to window resize handler**: Prevents excessive re-renders during window resize
+  - 150ms debounce delay on resize events
+  - Properly cleans up timeout on unmount
+  - Files: `frontend/src/components/hooks/WindowDimensionHook.tsx`
 
 #### Annotations View Refactoring
 - **Updated Annotations.tsx to use AnnotationsPanel**: DRY refactoring, keeps hero section, stats, semantic search, advanced filters

--- a/frontend/src/assets/configurations/constants.ts
+++ b/frontend/src/assets/configurations/constants.ts
@@ -140,3 +140,31 @@ export const ANNOTATION_PAGINATION = {
   /** Maximum accumulated semantic search results before capping */
   MAX_SEMANTIC_RESULTS: 500,
 } as const;
+
+// Mention type configuration
+// Defines which mention types have active navigation routes
+// When a route is added for a type, set navigable: true
+export const MENTION_TYPES = {
+  user: {
+    navigable: true,
+    label: "User",
+  },
+  corpus: {
+    navigable: true,
+    label: "Corpus",
+  },
+  document: {
+    navigable: true,
+    label: "Document",
+  },
+  annotation: {
+    navigable: true,
+    label: "Annotation",
+  },
+  agent: {
+    navigable: false, // No agent detail page yet
+    label: "AI Agent",
+  },
+} as const;
+
+export type MentionType = keyof typeof MENTION_TYPES;

--- a/frontend/src/assets/configurations/constants.ts
+++ b/frontend/src/assets/configurations/constants.ts
@@ -14,6 +14,8 @@ export const MENTION_PREVIEW_LENGTH = 24;
 export const DEFAULT_LABEL_COLOR = "94a3b8";
 // Primary teal color used for new label creation
 export const PRIMARY_LABEL_COLOR = "0F766E";
+// Default color for agent messages when no badge color is configured
+export const DEFAULT_AGENT_COLOR = "#4A90E2";
 
 // File size constants for formatting
 export const FILE_SIZE = {

--- a/frontend/src/atoms/threadAtoms.ts
+++ b/frontend/src/atoms/threadAtoms.ts
@@ -88,17 +88,3 @@ export const threadContextSidebarExpandedAtom = atomWithStorage(
   "threadContextSidebarExpanded",
   true
 );
-
-// ============================================================================
-// DERIVED ATOMS
-// ============================================================================
-
-/**
- * Computes whether current user can create threads in selected corpus
- * This will be implemented later with actual permission checks
- */
-export const canCreateThreadAtom = atom<boolean>((get) => {
-  // TODO: Implement permission checking from Apollo cache
-  // For now, return true as placeholder
-  return true;
-});

--- a/frontend/src/atoms/threadAtoms.ts
+++ b/frontend/src/atoms/threadAtoms.ts
@@ -1,4 +1,5 @@
 import { atom } from "jotai";
+import { atomWithStorage } from "jotai/utils";
 import { ConversationType, ChatMessageType } from "../types/graphql-api";
 
 // ============================================================================
@@ -68,6 +69,25 @@ export const replyingToMessageIdAtom = atom<string | null>(null);
  * Editing message (for edit functionality in future)
  */
 export const editingMessageIdAtom = atom<string | null>(null);
+
+// ============================================================================
+// INLINE THREAD VIEW STATE
+// ============================================================================
+
+/**
+ * Currently selected thread ID when viewing inline (in Discussions tab)
+ * When set, CorpusDiscussionsView shows ThreadDetailWithContext instead of ThreadList
+ */
+export const inlineSelectedThreadIdAtom = atom<string | null>(null);
+
+/**
+ * Corpus context sidebar expanded state (persisted to localStorage)
+ * Controls whether the sidebar is expanded or collapsed when viewing thread details
+ */
+export const threadContextSidebarExpandedAtom = atomWithStorage(
+  "threadContextSidebarExpanded",
+  true
+);
 
 // ============================================================================
 // DERIVED ATOMS

--- a/frontend/src/components/annotator/renderers/txt/utils.ts
+++ b/frontend/src/components/annotator/renderers/txt/utils.ts
@@ -1,5 +1,13 @@
 // src/utils.ts
 import { Annotation } from "./span";
+import {
+  hexToRgb as sharedHexToRgb,
+  hexToRgba,
+  blendColors,
+} from "../../../../utils/colorUtils";
+
+// Re-export for backwards compatibility
+export { hexToRgba, blendColors };
 
 export const mapTokensWithAnnotations = (
   tokens: string[],
@@ -24,55 +32,6 @@ export const mapTokensWithAnnotations = (
 
   return tokenAnnotations;
 };
-
-export const blendColors = (colors: string[]): string => {
-  if (colors.length === 1) return colors[0];
-
-  let r = 0;
-  let g = 0;
-  let b = 0;
-  for (const color of colors) {
-    const c = hexToRgb(color);
-    r += c.r;
-    g += c.g;
-    b += c.b;
-  }
-  r = Math.round(r / colors.length);
-  g = Math.round(g / colors.length);
-  b = Math.round(b / colors.length);
-  return `rgb(${r}, ${g}, ${b})`;
-};
-
-/**
- * Converts a hex color to an RGB object
- * @param hex - The hex color string (e.g., "#FF0000" or "#F00")
- * @returns An object with r, g, b number values
- */
-const hexToRgb = (hex: string): { r: number; g: number; b: number } => {
-  hex = hex.replace("#", "");
-  if (hex.length === 3) {
-    hex = hex
-      .split("")
-      .map((char) => char + char)
-      .join("");
-  }
-  const bigint = parseInt(hex, 16);
-  const r = (bigint >> 16) & 255;
-  const g = (bigint >> 8) & 255;
-  const b = bigint & 255;
-  return { r, g, b };
-};
-
-/**
- * Converts a hex color to an RGBA color string
- * @param hex - The hex color string (e.g., "#FF0000" or "#F00")
- * @param alpha - The opacity value (0 to 1)
- * @returns An RGBA color string
- */
-export function hexToRgba(hex: string, alpha: number): string {
-  const { r, g, b } = hexToRgb(hex);
-  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
-}
 
 export const selectionIsEmpty = (selection: Selection) => {
   let position =

--- a/frontend/src/components/discussions/CorpusDiscussionsView.tsx
+++ b/frontend/src/components/discussions/CorpusDiscussionsView.tsx
@@ -1,5 +1,4 @@
-import React, { useState, useMemo, useCallback } from "react";
-import { useNavigate, useLocation } from "react-router-dom";
+import React, { useState, useMemo, useCallback, useEffect } from "react";
 import { useReactiveVar, useQuery } from "@apollo/client";
 import { useAtom } from "jotai";
 import styled from "styled-components";
@@ -13,16 +12,26 @@ import {
   AlertCircle,
 } from "lucide-react";
 import { authToken, openedCorpus } from "../../graphql/cache";
-import { navigateToCorpusThread } from "../../utils/navigationUtils";
 import { getPermissions } from "../../utils/transform";
 import { PermissionTypes } from "../types";
 import { ThreadList } from "../threads/ThreadList";
 import { CreateThreadForm } from "../threads/CreateThreadForm";
+import { ThreadDetailWithContext } from "../threads/ThreadDetailWithContext";
 import { ThreadSearch } from "../search/ThreadSearch";
 import { ModerationDashboard } from "../moderation";
 import { ThreadFilterToggles } from "../threads/ThreadFilterToggles";
-import { color } from "../../theme/colors";
-import { threadSortAtom, ThreadSortOption } from "../../atoms/threadAtoms";
+import {
+  CORPUS_COLORS,
+  CORPUS_FONTS,
+  CORPUS_RADII,
+  CORPUS_TRANSITIONS,
+  mediaQuery,
+} from "../threads/styles/discussionStyles";
+import {
+  threadSortAtom,
+  ThreadSortOption,
+  inlineSelectedThreadIdAtom,
+} from "../../atoms/threadAtoms";
 import {
   GET_CONVERSATIONS,
   GetConversationsInputs,
@@ -37,20 +46,20 @@ const Container = styled.div`
   display: flex;
   flex-direction: column;
   height: 100%;
-  background: ${color.N2};
+  background: #fafafa;
 `;
 
 const Header = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0.75rem 1.5rem;
-  background: ${color.N1};
-  border-bottom: 1px solid ${color.N4};
+  padding: 1rem 2rem;
+  background: ${CORPUS_COLORS.white};
+  border-bottom: 1px solid ${CORPUS_COLORS.slate[200]};
   gap: 1rem;
 
   @media (max-width: 768px) {
-    padding: 0.75rem 1rem;
+    padding: 0.875rem 1rem;
     flex-wrap: wrap;
   }
 `;
@@ -63,16 +72,18 @@ const TitleSection = styled.div`
 `;
 
 const Breadcrumb = styled.div`
-  font-size: 13px;
-  color: ${color.N6};
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: 0.8125rem;
+  color: ${CORPUS_COLORS.slate[500]};
   white-space: nowrap;
 
   a {
-    color: ${color.N6};
+    color: ${CORPUS_COLORS.slate[500]};
     text-decoration: none;
+    transition: color ${CORPUS_TRANSITIONS.fast};
 
     &:hover {
-      color: ${color.G7};
+      color: ${CORPUS_COLORS.teal[700]};
       text-decoration: underline;
     }
   }
@@ -83,11 +94,11 @@ const Breadcrumb = styled.div`
 `;
 
 const Title = styled.h1`
-  font-size: 1.25rem;
-  font-weight: 700;
-  color: ${color.N10};
+  font-family: "Georgia", "Times New Roman", serif;
+  font-size: 24px;
+  font-weight: 400;
+  color: #0f766e;
   margin: 0;
-  letter-spacing: -0.025em;
 `;
 
 const CreateButton = styled.button`
@@ -96,32 +107,40 @@ const CreateButton = styled.button`
   gap: 0.375rem;
   padding: 0.5rem 1rem;
   border: none;
-  border-radius: 6px;
-  background: ${color.G6};
-  color: white;
+  border-radius: ${CORPUS_RADII.md};
+  background: linear-gradient(
+    135deg,
+    ${CORPUS_COLORS.teal[600]} 0%,
+    ${CORPUS_COLORS.teal[700]} 100%
+  );
+  color: ${CORPUS_COLORS.white};
+  font-family: ${CORPUS_FONTS.sans};
   font-size: 0.875rem;
   font-weight: 600;
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all ${CORPUS_TRANSITIONS.normal};
   white-space: nowrap;
   flex-shrink: 0;
+  box-shadow: 0 4px 12px rgba(15, 118, 110, 0.35);
 
   &:hover:not(:disabled) {
-    background: ${color.G7};
+    transform: translateY(-1px);
+    box-shadow: 0 6px 20px rgba(15, 118, 110, 0.45);
   }
 
   &:disabled {
-    background: ${color.N5};
+    background: ${CORPUS_COLORS.slate[300]};
     cursor: not-allowed;
     opacity: 0.7;
+    box-shadow: none;
   }
 
   svg {
-    width: 16px;
-    height: 16px;
+    width: 1rem;
+    height: 1rem;
   }
 
-  @media (max-width: 480px) {
+  ${mediaQuery.mobile} {
     padding: 0.5rem;
     span {
       display: none;
@@ -133,13 +152,13 @@ const Toolbar = styled.div`
   display: flex;
   align-items: center;
   gap: 0.75rem;
-  padding: 0.5rem 1.5rem;
-  background: ${color.N1};
-  border-bottom: 1px solid ${color.N4};
+  padding: 0.75rem 2rem;
+  background: ${CORPUS_COLORS.white};
+  border-bottom: 1px solid ${CORPUS_COLORS.slate[200]};
   flex-wrap: wrap;
 
   @media (max-width: 768px) {
-    padding: 0.5rem 1rem;
+    padding: 0.625rem 1rem;
     gap: 0.5rem;
   }
 `;
@@ -155,25 +174,32 @@ const FilterPill = styled.button<{ $isActive: boolean }>`
   display: inline-flex;
   align-items: center;
   gap: 0.25rem;
-  padding: 0.375rem 0.625rem;
-  border: 1px solid ${(props) => (props.$isActive ? color.G5 : color.N4)};
-  border-radius: 16px;
-  background: ${(props) => (props.$isActive ? color.G6 : color.N1)};
-  color: ${(props) => (props.$isActive ? "white" : color.N7)};
-  font-size: 12px;
+  padding: 0.375rem 0.75rem;
+  border: 1px solid
+    ${(props) =>
+      props.$isActive ? CORPUS_COLORS.teal[500] : CORPUS_COLORS.slate[200]};
+  border-radius: ${CORPUS_RADII.full};
+  background: ${(props) =>
+    props.$isActive ? CORPUS_COLORS.teal[600] : CORPUS_COLORS.white};
+  color: ${(props) =>
+    props.$isActive ? CORPUS_COLORS.white : CORPUS_COLORS.slate[600]};
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: 0.75rem;
   font-weight: 500;
   cursor: pointer;
-  transition: all 0.15s;
+  transition: all ${CORPUS_TRANSITIONS.fast};
 
   &:hover {
-    border-color: ${color.G5};
-    background: ${(props) => (props.$isActive ? color.G7 : color.G1)};
-    color: ${(props) => (props.$isActive ? "white" : color.G8)};
+    border-color: ${CORPUS_COLORS.teal[400]};
+    background: ${(props) =>
+      props.$isActive ? CORPUS_COLORS.teal[700] : CORPUS_COLORS.teal[50]};
+    color: ${(props) =>
+      props.$isActive ? CORPUS_COLORS.white : CORPUS_COLORS.teal[700]};
   }
 
   svg {
-    width: 12px;
-    height: 12px;
+    width: 0.75rem;
+    height: 0.75rem;
   }
 `;
 
@@ -181,23 +207,23 @@ const FilterCount = styled.span<{ $isActive: boolean }>`
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 16px;
-  height: 16px;
-  padding: 0 4px;
-  border-radius: 8px;
+  min-width: 1rem;
+  height: 1rem;
+  padding: 0 0.25rem;
+  border-radius: ${CORPUS_RADII.full};
   background: ${(props) =>
-    props.$isActive ? "rgba(255,255,255,0.25)" : color.N3};
-  font-size: 10px;
+    props.$isActive ? "rgba(255,255,255,0.25)" : CORPUS_COLORS.slate[100]};
+  font-size: 0.625rem;
   font-weight: 600;
 `;
 
 const ToolbarDivider = styled.div`
   width: 1px;
-  height: 24px;
-  background: ${color.N4};
+  height: 1.5rem;
+  background: ${CORPUS_COLORS.slate[200]};
   margin: 0 0.25rem;
 
-  @media (max-width: 640px) {
+  ${mediaQuery.mobile} {
     display: none;
   }
 `;
@@ -205,41 +231,42 @@ const ToolbarDivider = styled.div`
 const SearchInput = styled.div`
   position: relative;
   flex: 1;
-  min-width: 150px;
-  max-width: 280px;
+  min-width: 9.375rem;
+  max-width: 17.5rem;
 
   svg {
     position: absolute;
-    left: 10px;
+    left: 0.625rem;
     top: 50%;
     transform: translateY(-50%);
-    width: 14px;
-    height: 14px;
-    color: ${color.N6};
+    width: 0.875rem;
+    height: 0.875rem;
+    color: ${CORPUS_COLORS.slate[400]};
   }
 
   input {
     width: 100%;
     padding: 0.375rem 0.75rem 0.375rem 2rem;
-    border: 1px solid ${color.N4};
-    border-radius: 6px;
-    background: ${color.N1};
-    font-size: 13px;
-    color: ${color.N10};
-    transition: all 0.15s;
+    border: 1px solid ${CORPUS_COLORS.slate[200]};
+    border-radius: ${CORPUS_RADII.md};
+    background: ${CORPUS_COLORS.white};
+    font-family: ${CORPUS_FONTS.sans};
+    font-size: 0.8125rem;
+    color: ${CORPUS_COLORS.slate[800]};
+    transition: all ${CORPUS_TRANSITIONS.fast};
 
     &:focus {
       outline: none;
-      border-color: ${color.G5};
-      box-shadow: 0 0 0 2px ${color.G1};
+      border-color: ${CORPUS_COLORS.teal[500]};
+      box-shadow: 0 0 0 3px ${CORPUS_COLORS.teal[50]};
     }
 
     &::placeholder {
-      color: ${color.N6};
+      color: ${CORPUS_COLORS.slate[400]};
     }
   }
 
-  @media (max-width: 640px) {
+  ${mediaQuery.mobile} {
     max-width: none;
     flex-basis: 100%;
     order: 10;
@@ -248,24 +275,25 @@ const SearchInput = styled.div`
 
 const SortDropdown = styled.select`
   padding: 0.375rem 1.75rem 0.375rem 0.625rem;
-  border: 1px solid ${color.N4};
-  border-radius: 6px;
-  background: ${color.N1}
+  border: 1px solid ${CORPUS_COLORS.slate[200]};
+  border-radius: ${CORPUS_RADII.md};
+  background: ${CORPUS_COLORS.white}
     url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='%238C96A3' stroke-width='2'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E")
     no-repeat right 8px center;
-  font-size: 13px;
-  color: ${color.N9};
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: 0.8125rem;
+  color: ${CORPUS_COLORS.slate[700]};
   cursor: pointer;
   appearance: none;
-  transition: all 0.15s;
+  transition: all ${CORPUS_TRANSITIONS.fast};
 
   &:focus {
     outline: none;
-    border-color: ${color.G5};
+    border-color: ${CORPUS_COLORS.teal[500]};
   }
 
   &:hover {
-    border-color: ${color.N5};
+    border-color: ${CORPUS_COLORS.slate[300]};
   }
 `;
 
@@ -275,7 +303,7 @@ const TabGroup = styled.div`
   gap: 0.25rem;
   margin-left: auto;
 
-  @media (max-width: 640px) {
+  ${mediaQuery.mobile} {
     margin-left: 0;
   }
 `;
@@ -285,23 +313,29 @@ const TabButton = styled.button<{ $isActive: boolean }>`
   align-items: center;
   gap: 0.375rem;
   padding: 0.375rem 0.75rem;
-  border: 1px solid ${(props) => (props.$isActive ? color.G5 : color.N4)};
-  border-radius: 6px;
-  background: ${(props) => (props.$isActive ? color.G1 : color.N1)};
-  color: ${(props) => (props.$isActive ? color.G7 : color.N6)};
-  font-size: 12px;
+  border: 1px solid
+    ${(props) =>
+      props.$isActive ? CORPUS_COLORS.teal[500] : CORPUS_COLORS.slate[200]};
+  border-radius: ${CORPUS_RADII.md};
+  background: ${(props) =>
+    props.$isActive ? CORPUS_COLORS.teal[50] : CORPUS_COLORS.white};
+  color: ${(props) =>
+    props.$isActive ? CORPUS_COLORS.teal[700] : CORPUS_COLORS.slate[500]};
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: 0.75rem;
   font-weight: 500;
   cursor: pointer;
-  transition: all 0.15s;
+  transition: all ${CORPUS_TRANSITIONS.fast};
 
   &:hover {
-    border-color: ${color.G5};
-    color: ${color.G7};
+    border-color: ${CORPUS_COLORS.teal[400]};
+    color: ${CORPUS_COLORS.teal[700]};
+    background: ${CORPUS_COLORS.teal[50]};
   }
 
   svg {
-    width: 14px;
-    height: 14px;
+    width: 0.875rem;
+    height: 0.875rem;
   }
 `;
 
@@ -317,6 +351,11 @@ interface CorpusDiscussionsViewProps {
   corpusId: string;
   /** When true, hides the built-in header (for embedding in corpus tabs) */
   hideHeader?: boolean;
+  /**
+   * Callback fired when the component transitions between list view and thread detail view.
+   * Parent components can use this to adjust their navigation headers.
+   */
+  onViewModeChange?: (inThreadView: boolean) => void;
 }
 
 /**
@@ -332,9 +371,8 @@ interface CorpusDiscussionsViewProps {
 export const CorpusDiscussionsView: React.FC<CorpusDiscussionsViewProps> = ({
   corpusId,
   hideHeader = false,
+  onViewModeChange,
 }) => {
-  const navigate = useNavigate();
-  const location = useLocation();
   const corpus = useReactiveVar(openedCorpus);
   const token = useReactiveVar(authToken);
   const isAuthenticated = Boolean(token);
@@ -345,6 +383,17 @@ export const CorpusDiscussionsView: React.FC<CorpusDiscussionsViewProps> = ({
   const [categoryFilter, setCategoryFilter] = useState<CategoryFilter>("all");
   const [searchQuery, setSearchQuery] = useState("");
   const [sortBy, setSortBy] = useAtom(threadSortAtom);
+
+  // Track selected thread for inline viewing
+  const [selectedThreadId, setSelectedThreadId] = useAtom(
+    inlineSelectedThreadIdAtom
+  );
+  const inThreadView = selectedThreadId !== null;
+
+  // Notify parent when view mode changes
+  useEffect(() => {
+    onViewModeChange?.(inThreadView);
+  }, [inThreadView, onViewModeChange]);
 
   // Fetch all threads for stats calculation
   const { data: threadsData } = useQuery<
@@ -401,14 +450,18 @@ export const CorpusDiscussionsView: React.FC<CorpusDiscussionsViewProps> = ({
     return hasUpdate || hasPermission;
   }, [corpus]);
 
+  // Handle thread click - show inline instead of navigating away
   const handleThreadClick = useCallback(
     (threadId: string) => {
-      if (corpus) {
-        navigateToCorpusThread(corpus, threadId, navigate, location.pathname);
-      }
+      setSelectedThreadId(threadId);
     },
-    [corpus, navigate, location.pathname]
+    [setSelectedThreadId]
   );
+
+  // Handle back from thread detail - return to list view
+  const handleBackToList = useCallback(() => {
+    setSelectedThreadId(null);
+  }, [setSelectedThreadId]);
 
   const handleSearchChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -431,7 +484,22 @@ export const CorpusDiscussionsView: React.FC<CorpusDiscussionsViewProps> = ({
   if (!corpus) {
     return (
       <Container>
-        <p style={{ padding: "2rem", color: color.N6 }}>Loading corpus...</p>
+        <p style={{ padding: "2rem", color: CORPUS_COLORS.slate[500] }}>
+          Loading corpus...
+        </p>
+      </Container>
+    );
+  }
+
+  // If a thread is selected, show it inline with context sidebar
+  if (inThreadView && selectedThreadId) {
+    return (
+      <Container>
+        <ThreadDetailWithContext
+          conversationId={selectedThreadId}
+          corpusId={corpusId}
+          onBack={handleBackToList}
+        />
       </Container>
     );
   }

--- a/frontend/src/components/discussions/CorpusDiscussionsView.tsx
+++ b/frontend/src/components/discussions/CorpusDiscussionsView.tsx
@@ -395,6 +395,14 @@ export const CorpusDiscussionsView: React.FC<CorpusDiscussionsViewProps> = ({
     onViewModeChange?.(inThreadView);
   }, [inThreadView, onViewModeChange]);
 
+  // Reset inline selection when unmounting to prevent stale state
+  // when navigating back to the Discussions tab
+  useEffect(() => {
+    return () => {
+      setSelectedThreadId(null);
+    };
+  }, [setSelectedThreadId]);
+
   // Fetch all threads for stats calculation
   const { data: threadsData } = useQuery<
     GetConversationsOutputs,

--- a/frontend/src/components/hooks/WindowDimensionHook.tsx
+++ b/frontend/src/components/hooks/WindowDimensionHook.tsx
@@ -1,4 +1,6 @@
-import { useState, useLayoutEffect } from "react";
+import { useState, useLayoutEffect, useRef, useCallback } from "react";
+
+const RESIZE_DEBOUNCE_MS = 150;
 
 function getWindowDimensions() {
   const { innerWidth: width, innerHeight: height } = window;
@@ -12,15 +14,26 @@ export default function useWindowDimensions() {
   const [windowDimensions, setWindowDimensions] = useState(
     getWindowDimensions()
   );
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleResize = useCallback(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+    timeoutRef.current = setTimeout(() => {
+      setWindowDimensions(getWindowDimensions());
+    }, RESIZE_DEBOUNCE_MS);
+  }, []);
 
   useLayoutEffect(() => {
-    function handleResize() {
-      setWindowDimensions(getWindowDimensions());
-    }
-
     window.addEventListener("resize", handleResize);
-    return () => window.removeEventListener("resize", handleResize);
-  }, []);
+    return () => {
+      window.removeEventListener("resize", handleResize);
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, [handleResize]);
 
   return windowDimensions;
 }

--- a/frontend/src/components/threads/CorpusContextSidebar.tsx
+++ b/frontend/src/components/threads/CorpusContextSidebar.tsx
@@ -1,0 +1,294 @@
+/**
+ * CorpusContextSidebar - Displays corpus context when viewing thread details inline
+ *
+ * Features:
+ * - About section with corpus description (markdown rendered)
+ * - Documents section with table of contents
+ * - Quick stats (documents, threads, annotations)
+ * - Collapsible sections and responsive behavior
+ */
+
+import React, { useState, useMemo } from "react";
+import { useQuery, useReactiveVar } from "@apollo/client";
+import { useAtom } from "jotai";
+import {
+  BookOpen,
+  FileText,
+  BarChart3,
+  ChevronDown,
+  X,
+  PanelRightClose,
+  PanelRightOpen,
+  MessageSquare,
+  Tag,
+} from "lucide-react";
+import { AnimatePresence } from "framer-motion";
+
+import {
+  GET_CORPUS_STATS,
+  GetCorpusStatsOutputType,
+  CorpusStats,
+} from "../../graphql/queries";
+import { openedCorpus } from "../../graphql/cache";
+import { threadContextSidebarExpandedAtom } from "../../atoms/threadAtoms";
+import { DocumentTableOfContents } from "../corpuses/DocumentTableOfContents";
+import { SafeMarkdown } from "../knowledge_base/markdown/SafeMarkdown";
+import useWindowDimensions from "../hooks/WindowDimensionHook";
+
+import {
+  ContextSidebarContainer,
+  SidebarHeader,
+  SidebarTitle,
+  ContextSidebarToggle,
+  CollapsedSidebar,
+  ExpandSidebarButton,
+  SidebarContent,
+  SidebarSection,
+  SectionHeader,
+  SectionTitle,
+  SectionChevron,
+  SectionContent,
+  SectionInner,
+  StatsGrid,
+  StatItem,
+  StatValue,
+  StatLabel,
+  CompactAboutWrapper,
+  CompactTocWrapper,
+  EmptySectionState,
+  SIDEBAR_BREAKPOINT_HIDE,
+  SIDEBAR_BREAKPOINT_COLLAPSE,
+} from "./styles/contextSidebarStyles";
+
+interface CorpusContextSidebarProps {
+  corpusId: string;
+}
+
+/**
+ * CorpusContextSidebar - Shows corpus context alongside thread details
+ */
+export const CorpusContextSidebar: React.FC<CorpusContextSidebarProps> = ({
+  corpusId,
+}) => {
+  const { width } = useWindowDimensions();
+  const corpus = useReactiveVar(openedCorpus);
+  const [isExpanded, setIsExpanded] = useAtom(threadContextSidebarExpandedAtom);
+
+  // Section expansion states
+  const [aboutExpanded, setAboutExpanded] = useState(true);
+  const [docsExpanded, setDocsExpanded] = useState(true);
+  const [statsExpanded, setStatsExpanded] = useState(true);
+
+  // Determine if we're in collapsible mode (medium screens)
+  const isCollapsible =
+    width >= SIDEBAR_BREAKPOINT_HIDE && width < SIDEBAR_BREAKPOINT_COLLAPSE;
+
+  // Fetch corpus stats
+  const { data: statsData } = useQuery<
+    GetCorpusStatsOutputType,
+    { corpusId: string }
+  >(GET_CORPUS_STATS, {
+    variables: { corpusId },
+    skip: !corpusId,
+    fetchPolicy: "cache-and-network",
+  });
+
+  const stats: CorpusStats | null = statsData?.corpusStats ?? null;
+
+  // Get description from corpus
+  const description = useMemo(() => {
+    if (!corpus) return null;
+    return corpus.description || null;
+  }, [corpus]);
+
+  // Don't render on small screens
+  if (width < SIDEBAR_BREAKPOINT_HIDE) {
+    return null;
+  }
+
+  // Collapsed state (on medium screens when user collapsed it)
+  if (isCollapsible && !isExpanded) {
+    return (
+      <ContextSidebarContainer
+        $isExpanded={false}
+        $isCollapsible={isCollapsible}
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 0.2 }}
+      >
+        <CollapsedSidebar>
+          <ExpandSidebarButton
+            onClick={() => setIsExpanded(true)}
+            aria-label="Expand corpus context sidebar"
+            title="Expand sidebar"
+          >
+            <PanelRightOpen />
+          </ExpandSidebarButton>
+        </CollapsedSidebar>
+      </ContextSidebarContainer>
+    );
+  }
+
+  return (
+    <ContextSidebarContainer
+      $isExpanded={isExpanded}
+      $isCollapsible={isCollapsible}
+      initial={{ opacity: 0, x: 20 }}
+      animate={{ opacity: 1, x: 0 }}
+      transition={{ duration: 0.3 }}
+    >
+      <SidebarHeader>
+        <SidebarTitle>{corpus?.title || "Corpus Info"}</SidebarTitle>
+        {isCollapsible && (
+          <ContextSidebarToggle
+            onClick={() => setIsExpanded(false)}
+            aria-label="Collapse sidebar"
+            title="Collapse sidebar"
+          >
+            <PanelRightClose />
+          </ContextSidebarToggle>
+        )}
+      </SidebarHeader>
+
+      <SidebarContent>
+        {/* About Section */}
+        <SidebarSection>
+          <SectionHeader
+            $isExpanded={aboutExpanded}
+            onClick={() => setAboutExpanded(!aboutExpanded)}
+            aria-expanded={aboutExpanded}
+            aria-controls="sidebar-about-content"
+          >
+            <SectionTitle>
+              <BookOpen />
+              About
+            </SectionTitle>
+            <SectionChevron $isExpanded={aboutExpanded}>
+              <ChevronDown />
+            </SectionChevron>
+          </SectionHeader>
+          <AnimatePresence initial={false}>
+            {aboutExpanded && (
+              <SectionContent
+                id="sidebar-about-content"
+                initial={{ height: 0, opacity: 0 }}
+                animate={{ height: "auto", opacity: 1 }}
+                exit={{ height: 0, opacity: 0 }}
+                transition={{ duration: 0.2 }}
+              >
+                <SectionInner>
+                  {description ? (
+                    <CompactAboutWrapper>
+                      <SafeMarkdown>{description}</SafeMarkdown>
+                    </CompactAboutWrapper>
+                  ) : (
+                    <EmptySectionState>
+                      <BookOpen />
+                      <p>No description available</p>
+                    </EmptySectionState>
+                  )}
+                </SectionInner>
+              </SectionContent>
+            )}
+          </AnimatePresence>
+        </SidebarSection>
+
+        {/* Documents Section */}
+        <SidebarSection>
+          <SectionHeader
+            $isExpanded={docsExpanded}
+            onClick={() => setDocsExpanded(!docsExpanded)}
+            aria-expanded={docsExpanded}
+            aria-controls="sidebar-docs-content"
+          >
+            <SectionTitle>
+              <FileText />
+              Documents
+              {stats?.totalDocs != null && (
+                <span style={{ fontWeight: 400, color: "#94a3b8" }}>
+                  ({stats.totalDocs})
+                </span>
+              )}
+            </SectionTitle>
+            <SectionChevron $isExpanded={docsExpanded}>
+              <ChevronDown />
+            </SectionChevron>
+          </SectionHeader>
+          <AnimatePresence initial={false}>
+            {docsExpanded && (
+              <SectionContent
+                id="sidebar-docs-content"
+                initial={{ height: 0, opacity: 0 }}
+                animate={{ height: "auto", opacity: 1 }}
+                exit={{ height: 0, opacity: 0 }}
+                transition={{ duration: 0.2 }}
+              >
+                <SectionInner>
+                  <CompactTocWrapper>
+                    <DocumentTableOfContents
+                      corpusId={corpusId}
+                      embedded
+                      maxDepth={2}
+                    />
+                  </CompactTocWrapper>
+                </SectionInner>
+              </SectionContent>
+            )}
+          </AnimatePresence>
+        </SidebarSection>
+
+        {/* Stats Section */}
+        <SidebarSection>
+          <SectionHeader
+            $isExpanded={statsExpanded}
+            onClick={() => setStatsExpanded(!statsExpanded)}
+            aria-expanded={statsExpanded}
+            aria-controls="sidebar-stats-content"
+          >
+            <SectionTitle>
+              <BarChart3 />
+              Quick Stats
+            </SectionTitle>
+            <SectionChevron $isExpanded={statsExpanded}>
+              <ChevronDown />
+            </SectionChevron>
+          </SectionHeader>
+          <AnimatePresence initial={false}>
+            {statsExpanded && (
+              <SectionContent
+                id="sidebar-stats-content"
+                initial={{ height: 0, opacity: 0 }}
+                animate={{ height: "auto", opacity: 1 }}
+                exit={{ height: 0, opacity: 0 }}
+                transition={{ duration: 0.2 }}
+              >
+                <SectionInner>
+                  <StatsGrid>
+                    <StatItem>
+                      <StatValue>{stats?.totalDocs ?? 0}</StatValue>
+                      <StatLabel>Documents</StatLabel>
+                    </StatItem>
+                    <StatItem>
+                      <StatValue>{stats?.totalThreads ?? 0}</StatValue>
+                      <StatLabel>Discussions</StatLabel>
+                    </StatItem>
+                    <StatItem>
+                      <StatValue>{stats?.totalAnnotations ?? 0}</StatValue>
+                      <StatLabel>Annotations</StatLabel>
+                    </StatItem>
+                    <StatItem>
+                      <StatValue>{stats?.totalComments ?? 0}</StatValue>
+                      <StatLabel>Comments</StatLabel>
+                    </StatItem>
+                  </StatsGrid>
+                </SectionInner>
+              </SectionContent>
+            )}
+          </AnimatePresence>
+        </SidebarSection>
+      </SidebarContent>
+    </ContextSidebarContainer>
+  );
+};
+
+export default CorpusContextSidebar;

--- a/frontend/src/components/threads/CorpusContextSidebar.tsx
+++ b/frontend/src/components/threads/CorpusContextSidebar.tsx
@@ -67,228 +67,232 @@ interface CorpusContextSidebarProps {
 /**
  * CorpusContextSidebar - Shows corpus context alongside thread details
  */
-export const CorpusContextSidebar: React.FC<CorpusContextSidebarProps> = ({
-  corpusId,
-}) => {
-  const { width } = useWindowDimensions();
-  const corpus = useReactiveVar(openedCorpus);
-  const [isExpanded, setIsExpanded] = useAtom(threadContextSidebarExpandedAtom);
+export const CorpusContextSidebar: React.FC<CorpusContextSidebarProps> =
+  React.memo(({ corpusId }) => {
+    const { width } = useWindowDimensions();
+    const corpus = useReactiveVar(openedCorpus);
+    const [isExpanded, setIsExpanded] = useAtom(
+      threadContextSidebarExpandedAtom
+    );
 
-  // Section expansion states
-  const [aboutExpanded, setAboutExpanded] = useState(true);
-  const [docsExpanded, setDocsExpanded] = useState(true);
-  const [statsExpanded, setStatsExpanded] = useState(true);
+    // Section expansion states
+    const [aboutExpanded, setAboutExpanded] = useState(true);
+    const [docsExpanded, setDocsExpanded] = useState(true);
+    const [statsExpanded, setStatsExpanded] = useState(true);
 
-  // Determine if we're in collapsible mode (medium screens)
-  const isCollapsible =
-    width >= SIDEBAR_BREAKPOINT_HIDE && width < SIDEBAR_BREAKPOINT_COLLAPSE;
+    // Determine if we're in collapsible mode (medium screens)
+    const isCollapsible =
+      width >= SIDEBAR_BREAKPOINT_HIDE && width < SIDEBAR_BREAKPOINT_COLLAPSE;
 
-  // Fetch corpus stats
-  const { data: statsData } = useQuery<
-    GetCorpusStatsOutputType,
-    { corpusId: string }
-  >(GET_CORPUS_STATS, {
-    variables: { corpusId },
-    skip: !corpusId,
-    fetchPolicy: "cache-and-network",
-  });
+    // Fetch corpus stats
+    const { data: statsData } = useQuery<
+      GetCorpusStatsOutputType,
+      { corpusId: string }
+    >(GET_CORPUS_STATS, {
+      variables: { corpusId },
+      skip: !corpusId,
+      fetchPolicy: "cache-and-network",
+    });
 
-  const stats: CorpusStats | null = statsData?.corpusStats ?? null;
+    const stats: CorpusStats | null = statsData?.corpusStats ?? null;
 
-  // Get description from corpus
-  const description = useMemo(() => {
-    if (!corpus) return null;
-    return corpus.description || null;
-  }, [corpus]);
+    // Get description from corpus
+    const description = useMemo(() => {
+      if (!corpus) return null;
+      return corpus.description || null;
+    }, [corpus]);
 
-  // Don't render on small screens
-  if (width < SIDEBAR_BREAKPOINT_HIDE) {
-    return null;
-  }
+    // Don't render on small screens
+    if (width < SIDEBAR_BREAKPOINT_HIDE) {
+      return null;
+    }
 
-  // Collapsed state (on medium screens when user collapsed it)
-  if (isCollapsible && !isExpanded) {
+    // Collapsed state (on medium screens when user collapsed it)
+    if (isCollapsible && !isExpanded) {
+      return (
+        <ContextSidebarContainer
+          $isExpanded={false}
+          $isCollapsible={isCollapsible}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: 0.2 }}
+        >
+          <CollapsedSidebar>
+            <ExpandSidebarButton
+              onClick={() => setIsExpanded(true)}
+              aria-label="Expand corpus context sidebar"
+              title="Expand sidebar"
+            >
+              <PanelRightOpen />
+            </ExpandSidebarButton>
+          </CollapsedSidebar>
+        </ContextSidebarContainer>
+      );
+    }
+
     return (
       <ContextSidebarContainer
-        $isExpanded={false}
+        $isExpanded={isExpanded}
         $isCollapsible={isCollapsible}
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        transition={{ duration: 0.2 }}
+        initial={{ opacity: 0, x: 20 }}
+        animate={{ opacity: 1, x: 0 }}
+        transition={{ duration: 0.3 }}
       >
-        <CollapsedSidebar>
-          <ExpandSidebarButton
-            onClick={() => setIsExpanded(true)}
-            aria-label="Expand corpus context sidebar"
-            title="Expand sidebar"
-          >
-            <PanelRightOpen />
-          </ExpandSidebarButton>
-        </CollapsedSidebar>
+        <SidebarHeader>
+          <SidebarTitle>{corpus?.title || "Corpus Info"}</SidebarTitle>
+          {isCollapsible && (
+            <ContextSidebarToggle
+              onClick={() => setIsExpanded(false)}
+              aria-label="Collapse sidebar"
+              title="Collapse sidebar"
+            >
+              <PanelRightClose />
+            </ContextSidebarToggle>
+          )}
+        </SidebarHeader>
+
+        <SidebarContent>
+          {/* About Section */}
+          <SidebarSection>
+            <SectionHeader
+              $isExpanded={aboutExpanded}
+              onClick={() => setAboutExpanded(!aboutExpanded)}
+              aria-expanded={aboutExpanded}
+              aria-controls="sidebar-about-content"
+            >
+              <SectionTitle>
+                <BookOpen />
+                About
+              </SectionTitle>
+              <SectionChevron $isExpanded={aboutExpanded}>
+                <ChevronDown />
+              </SectionChevron>
+            </SectionHeader>
+            <AnimatePresence initial={false}>
+              {aboutExpanded && (
+                <SectionContent
+                  id="sidebar-about-content"
+                  initial={{ height: 0, opacity: 0 }}
+                  animate={{ height: "auto", opacity: 1 }}
+                  exit={{ height: 0, opacity: 0 }}
+                  transition={{ duration: 0.2 }}
+                >
+                  <SectionInner>
+                    {description ? (
+                      <CompactAboutWrapper>
+                        <SafeMarkdown>{description}</SafeMarkdown>
+                      </CompactAboutWrapper>
+                    ) : (
+                      <EmptySectionState>
+                        <BookOpen />
+                        <p>No description available</p>
+                      </EmptySectionState>
+                    )}
+                  </SectionInner>
+                </SectionContent>
+              )}
+            </AnimatePresence>
+          </SidebarSection>
+
+          {/* Documents Section */}
+          <SidebarSection>
+            <SectionHeader
+              $isExpanded={docsExpanded}
+              onClick={() => setDocsExpanded(!docsExpanded)}
+              aria-expanded={docsExpanded}
+              aria-controls="sidebar-docs-content"
+            >
+              <SectionTitle>
+                <FileText />
+                Documents
+                {stats?.totalDocs != null && (
+                  <span style={{ fontWeight: 400, color: "#94a3b8" }}>
+                    ({stats.totalDocs})
+                  </span>
+                )}
+              </SectionTitle>
+              <SectionChevron $isExpanded={docsExpanded}>
+                <ChevronDown />
+              </SectionChevron>
+            </SectionHeader>
+            <AnimatePresence initial={false}>
+              {docsExpanded && (
+                <SectionContent
+                  id="sidebar-docs-content"
+                  initial={{ height: 0, opacity: 0 }}
+                  animate={{ height: "auto", opacity: 1 }}
+                  exit={{ height: 0, opacity: 0 }}
+                  transition={{ duration: 0.2 }}
+                >
+                  <SectionInner>
+                    <CompactTocWrapper>
+                      <DocumentTableOfContents
+                        corpusId={corpusId}
+                        embedded
+                        maxDepth={2}
+                      />
+                    </CompactTocWrapper>
+                  </SectionInner>
+                </SectionContent>
+              )}
+            </AnimatePresence>
+          </SidebarSection>
+
+          {/* Stats Section */}
+          <SidebarSection>
+            <SectionHeader
+              $isExpanded={statsExpanded}
+              onClick={() => setStatsExpanded(!statsExpanded)}
+              aria-expanded={statsExpanded}
+              aria-controls="sidebar-stats-content"
+            >
+              <SectionTitle>
+                <BarChart3 />
+                Quick Stats
+              </SectionTitle>
+              <SectionChevron $isExpanded={statsExpanded}>
+                <ChevronDown />
+              </SectionChevron>
+            </SectionHeader>
+            <AnimatePresence initial={false}>
+              {statsExpanded && (
+                <SectionContent
+                  id="sidebar-stats-content"
+                  initial={{ height: 0, opacity: 0 }}
+                  animate={{ height: "auto", opacity: 1 }}
+                  exit={{ height: 0, opacity: 0 }}
+                  transition={{ duration: 0.2 }}
+                >
+                  <SectionInner>
+                    <StatsGrid>
+                      <StatItem>
+                        <StatValue>{stats?.totalDocs ?? 0}</StatValue>
+                        <StatLabel>Documents</StatLabel>
+                      </StatItem>
+                      <StatItem>
+                        <StatValue>{stats?.totalThreads ?? 0}</StatValue>
+                        <StatLabel>Discussions</StatLabel>
+                      </StatItem>
+                      <StatItem>
+                        <StatValue>{stats?.totalAnnotations ?? 0}</StatValue>
+                        <StatLabel>Annotations</StatLabel>
+                      </StatItem>
+                      <StatItem>
+                        <StatValue>{stats?.totalComments ?? 0}</StatValue>
+                        <StatLabel>Comments</StatLabel>
+                      </StatItem>
+                    </StatsGrid>
+                  </SectionInner>
+                </SectionContent>
+              )}
+            </AnimatePresence>
+          </SidebarSection>
+        </SidebarContent>
       </ContextSidebarContainer>
     );
-  }
+  });
 
-  return (
-    <ContextSidebarContainer
-      $isExpanded={isExpanded}
-      $isCollapsible={isCollapsible}
-      initial={{ opacity: 0, x: 20 }}
-      animate={{ opacity: 1, x: 0 }}
-      transition={{ duration: 0.3 }}
-    >
-      <SidebarHeader>
-        <SidebarTitle>{corpus?.title || "Corpus Info"}</SidebarTitle>
-        {isCollapsible && (
-          <ContextSidebarToggle
-            onClick={() => setIsExpanded(false)}
-            aria-label="Collapse sidebar"
-            title="Collapse sidebar"
-          >
-            <PanelRightClose />
-          </ContextSidebarToggle>
-        )}
-      </SidebarHeader>
-
-      <SidebarContent>
-        {/* About Section */}
-        <SidebarSection>
-          <SectionHeader
-            $isExpanded={aboutExpanded}
-            onClick={() => setAboutExpanded(!aboutExpanded)}
-            aria-expanded={aboutExpanded}
-            aria-controls="sidebar-about-content"
-          >
-            <SectionTitle>
-              <BookOpen />
-              About
-            </SectionTitle>
-            <SectionChevron $isExpanded={aboutExpanded}>
-              <ChevronDown />
-            </SectionChevron>
-          </SectionHeader>
-          <AnimatePresence initial={false}>
-            {aboutExpanded && (
-              <SectionContent
-                id="sidebar-about-content"
-                initial={{ height: 0, opacity: 0 }}
-                animate={{ height: "auto", opacity: 1 }}
-                exit={{ height: 0, opacity: 0 }}
-                transition={{ duration: 0.2 }}
-              >
-                <SectionInner>
-                  {description ? (
-                    <CompactAboutWrapper>
-                      <SafeMarkdown>{description}</SafeMarkdown>
-                    </CompactAboutWrapper>
-                  ) : (
-                    <EmptySectionState>
-                      <BookOpen />
-                      <p>No description available</p>
-                    </EmptySectionState>
-                  )}
-                </SectionInner>
-              </SectionContent>
-            )}
-          </AnimatePresence>
-        </SidebarSection>
-
-        {/* Documents Section */}
-        <SidebarSection>
-          <SectionHeader
-            $isExpanded={docsExpanded}
-            onClick={() => setDocsExpanded(!docsExpanded)}
-            aria-expanded={docsExpanded}
-            aria-controls="sidebar-docs-content"
-          >
-            <SectionTitle>
-              <FileText />
-              Documents
-              {stats?.totalDocs != null && (
-                <span style={{ fontWeight: 400, color: "#94a3b8" }}>
-                  ({stats.totalDocs})
-                </span>
-              )}
-            </SectionTitle>
-            <SectionChevron $isExpanded={docsExpanded}>
-              <ChevronDown />
-            </SectionChevron>
-          </SectionHeader>
-          <AnimatePresence initial={false}>
-            {docsExpanded && (
-              <SectionContent
-                id="sidebar-docs-content"
-                initial={{ height: 0, opacity: 0 }}
-                animate={{ height: "auto", opacity: 1 }}
-                exit={{ height: 0, opacity: 0 }}
-                transition={{ duration: 0.2 }}
-              >
-                <SectionInner>
-                  <CompactTocWrapper>
-                    <DocumentTableOfContents
-                      corpusId={corpusId}
-                      embedded
-                      maxDepth={2}
-                    />
-                  </CompactTocWrapper>
-                </SectionInner>
-              </SectionContent>
-            )}
-          </AnimatePresence>
-        </SidebarSection>
-
-        {/* Stats Section */}
-        <SidebarSection>
-          <SectionHeader
-            $isExpanded={statsExpanded}
-            onClick={() => setStatsExpanded(!statsExpanded)}
-            aria-expanded={statsExpanded}
-            aria-controls="sidebar-stats-content"
-          >
-            <SectionTitle>
-              <BarChart3 />
-              Quick Stats
-            </SectionTitle>
-            <SectionChevron $isExpanded={statsExpanded}>
-              <ChevronDown />
-            </SectionChevron>
-          </SectionHeader>
-          <AnimatePresence initial={false}>
-            {statsExpanded && (
-              <SectionContent
-                id="sidebar-stats-content"
-                initial={{ height: 0, opacity: 0 }}
-                animate={{ height: "auto", opacity: 1 }}
-                exit={{ height: 0, opacity: 0 }}
-                transition={{ duration: 0.2 }}
-              >
-                <SectionInner>
-                  <StatsGrid>
-                    <StatItem>
-                      <StatValue>{stats?.totalDocs ?? 0}</StatValue>
-                      <StatLabel>Documents</StatLabel>
-                    </StatItem>
-                    <StatItem>
-                      <StatValue>{stats?.totalThreads ?? 0}</StatValue>
-                      <StatLabel>Discussions</StatLabel>
-                    </StatItem>
-                    <StatItem>
-                      <StatValue>{stats?.totalAnnotations ?? 0}</StatValue>
-                      <StatLabel>Annotations</StatLabel>
-                    </StatItem>
-                    <StatItem>
-                      <StatValue>{stats?.totalComments ?? 0}</StatValue>
-                      <StatLabel>Comments</StatLabel>
-                    </StatItem>
-                  </StatsGrid>
-                </SectionInner>
-              </SectionContent>
-            )}
-          </AnimatePresence>
-        </SidebarSection>
-      </SidebarContent>
-    </ContextSidebarContainer>
-  );
-};
+// Display name for React DevTools
+CorpusContextSidebar.displayName = "CorpusContextSidebar";
 
 export default CorpusContextSidebar;

--- a/frontend/src/components/threads/CreateThreadButton.tsx
+++ b/frontend/src/components/threads/CreateThreadButton.tsx
@@ -4,33 +4,55 @@ import { Plus, MessageSquarePlus } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { useReactiveVar } from "@apollo/client";
 import { CreateThreadForm } from "./CreateThreadForm";
-import { color } from "../../theme/colors";
-import { spacing } from "../../theme/spacing";
+import {
+  CORPUS_COLORS,
+  CORPUS_FONTS,
+  CORPUS_RADII,
+  CORPUS_SHADOWS,
+  CORPUS_TRANSITIONS,
+  mediaQuery,
+} from "./styles/discussionStyles";
 import { authToken, openedCorpus } from "../../graphql/cache";
 import { getCorpusThreadUrl } from "../../utils/navigationUtils";
 
 const Button = styled.button<{ $variant?: "primary" | "secondary" }>`
   display: flex;
   align-items: center;
-  gap: ${spacing.xs};
-  padding: ${spacing.xs} ${spacing.md};
+  gap: 0.375rem;
+  padding: 0.5rem 1rem;
   border: ${(props) =>
-    props.$variant === "primary" ? "none" : `1px solid ${color.B5}`};
-  border-radius: 6px;
+    props.$variant === "primary"
+      ? "none"
+      : `1px solid ${CORPUS_COLORS.teal[500]}`};
+  border-radius: ${CORPUS_RADII.md};
   background: ${(props) =>
-    props.$variant === "primary" ? color.B5 : "transparent"};
-  color: ${(props) => (props.$variant === "primary" ? color.N1 : color.B7)};
-  font-size: 14px;
+    props.$variant === "primary"
+      ? `linear-gradient(135deg, ${CORPUS_COLORS.teal[600]} 0%, ${CORPUS_COLORS.teal[700]} 100%)`
+      : "transparent"};
+  color: ${(props) =>
+    props.$variant === "primary"
+      ? CORPUS_COLORS.white
+      : CORPUS_COLORS.teal[700]};
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: 0.875rem;
   font-weight: 600;
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all ${CORPUS_TRANSITIONS.normal};
+  box-shadow: ${(props) =>
+    props.$variant === "primary"
+      ? "0 4px 12px rgba(15, 118, 110, 0.35)"
+      : "none"};
 
   &:hover {
     background: ${(props) =>
-      props.$variant === "primary" ? color.B6 : color.B1};
-    transform: translateY(-1px);
+      props.$variant === "primary"
+        ? `linear-gradient(135deg, ${CORPUS_COLORS.teal[500]} 0%, ${CORPUS_COLORS.teal[600]} 100%)`
+        : CORPUS_COLORS.teal[50]};
+    transform: translateY(-2px);
     box-shadow: ${(props) =>
-      props.$variant === "primary" ? "0 2px 8px rgba(0, 0, 0, 0.15)" : "none"};
+      props.$variant === "primary"
+        ? "0 6px 20px rgba(15, 118, 110, 0.45)"
+        : "none"};
   }
 
   &:active {
@@ -44,33 +66,36 @@ const Button = styled.button<{ $variant?: "primary" | "secondary" }>`
   }
 
   svg {
-    width: 16px;
-    height: 16px;
+    width: 1rem;
+    height: 1rem;
   }
 `;
 
 const FloatingActionButton = styled.button`
   position: fixed;
-  bottom: ${spacing.xl};
-  right: ${spacing.xl};
-  width: 56px;
-  height: 56px;
+  bottom: 2rem;
+  right: 2rem;
+  width: 3.5rem;
+  height: 3.5rem;
   display: flex;
   align-items: center;
   justify-content: center;
   border: none;
-  border-radius: 50%;
-  background: ${color.B5};
-  color: ${color.N1};
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+  border-radius: ${CORPUS_RADII.xl};
+  background: linear-gradient(
+    135deg,
+    ${CORPUS_COLORS.teal[600]} 0%,
+    ${CORPUS_COLORS.teal[700]} 100%
+  );
+  color: ${CORPUS_COLORS.white};
+  box-shadow: 0 8px 24px rgba(15, 118, 110, 0.4);
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all ${CORPUS_TRANSITIONS.normal};
   z-index: 50;
 
   &:hover {
-    background: ${color.B6};
     transform: scale(1.1);
-    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.25);
+    box-shadow: 0 12px 32px rgba(15, 118, 110, 0.5);
   }
 
   &:active {
@@ -78,19 +103,19 @@ const FloatingActionButton = styled.button`
   }
 
   svg {
-    width: 24px;
-    height: 24px;
+    width: 1.5rem;
+    height: 1.5rem;
   }
 
-  @media (max-width: 640px) {
-    bottom: ${spacing.lg};
-    right: ${spacing.lg};
-    width: 48px;
-    height: 48px;
+  ${mediaQuery.mobile} {
+    bottom: 1rem;
+    right: 1rem;
+    width: 3rem;
+    height: 3rem;
 
     svg {
-      width: 20px;
-      height: 20px;
+      width: 1.25rem;
+      height: 1.25rem;
     }
   }
 `;

--- a/frontend/src/components/threads/CreateThreadForm.tsx
+++ b/frontend/src/components/threads/CreateThreadForm.tsx
@@ -9,7 +9,14 @@ import {
 } from "../../graphql/mutations";
 import { GET_CONVERSATIONS } from "../../graphql/queries";
 import { MessageComposer } from "./MessageComposer";
-import { color } from "../../theme/colors";
+import {
+  CORPUS_COLORS,
+  CORPUS_FONTS,
+  CORPUS_RADII,
+  CORPUS_SHADOWS,
+  CORPUS_TRANSITIONS,
+  mediaQuery,
+} from "./styles/discussionStyles";
 
 const Overlay = styled.div`
   position: fixed;
@@ -22,135 +29,143 @@ const Overlay = styled.div`
   align-items: center;
   justify-content: center;
   z-index: 1000;
-  padding: 16px;
+  padding: 1rem;
 `;
 
 const Modal = styled.div`
-  background: ${({ theme }) => color.N1};
-  border-radius: 8px;
+  background: ${CORPUS_COLORS.white};
+  border-radius: ${CORPUS_RADII.xl};
   width: 100%;
-  max-width: 600px;
+  max-width: 37.5rem;
   max-height: 90vh;
   overflow: hidden;
   display: flex;
   flex-direction: column;
-  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.15);
+  box-shadow: ${CORPUS_SHADOWS.xl};
 `;
 
 const Header = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 16px 20px;
-  border-bottom: 1px solid ${({ theme }) => color.N4};
+  padding: 1.25rem 1.5rem;
+  border-bottom: 1px solid ${CORPUS_COLORS.slate[200]};
+  background: ${CORPUS_COLORS.slate[50]};
 `;
 
 const Title = styled.h2`
   margin: 0;
-  font-size: 18px;
+  font-family: ${CORPUS_FONTS.serif};
+  font-size: 1.25rem;
   font-weight: 600;
-  color: ${({ theme }) => color.N10};
+  color: ${CORPUS_COLORS.slate[800]};
 `;
 
 const CloseButton = styled.button`
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 32px;
-  height: 32px;
+  width: 2rem;
+  height: 2rem;
   border: none;
-  border-radius: 4px;
+  border-radius: ${CORPUS_RADII.md};
   background: transparent;
-  color: ${({ theme }) => color.N7};
+  color: ${CORPUS_COLORS.slate[500]};
   cursor: pointer;
-  transition: background 0.15s ease;
+  transition: all ${CORPUS_TRANSITIONS.fast};
 
   &:hover {
-    background: ${({ theme }) => color.N2};
+    background: ${CORPUS_COLORS.slate[100]};
+    color: ${CORPUS_COLORS.slate[700]};
   }
 
   svg {
-    width: 20px;
-    height: 20px;
+    width: 1.25rem;
+    height: 1.25rem;
   }
 `;
 
 const Content = styled.div`
   flex: 1;
   overflow-y: auto;
-  padding: 20px;
+  padding: 1.5rem;
 `;
 
 const Field = styled.div`
-  margin-bottom: 20px;
+  margin-bottom: 1.5rem;
 `;
 
 const Label = styled.label`
   display: block;
-  margin-bottom: 6px;
-  font-size: 14px;
-  font-weight: 500;
-  color: ${({ theme }) => color.N10};
+  margin-bottom: 0.5rem;
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: ${CORPUS_COLORS.slate[700]};
 `;
 
 const Input = styled.input`
   width: 100%;
-  padding: 10px 12px;
-  border: 1px solid ${({ theme }) => color.N4};
-  border-radius: 6px;
-  background: ${({ theme }) => color.N1};
-  color: ${({ theme }) => color.N10};
-  font-size: 14px;
-  font-family: inherit;
-  transition: border-color 0.15s ease;
+  padding: 0.625rem 0.875rem;
+  border: 1px solid ${CORPUS_COLORS.slate[200]};
+  border-radius: ${CORPUS_RADII.md};
+  background: ${CORPUS_COLORS.white};
+  font-family: ${CORPUS_FONTS.sans};
+  color: ${CORPUS_COLORS.slate[800]};
+  font-size: 0.9375rem;
+  transition: all ${CORPUS_TRANSITIONS.fast};
 
   &:focus {
     outline: none;
-    border-color: ${({ theme }) => color.B5};
+    border-color: ${CORPUS_COLORS.teal[500]};
+    box-shadow: 0 0 0 3px ${CORPUS_COLORS.teal[50]};
   }
 
   &::placeholder {
-    color: ${({ theme }) => color.N6};
+    color: ${CORPUS_COLORS.slate[400]};
   }
 `;
 
 const TextArea = styled.textarea`
   width: 100%;
-  min-height: 80px;
-  padding: 10px 12px;
-  border: 1px solid ${({ theme }) => color.N4};
-  border-radius: 6px;
-  background: ${({ theme }) => color.N1};
-  color: ${({ theme }) => color.N10};
-  font-size: 14px;
-  font-family: inherit;
+  min-height: 5rem;
+  padding: 0.625rem 0.875rem;
+  border: 1px solid ${CORPUS_COLORS.slate[200]};
+  border-radius: ${CORPUS_RADII.md};
+  background: ${CORPUS_COLORS.white};
+  font-family: ${CORPUS_FONTS.sans};
+  color: ${CORPUS_COLORS.slate[800]};
+  font-size: 0.9375rem;
   resize: vertical;
-  transition: border-color 0.15s ease;
+  transition: all ${CORPUS_TRANSITIONS.fast};
 
   &:focus {
     outline: none;
-    border-color: ${({ theme }) => color.B5};
+    border-color: ${CORPUS_COLORS.teal[500]};
+    box-shadow: 0 0 0 3px ${CORPUS_COLORS.teal[50]};
   }
 
   &::placeholder {
-    color: ${({ theme }) => color.N6};
+    color: ${CORPUS_COLORS.slate[400]};
   }
 `;
 
 const HelpText = styled.p`
-  margin: 4px 0 0 0;
-  font-size: 12px;
-  color: ${({ theme }) => color.N6};
+  margin: 0.375rem 0 0 0;
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: 0.75rem;
+  color: ${CORPUS_COLORS.slate[500]};
 `;
 
 const ErrorMessage = styled.div`
-  padding: 12px;
-  margin-bottom: 16px;
-  background: ${({ theme }) => color.R7}15;
-  border: 1px solid ${({ theme }) => color.R7}40;
-  border-radius: 6px;
-  color: ${({ theme }) => color.R7};
-  font-size: 13px;
+  padding: 0.75rem 1rem;
+  margin-bottom: 1rem;
+  background: #fee2e2;
+  border: 1px solid #fca5a5;
+  border-radius: ${CORPUS_RADII.md};
+  font-family: ${CORPUS_FONTS.sans};
+  color: #dc2626;
+  font-size: 0.8125rem;
 `;
 
 export interface CreateThreadFormProps {

--- a/frontend/src/components/threads/DiscussionTypeBadge.tsx
+++ b/frontend/src/components/threads/DiscussionTypeBadge.tsx
@@ -1,7 +1,12 @@
 import React from "react";
 import styled from "styled-components";
 import { HelpCircle, Lightbulb, AlertCircle, CheckCircle } from "lucide-react";
-import { color } from "../../theme/colors";
+import {
+  CORPUS_COLORS,
+  CORPUS_FONTS,
+  CORPUS_RADII,
+  CORPUS_TRANSITIONS,
+} from "./styles/discussionStyles";
 
 /**
  * Discussion category types that can be inferred from thread content
@@ -17,52 +22,54 @@ interface DiscussionTypeBadgeProps {
 const BadgeContainer = styled.span<{ $category: DiscussionCategory }>`
   display: inline-flex;
   align-items: center;
-  gap: 4px;
-  padding: 4px 10px;
-  border-radius: 16px;
-  font-size: 11px;
+  gap: 0.25rem;
+  padding: 0.25rem 0.625rem;
+  border-radius: ${CORPUS_RADII.full};
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: 0.6875rem;
   font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.02em;
+  letter-spacing: 0.05em;
+  transition: all ${CORPUS_TRANSITIONS.fast};
 
   ${(props) => {
     switch (props.$category) {
       case "question":
         return `
-          background: ${color.T2};
-          color: ${color.T9};
-          border: 1px solid ${color.T4};
+          background: ${CORPUS_COLORS.teal[50]};
+          color: ${CORPUS_COLORS.teal[700]};
+          border: 1px solid ${CORPUS_COLORS.teal[200]};
         `;
       case "idea":
         return `
-          background: ${color.G2};
-          color: ${color.G9};
-          border: 1px solid ${color.G4};
+          background: #fef3c7;
+          color: #92400e;
+          border: 1px solid #fcd34d;
         `;
       case "help":
         return `
-          background: ${color.R2};
-          color: ${color.R8};
-          border: 1px solid ${color.R4};
+          background: #fee2e2;
+          color: #991b1b;
+          border: 1px solid #fca5a5;
         `;
       case "answered":
         return `
-          background: ${color.G2};
-          color: ${color.G8};
-          border: 1px solid ${color.G5};
+          background: #dcfce7;
+          color: #166534;
+          border: 1px solid #86efac;
         `;
       default:
         return `
-          background: ${color.N3};
-          color: ${color.N8};
-          border: 1px solid ${color.N5};
+          background: ${CORPUS_COLORS.slate[100]};
+          color: ${CORPUS_COLORS.slate[600]};
+          border: 1px solid ${CORPUS_COLORS.slate[300]};
         `;
     }
   }}
 
   svg {
-    width: 12px;
-    height: 12px;
+    width: 0.75rem;
+    height: 0.75rem;
     flex-shrink: 0;
   }
 `;

--- a/frontend/src/components/threads/EditMessageModal.tsx
+++ b/frontend/src/components/threads/EditMessageModal.tsx
@@ -19,7 +19,14 @@ import { Modal, Button } from "semantic-ui-react";
 import styled from "styled-components";
 import { useMutation } from "@apollo/client";
 import { X, Save, AlertCircle } from "lucide-react";
-import { color } from "../../theme/colors";
+import {
+  CORPUS_COLORS,
+  CORPUS_FONTS,
+  CORPUS_RADII,
+  CORPUS_SHADOWS,
+  CORPUS_TRANSITIONS,
+  mediaQuery,
+} from "./styles/discussionStyles";
 import { spacing } from "../../theme/spacing";
 import { MessageComposer } from "./MessageComposer";
 import {
@@ -54,12 +61,12 @@ const StyledModal = styled(Modal)`
     /* Desktop/tablet styles */
     width: 90vw;
     max-width: 700px;
-    border-radius: 16px;
+    border-radius: ${CORPUS_RADII.xl};
     overflow: hidden;
-    box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
+    box-shadow: ${CORPUS_SHADOWS.xl};
 
     /* Mobile: Full screen modal for better touch interaction */
-    @media (max-width: 600px) {
+    ${mediaQuery.mobile} {
       width: 100vw !important;
       max-width: 100vw !important;
       height: 100vh !important;
@@ -76,7 +83,7 @@ const StyledModal = styled(Modal)`
     & > .content {
       padding: 0;
 
-      @media (max-width: 600px) {
+      ${mediaQuery.mobile} {
         height: 100%;
         display: flex;
         flex-direction: column;
@@ -89,68 +96,69 @@ const ModalHeader = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: ${spacing.md} ${spacing.lg};
-  background: ${color.N2};
-  border-bottom: 1px solid ${color.N4};
+  padding: 1rem 1.5rem;
+  background: ${CORPUS_COLORS.slate[50]};
+  border-bottom: 1px solid ${CORPUS_COLORS.slate[200]};
 
-  @media (max-width: 600px) {
-    padding: ${spacing.md};
+  ${mediaQuery.mobile} {
+    padding: 1rem;
     /* Safe area for notched devices */
-    padding-top: max(${spacing.md}, env(safe-area-inset-top));
+    padding-top: max(1rem, env(safe-area-inset-top));
   }
 `;
 
 const ModalTitle = styled.h2`
   margin: 0;
-  font-size: 18px;
+  font-family: ${CORPUS_FONTS.serif};
+  font-size: 1.25rem;
   font-weight: 600;
-  color: ${color.N10};
+  color: ${CORPUS_COLORS.slate[800]};
   display: flex;
   align-items: center;
-  gap: ${spacing.sm};
+  gap: 0.5rem;
 
-  @media (max-width: 600px) {
-    font-size: 16px;
+  ${mediaQuery.mobile} {
+    font-size: 1.125rem;
   }
 `;
 
 const CloseButton = styled.button`
   background: none;
   border: none;
-  color: ${color.N7};
+  color: ${CORPUS_COLORS.slate[500]};
   cursor: pointer;
-  padding: ${spacing.xs};
-  border-radius: 8px;
+  padding: 0.375rem;
+  border-radius: ${CORPUS_RADII.md};
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: all 0.2s;
+  transition: all ${CORPUS_TRANSITIONS.fast};
 
   /* Larger touch target on mobile */
-  @media (max-width: 600px) {
-    width: 44px;
-    height: 44px;
+  ${mediaQuery.mobile} {
+    width: 2.75rem;
+    height: 2.75rem;
   }
 
   &:hover {
-    background: ${color.N3};
-    color: ${color.N9};
+    background: ${CORPUS_COLORS.slate[100]};
+    color: ${CORPUS_COLORS.slate[700]};
   }
 
   &:active {
-    background: ${color.N4};
+    background: ${CORPUS_COLORS.slate[200]};
   }
 `;
 
 const ModalContent = styled.div`
-  padding: ${spacing.lg};
+  padding: 1.5rem;
   flex: 1;
   overflow-y: auto;
 
-  @media (max-width: 600px) {
-    padding: ${spacing.md};
+  ${mediaQuery.mobile} {
+    padding: 1rem;
     /* Account for virtual keyboard */
-    padding-bottom: max(${spacing.md}, env(safe-area-inset-bottom));
+    padding-bottom: max(1rem, env(safe-area-inset-bottom));
   }
 `;
 
@@ -158,18 +166,18 @@ const ModalFooter = styled.div`
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  gap: ${spacing.sm};
-  padding: ${spacing.md} ${spacing.lg};
-  background: ${color.N2};
-  border-top: 1px solid ${color.N4};
+  gap: 0.5rem;
+  padding: 1rem 1.5rem;
+  background: ${CORPUS_COLORS.slate[50]};
+  border-top: 1px solid ${CORPUS_COLORS.slate[200]};
 
-  @media (max-width: 600px) {
-    padding: ${spacing.md};
+  ${mediaQuery.mobile} {
+    padding: 1rem;
     /* Safe area for bottom */
-    padding-bottom: max(${spacing.md}, env(safe-area-inset-bottom));
+    padding-bottom: max(1rem, env(safe-area-inset-bottom));
     /* Full-width buttons on mobile */
     flex-direction: column-reverse;
-    gap: ${spacing.xs};
+    gap: 0.375rem;
   }
 `;
 
@@ -178,31 +186,32 @@ const ActionButton = styled(Button)<{ $variant?: "primary" | "secondary" }>`
     display: flex;
     align-items: center;
     justify-content: center;
-    gap: ${spacing.xs};
-    padding: 10px 20px;
-    border-radius: 8px;
+    gap: 0.375rem;
+    padding: 0.625rem 1.25rem;
+    border-radius: ${CORPUS_RADII.md};
+    font-family: ${CORPUS_FONTS.sans};
     font-weight: 600;
-    font-size: 14px;
-    transition: all 0.2s;
-    min-height: 44px;
+    font-size: 0.875rem;
+    transition: all ${CORPUS_TRANSITIONS.normal};
+    min-height: 2.75rem;
 
-    @media (max-width: 600px) {
+    ${mediaQuery.mobile} {
       width: 100%;
-      padding: 12px 20px;
+      padding: 0.75rem 1.25rem;
     }
 
     ${(props) =>
       props.$variant === "primary" &&
       `
-      background: linear-gradient(135deg, ${color.B6} 0%, ${color.B5} 100%);
+      background: linear-gradient(135deg, ${CORPUS_COLORS.teal[600]} 0%, ${CORPUS_COLORS.teal[700]} 100%);
       color: white;
       border: none;
-      box-shadow: 0 4px 12px rgba(74, 144, 226, 0.35);
+      box-shadow: 0 4px 12px rgba(15, 118, 110, 0.35);
 
       &:hover:not(:disabled) {
-        background: linear-gradient(135deg, #5a7ee2 0%, ${color.B6} 100%);
+        background: linear-gradient(135deg, ${CORPUS_COLORS.teal[500]} 0%, ${CORPUS_COLORS.teal[600]} 100%);
         transform: translateY(-1px);
-        box-shadow: 0 6px 16px rgba(74, 144, 226, 0.45);
+        box-shadow: 0 6px 16px rgba(15, 118, 110, 0.45);
       }
 
       &:active:not(:disabled) {
@@ -219,13 +228,13 @@ const ActionButton = styled(Button)<{ $variant?: "primary" | "secondary" }>`
     ${(props) =>
       props.$variant === "secondary" &&
       `
-      background: ${color.N1};
-      color: ${color.N8};
-      border: 1px solid ${color.N4};
+      background: ${CORPUS_COLORS.white};
+      color: ${CORPUS_COLORS.slate[700]};
+      border: 1px solid ${CORPUS_COLORS.slate[200]};
 
       &:hover:not(:disabled) {
-        background: ${color.N2};
-        border-color: ${color.N5};
+        background: ${CORPUS_COLORS.slate[50]};
+        border-color: ${CORPUS_COLORS.slate[300]};
       }
     `}
   }
@@ -234,14 +243,15 @@ const ActionButton = styled(Button)<{ $variant?: "primary" | "secondary" }>`
 const ErrorMessage = styled.div`
   display: flex;
   align-items: center;
-  gap: ${spacing.xs};
-  padding: ${spacing.sm} ${spacing.md};
-  background: ${color.R1};
-  color: ${color.R7};
-  border: 1px solid ${color.R3};
-  border-radius: 8px;
-  font-size: 13px;
-  margin-bottom: ${spacing.md};
+  gap: 0.375rem;
+  padding: 0.625rem 0.875rem;
+  background: #fee2e2;
+  color: #dc2626;
+  border: 1px solid #fca5a5;
+  border-radius: ${CORPUS_RADII.md};
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: 0.8125rem;
+  margin-bottom: 1rem;
 
   svg {
     flex-shrink: 0;
@@ -258,84 +268,87 @@ const UnsavedWarningOverlay = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: ${spacing.md};
+  padding: 1rem;
   z-index: 1000;
 `;
 
 const UnsavedWarningBox = styled.div`
-  background: white;
-  border-radius: 12px;
-  padding: ${spacing.lg};
-  max-width: 400px;
+  background: ${CORPUS_COLORS.white};
+  border-radius: ${CORPUS_RADII.lg};
+  padding: 1.5rem;
+  max-width: 25rem;
   width: 100%;
-  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
+  box-shadow: ${CORPUS_SHADOWS.xl};
 
-  @media (max-width: 600px) {
+  ${mediaQuery.mobile} {
     max-width: 90vw;
   }
 `;
 
 const UnsavedWarningTitle = styled.h3`
-  margin: 0 0 ${spacing.sm} 0;
-  font-size: 18px;
+  margin: 0 0 0.5rem 0;
+  font-family: ${CORPUS_FONTS.serif};
+  font-size: 1.125rem;
   font-weight: 600;
-  color: ${color.N10};
+  color: ${CORPUS_COLORS.slate[800]};
   display: flex;
   align-items: center;
-  gap: ${spacing.xs};
+  gap: 0.375rem;
 `;
 
 const UnsavedWarningText = styled.p`
-  margin: 0 0 ${spacing.md} 0;
-  color: ${color.N8};
-  font-size: 14px;
+  margin: 0 0 1rem 0;
+  font-family: ${CORPUS_FONTS.sans};
+  color: ${CORPUS_COLORS.slate[600]};
+  font-size: 0.875rem;
   line-height: 1.5;
 `;
 
 const UnsavedWarningButtons = styled.div`
   display: flex;
-  gap: ${spacing.sm};
+  gap: 0.5rem;
   justify-content: flex-end;
 
-  @media (max-width: 600px) {
+  ${mediaQuery.mobile} {
     flex-direction: column-reverse;
   }
 `;
 
 const UnsavedWarningButton = styled.button<{ $variant: "cancel" | "discard" }>`
-  padding: ${spacing.sm} ${spacing.md};
-  border-radius: 8px;
-  font-size: 14px;
+  padding: 0.5rem 1rem;
+  border-radius: ${CORPUS_RADII.md};
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: 0.875rem;
   font-weight: 600;
   cursor: pointer;
-  transition: all 0.15s;
+  transition: all ${CORPUS_TRANSITIONS.fast};
   border: none;
 
-  @media (max-width: 600px) {
-    padding: ${spacing.md};
+  ${mediaQuery.mobile} {
+    padding: 0.75rem;
     width: 100%;
   }
 
   ${(props) =>
     props.$variant === "cancel" &&
     `
-    background: ${color.N2};
-    border: 1px solid ${color.N4};
-    color: ${color.N8};
+    background: ${CORPUS_COLORS.white};
+    border: 1px solid ${CORPUS_COLORS.slate[200]};
+    color: ${CORPUS_COLORS.slate[700]};
 
     &:hover {
-      background: ${color.N3};
+      background: ${CORPUS_COLORS.slate[50]};
     }
   `}
 
   ${(props) =>
     props.$variant === "discard" &&
     `
-    background: ${color.R6};
+    background: #dc2626;
     color: white;
 
     &:hover {
-      background: ${color.R7};
+      background: #b91c1c;
     }
   `}
 `;

--- a/frontend/src/components/threads/MarkdownMessageRenderer.tsx
+++ b/frontend/src/components/threads/MarkdownMessageRenderer.tsx
@@ -4,10 +4,14 @@ import remarkGfm from "remark-gfm";
 import rehypeSanitize from "rehype-sanitize";
 import styled from "styled-components";
 import { useNavigate } from "react-router-dom";
-import { Database, FileText, Tag, User } from "lucide-react";
+import { Bot, Database, FileText, Tag, User } from "lucide-react";
 import { color } from "../../theme/colors";
 import { MentionedResourceType } from "../../types/graphql-api";
 import { sanitizeForTooltip } from "../../utils/textSanitization";
+import {
+  MENTION_TYPES,
+  MentionType,
+} from "../../assets/configurations/constants";
 
 const MarkdownContainer = styled.div`
   p {
@@ -51,19 +55,20 @@ const MarkdownContainer = styled.div`
   }
 `;
 
-const MentionLink = styled.a<{ $type: string }>`
+const MentionLink = styled.a<{ $type: string; $navigable?: boolean }>`
   display: inline-flex;
   align-items: center;
   gap: 4px;
   padding: 2px 8px 2px 6px;
   border-radius: 4px;
   font-weight: 500;
-  cursor: pointer;
+  cursor: ${({ $navigable = true }) => ($navigable ? "pointer" : "default")};
   transition: all 0.15s ease;
   text-decoration: none;
   vertical-align: middle;
   margin: 0 2px;
   font-size: 0.9em;
+  opacity: ${({ $navigable = true }) => ($navigable ? 1 : 0.85)};
 
   background: ${(props) => {
     if (props.$type === "user")
@@ -74,6 +79,8 @@ const MentionLink = styled.a<{ $type: string }>`
       return "linear-gradient(135deg, #f093fb15 0%, #f5576c15 100%)";
     if (props.$type === "annotation")
       return "linear-gradient(135deg, #43e97b15 0%, #38f9d715 100%)";
+    if (props.$type === "agent")
+      return "linear-gradient(135deg, #8b5cf615 0%, #6366f115 100%)";
     return "linear-gradient(135deg, #e0e0e015 0%, #c0c0c015 100%)";
   }};
 
@@ -83,6 +90,7 @@ const MentionLink = styled.a<{ $type: string }>`
       if (props.$type === "corpus") return color.P4;
       if (props.$type === "document") return "#f5576c40";
       if (props.$type === "annotation") return "#38f9d780";
+      if (props.$type === "agent") return "#8b5cf660";
       return color.N4;
     }};
 
@@ -91,32 +99,43 @@ const MentionLink = styled.a<{ $type: string }>`
     if (props.$type === "corpus") return color.P8;
     if (props.$type === "document") return "#c41e3a";
     if (props.$type === "annotation") return "#0d9488";
+    if (props.$type === "agent") return "#7c3aed";
     return color.N8;
   }};
 
   &:hover {
-    background: ${(props) => {
-      if (props.$type === "user")
-        return "linear-gradient(135deg, #06b6d425 0%, #10b98125 100%)";
-      if (props.$type === "corpus")
-        return "linear-gradient(135deg, #667eea25 0%, #764ba225 100%)";
-      if (props.$type === "document")
-        return "linear-gradient(135deg, #f093fb25 0%, #f5576c25 100%)";
-      if (props.$type === "annotation")
-        return "linear-gradient(135deg, #43e97b25 0%, #38f9d725 100%)";
-      return "linear-gradient(135deg, #e0e0e025 0%, #c0c0c025 100%)";
-    }};
-
-    border-color: ${(props) => {
-      if (props.$type === "user") return "#10b981";
-      if (props.$type === "corpus") return color.P6;
-      if (props.$type === "document") return "#f5576c80";
-      if (props.$type === "annotation") return "#38f9d7";
-      return color.N6;
-    }};
-
-    transform: translateY(-1px);
-    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+    ${(props) =>
+      props.$navigable !== false &&
+      `
+      background: ${
+        props.$type === "user"
+          ? "linear-gradient(135deg, #06b6d425 0%, #10b98125 100%)"
+          : props.$type === "corpus"
+          ? "linear-gradient(135deg, #667eea25 0%, #764ba225 100%)"
+          : props.$type === "document"
+          ? "linear-gradient(135deg, #f093fb25 0%, #f5576c25 100%)"
+          : props.$type === "annotation"
+          ? "linear-gradient(135deg, #43e97b25 0%, #38f9d725 100%)"
+          : props.$type === "agent"
+          ? "linear-gradient(135deg, #8b5cf625 0%, #6366f125 100%)"
+          : "linear-gradient(135deg, #e0e0e025 0%, #c0c0c025 100%)"
+      };
+      border-color: ${
+        props.$type === "user"
+          ? "#10b981"
+          : props.$type === "corpus"
+          ? color.P6
+          : props.$type === "document"
+          ? "#f5576c80"
+          : props.$type === "annotation"
+          ? "#38f9d7"
+          : props.$type === "agent"
+          ? "#8b5cf6"
+          : color.N6
+      };
+      transform: translateY(-1px);
+      box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+    `}
   }
 
   &:active {
@@ -178,6 +197,13 @@ export function MarkdownMessageRenderer({
     // User: /users/{slug}
     if (href.startsWith("/users/")) return "user";
 
+    // Global Agent: /agents/{slug}
+    if (href.startsWith("/agents/")) return "agent";
+
+    // Corpus-scoped Agent: /c/{creator}/{corpus}/agents/{agent-slug}
+    // Must check before corpus since it also starts with /c/
+    if (href.startsWith("/c/") && href.includes("/agents/")) return "agent";
+
     // Corpus: /c/{creator}/{slug}
     if (href.startsWith("/c/")) return "corpus";
 
@@ -206,6 +232,8 @@ export function MarkdownMessageRenderer({
         return <FileText size={14} />;
       case "annotation":
         return <Tag size={14} />;
+      case "agent":
+        return <Bot size={14} />;
       default:
         return null;
     }
@@ -246,16 +274,27 @@ export function MarkdownMessageRenderer({
       return parts.join("\n");
     }
 
+    // Check if this mention type is navigable
+    const mentionConfig = MENTION_TYPES[type as MentionType];
+    const isNavigable = mentionConfig?.navigable ?? true;
+    const suffix = isNavigable ? "" : "\n(Detail page coming soon)";
+
     // Fallback to simple tooltips for other types (sanitize all user content)
     switch (type) {
       case "user":
-        return `User: ${sanitizeForTooltip(text)}`;
+        return `User: ${sanitizeForTooltip(text)}${suffix}`;
       case "corpus":
-        return `Corpus: ${sanitizeForTooltip(resource?.title || text)}`;
+        return `Corpus: ${sanitizeForTooltip(
+          resource?.title || text
+        )}${suffix}`;
       case "document":
-        return `Document: ${sanitizeForTooltip(resource?.title || text)}`;
+        return `Document: ${sanitizeForTooltip(
+          resource?.title || text
+        )}${suffix}`;
       case "annotation":
-        return `Annotation: ${sanitizeForTooltip(text)}`;
+        return `Annotation: ${sanitizeForTooltip(text)}${suffix}`;
+      case "agent":
+        return `AI Agent: ${sanitizeForTooltip(text)}${suffix}`;
       default:
         return sanitizeForTooltip(text);
     }
@@ -283,15 +322,20 @@ export function MarkdownMessageRenderer({
               // Look up rich metadata from mentionedResources (Issue #689)
               const resource = href ? resourceByUrl.get(href) : undefined;
 
+              // Check if this mention type has an active route
+              const mentionConfig = MENTION_TYPES[mentionType as MentionType];
+              const isNavigable = mentionConfig?.navigable ?? true;
+
               // This is a mention link - style it specially with icon (Issue #689)
               return (
                 <MentionLink
-                  href={href}
+                  href={isNavigable ? href : undefined}
                   $type={mentionType}
+                  $navigable={isNavigable}
                   title={getMentionTooltip(mentionType, textContent, resource)}
                   onClick={(e) => {
                     e.preventDefault();
-                    if (href) {
+                    if (isNavigable && href) {
                       navigate(href);
                     }
                   }}

--- a/frontend/src/components/threads/MessageComposer.tsx
+++ b/frontend/src/components/threads/MessageComposer.tsx
@@ -9,7 +9,14 @@ import { ReactRenderer } from "@tiptap/react";
 import { computePosition, flip, shift, offset } from "@floating-ui/dom";
 import styled from "styled-components";
 import { Send, Bold, Italic, List, ListOrdered } from "lucide-react";
-import { color } from "../../theme/colors";
+import {
+  CORPUS_COLORS,
+  CORPUS_FONTS,
+  CORPUS_RADII,
+  CORPUS_SHADOWS,
+  CORPUS_TRANSITIONS,
+  mediaQuery,
+} from "./styles/discussionStyles";
 import { MENTION_PREVIEW_LENGTH } from "../../assets/configurations/constants";
 import {
   UnifiedMentionPicker,
@@ -25,32 +32,31 @@ import type { MarkdownStorage } from "tiptap-markdown";
 const ComposerContainer = styled.div`
   display: flex;
   flex-direction: column;
-  border: 2px solid rgba(0, 0, 0, 0.08);
-  border-radius: 16px;
-  background: white;
+  border: 2px solid ${CORPUS_COLORS.slate[200]};
+  border-radius: ${CORPUS_RADII.xl};
+  background: ${CORPUS_COLORS.white};
   overflow: hidden;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.06), 0 2px 4px rgba(0, 0, 0, 0.04);
-  transition: all 0.2s ease;
+  box-shadow: ${CORPUS_SHADOWS.sm};
+  transition: all ${CORPUS_TRANSITIONS.normal};
 
   &:focus-within {
-    border-color: ${color.B5};
-    box-shadow: 0 6px 24px rgba(74, 144, 226, 0.15),
-      0 2px 8px rgba(74, 144, 226, 0.1);
+    border-color: ${CORPUS_COLORS.teal[500]};
+    box-shadow: 0 0 0 3px ${CORPUS_COLORS.teal[50]}, ${CORPUS_SHADOWS.md};
   }
 `;
 
 const Toolbar = styled.div`
   display: flex;
   align-items: center;
-  gap: 4px;
-  padding: 8px;
-  border-bottom: 1px solid ${({ theme }) => color.N4};
-  background: ${({ theme }) => color.N2};
+  gap: 0.25rem;
+  padding: 0.5rem;
+  border-bottom: 1px solid ${CORPUS_COLORS.slate[200]};
+  background: ${CORPUS_COLORS.slate[50]};
 
-  /* Mobile: Larger touch targets - Part of Issue #686 */
-  @media (max-width: 600px) {
-    padding: 8px 12px;
-    gap: 8px;
+  /* Mobile: Larger touch targets */
+  ${mediaQuery.mobile} {
+    padding: 0.5rem 0.75rem;
+    gap: 0.5rem;
   }
 `;
 
@@ -58,18 +64,20 @@ const ToolbarButton = styled.button<{ $isActive?: boolean }>`
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 32px;
-  height: 32px;
+  width: 2rem;
+  height: 2rem;
   border: none;
-  border-radius: 4px;
-  background: ${({ $isActive, theme }) =>
-    $isActive ? color.N3 : "transparent"};
-  color: ${({ theme }) => color.N10};
+  border-radius: ${CORPUS_RADII.sm};
+  background: ${({ $isActive }) =>
+    $isActive ? CORPUS_COLORS.teal[100] : "transparent"};
+  color: ${({ $isActive }) =>
+    $isActive ? CORPUS_COLORS.teal[700] : CORPUS_COLORS.slate[600]};
   cursor: pointer;
-  transition: background 0.15s ease;
+  transition: all ${CORPUS_TRANSITIONS.fast};
 
   &:hover:not(:disabled) {
-    background: ${({ theme }) => color.N3};
+    background: ${CORPUS_COLORS.teal[50]};
+    color: ${CORPUS_COLORS.teal[700]};
   }
 
   &:disabled {
@@ -78,44 +86,48 @@ const ToolbarButton = styled.button<{ $isActive?: boolean }>`
   }
 
   svg {
-    width: 16px;
-    height: 16px;
+    width: 1rem;
+    height: 1rem;
   }
 
-  /* Mobile: Larger touch targets - Part of Issue #686 */
-  @media (max-width: 600px) {
-    width: 40px;
-    height: 40px;
-    border-radius: 8px;
+  /* Mobile: Larger touch targets */
+  ${mediaQuery.mobile} {
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: ${CORPUS_RADII.md};
 
     svg {
-      width: 18px;
-      height: 18px;
+      width: 1.125rem;
+      height: 1.125rem;
     }
   }
 `;
 
 const EditorContainer = styled.div`
   flex: 1;
-  padding: 12px;
-  min-height: 120px;
-  max-height: 400px;
+  padding: 0.875rem;
+  min-height: 7.5rem;
+  max-height: 25rem;
   overflow-y: auto;
 
   .ProseMirror {
     outline: none;
-    min-height: 96px;
+    min-height: 6rem;
+    font-family: ${CORPUS_FONTS.sans};
+    font-size: 0.9375rem;
+    color: ${CORPUS_COLORS.slate[800]};
+    line-height: 1.6;
 
     p.is-editor-empty:first-child::before {
       content: attr(data-placeholder);
       float: left;
-      color: ${({ theme }) => color.N6};
+      color: ${CORPUS_COLORS.slate[400]};
       pointer-events: none;
       height: 0;
     }
 
     p {
-      margin: 0 0 8px 0;
+      margin: 0 0 0.5rem 0;
 
       &:last-child {
         margin-bottom: 0;
@@ -124,8 +136,8 @@ const EditorContainer = styled.div`
 
     ul,
     ol {
-      padding-left: 24px;
-      margin: 8px 0;
+      padding-left: 1.5rem;
+      margin: 0.5rem 0;
     }
 
     strong {
@@ -138,36 +150,44 @@ const EditorContainer = styled.div`
 
     /* Mention styling */
     .mention {
-      padding: 2px 6px;
-      border-radius: 4px;
+      padding: 0.125rem 0.375rem;
+      border-radius: ${CORPUS_RADII.sm};
       font-weight: 500;
-      font-size: 0.95em;
+      font-size: 0.9em;
     }
 
     .mention-user {
-      background-color: ${({ theme }) => color.B2};
-      color: ${({ theme }) => color.B8};
+      background-color: ${CORPUS_COLORS.teal[50]};
+      color: ${CORPUS_COLORS.teal[700]};
     }
 
     .mention-resource {
-      background: linear-gradient(135deg, #667eea20 0%, #764ba220 100%);
-      color: ${({ theme }) => color.P8};
-      border: 1px solid ${({ theme }) => color.P4};
+      background: linear-gradient(
+        135deg,
+        ${CORPUS_COLORS.teal[50]} 0%,
+        #f0fdfa 100%
+      );
+      color: ${CORPUS_COLORS.teal[700]};
+      border: 1px solid ${CORPUS_COLORS.teal[200]};
     }
 
     /* Agent mention link styling */
     a[href^="/agents/"],
     a[href*="/agents/"] {
-      background: linear-gradient(135deg, #3b82f620 0%, #8b5cf620 100%);
-      color: #6366f1;
-      padding: 2px 6px;
-      border-radius: 4px;
+      background: linear-gradient(
+        135deg,
+        ${CORPUS_COLORS.teal[50]} 0%,
+        #f0fdfa 100%
+      );
+      color: ${CORPUS_COLORS.teal[700]};
+      padding: 0.125rem 0.375rem;
+      border-radius: ${CORPUS_RADII.sm};
       font-weight: 500;
       text-decoration: none;
-      border: 1px solid #8b5cf640;
+      border: 1px solid ${CORPUS_COLORS.teal[200]};
 
       &:hover {
-        background: linear-gradient(135deg, #3b82f630 0%, #8b5cf630 100%);
+        background: ${CORPUS_COLORS.teal[100]};
       }
     }
   }
@@ -177,62 +197,73 @@ const Footer = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 8px 12px;
-  border-top: 1px solid ${({ theme }) => color.N4};
-  background: ${({ theme }) => color.N2};
+  padding: 0.5rem 0.875rem;
+  border-top: 1px solid ${CORPUS_COLORS.slate[200]};
+  background: ${CORPUS_COLORS.slate[50]};
 `;
 
 const CharacterCount = styled.span`
-  font-size: 12px;
-  color: ${({ theme }) => color.N6};
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: 0.75rem;
+  color: ${CORPUS_COLORS.slate[400]};
 `;
 
 const SendButton = styled.button`
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 10px 20px;
+  gap: 0.5rem;
+  padding: 0.625rem 1.25rem;
   border: none;
-  border-radius: 10px;
-  background: linear-gradient(135deg, ${color.B6} 0%, ${color.B5} 100%);
-  color: white;
-  font-size: 15px;
-  font-weight: 700;
+  border-radius: ${CORPUS_RADII.lg};
+  background: linear-gradient(
+    135deg,
+    ${CORPUS_COLORS.teal[600]} 0%,
+    ${CORPUS_COLORS.teal[700]} 100%
+  );
+  color: ${CORPUS_COLORS.white};
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: 0.9375rem;
+  font-weight: 600;
   cursor: pointer;
-  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
-  box-shadow: 0 4px 12px rgba(74, 144, 226, 0.35);
+  transition: all ${CORPUS_TRANSITIONS.normal};
+  box-shadow: 0 4px 12px rgba(15, 118, 110, 0.35);
   letter-spacing: -0.01em;
 
   &:hover:not(:disabled) {
     transform: translateY(-2px);
-    box-shadow: 0 6px 20px rgba(74, 144, 226, 0.45);
-    background: linear-gradient(135deg, #5a7ee2 0%, #4a90e2 100%);
+    box-shadow: 0 6px 20px rgba(15, 118, 110, 0.45);
+    background: linear-gradient(
+      135deg,
+      ${CORPUS_COLORS.teal[500]} 0%,
+      ${CORPUS_COLORS.teal[600]} 100%
+    );
   }
 
   &:active:not(:disabled) {
     transform: translateY(0);
-    box-shadow: 0 2px 8px rgba(74, 144, 226, 0.3);
+    box-shadow: 0 2px 8px rgba(15, 118, 110, 0.3);
   }
 
   &:disabled {
     opacity: 0.4;
     cursor: not-allowed;
     transform: none;
-    box-shadow: 0 2px 6px rgba(74, 144, 226, 0.2);
+    box-shadow: 0 2px 6px rgba(15, 118, 110, 0.2);
   }
 
   svg {
-    width: 18px;
-    height: 18px;
+    width: 1.125rem;
+    height: 1.125rem;
   }
 `;
 
 const ErrorMessage = styled.div`
-  padding: 8px 12px;
-  background: ${({ theme }) => color.R7}15;
-  color: ${({ theme }) => color.R7};
-  font-size: 13px;
-  border-top: 1px solid ${({ theme }) => color.R7}40;
+  padding: 0.5rem 0.75rem;
+  background: #fee2e2;
+  color: #dc2626;
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: 0.8125rem;
+  border-top: 1px solid #fca5a5;
 `;
 
 export interface MessageComposerProps {
@@ -434,12 +465,15 @@ export function MessageComposer({
                         const agentLabel =
                           agent.mentionFormat || `@agent:${agent.slug}`;
                         // Agent URL - global agents at /agents/{slug}, corpus agents at corpus path
+                        // URL-encode the corpus title to handle spaces and special characters
                         const agentHref =
                           agent.scope === "GLOBAL"
-                            ? `/agents/${agent.slug}`
+                            ? `/agents/${encodeURIComponent(agent.slug)}`
                             : agent.corpus
-                            ? `/c/${agent.corpus.id}/${agent.corpus.title}/agents/${agent.slug}`
-                            : `/agents/${agent.slug}`;
+                            ? `/c/${agent.corpus.id}/${encodeURIComponent(
+                                agent.corpus.title
+                              )}/agents/${encodeURIComponent(agent.slug)}`
+                            : `/agents/${encodeURIComponent(agent.slug)}`;
                         return {
                           label: agentLabel,
                           href: agentHref,

--- a/frontend/src/components/threads/MessageItem.tsx
+++ b/frontend/src/components/threads/MessageItem.tsx
@@ -19,7 +19,14 @@ import {
 } from "lucide-react";
 import { useSetAtom } from "jotai";
 import { useMutation } from "@apollo/client";
-import { color } from "../../theme/colors";
+import {
+  CORPUS_COLORS,
+  CORPUS_FONTS,
+  CORPUS_RADII,
+  CORPUS_SHADOWS,
+  CORPUS_TRANSITIONS,
+  mediaQuery,
+} from "./styles/discussionStyles";
 import { spacing } from "../../theme/spacing";
 import { MessageNode } from "./utils";
 import { RelativeTime } from "./RelativeTime";
@@ -169,38 +176,37 @@ const MessageContainer = styled.div<
   } & AgentColorProps
 >`
   display: flex;
-  gap: 0.75rem;
-  padding: 1rem;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 1.25rem 1.5rem;
   background: ${(props) => {
-    if (props.$isDeleted) return color.N2;
-    if (props.$isHighlighted) return color.B1;
+    if (props.$isDeleted) return "#f8fafc";
+    if (props.$isHighlighted) return "#f0fdfa";
     if (props.$isAgent && props.$agentBgStart && props.$agentBgEnd) {
       return `linear-gradient(135deg, ${props.$agentBgStart} 0%, ${props.$agentBgEnd} 100%)`;
     }
-    return color.N1;
+    return "transparent";
   }};
-  border: 1px solid
-    ${(props) => {
-      if (props.$isHighlighted) return color.B5;
-      if (props.$isAgent) return props.$agentColor || "#4A90E2";
-      return color.N4;
-    }};
-  border-radius: 8px;
-  transition: all 0.15s;
+  border: none;
+  border-radius: 0;
+  transition: all 0.2s ease;
   position: relative;
 
-  /* Subtle left border for nested replies */
+  /* Subtle left accent for nested replies */
   ${(props) =>
     props.$depth > 0 &&
     `
-    border-left: 3px solid ${color.N4};
+    margin-left: ${Math.min(props.$depth * 1.5, 4)}rem;
+    padding-left: 1rem;
+    border-left: 2px solid #e2e8f0;
   `}
 
   /* Accent strip for highlighted messages */
   ${(props) =>
     props.$isHighlighted &&
     `
-    border-left: 3px solid ${color.B6};
+    background: #f0fdfa;
+    border-left: 3px solid #14b8a6;
   `}
 
   /* Accent strip for agent messages */
@@ -208,34 +214,38 @@ const MessageContainer = styled.div<
     props.$isAgent &&
     !props.$isHighlighted &&
     `
-    border-left: 3px solid ${props.$agentColor || "#4A90E2"};
+    border-left: 3px solid ${props.$agentColor || "#0f766e"};
+    background: ${props.$agentBgStart || "transparent"};
   `}
 
+  /* Show actions on hover */
   &:hover {
-    border-color: ${(props) => {
-      if (props.$isHighlighted) return color.B6;
-      if (props.$isAgent) return props.$agentColor || "#4A90E2";
-      return color.N5;
+    background: ${(props) => {
+      if (props.$isHighlighted) return "#f0fdfa";
+      if (props.$isAgent) return props.$agentBgStart || "#fafafa";
+      return "#fafafa";
     }};
+  }
+
+  /* Reveal footer actions on hover */
+  &:hover .message-footer-actions {
+    opacity: 1;
   }
 
   ${(props) =>
     props.$isDeleted &&
     `
-    opacity: 0.7;
+    opacity: 0.6;
   `}
 
-  @media (max-width: 480px) {
-    padding: 0.75rem;
-    gap: 0.5rem;
-  }
-`;
+  ${mediaQuery.mobile} {
+    padding: 1rem;
 
-const VoteColumn = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  flex-shrink: 0;
+    /* Always show actions on mobile (no hover) */
+    .message-footer-actions {
+      opacity: 1;
+    }
+  }
 `;
 
 const ContentColumn = styled.div`
@@ -262,33 +272,33 @@ const MessageHeaderLeft = styled.div`
 `;
 
 const UserAvatar = styled.div<{ $isAgent?: boolean } & AgentColorProps>`
-  width: 28px;
-  height: 28px;
+  width: 1.5rem;
+  height: 1.5rem;
   border-radius: 50%;
   background: ${(props) =>
     props.$isAgent
       ? `linear-gradient(135deg, ${props.$agentColor || "#4A90E2"} 0%, ${
           props.$agentColor || "#4A90E2"
         }dd 100%)`
-      : `linear-gradient(135deg, ${color.G6} 0%, ${color.G7} 100%)`};
+      : `linear-gradient(135deg, ${CORPUS_COLORS.teal[600]} 0%, ${CORPUS_COLORS.teal[700]} 100%)`};
   display: flex;
   align-items: center;
   justify-content: center;
-  color: white;
+  color: ${CORPUS_COLORS.white};
   flex-shrink: 0;
 
   svg {
-    width: 14px;
-    height: 14px;
+    width: 0.75rem;
+    height: 0.75rem;
   }
 
-  @media (max-width: 480px) {
-    width: 24px;
-    height: 24px;
+  ${mediaQuery.mobile} {
+    width: 1.25rem;
+    height: 1.25rem;
 
     svg {
-      width: 12px;
-      height: 12px;
+      width: 0.625rem;
+      height: 0.625rem;
     }
   }
 `;
@@ -297,20 +307,22 @@ const ReplyIndicator = styled.div`
   display: flex;
   align-items: center;
   gap: 0.25rem;
-  font-size: 11px;
-  color: ${color.N6};
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: 0.6875rem;
+  color: ${CORPUS_COLORS.slate[500]};
   padding: 0.25rem 0.5rem;
-  background: ${color.N2};
-  border-radius: 4px;
+  background: ${CORPUS_COLORS.slate[50]};
+  border-radius: ${CORPUS_RADII.sm};
   margin-bottom: 0.25rem;
 
   svg {
-    width: 12px;
-    height: 12px;
+    width: 0.75rem;
+    height: 0.75rem;
+    color: ${CORPUS_COLORS.teal[500]};
   }
 
   strong {
-    color: ${color.N8};
+    color: ${CORPUS_COLORS.teal[700]};
     font-weight: 600;
   }
 `;
@@ -324,14 +336,16 @@ const UserInfo = styled.div`
 `;
 
 const Username = styled.span`
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
   font-weight: 600;
-  color: ${color.N9};
-  font-size: 13px;
+  color: #1e293b;
+  font-size: 15px;
 `;
 
 const MessageTimestamp = styled.span`
-  font-size: 12px;
-  color: ${color.N6};
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: 0.75rem;
+  color: ${CORPUS_COLORS.slate[400]};
 `;
 
 const MessageActionsContainer = styled.div`
@@ -341,28 +355,28 @@ const MessageActionsContainer = styled.div`
 const MessageActionsButton = styled.button`
   background: none;
   border: none;
-  color: ${color.N6};
+  color: ${CORPUS_COLORS.slate[400]};
   cursor: pointer;
-  padding: 4px;
+  padding: 0.25rem;
   display: flex;
   align-items: center;
-  border-radius: 4px;
-  transition: all 0.15s;
+  border-radius: ${CORPUS_RADII.sm};
+  transition: all ${CORPUS_TRANSITIONS.fast};
 
   /* Larger touch target on mobile */
-  @media (max-width: 600px) {
-    width: 40px;
-    height: 40px;
+  ${mediaQuery.mobile} {
+    width: 2.5rem;
+    height: 2.5rem;
     justify-content: center;
   }
 
   &:hover {
-    background: ${color.N3};
-    color: ${color.N9};
+    background: ${CORPUS_COLORS.slate[100]};
+    color: ${CORPUS_COLORS.slate[700]};
   }
 
   &:active {
-    background: ${color.N4};
+    background: ${CORPUS_COLORS.slate[200]};
   }
 `;
 
@@ -370,28 +384,28 @@ const ActionsDropdown = styled.div<{ $isOpen: boolean }>`
   position: absolute;
   top: 100%;
   right: 0;
-  margin-top: 4px;
-  min-width: 160px;
-  background: ${color.N1};
-  border: 1px solid ${color.N4};
-  border-radius: 8px;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+  margin-top: 0.25rem;
+  min-width: 10rem;
+  background: ${CORPUS_COLORS.white};
+  border: 1px solid ${CORPUS_COLORS.slate[200]};
+  border-radius: ${CORPUS_RADII.md};
+  box-shadow: ${CORPUS_SHADOWS.lg};
   z-index: 100;
   opacity: ${(props) => (props.$isOpen ? 1 : 0)};
   visibility: ${(props) => (props.$isOpen ? "visible" : "hidden")};
   transform: ${(props) =>
     props.$isOpen ? "translateY(0)" : "translateY(-8px)"};
-  transition: all 0.15s ease;
+  transition: all ${CORPUS_TRANSITIONS.fast};
 
   /* Mobile: Bottom sheet style */
-  @media (max-width: 600px) {
+  ${mediaQuery.mobile} {
     position: fixed;
     top: auto;
     left: 0;
     right: 0;
     bottom: 0;
     margin: 0;
-    border-radius: 16px 16px 0 0;
+    border-radius: ${CORPUS_RADII.xl} ${CORPUS_RADII.xl} 0 0;
     min-width: unset;
     transform: ${(props) =>
       props.$isOpen ? "translateY(0)" : "translateY(100%)"};
@@ -404,7 +418,7 @@ const DropdownBackdrop = styled.div<{ $isOpen: boolean }>`
   display: none;
 
   /* Mobile: Show backdrop for bottom sheet */
-  @media (max-width: 600px) {
+  ${mediaQuery.mobile} {
     display: ${(props) => (props.$isOpen ? "block" : "none")};
     position: fixed;
     top: 0;
@@ -419,44 +433,43 @@ const DropdownBackdrop = styled.div<{ $isOpen: boolean }>`
 const DropdownItem = styled.button<{ $variant?: "danger" }>`
   display: flex;
   align-items: center;
-  gap: ${spacing.sm};
+  gap: 0.5rem;
   width: 100%;
-  padding: ${spacing.sm} ${spacing.md};
+  padding: 0.5rem 0.75rem;
   border: none;
   background: transparent;
-  color: ${(props) => (props.$variant === "danger" ? color.R7 : color.N9)};
-  font-size: 14px;
+  font-family: ${CORPUS_FONTS.sans};
+  color: ${(props) =>
+    props.$variant === "danger" ? "#dc2626" : CORPUS_COLORS.slate[700]};
+  font-size: 0.875rem;
   text-align: left;
   cursor: pointer;
-  transition: background 0.15s;
+  transition: background ${CORPUS_TRANSITIONS.fast};
 
   /* Larger touch targets on mobile */
-  @media (max-width: 600px) {
-    padding: ${spacing.md};
-    min-height: 52px;
-    font-size: 16px;
+  ${mediaQuery.mobile} {
+    padding: 0.875rem 1rem;
+    min-height: 3.25rem;
+    font-size: 1rem;
   }
 
   &:first-child {
-    border-radius: 8px 8px 0 0;
+    border-radius: ${CORPUS_RADII.md} ${CORPUS_RADII.md} 0 0;
   }
 
   &:last-child {
-    border-radius: 0 0 8px 8px;
+    border-radius: 0 0 ${CORPUS_RADII.md} ${CORPUS_RADII.md};
   }
 
   &:only-child {
-    border-radius: 8px;
+    border-radius: ${CORPUS_RADII.md};
   }
 
   &:hover {
     background: ${(props) =>
-      props.$variant === "danger" ? color.R1 : color.N2};
-  }
-
-  &:active {
-    background: ${(props) =>
-      props.$variant === "danger" ? color.R2 : color.N3};
+      props.$variant === "danger" ? "#fee2e2" : CORPUS_COLORS.teal[50]};
+    color: ${(props) =>
+      props.$variant === "danger" ? "#dc2626" : CORPUS_COLORS.teal[700]};
   }
 
   svg {
@@ -466,61 +479,63 @@ const DropdownItem = styled.button<{ $variant?: "danger" }>`
 
 const DropdownDivider = styled.div`
   height: 1px;
-  background: ${color.N4};
-  margin: ${spacing.xs} 0;
+  background: ${CORPUS_COLORS.slate[200]};
+  margin: 0.25rem 0;
 `;
 
 const MobileDropdownHeader = styled.div`
   display: none;
 
-  @media (max-width: 600px) {
+  ${mediaQuery.mobile} {
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: ${spacing.md};
-    border-bottom: 1px solid ${color.N4};
+    padding: 0.75rem;
+    border-bottom: 1px solid ${CORPUS_COLORS.slate[200]};
 
     &::before {
       content: "";
-      width: 40px;
-      height: 4px;
-      background: ${color.N4};
-      border-radius: 2px;
+      width: 2.5rem;
+      height: 0.25rem;
+      background: ${CORPUS_COLORS.slate[300]};
+      border-radius: 0.125rem;
     }
   }
 `;
 
 const DeleteConfirmation = styled.div`
-  padding: ${spacing.md};
+  padding: 1rem;
   text-align: center;
 `;
 
 const DeleteConfirmText = styled.p`
-  margin: 0 0 ${spacing.md} 0;
-  color: ${color.N8};
-  font-size: 14px;
+  margin: 0 0 1rem 0;
+  font-family: ${CORPUS_FONTS.sans};
+  color: ${CORPUS_COLORS.slate[700]};
+  font-size: 0.875rem;
 `;
 
 const DeleteConfirmButtons = styled.div`
   display: flex;
-  gap: ${spacing.sm};
+  gap: 0.5rem;
   justify-content: center;
 
-  @media (max-width: 600px) {
+  ${mediaQuery.mobile} {
     flex-direction: column-reverse;
   }
 `;
 
 const ConfirmButton = styled.button<{ $variant: "cancel" | "delete" }>`
-  padding: ${spacing.sm} ${spacing.md};
-  border-radius: 8px;
-  font-size: 14px;
+  padding: 0.5rem 1rem;
+  border-radius: ${CORPUS_RADII.md};
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: 0.875rem;
   font-weight: 600;
   cursor: pointer;
-  transition: all 0.15s;
+  transition: all ${CORPUS_TRANSITIONS.fast};
 
-  @media (max-width: 600px) {
-    padding: ${spacing.md};
+  ${mediaQuery.mobile} {
+    padding: 0.75rem;
     width: 100%;
   }
 
@@ -532,43 +547,44 @@ const ConfirmButton = styled.button<{ $variant: "cancel" | "delete" }>`
   ${(props) =>
     props.$variant === "cancel" &&
     `
-    background: ${color.N2};
-    border: 1px solid ${color.N4};
-    color: ${color.N8};
+    background: ${CORPUS_COLORS.white};
+    border: 1px solid ${CORPUS_COLORS.slate[200]};
+    color: ${CORPUS_COLORS.slate[700]};
 
     &:hover:not(:disabled) {
-      background: ${color.N3};
+      background: ${CORPUS_COLORS.slate[50]};
     }
   `}
 
   ${(props) =>
     props.$variant === "delete" &&
     `
-    background: ${color.R6};
+    background: #dc2626;
     border: none;
     color: white;
 
     &:hover:not(:disabled) {
-      background: ${color.R7};
+      background: #b91c1c;
     }
   `}
 `;
 
 const MessageContent = styled.div<{ $isDeleted?: boolean }>`
-  color: ${color.N9};
-  line-height: 1.5;
-  font-size: 13px;
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
+  color: #334155;
+  line-height: 1.7;
+  font-size: 16px;
   word-wrap: break-word;
 
   ${(props) =>
     props.$isDeleted &&
     `
     font-style: italic;
-    color: ${color.N6};
+    color: #94a3b8;
   `}
 
   p {
-    margin: 0 0 0.5rem 0;
+    margin: 0 0 12px 0;
     line-height: inherit;
 
     &:last-child {
@@ -577,74 +593,91 @@ const MessageContent = styled.div<{ $isDeleted?: boolean }>`
   }
 
   code {
-    background: ${color.N2};
-    border: 1px solid ${color.N4};
-    padding: 1px 4px;
-    border-radius: 3px;
+    background: #f1f5f9;
+    border: 1px solid #e2e8f0;
+    padding: 2px 6px;
+    border-radius: 4px;
     font-size: 0.9em;
-    font-family: monospace;
-    color: ${color.R7};
+    font-family: "SF Mono", Monaco, monospace;
+    color: #0f766e;
   }
 
   pre {
-    background: ${color.N2};
-    border: 1px solid ${color.N4};
-    padding: 0.5rem;
-    border-radius: 4px;
+    background: #f8fafc;
+    border: 1px solid #e2e8f0;
+    padding: 16px;
+    border-radius: 8px;
     overflow-x: auto;
-    margin: 0.5rem 0;
+    margin: 12px 0;
   }
 
   blockquote {
-    border-left: 3px solid ${color.G5};
-    padding-left: 0.75rem;
-    margin: 0.5rem 0;
-    color: ${color.N7};
+    border-left: 3px solid #5eead4;
+    padding-left: 16px;
+    margin: 12px 0;
+    color: #475569;
   }
 `;
 
 const MessageFooter = styled.div`
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.25rem;
+  margin-top: 0.25rem;
+`;
+
+const FooterActions = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.125rem;
+  opacity: 0;
+  transition: opacity 0.15s ease;
 `;
 
 const FooterButton = styled.button`
   background: transparent;
-  border: 1px solid ${color.N4};
-  color: ${color.N7};
+  border: none;
+  color: #94a3b8;
   cursor: pointer;
-  font-size: 12px;
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
+  font-size: 0.8125rem;
   font-weight: 500;
-  padding: 0.25rem 0.5rem;
-  border-radius: 4px;
+  padding: 0.375rem 0.625rem;
+  border-radius: 6px;
   display: inline-flex;
   align-items: center;
-  gap: 0.25rem;
-  transition: all 0.15s;
+  gap: 0.375rem;
+  transition: all 0.15s ease;
 
   &:hover {
-    background: ${color.G1};
-    border-color: ${color.G5};
-    color: ${color.G7};
+    background: #f0fdfa;
+    color: #0f766e;
   }
 
   svg {
-    width: 12px;
-    height: 12px;
+    width: 0.875rem;
+    height: 0.875rem;
   }
 `;
 
+const FooterDivider = styled.span`
+  width: 1px;
+  height: 1rem;
+  background: #e2e8f0;
+  margin: 0 0.25rem;
+`;
+
 const ReplyCount = styled.span`
-  font-size: 11px;
-  color: ${color.N6};
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: 0.75rem;
+  color: ${CORPUS_COLORS.slate[400]};
   margin-left: auto;
 `;
 
 const SourcesContainer = styled.div`
-  margin-top: ${spacing.sm};
-  border-top: 1px solid ${color.N4};
-  padding-top: ${spacing.sm};
+  margin-top: 0.75rem;
+  border-top: 1px solid ${CORPUS_COLORS.slate[200]};
+  padding-top: 0.75rem;
 `;
 
 const SourcesHeader = styled.div`
@@ -652,7 +685,7 @@ const SourcesHeader = styled.div`
   align-items: center;
   justify-content: space-between;
   cursor: pointer;
-  padding: ${spacing.xs} 0;
+  padding: 0.25rem 0;
   user-select: none;
 
   &:hover {
@@ -663,32 +696,39 @@ const SourcesHeader = styled.div`
 const SourcesTitle = styled.div`
   display: flex;
   align-items: center;
-  gap: 6px;
-  font-size: 13px;
+  gap: 0.375rem;
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: 0.8125rem;
   font-weight: 500;
-  color: ${color.N7};
+  color: ${CORPUS_COLORS.slate[600]};
+
+  svg {
+    color: ${CORPUS_COLORS.teal[600]};
+  }
 `;
 
 const SourcesList = styled.div`
   display: flex;
   flex-direction: column;
-  gap: ${spacing.xs};
-  margin-top: ${spacing.xs};
+  gap: 0.375rem;
+  margin-top: 0.375rem;
 `;
 
 const SourceItem = styled.div`
-  padding: ${spacing.xs} ${spacing.sm};
-  background: ${color.N2};
-  border: 1px solid ${color.N4};
-  border-radius: 4px;
-  font-size: 13px;
-  color: ${color.N8};
+  padding: 0.375rem 0.625rem;
+  background: ${CORPUS_COLORS.slate[50]};
+  border: 1px solid ${CORPUS_COLORS.slate[200]};
+  border-radius: ${CORPUS_RADII.sm};
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: 0.8125rem;
+  color: ${CORPUS_COLORS.slate[700]};
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all ${CORPUS_TRANSITIONS.fast};
 
   &:hover {
-    background: ${color.N3};
-    border-color: ${color.B5};
+    background: ${CORPUS_COLORS.teal[50]};
+    border-color: ${CORPUS_COLORS.teal[300]};
+    color: ${CORPUS_COLORS.teal[700]};
   }
 `;
 
@@ -912,19 +952,6 @@ export const MessageItem = React.memo(function MessageItem({
         isAgent ? `${agentData.name} (AI Agent)` : username
       }`}
     >
-      {/* Vote Column */}
-      <VoteColumn>
-        <VoteButtons
-          messageId={message.id}
-          upvoteCount={message.upvoteCount ?? 0}
-          downvoteCount={message.downvoteCount ?? 0}
-          userVote={message.userVote}
-          senderId={message.creator?.id || ""}
-          currentUserId={currentUserId}
-          disabled={isDeleted}
-        />
-      </VoteColumn>
-
       {/* Content Column */}
       <ContentColumn>
         {/* Header */}
@@ -1085,13 +1112,26 @@ export const MessageItem = React.memo(function MessageItem({
         {/* Footer */}
         {!isDeleted && (
           <MessageFooter>
-            <FooterButton
-              onClick={handleReply}
-              aria-label="Reply to this message"
-            >
-              <CornerDownRight />
-              Reply
-            </FooterButton>
+            <FooterActions className="message-footer-actions">
+              <VoteButtons
+                messageId={message.id}
+                upvoteCount={message.upvoteCount ?? 0}
+                downvoteCount={message.downvoteCount ?? 0}
+                userVote={message.userVote}
+                senderId={message.creator?.id || ""}
+                currentUserId={currentUserId}
+                disabled={isDeleted}
+                compact
+              />
+              <FooterDivider />
+              <FooterButton
+                onClick={handleReply}
+                aria-label="Reply to this message"
+              >
+                <CornerDownRight />
+                Reply
+              </FooterButton>
+            </FooterActions>
 
             {message.children && message.children.length > 0 && (
               <ReplyCount>

--- a/frontend/src/components/threads/MessageItem.tsx
+++ b/frontend/src/components/threads/MessageItem.tsx
@@ -47,11 +47,7 @@ import {
   DeleteMessageInput,
   DeleteMessageOutput,
 } from "../../graphql/mutations";
-
-/**
- * Default color for agent messages when no badge color is configured
- */
-const DEFAULT_AGENT_COLOR = "#4A90E2";
+import { DEFAULT_AGENT_COLOR } from "../../assets/configurations/constants";
 
 /**
  * Validates that a value is a string
@@ -143,7 +139,13 @@ function normalizeHexColor(hex: string): string {
  * Helper to create an rgba color from a hex color with alpha.
  * Supports both 3-digit (#abc) and 6-digit (#aabbcc) hex formats.
  */
-export function hexToRgba(hex: string, alpha: number): string {
+export function hexToRgba(
+  hex: string | null | undefined,
+  alpha: number
+): string {
+  // Guard against null/undefined
+  if (!hex) return `rgba(74, 144, 226, ${alpha})`; // Fallback to default blue
+
   // Normalize 3-digit hex to 6-digit
   const normalizedHex = normalizeHexColor(hex);
   const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(

--- a/frontend/src/components/threads/MessageItem.tsx
+++ b/frontend/src/components/threads/MessageItem.tsx
@@ -48,19 +48,13 @@ import {
   DeleteMessageOutput,
 } from "../../graphql/mutations";
 import { DEFAULT_AGENT_COLOR } from "../../assets/configurations/constants";
+import { hexToRgba, isValidHexColor } from "../../utils/colorUtils";
 
 /**
  * Validates that a value is a string
  */
 function isString(value: unknown): value is string {
   return typeof value === "string";
-}
-
-/**
- * Validates that a string is a valid hex color (3 or 6 digit format)
- */
-function isValidHexColor(value: string): boolean {
-  return /^#([A-Fa-f0-9]{3}|[A-Fa-f0-9]{6})$/.test(value);
 }
 
 /**
@@ -121,41 +115,6 @@ interface MessageItemProps {
   currentUserId?: string;
   /** Parent message author for "Replying to" display */
   parentAuthor?: string;
-}
-
-/**
- * Normalizes a 3-digit hex color to 6-digit format.
- * e.g., "#abc" -> "#aabbcc"
- */
-function normalizeHexColor(hex: string): string {
-  const shortHexMatch = /^#?([a-f\d])([a-f\d])([a-f\d])$/i.exec(hex);
-  if (shortHexMatch) {
-    return `#${shortHexMatch[1]}${shortHexMatch[1]}${shortHexMatch[2]}${shortHexMatch[2]}${shortHexMatch[3]}${shortHexMatch[3]}`;
-  }
-  return hex;
-}
-
-/**
- * Helper to create an rgba color from a hex color with alpha.
- * Supports both 3-digit (#abc) and 6-digit (#aabbcc) hex formats.
- */
-export function hexToRgba(
-  hex: string | null | undefined,
-  alpha: number
-): string {
-  // Guard against null/undefined
-  if (!hex) return `rgba(74, 144, 226, ${alpha})`; // Fallback to default blue
-
-  // Normalize 3-digit hex to 6-digit
-  const normalizedHex = normalizeHexColor(hex);
-  const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(
-    normalizedHex
-  );
-  if (!result) return `rgba(74, 144, 226, ${alpha})`; // Fallback to default blue
-  return `rgba(${parseInt(result[1], 16)}, ${parseInt(
-    result[2],
-    16
-  )}, ${parseInt(result[3], 16)}, ${alpha})`;
 }
 
 /**

--- a/frontend/src/components/threads/ModerationControls.tsx
+++ b/frontend/src/components/threads/ModerationControls.tsx
@@ -2,7 +2,14 @@ import React, { useState } from "react";
 import styled from "styled-components";
 import { Pin, Lock, Trash2, RotateCcw } from "lucide-react";
 import { useMutation } from "@apollo/client";
-import { color } from "../../theme/colors";
+import {
+  CORPUS_COLORS,
+  CORPUS_FONTS,
+  CORPUS_RADII,
+  CORPUS_SHADOWS,
+  CORPUS_TRANSITIONS,
+  mediaQuery,
+} from "./styles/discussionStyles";
 import {
   PIN_THREAD,
   UNPIN_THREAD,
@@ -28,11 +35,11 @@ import { GET_CONVERSATIONS, GET_THREAD_DETAIL } from "../../graphql/queries";
 const Container = styled.div`
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 12px;
-  background: ${({ theme }) => color.N2};
-  border: 1px solid ${({ theme }) => color.N4};
-  border-radius: 6px;
+  gap: 0.5rem;
+  padding: 0.875rem;
+  background: ${CORPUS_COLORS.slate[50]};
+  border: 1px solid ${CORPUS_COLORS.slate[200]};
+  border-radius: ${CORPUS_RADII.lg};
 `;
 
 const ModerationButton = styled.button<{
@@ -40,45 +47,46 @@ const ModerationButton = styled.button<{
 }>`
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 6px 12px;
+  gap: 0.375rem;
+  padding: 0.375rem 0.75rem;
   border: 1px solid;
-  border-radius: 4px;
-  font-size: 13px;
+  border-radius: ${CORPUS_RADII.md};
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: 0.8125rem;
   font-weight: 500;
   cursor: pointer;
-  transition: all 0.15s ease;
+  transition: all ${CORPUS_TRANSITIONS.fast};
 
-  ${({ $variant, theme }) => {
+  ${({ $variant }) => {
     switch ($variant) {
       case "danger":
         return `
-          background: ${color.R7}10;
-          border-color: ${color.R7}40;
-          color: ${color.R7};
+          background: #fee2e2;
+          border-color: #fca5a5;
+          color: #dc2626;
           &:hover:not(:disabled) {
-            background: ${color.R7}20;
-            border-color: ${color.R7};
+            background: #fecaca;
+            border-color: #f87171;
           }
         `;
       case "warning":
         return `
-          background: ${color.Y6}10;
-          border-color: ${color.Y6}40;
-          color: ${color.Y6};
+          background: #fef3c7;
+          border-color: #fcd34d;
+          color: #92400e;
           &:hover:not(:disabled) {
-            background: ${color.Y6}20;
-            border-color: ${color.Y6};
+            background: #fde68a;
+            border-color: #fbbf24;
           }
         `;
       default:
         return `
-          background: ${color.B5}10;
-          border-color: ${color.B5}40;
-          color: ${color.B5};
+          background: ${CORPUS_COLORS.teal[50]};
+          border-color: ${CORPUS_COLORS.teal[200]};
+          color: ${CORPUS_COLORS.teal[700]};
           &:hover:not(:disabled) {
-            background: ${color.B5}20;
-            border-color: ${color.B5};
+            background: ${CORPUS_COLORS.teal[100]};
+            border-color: ${CORPUS_COLORS.teal[300]};
           }
         `;
     }
@@ -90,8 +98,8 @@ const ModerationButton = styled.button<{
   }
 
   svg {
-    width: 14px;
-    height: 14px;
+    width: 0.875rem;
+    height: 0.875rem;
   }
 `;
 
@@ -106,61 +114,65 @@ const ConfirmDialog = styled.div`
   align-items: center;
   justify-content: center;
   z-index: 1000;
-  padding: 16px;
+  padding: 1rem;
 `;
 
 const ConfirmBox = styled.div`
-  background: ${({ theme }) => color.N1};
-  border-radius: 8px;
-  padding: 24px;
-  max-width: 400px;
+  background: ${CORPUS_COLORS.white};
+  border-radius: ${CORPUS_RADII.lg};
+  padding: 1.5rem;
+  max-width: 25rem;
   width: 100%;
-  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.15);
+  box-shadow: ${CORPUS_SHADOWS.xl};
 `;
 
 const ConfirmTitle = styled.h3`
-  margin: 0 0 12px 0;
-  font-size: 18px;
+  margin: 0 0 0.75rem 0;
+  font-family: ${CORPUS_FONTS.serif};
+  font-size: 1.125rem;
   font-weight: 600;
-  color: ${({ theme }) => color.N10};
+  color: ${CORPUS_COLORS.slate[800]};
 `;
 
 const ConfirmMessage = styled.p`
-  margin: 0 0 20px 0;
-  font-size: 14px;
-  color: ${({ theme }) => color.N7};
+  margin: 0 0 1.25rem 0;
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: 0.875rem;
+  color: ${CORPUS_COLORS.slate[600]};
   line-height: 1.5;
 `;
 
 const ConfirmActions = styled.div`
   display: flex;
-  gap: 8px;
+  gap: 0.5rem;
   justify-content: flex-end;
 `;
 
 const ConfirmButton = styled.button<{ $primary?: boolean }>`
-  padding: 8px 16px;
+  padding: 0.5rem 1rem;
   border: none;
-  border-radius: 4px;
-  font-size: 14px;
-  font-weight: 500;
+  border-radius: ${CORPUS_RADII.md};
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: 0.875rem;
+  font-weight: 600;
   cursor: pointer;
-  transition: opacity 0.15s ease;
+  transition: all ${CORPUS_TRANSITIONS.fast};
 
-  ${({ $primary, theme }) =>
+  ${({ $primary }) =>
     $primary
       ? `
-    background: ${color.R7};
+    background: #dc2626;
     color: white;
     &:hover:not(:disabled) {
-      opacity: 0.9;
+      background: #b91c1c;
     }
   `
       : `
-    background: ${color.N3};
-    color: ${color.N10};
+    background: ${CORPUS_COLORS.white};
+    border: 1px solid ${CORPUS_COLORS.slate[200]};
+    color: ${CORPUS_COLORS.slate[700]};
     &:hover:not(:disabled) {
-      background: ${color.N2};
+      background: ${CORPUS_COLORS.slate[50]};
     }
   `}
 
@@ -171,12 +183,13 @@ const ConfirmButton = styled.button<{ $primary?: boolean }>`
 `;
 
 const ErrorMessage = styled.div`
-  padding: 8px 12px;
-  background: ${({ theme }) => color.R7}15;
-  color: ${({ theme }) => color.R7};
-  font-size: 13px;
-  border-radius: 4px;
-  margin-top: 8px;
+  padding: 0.5rem 0.75rem;
+  background: #fee2e2;
+  color: #dc2626;
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: 0.8125rem;
+  border-radius: ${CORPUS_RADII.sm};
+  margin-top: 0.5rem;
 `;
 
 export interface ModerationControlsProps {

--- a/frontend/src/components/threads/RelativeTime.tsx
+++ b/frontend/src/components/threads/RelativeTime.tsx
@@ -1,11 +1,20 @@
 import React, { useState, useEffect } from "react";
+import styled from "styled-components";
 import { formatDistanceToNow } from "date-fns";
+import { CORPUS_COLORS, CORPUS_FONTS } from "./styles/discussionStyles";
 
 interface RelativeTimeProps {
   date: string | Date;
   suffix?: boolean;
   updateInterval?: number; // milliseconds
 }
+
+const TimeSpan = styled.span`
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: 0.75rem;
+  color: ${CORPUS_COLORS.slate[400]};
+  white-space: nowrap;
+`;
 
 /**
  * Displays timestamp as relative time (e.g., "2 hours ago")
@@ -32,5 +41,5 @@ export function RelativeTime({
   // Show full timestamp on hover
   const fullTimestamp = new Date(date).toLocaleString();
 
-  return <span title={fullTimestamp}>{time}</span>;
+  return <TimeSpan title={fullTimestamp}>{time}</TimeSpan>;
 }

--- a/frontend/src/components/threads/ReplyForm.tsx
+++ b/frontend/src/components/threads/ReplyForm.tsx
@@ -12,100 +12,110 @@ import {
 } from "../../graphql/mutations";
 import { GET_THREAD_DETAIL } from "../../graphql/queries";
 import { MessageComposer } from "./MessageComposer";
-import { color } from "../../theme/colors";
-import { spacing } from "../../theme/spacing";
+import {
+  CORPUS_COLORS,
+  CORPUS_FONTS,
+  CORPUS_RADII,
+  CORPUS_TRANSITIONS,
+} from "./styles/discussionStyles";
 
 const Container = styled.div`
-  border: 1px solid ${({ theme }) => color.N4};
-  border-radius: 8px;
-  background: ${({ theme }) => color.N2};
-  padding: 12px;
+  border: 1px solid ${CORPUS_COLORS.slate[200]};
+  border-radius: ${CORPUS_RADII.lg};
+  background: ${CORPUS_COLORS.slate[50]};
+  padding: 0.875rem;
 `;
 
 const Header = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 12px;
+  margin-bottom: 0.75rem;
 `;
 
 const ReplyingTo = styled.div`
-  font-size: 13px;
-  color: ${({ theme }) => color.N7};
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: 0.8125rem;
+  color: ${CORPUS_COLORS.slate[600]};
 
   strong {
-    color: ${({ theme }) => color.N10};
-    font-weight: 500;
+    color: ${CORPUS_COLORS.teal[700]};
+    font-weight: 600;
   }
 `;
 
 const CancelButton = styled.button`
   display: flex;
   align-items: center;
-  gap: 4px;
-  padding: 4px 8px;
+  gap: 0.25rem;
+  padding: 0.25rem 0.5rem;
   border: none;
-  border-radius: 4px;
+  border-radius: ${CORPUS_RADII.sm};
   background: transparent;
-  color: ${({ theme }) => color.N7};
-  font-size: 13px;
+  font-family: ${CORPUS_FONTS.sans};
+  color: ${CORPUS_COLORS.slate[500]};
+  font-size: 0.8125rem;
   cursor: pointer;
-  transition: background 0.15s ease;
+  transition: all ${CORPUS_TRANSITIONS.fast};
 
   &:hover {
-    background: ${({ theme }) => color.N3};
+    background: ${CORPUS_COLORS.slate[200]};
+    color: ${CORPUS_COLORS.slate[700]};
   }
 
   svg {
-    width: 14px;
-    height: 14px;
+    width: 0.875rem;
+    height: 0.875rem;
   }
 `;
 
 const ErrorMessage = styled.div`
-  padding: 8px 12px;
-  margin-bottom: 12px;
-  background: ${({ theme }) => color.R7}15;
-  border: 1px solid ${({ theme }) => color.R7}40;
-  border-radius: 6px;
-  color: ${({ theme }) => color.R7};
-  font-size: 13px;
+  padding: 0.5rem 0.75rem;
+  margin-bottom: 0.75rem;
+  background: #fee2e2;
+  border: 1px solid #fca5a5;
+  border-radius: ${CORPUS_RADII.md};
+  font-family: ${CORPUS_FONTS.sans};
+  color: #dc2626;
+  font-size: 0.8125rem;
 `;
 
 const QuoteButton = styled.button`
   display: flex;
   align-items: center;
-  gap: 4px;
-  padding: 4px 8px;
-  border: 1px solid ${({ theme }) => color.N4};
-  border-radius: 4px;
-  background: ${({ theme }) => color.N1};
-  color: ${({ theme }) => color.N7};
-  font-size: 12px;
+  gap: 0.25rem;
+  padding: 0.25rem 0.5rem;
+  border: 1px solid ${CORPUS_COLORS.slate[200]};
+  border-radius: ${CORPUS_RADII.sm};
+  background: ${CORPUS_COLORS.white};
+  font-family: ${CORPUS_FONTS.sans};
+  color: ${CORPUS_COLORS.slate[600]};
+  font-size: 0.75rem;
   cursor: pointer;
-  transition: all 0.15s ease;
+  transition: all ${CORPUS_TRANSITIONS.fast};
   margin-left: auto;
 
   &:hover {
-    background: ${({ theme }) => color.N2};
-    border-color: ${({ theme }) => color.B5};
-    color: ${({ theme }) => color.B7};
+    background: ${CORPUS_COLORS.teal[50]};
+    border-color: ${CORPUS_COLORS.teal[300]};
+    color: ${CORPUS_COLORS.teal[700]};
   }
 
   svg {
-    width: 14px;
-    height: 14px;
+    width: 0.875rem;
+    height: 0.875rem;
   }
 `;
 
 const QuotedMessage = styled.div`
-  padding: ${spacing.sm};
-  margin-bottom: ${spacing.sm};
-  border-left: 3px solid ${({ theme }) => color.B5};
-  background: ${({ theme }) => color.N2};
-  border-radius: 4px;
-  font-size: 13px;
-  color: ${({ theme }) => color.N7};
+  padding: 0.625rem;
+  margin-bottom: 0.625rem;
+  border-left: 3px solid ${CORPUS_COLORS.teal[400]};
+  background: ${CORPUS_COLORS.slate[100]};
+  border-radius: ${CORPUS_RADII.sm};
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: 0.8125rem;
+  color: ${CORPUS_COLORS.slate[600]};
   font-style: italic;
 
   &::before {
@@ -113,8 +123,8 @@ const QuotedMessage = styled.div`
     display: block;
     font-weight: 600;
     font-style: normal;
-    margin-bottom: 4px;
-    color: ${({ theme }) => color.N10};
+    margin-bottom: 0.25rem;
+    color: ${CORPUS_COLORS.slate[700]};
   }
 `;
 

--- a/frontend/src/components/threads/ThreadBadge.tsx
+++ b/frontend/src/components/threads/ThreadBadge.tsx
@@ -1,7 +1,12 @@
 import React from "react";
 import styled from "styled-components";
 import { Pin, Lock, Trash2 } from "lucide-react";
-import { color } from "../../theme/colors";
+import {
+  CORPUS_COLORS,
+  CORPUS_FONTS,
+  CORPUS_RADII,
+  CORPUS_TRANSITIONS,
+} from "./styles/discussionStyles";
 
 interface ThreadBadgeProps {
   type: "pinned" | "locked" | "deleted";
@@ -11,28 +16,35 @@ interface ThreadBadgeProps {
 const BadgeContainer = styled.span<{ $type: string }>`
   display: inline-flex;
   align-items: center;
-  gap: 4px;
-  padding: 4px 8px;
-  border-radius: 4px;
-  font-size: 12px;
-  font-weight: 500;
+  gap: 0.25rem;
+  padding: 0.125rem 0.5rem;
+  border-radius: ${CORPUS_RADII.full};
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: 0.625rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  transition: all ${CORPUS_TRANSITIONS.fast};
 
   ${(props) => {
     switch (props.$type) {
       case "pinned":
         return `
-          background: ${color.B2};
-          color: ${color.B8};
+          background: ${CORPUS_COLORS.teal[50]};
+          color: ${CORPUS_COLORS.teal[700]};
+          border: 1px solid ${CORPUS_COLORS.teal[200]};
         `;
       case "locked":
         return `
-          background: ${color.R2};
-          color: ${color.R8};
+          background: #fef3c7;
+          color: #92400e;
+          border: 1px solid #fcd34d;
         `;
       case "deleted":
         return `
-          background: ${color.N4};
-          color: ${color.N7};
+          background: ${CORPUS_COLORS.slate[100]};
+          color: ${CORPUS_COLORS.slate[500]};
+          border: 1px solid ${CORPUS_COLORS.slate[300]};
         `;
       default:
         return "";
@@ -45,9 +57,9 @@ const BadgeContainer = styled.span<{ $type: string }>`
  */
 export function ThreadBadge({ type, compact = false }: ThreadBadgeProps) {
   const icons = {
-    pinned: <Pin size={14} />,
-    locked: <Lock size={14} />,
-    deleted: <Trash2 size={14} />,
+    pinned: <Pin size={11} />,
+    locked: <Lock size={11} />,
+    deleted: <Trash2 size={11} />,
   };
 
   const labels = {

--- a/frontend/src/components/threads/ThreadDetail.tsx
+++ b/frontend/src/components/threads/ThreadDetail.tsx
@@ -17,7 +17,14 @@ import {
   GetThreadDetailInput,
   GetThreadDetailOutput,
 } from "../../graphql/queries";
-import { color } from "../../theme/colors";
+import {
+  CORPUS_COLORS,
+  CORPUS_FONTS,
+  CORPUS_RADII,
+  CORPUS_SHADOWS,
+  CORPUS_TRANSITIONS,
+  mediaQuery,
+} from "./styles/discussionStyles";
 import {
   selectedMessageIdAtom,
   replyingToMessageIdAtom,
@@ -54,20 +61,20 @@ const Container = styled.div`
   display: flex;
   flex-direction: column;
   height: 100%;
-  background: ${color.N2};
+  background: #fafafa;
 `;
 
 const Header = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  padding: 0.75rem 1.5rem;
-  background: ${color.N1};
-  border-bottom: 1px solid ${color.N4};
+  padding: 1rem 2rem;
+  background: ${CORPUS_COLORS.white};
+  border-bottom: 1px solid ${CORPUS_COLORS.slate[200]};
   gap: 1rem;
 
   @media (max-width: 768px) {
-    padding: 0.75rem 1rem;
+    padding: 1rem;
     flex-direction: column;
   }
 `;
@@ -75,7 +82,7 @@ const Header = styled.div`
 const HeaderLeft = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.625rem;
   flex: 1;
   min-width: 0;
 `;
@@ -91,24 +98,26 @@ const BackButton = styled.button`
   display: inline-flex;
   align-items: center;
   gap: 0.25rem;
-  padding: 0.375rem 0.625rem;
-  border: 1px solid ${color.N4};
-  border-radius: 6px;
-  background: ${color.N1};
-  color: ${color.N7};
-  font-size: 12px;
+  padding: 0.375rem 0.75rem;
+  border: 1px solid ${CORPUS_COLORS.slate[200]};
+  border-radius: ${CORPUS_RADII.md};
+  background: ${CORPUS_COLORS.white};
+  font-family: ${CORPUS_FONTS.sans};
+  color: ${CORPUS_COLORS.slate[600]};
+  font-size: 0.8125rem;
   font-weight: 500;
   cursor: pointer;
-  transition: all 0.15s;
+  transition: all ${CORPUS_TRANSITIONS.fast};
 
   &:hover {
-    border-color: ${color.G5};
-    color: ${color.G7};
+    border-color: ${CORPUS_COLORS.teal[300]};
+    background: ${CORPUS_COLORS.teal[50]};
+    color: ${CORPUS_COLORS.teal[700]};
   }
 
   svg {
-    width: 14px;
-    height: 14px;
+    width: 0.875rem;
+    height: 0.875rem;
   }
 `;
 
@@ -117,23 +126,25 @@ const ContextLink = styled.a`
   align-items: center;
   gap: 0.25rem;
   padding: 0.25rem 0.5rem;
-  background: ${color.N2};
-  border: 1px solid ${color.N4};
-  border-radius: 4px;
-  font-size: 11px;
+  background: ${CORPUS_COLORS.slate[50]};
+  border: 1px solid ${CORPUS_COLORS.slate[200]};
+  border-radius: ${CORPUS_RADII.sm};
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: 0.75rem;
   font-weight: 500;
-  color: ${color.N7};
+  color: ${CORPUS_COLORS.slate[600]};
   text-decoration: none;
-  transition: all 0.15s;
+  transition: all ${CORPUS_TRANSITIONS.fast};
 
   &:hover {
-    border-color: ${color.G5};
-    color: ${color.G7};
+    border-color: ${CORPUS_COLORS.teal[300]};
+    background: ${CORPUS_COLORS.teal[50]};
+    color: ${CORPUS_COLORS.teal[700]};
   }
 
   svg {
-    width: 12px;
-    height: 12px;
+    width: 0.75rem;
+    height: 0.75rem;
   }
 `;
 
@@ -142,34 +153,40 @@ const StatusBadge = styled.span<{ $variant: "pinned" | "locked" | "deleted" }>`
   align-items: center;
   gap: 0.25rem;
   padding: 0.25rem 0.5rem;
-  border-radius: 4px;
-  font-size: 11px;
+  border-radius: ${CORPUS_RADII.full};
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: 0.6875rem;
   font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
 
   ${(props) =>
     props.$variant === "pinned" &&
     `
-    background: ${color.G1};
-    color: ${color.G7};
+    background: ${CORPUS_COLORS.teal[50]};
+    color: ${CORPUS_COLORS.teal[700]};
+    border: 1px solid ${CORPUS_COLORS.teal[200]};
   `}
 
   ${(props) =>
     props.$variant === "locked" &&
     `
-    background: ${color.Y1};
-    color: ${color.Y8};
+    background: #fef3c7;
+    color: #92400e;
+    border: 1px solid #fcd34d;
   `}
 
   ${(props) =>
     props.$variant === "deleted" &&
     `
-    background: ${color.R1};
-    color: ${color.R7};
+    background: ${CORPUS_COLORS.slate[100]};
+    color: ${CORPUS_COLORS.slate[500]};
+    border: 1px solid ${CORPUS_COLORS.slate[300]};
   `}
 
   svg {
-    width: 12px;
-    height: 12px;
+    width: 0.75rem;
+    height: 0.75rem;
   }
 `;
 
@@ -181,26 +198,28 @@ const TitleRow = styled.div`
 `;
 
 const Title = styled.h1`
-  font-size: 1.125rem;
-  font-weight: 700;
-  color: ${color.N10};
+  font-family: "Georgia", "Times New Roman", serif;
+  font-size: 28px;
+  font-weight: 400;
+  color: #1e293b;
   margin: 0;
-  letter-spacing: -0.025em;
 `;
 
 const Description = styled.p`
-  font-size: 0.875rem;
-  color: ${color.N6};
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
+  font-size: 16px;
+  color: #475569;
   margin: 0;
-  line-height: 1.5;
+  line-height: 1.6;
 `;
 
 const MetaRow = styled.div`
   display: flex;
   align-items: center;
   gap: 0.75rem;
-  font-size: 12px;
-  color: ${color.N6};
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: 0.8125rem;
+  color: ${CORPUS_COLORS.slate[500]};
   flex-wrap: wrap;
 `;
 
@@ -210,34 +229,35 @@ const MetaItem = styled.span`
   gap: 0.25rem;
 
   strong {
-    color: ${color.N8};
+    color: ${CORPUS_COLORS.slate[700]};
     font-weight: 600;
   }
 
   svg {
-    width: 12px;
-    height: 12px;
+    width: 0.875rem;
+    height: 0.875rem;
+    color: ${CORPUS_COLORS.teal[600]};
   }
 `;
 
 const MetaDot = styled.span`
-  color: ${color.N5};
+  color: ${CORPUS_COLORS.slate[300]};
 `;
 
 const ContentArea = styled.div`
   flex: 1;
   overflow: auto;
-  padding: 1rem 1.5rem;
+  padding: 32px 24px;
 
   @media (max-width: 768px) {
-    padding: 0.75rem 1rem;
+    padding: 24px 16px;
   }
 `;
 
 const MessageListContainer = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 16px;
   max-width: 900px;
   margin: 0 auto;
   width: 100%;
@@ -245,17 +265,17 @@ const MessageListContainer = styled.div`
 
 const EmptyMessageState = styled.div`
   text-align: center;
-  padding: 2rem;
-  color: ${color.N6};
+  padding: 3rem;
+  color: ${CORPUS_COLORS.slate[500]};
 `;
 
 const ReplyComposerArea = styled.div`
-  padding: 1rem 1.5rem;
-  background: ${color.N1};
-  border-top: 1px solid ${color.N4};
+  padding: 1rem 2rem;
+  background: ${CORPUS_COLORS.white};
+  border-top: 1px solid ${CORPUS_COLORS.slate[200]};
 
   @media (max-width: 768px) {
-    padding: 0.75rem 1rem;
+    padding: 1rem;
   }
 `;
 

--- a/frontend/src/components/threads/ThreadDetailWithContext.tsx
+++ b/frontend/src/components/threads/ThreadDetailWithContext.tsx
@@ -1,0 +1,58 @@
+/**
+ * ThreadDetailWithContext - Wrapper that combines ThreadDetail with CorpusContextSidebar
+ *
+ * Used when viewing thread details inline within the Discussions tab.
+ * Provides a two-column layout on larger screens:
+ * - Left: Thread detail with compact mode and back navigation
+ * - Right: Corpus context sidebar (collapsible on medium screens, hidden on small)
+ */
+
+import React from "react";
+
+import { ThreadDetail } from "./ThreadDetail";
+import { CorpusContextSidebar } from "./CorpusContextSidebar";
+import {
+  ThreadWithContextContainer,
+  ThreadDetailPane,
+  VerticalDivider,
+} from "./styles/contextSidebarStyles";
+
+interface ThreadDetailWithContextProps {
+  /** The conversation/thread ID to display */
+  conversationId: string;
+  /** The corpus ID for context sidebar */
+  corpusId: string;
+  /** Callback when back button is clicked - returns to thread list */
+  onBack: () => void;
+}
+
+/**
+ * ThreadDetailWithContext - Thread detail view with corpus context sidebar
+ *
+ * Layout:
+ * - Screen >= 1200px: Thread detail + expanded sidebar (320px)
+ * - Screen 1024-1199px: Thread detail + collapsible sidebar (48px collapsed)
+ * - Screen < 1024px: Thread detail only (sidebar hidden)
+ */
+export const ThreadDetailWithContext: React.FC<
+  ThreadDetailWithContextProps
+> = ({ conversationId, corpusId, onBack }) => {
+  return (
+    <ThreadWithContextContainer>
+      <ThreadDetailPane>
+        <ThreadDetail
+          conversationId={conversationId}
+          corpusId={corpusId}
+          compact
+          onBack={onBack}
+        />
+      </ThreadDetailPane>
+
+      <VerticalDivider />
+
+      <CorpusContextSidebar corpusId={corpusId} />
+    </ThreadWithContextContainer>
+  );
+};
+
+export default ThreadDetailWithContext;

--- a/frontend/src/components/threads/ThreadDetailWithContext.tsx
+++ b/frontend/src/components/threads/ThreadDetailWithContext.tsx
@@ -7,7 +7,7 @@
  * - Right: Corpus context sidebar (collapsible on medium screens, hidden on small)
  */
 
-import React from "react";
+import React, { useRef, useEffect } from "react";
 
 import { ThreadDetail } from "./ThreadDetail";
 import { CorpusContextSidebar } from "./CorpusContextSidebar";
@@ -37,8 +37,25 @@ interface ThreadDetailWithContextProps {
 export const ThreadDetailWithContext: React.FC<
   ThreadDetailWithContextProps
 > = ({ conversationId, corpusId, onBack }) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Focus management: move focus to thread detail container when mounted
+  // This helps screen reader users understand the view has changed
+  useEffect(() => {
+    // Small delay to ensure content is rendered
+    const timeoutId = setTimeout(() => {
+      containerRef.current?.focus();
+    }, 100);
+    return () => clearTimeout(timeoutId);
+  }, [conversationId]);
+
   return (
-    <ThreadWithContextContainer>
+    <ThreadWithContextContainer
+      ref={containerRef}
+      tabIndex={-1}
+      role="region"
+      aria-label="Thread detail view"
+    >
       <ThreadDetailPane>
         <ThreadDetail
           conversationId={conversationId}

--- a/frontend/src/components/threads/ThreadFilterToggles.tsx
+++ b/frontend/src/components/threads/ThreadFilterToggles.tsx
@@ -3,44 +3,55 @@ import styled from "styled-components";
 import { useAtom } from "jotai";
 import { Lock, Trash2 } from "lucide-react";
 import { threadFiltersAtom } from "../../atoms/threadAtoms";
-import { color } from "../../theme/colors";
-import { spacing } from "../../theme/spacing";
+import {
+  CORPUS_COLORS,
+  CORPUS_FONTS,
+  CORPUS_RADII,
+  CORPUS_TRANSITIONS,
+} from "./styles/discussionStyles";
 
 const Container = styled.div`
   display: flex;
   align-items: center;
-  gap: ${spacing.sm};
+  gap: 0.5rem;
   flex-wrap: wrap;
 `;
 
 const Label = styled.span`
-  font-size: 14px;
-  color: ${color.N7};
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: 0.8125rem;
+  color: ${CORPUS_COLORS.slate[500]};
   font-weight: 500;
 `;
 
 const ToggleButton = styled.button<{ $isActive: boolean }>`
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 6px 12px;
-  border: 1px solid ${(props) => (props.$isActive ? color.B5 : color.N4)};
-  border-radius: 6px;
-  background: ${(props) => (props.$isActive ? color.B1 : color.N1)};
-  color: ${(props) => (props.$isActive ? color.B8 : color.N7)};
-  font-size: 13px;
+  gap: 0.375rem;
+  padding: 0.375rem 0.75rem;
+  border: 1px solid
+    ${(props) =>
+      props.$isActive ? CORPUS_COLORS.teal[500] : CORPUS_COLORS.slate[200]};
+  border-radius: ${CORPUS_RADII.full};
+  background: ${(props) =>
+    props.$isActive ? CORPUS_COLORS.teal[50] : CORPUS_COLORS.white};
+  color: ${(props) =>
+    props.$isActive ? CORPUS_COLORS.teal[700] : CORPUS_COLORS.slate[600]};
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: 0.8125rem;
   font-weight: 500;
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all ${CORPUS_TRANSITIONS.fast};
 
   &:hover {
-    border-color: ${(props) => (props.$isActive ? color.B6 : color.N5)};
-    background: ${(props) => (props.$isActive ? color.B2 : color.N2)};
+    border-color: ${CORPUS_COLORS.teal[400]};
+    background: ${CORPUS_COLORS.teal[50]};
+    color: ${CORPUS_COLORS.teal[700]};
   }
 
   svg {
-    width: 14px;
-    height: 14px;
+    width: 0.875rem;
+    height: 0.875rem;
   }
 `;
 

--- a/frontend/src/components/threads/ThreadList.tsx
+++ b/frontend/src/components/threads/ThreadList.tsx
@@ -9,7 +9,12 @@ import {
 } from "../../graphql/queries";
 import { ConversationType } from "../../types/graphql-api";
 import { CONVERSATION_TYPE } from "../../assets/configurations/constants";
-import { color } from "../../theme/colors";
+import {
+  CORPUS_COLORS,
+  CORPUS_FONTS,
+  CORPUS_RADII,
+  mediaQuery,
+} from "./styles/discussionStyles";
 import { threadSortAtom, threadFiltersAtom } from "../../atoms/threadAtoms";
 import { ThreadListItem } from "./ThreadListItem";
 import { ThreadSortDropdown } from "./ThreadSortDropdown";
@@ -47,30 +52,31 @@ interface ThreadListProps {
 const ThreadListContainer = styled.div<{ $embedded?: boolean }>`
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  padding: ${(props) => (props.$embedded ? "1rem" : "1.5rem")};
-  max-width: ${(props) => (props.$embedded ? "100%" : "1200px")};
+  gap: 20px;
+  padding: ${(props) => (props.$embedded ? "16px 24px" : "32px 24px")};
+  max-width: ${(props) => (props.$embedded ? "100%" : "900px")};
   margin: 0 auto;
   width: 100%;
+  background: #fafafa;
 
   @media (max-width: 768px) {
-    padding: ${(props) => (props.$embedded ? "0.75rem" : "1rem")};
-    gap: 0.75rem;
+    padding: ${(props) => (props.$embedded ? "12px 16px" : "24px 16px")};
+    gap: 16px;
   }
 
-  @media (max-width: 480px) {
-    padding: 0.75rem;
-    gap: 0.625rem;
+  ${mediaQuery.mobile} {
+    padding: 16px;
+    gap: 12px;
   }
 `;
 
 const ThreadGrid = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 16px;
 
-  @media (max-width: 480px) {
-    gap: 0.5rem;
+  ${mediaQuery.mobile} {
+    gap: 12px;
   }
 `;
 
@@ -88,12 +94,13 @@ const ThreadListHeader = styled.div`
 `;
 
 const Title = styled.h2`
+  font-family: "Georgia", "Times New Roman", serif;
   font-size: 24px;
-  font-weight: 700;
-  color: ${color.N10};
+  font-weight: 400;
+  color: #0f766e;
   margin: 0;
 
-  @media (max-width: 640px) {
+  ${mediaQuery.mobile} {
     font-size: 20px;
   }
 `;
@@ -108,7 +115,7 @@ const HeaderActions = styled.div`
     gap: 0.75rem;
   }
 
-  @media (max-width: 640px) {
+  ${mediaQuery.mobile} {
     flex-direction: column;
     align-items: stretch;
     width: 100%;

--- a/frontend/src/components/threads/ThreadListItem.tsx
+++ b/frontend/src/components/threads/ThreadListItem.tsx
@@ -4,7 +4,14 @@ import { useNavigate } from "react-router-dom";
 import { useReactiveVar } from "@apollo/client";
 import { Eye, MessageCircle } from "lucide-react";
 import { ConversationType } from "../../types/graphql-api";
-import { color } from "../../theme/colors";
+import {
+  CORPUS_COLORS,
+  CORPUS_FONTS,
+  CORPUS_RADII,
+  CORPUS_SHADOWS,
+  CORPUS_TRANSITIONS,
+  mediaQuery,
+} from "./styles/discussionStyles";
 import { ThreadBadge } from "./ThreadBadge";
 import {
   DiscussionTypeBadge,
@@ -31,47 +38,47 @@ const ThreadCard = styled.div<{
   $isDeleted?: boolean;
   $isSelected?: boolean;
 }>`
-  background: ${color.N1};
-  border: 1px solid ${color.N4};
-  border-radius: 8px;
-  padding: 1rem 1.25rem;
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 20px 24px;
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all 0.2s ease;
   display: flex;
-  gap: 1rem;
+  gap: 16px;
   position: relative;
 
   ${(props) =>
     props.$isSelected &&
     `
-    border-left: 4px solid ${color.G6};
-    background: ${color.G1};
+    border-left: 4px solid #0f766e;
+    background: #f0fdfa;
   `}
 
   ${(props) =>
     props.$isPinned &&
     !props.$isSelected &&
     `
-    border-left: 4px solid ${color.B5};
-    background: ${color.B1};
+    border-left: 4px solid #14b8a6;
+    background: linear-gradient(135deg, #f0fdfa 0%, #ffffff 100%);
   `}
 
   ${(props) =>
     props.$isDeleted &&
     `
     opacity: 0.6;
-    background: ${color.N3};
+    background: #f8fafc;
   `}
 
   &:hover {
-    border-color: ${color.G6};
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+    border-color: #cbd5e1;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
     transform: translateY(-1px);
   }
 
-  @media (max-width: 640px) {
-    padding: 0.875rem;
-    gap: 0.75rem;
+  ${mediaQuery.mobile} {
+    padding: 16px;
+    gap: 12px;
   }
 `;
 
@@ -79,12 +86,12 @@ const VoteSection = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 2px;
-  min-width: 40px;
-  padding-top: 4px;
+  gap: 0;
+  min-width: 2.5rem;
+  padding-top: 0.25rem;
 
-  @media (max-width: 640px) {
-    min-width: 32px;
+  ${mediaQuery.mobile} {
+    min-width: 2rem;
   }
 `;
 
@@ -107,52 +114,56 @@ const HeaderRow = styled.div`
 const BadgeGroup = styled.div`
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.375rem;
   flex-wrap: wrap;
 `;
 
 const TagChip = styled.span`
   display: inline-flex;
   align-items: center;
-  padding: 2px 8px;
-  background: ${color.N3};
-  border-radius: 4px;
-  font-size: 11px;
+  padding: 0.125rem 0.5rem;
+  background: ${CORPUS_COLORS.slate[100]};
+  border-radius: ${CORPUS_RADII.full};
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: 0.6875rem;
   font-weight: 500;
-  color: ${color.N7};
+  color: ${CORPUS_COLORS.slate[600]};
 `;
 
 const Timestamp = styled.span`
-  font-size: 12px;
-  color: ${color.N6};
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: 0.75rem;
+  color: ${CORPUS_COLORS.slate[400]};
   white-space: nowrap;
   flex-shrink: 0;
 `;
 
 const ThreadTitle = styled.h3`
-  font-size: 16px;
-  font-weight: 600;
-  color: ${color.N10};
+  font-family: "Georgia", "Times New Roman", serif;
+  font-size: 20px;
+  font-weight: 400;
+  color: #1e293b;
   margin: 0;
   line-height: 1.4;
 
-  @media (max-width: 640px) {
-    font-size: 15px;
+  ${mediaQuery.mobile} {
+    font-size: 18px;
   }
 `;
 
 const ThreadDescription = styled.p`
-  font-size: 14px;
-  color: ${color.N7};
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
+  font-size: 15px;
+  color: #475569;
   margin: 0;
-  line-height: 1.5;
+  line-height: 1.6;
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
 
-  @media (max-width: 640px) {
-    font-size: 13px;
+  ${mediaQuery.mobile} {
+    font-size: 14px;
     -webkit-line-clamp: 1;
   }
 `;
@@ -165,7 +176,7 @@ const FooterRow = styled.div`
   margin-top: 0.25rem;
   flex-wrap: wrap;
 
-  @media (max-width: 640px) {
+  ${mediaQuery.mobile} {
     gap: 0.5rem;
   }
 `;
@@ -177,22 +188,27 @@ const AuthorSection = styled.div`
 `;
 
 const AuthorAvatar = styled.div`
-  width: 28px;
-  height: 28px;
+  width: 1.5rem;
+  height: 1.5rem;
   border-radius: 50%;
-  background: linear-gradient(135deg, ${color.G5} 0%, ${color.G7} 100%);
+  background: linear-gradient(
+    135deg,
+    ${CORPUS_COLORS.teal[600]} 0%,
+    ${CORPUS_COLORS.teal[700]} 100%
+  );
   display: flex;
   align-items: center;
   justify-content: center;
-  color: white;
+  color: ${CORPUS_COLORS.white};
+  font-family: ${CORPUS_FONTS.sans};
   font-weight: 600;
-  font-size: 11px;
+  font-size: 0.625rem;
   flex-shrink: 0;
 
-  @media (max-width: 640px) {
-    width: 24px;
-    height: 24px;
-    font-size: 10px;
+  ${mediaQuery.mobile} {
+    width: 1.25rem;
+    height: 1.25rem;
+    font-size: 0.5625rem;
   }
 `;
 
@@ -204,21 +220,23 @@ const AuthorInfo = styled.div`
 `;
 
 const AuthorName = styled.span`
-  font-size: 13px;
-  font-weight: 500;
-  color: ${color.N9};
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
+  font-size: 14px;
+  font-weight: 600;
+  color: #334155;
 
-  @media (max-width: 640px) {
-    font-size: 12px;
+  ${mediaQuery.mobile} {
+    font-size: 13px;
   }
 `;
 
 const AuthorTime = styled.span`
-  font-size: 12px;
-  color: ${color.N6};
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: 0.75rem;
+  color: ${CORPUS_COLORS.slate[400]};
 
-  @media (max-width: 640px) {
-    font-size: 11px;
+  ${mediaQuery.mobile} {
+    font-size: 0.6875rem;
   }
 `;
 
@@ -227,7 +245,7 @@ const StatsSection = styled.div`
   align-items: center;
   gap: 1rem;
 
-  @media (max-width: 640px) {
+  ${mediaQuery.mobile} {
     gap: 0.75rem;
   }
 `;
@@ -235,21 +253,23 @@ const StatsSection = styled.div`
 const StatItem = styled.span`
   display: flex;
   align-items: center;
-  gap: 4px;
-  font-size: 13px;
-  color: ${color.N6};
+  gap: 0.25rem;
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: 0.8125rem;
+  color: ${CORPUS_COLORS.slate[500]};
 
   svg {
-    width: 14px;
-    height: 14px;
+    width: 0.875rem;
+    height: 0.875rem;
+    color: ${CORPUS_COLORS.slate[400]};
   }
 
-  @media (max-width: 640px) {
-    font-size: 12px;
+  ${mediaQuery.mobile} {
+    font-size: 0.75rem;
 
     svg {
-      width: 12px;
-      height: 12px;
+      width: 0.75rem;
+      height: 0.75rem;
     }
   }
 `;
@@ -260,33 +280,35 @@ const ParticipantAvatars = styled.div`
 `;
 
 const ParticipantAvatar = styled.div<{ $index: number }>`
-  width: 22px;
-  height: 22px;
+  width: 1.375rem;
+  height: 1.375rem;
   border-radius: 50%;
-  background: ${color.N5};
-  border: 2px solid ${color.N1};
+  background: ${CORPUS_COLORS.teal[100]};
+  border: 2px solid ${CORPUS_COLORS.white};
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 9px;
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: 0.5625rem;
   font-weight: 600;
-  color: ${color.N8};
-  margin-left: ${(props) => (props.$index > 0 ? "-8px" : "0")};
+  color: ${CORPUS_COLORS.teal[700]};
+  margin-left: ${(props) => (props.$index > 0 ? "-0.5rem" : "0")};
   position: relative;
   z-index: ${(props) => 10 - props.$index};
 
-  @media (max-width: 640px) {
-    width: 20px;
-    height: 20px;
-    font-size: 8px;
-    margin-left: ${(props) => (props.$index > 0 ? "-6px" : "0")};
+  ${mediaQuery.mobile} {
+    width: 1.25rem;
+    height: 1.25rem;
+    font-size: 0.5rem;
+    margin-left: ${(props) => (props.$index > 0 ? "-0.375rem" : "0")};
   }
 `;
 
 const MoreParticipants = styled.span`
-  font-size: 11px;
-  color: ${color.N6};
-  margin-left: 4px;
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: 0.6875rem;
+  color: ${CORPUS_COLORS.slate[500]};
+  margin-left: 0.25rem;
 `;
 
 /**

--- a/frontend/src/components/threads/ThreadSortDropdown.tsx
+++ b/frontend/src/components/threads/ThreadSortDropdown.tsx
@@ -3,8 +3,13 @@ import styled from "styled-components";
 import { useAtom } from "jotai";
 import { ChevronDown, Check } from "lucide-react";
 import { threadSortAtom, ThreadSortOption } from "../../atoms/threadAtoms";
-import { color } from "../../theme/colors";
-import { spacing } from "../../theme/spacing";
+import {
+  CORPUS_COLORS,
+  CORPUS_FONTS,
+  CORPUS_RADII,
+  CORPUS_SHADOWS,
+  CORPUS_TRANSITIONS,
+} from "./styles/discussionStyles";
 
 const DropdownContainer = styled.div`
   position: relative;
@@ -13,41 +18,43 @@ const DropdownContainer = styled.div`
 const DropdownButton = styled.button`
   display: flex;
   align-items: center;
-  gap: ${spacing.xs};
-  padding: ${spacing.xs} ${spacing.sm};
-  border: 1px solid ${color.N4};
-  border-radius: 6px;
-  background: ${color.N1};
-  color: ${color.N10};
-  font-size: 14px;
+  gap: 0.375rem;
+  padding: 0.375rem 0.75rem;
+  border: 1px solid ${CORPUS_COLORS.slate[200]};
+  border-radius: ${CORPUS_RADII.md};
+  background: ${CORPUS_COLORS.white};
+  font-family: ${CORPUS_FONTS.sans};
+  color: ${CORPUS_COLORS.slate[700]};
+  font-size: 0.875rem;
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all ${CORPUS_TRANSITIONS.fast};
 
   &:hover {
-    border-color: ${color.B5};
-    background: ${color.N2};
+    border-color: ${CORPUS_COLORS.teal[400]};
+    background: ${CORPUS_COLORS.teal[50]};
   }
 
   svg {
-    width: 16px;
-    height: 16px;
+    width: 1rem;
+    height: 1rem;
+    color: ${CORPUS_COLORS.slate[500]};
   }
 `;
 
 const DropdownMenu = styled.div<{ $isOpen: boolean }>`
   position: absolute;
-  top: calc(100% + 4px);
+  top: calc(100% + 0.25rem);
   right: 0;
-  min-width: 180px;
-  background: ${color.N1};
-  border: 1px solid ${color.N4};
-  border-radius: 6px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  min-width: 12rem;
+  background: ${CORPUS_COLORS.white};
+  border: 1px solid ${CORPUS_COLORS.slate[200]};
+  border-radius: ${CORPUS_RADII.md};
+  box-shadow: ${CORPUS_SHADOWS.lg};
   opacity: ${(props) => (props.$isOpen ? 1 : 0)};
   visibility: ${(props) => (props.$isOpen ? "visible" : "hidden")};
   transform: ${(props) =>
     props.$isOpen ? "translateY(0)" : "translateY(-8px)"};
-  transition: all 0.2s;
+  transition: all ${CORPUS_TRANSITIONS.fast};
   z-index: 100;
 `;
 
@@ -56,47 +63,52 @@ const MenuItem = styled.button<{ $isActive: boolean }>`
   align-items: center;
   justify-content: space-between;
   width: 100%;
-  padding: ${spacing.sm} ${spacing.md};
+  padding: 0.625rem 0.875rem;
   border: none;
-  background: ${(props) => (props.$isActive ? color.B1 : "transparent")};
-  color: ${(props) => (props.$isActive ? color.B8 : color.N10)};
-  font-size: 14px;
+  background: ${(props) =>
+    props.$isActive ? CORPUS_COLORS.teal[50] : "transparent"};
+  color: ${(props) =>
+    props.$isActive ? CORPUS_COLORS.teal[700] : CORPUS_COLORS.slate[700]};
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: 0.875rem;
   text-align: left;
   cursor: pointer;
-  transition: background 0.15s;
+  transition: background ${CORPUS_TRANSITIONS.fast};
 
   &:hover {
-    background: ${(props) => (props.$isActive ? color.B1 : color.N2)};
+    background: ${(props) =>
+      props.$isActive ? CORPUS_COLORS.teal[50] : CORPUS_COLORS.slate[50]};
   }
 
   &:first-child {
-    border-radius: 6px 6px 0 0;
+    border-radius: ${CORPUS_RADII.md} ${CORPUS_RADII.md} 0 0;
   }
 
   &:last-child {
-    border-radius: 0 0 6px 6px;
+    border-radius: 0 0 ${CORPUS_RADII.md} ${CORPUS_RADII.md};
   }
 
   svg {
-    width: 16px;
-    height: 16px;
+    width: 1rem;
+    height: 1rem;
     flex-shrink: 0;
+    color: ${CORPUS_COLORS.teal[600]};
   }
 `;
 
 const MenuItemContent = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 0.125rem;
 `;
 
 const MenuItemLabel = styled.span`
-  font-weight: 500;
+  font-weight: 600;
 `;
 
 const MenuItemDescription = styled.span`
-  font-size: 12px;
-  color: ${color.N6};
+  font-size: 0.75rem;
+  color: ${CORPUS_COLORS.slate[500]};
 `;
 
 interface SortOption {

--- a/frontend/src/components/threads/VoteButtons.tsx
+++ b/frontend/src/components/threads/VoteButtons.tsx
@@ -1,8 +1,13 @@
 import React, { useState, useCallback } from "react";
 import { useMutation, ApolloCache } from "@apollo/client";
-import styled from "styled-components";
-import { ChevronUp, ChevronDown } from "lucide-react";
-import { color } from "../../theme/colors";
+import styled, { css } from "styled-components";
+import { ThumbsUp, ThumbsDown, ChevronUp, ChevronDown } from "lucide-react";
+import {
+  CORPUS_COLORS,
+  CORPUS_FONTS,
+  CORPUS_RADII,
+  CORPUS_TRANSITIONS,
+} from "./styles/discussionStyles";
 import {
   UPVOTE_MESSAGE,
   DOWNVOTE_MESSAGE,
@@ -16,48 +21,43 @@ import {
   VoteMessageResponse,
 } from "../../graphql/mutations";
 
-const Container = styled.div`
+const Container = styled.div<{ $compact?: boolean }>`
   display: flex;
-  flex-direction: column;
+  flex-direction: ${({ $compact }) => ($compact ? "row" : "column")};
   align-items: center;
-  gap: 2px;
+  gap: ${({ $compact }) => ($compact ? "0.125rem" : "0")};
 `;
 
 const VoteButton = styled.button<{
   $isActive?: boolean;
   $variant?: "up" | "down";
+  $compact?: boolean;
 }>`
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 32px;
-  height: 32px;
+  width: ${({ $compact }) => ($compact ? "1.5rem" : "1.75rem")};
+  height: ${({ $compact }) => ($compact ? "1.5rem" : "1.75rem")};
   border: none;
-  border-radius: 4px;
-  background: ${({ $isActive, $variant, theme }) => {
-    if ($isActive && $variant === "up") return theme.color.success + "20";
-    if ($isActive && $variant === "down") return color.R7 + "20";
+  border-radius: ${CORPUS_RADII.sm};
+  background: ${({ $isActive, $variant }) => {
+    if ($isActive && $variant === "up") return CORPUS_COLORS.teal[50];
+    if ($isActive && $variant === "down") return "#fee2e2";
     return "transparent";
   }};
-  color: ${({ $isActive, $variant, theme }) => {
-    if ($isActive && $variant === "up") return theme.color.success;
-    if ($isActive && $variant === "down") return color.R7;
-    return color.N7;
+  color: ${({ $isActive, $variant }) => {
+    if ($isActive && $variant === "up") return CORPUS_COLORS.teal[700];
+    if ($isActive && $variant === "down") return "#dc2626";
+    return CORPUS_COLORS.slate[400];
   }};
   cursor: pointer;
-  transition: all 0.15s ease;
+  transition: all ${CORPUS_TRANSITIONS.fast};
 
   &:hover:not(:disabled) {
-    background: ${({ $variant, theme }) => {
-      if ($variant === "up") return theme.color.success + "15";
-      if ($variant === "down") return color.R7 + "15";
-      return color.N2;
-    }};
-    color: ${({ $variant, theme }) => {
-      if ($variant === "up") return theme.color.success;
-      if ($variant === "down") return color.R7;
-      return color.N10;
-    }};
+    background: ${({ $variant }) =>
+      $variant === "up" ? CORPUS_COLORS.teal[50] : "#fee2e2"};
+    color: ${({ $variant }) =>
+      $variant === "up" ? CORPUS_COLORS.teal[700] : "#dc2626"};
   }
 
   &:disabled {
@@ -66,21 +66,22 @@ const VoteButton = styled.button<{
   }
 
   svg {
-    width: 20px;
-    height: 20px;
+    width: ${({ $compact }) => ($compact ? "0.875rem" : "1.125rem")};
+    height: ${({ $compact }) => ($compact ? "0.875rem" : "1.125rem")};
   }
 `;
 
-const VoteCount = styled.div<{ $score: number }>`
-  font-size: 14px;
+const VoteCount = styled.div<{ $score: number; $compact?: boolean }>`
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: ${({ $compact }) => ($compact ? "0.75rem" : "0.8125rem")};
   font-weight: 600;
-  color: ${({ $score, theme }) => {
-    if ($score > 0) return theme.color.success;
-    if ($score < 0) return color.R7;
-    return color.N7;
+  color: ${({ $score }) => {
+    if ($score > 0) return CORPUS_COLORS.teal[700];
+    if ($score < 0) return "#dc2626";
+    return CORPUS_COLORS.slate[500];
   }};
-  padding: 2px 0;
-  min-width: 24px;
+  padding: ${({ $compact }) => ($compact ? "0 0.25rem" : "0.125rem 0")};
+  min-width: ${({ $compact }) => ($compact ? "auto" : "1.5rem")};
   text-align: center;
 `;
 
@@ -89,12 +90,13 @@ const ErrorMessage = styled.div`
   top: 100%;
   left: 50%;
   transform: translateX(-50%);
-  margin-top: 4px;
-  padding: 6px 10px;
-  background: ${({ theme }) => color.R7};
+  margin-top: 0.25rem;
+  padding: 0.375rem 0.625rem;
+  background: #dc2626;
   color: white;
-  font-size: 12px;
-  border-radius: 4px;
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: 0.75rem;
+  border-radius: ${CORPUS_RADII.sm};
   white-space: nowrap;
   z-index: 10;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
@@ -106,7 +108,7 @@ const ErrorMessage = styled.div`
     left: 50%;
     transform: translateX(-50%);
     border: 4px solid transparent;
-    border-bottom-color: ${({ theme }) => color.R7};
+    border-bottom-color: #dc2626;
   }
 `;
 
@@ -131,6 +133,8 @@ export interface VoteButtonsProps {
   disabled?: boolean;
   /** Optional callback when vote changes */
   onVoteChange?: (newScore: number) => void;
+  /** Compact horizontal layout with thumbs icons */
+  compact?: boolean;
 }
 
 /**
@@ -167,6 +171,7 @@ export const VoteButtons = React.memo(function VoteButtons({
   currentUserId,
   disabled = false,
   onVoteChange,
+  compact = false,
 }: VoteButtonsProps) {
   const [error, setError] = useState<string | null>(null);
   const [optimisticVote, setOptimisticVote] = useState<string | null>(null);
@@ -339,31 +344,38 @@ export const VoteButtons = React.memo(function VoteButtons({
     displayScore += 1;
   }
 
+  const UpIcon = compact ? ThumbsUp : ChevronUp;
+  const DownIcon = compact ? ThumbsDown : ChevronDown;
+
   return (
     <Wrapper>
-      <Container>
+      <Container $compact={compact}>
         <VoteButton
           $variant="up"
           $isActive={currentVote === "UPVOTE"}
+          $compact={compact}
           onClick={handleUpvote}
           disabled={disabled || loading}
           title={isOwnMessage ? "Cannot vote on own message" : "Upvote"}
           aria-label="Upvote"
         >
-          <ChevronUp />
+          <UpIcon />
         </VoteButton>
 
-        <VoteCount $score={displayScore}>{displayScore}</VoteCount>
+        <VoteCount $score={displayScore} $compact={compact}>
+          {displayScore}
+        </VoteCount>
 
         <VoteButton
           $variant="down"
           $isActive={currentVote === "DOWNVOTE"}
+          $compact={compact}
           onClick={handleDownvote}
           disabled={disabled || loading}
           title={isOwnMessage ? "Cannot vote on own message" : "Downvote"}
           aria-label="Downvote"
         >
-          <ChevronDown />
+          <DownIcon />
         </VoteButton>
       </Container>
 

--- a/frontend/src/components/threads/__tests__/MessageItem.test.ts
+++ b/frontend/src/components/threads/__tests__/MessageItem.test.ts
@@ -1,11 +1,12 @@
 /**
  * Unit tests for MessageItem helper functions
  *
- * Tests the getAgentDisplayData and hexToRgba helper functions
- * that support agent message styling.
+ * Tests the getAgentDisplayData function that supports agent message styling.
+ * hexToRgba tests are now in utils/__tests__/colorUtils.test.ts
  */
 import { describe, it, expect } from "vitest";
-import { getAgentDisplayData, hexToRgba } from "../MessageItem";
+import { getAgentDisplayData } from "../MessageItem";
+import { hexToRgba } from "../../../utils/colorUtils";
 import { AgentConfigurationType } from "../../../types/graphql-api";
 
 describe("getAgentDisplayData", () => {

--- a/frontend/src/components/threads/styles/contextSidebarStyles.ts
+++ b/frontend/src/components/threads/styles/contextSidebarStyles.ts
@@ -34,6 +34,11 @@ export const ThreadWithContextContainer = styled.div`
   min-height: 0;
   overflow: hidden;
   background: ${CORPUS_COLORS.slate[50]};
+
+  /* Focus styles for accessibility - programmatic focus shouldn't show outline */
+  &:focus {
+    outline: none;
+  }
 `;
 
 /** Thread detail pane - takes remaining space */

--- a/frontend/src/components/threads/styles/contextSidebarStyles.ts
+++ b/frontend/src/components/threads/styles/contextSidebarStyles.ts
@@ -67,6 +67,7 @@ export const ContextSidebarContainer = styled(motion.aside)<{
 }>`
   display: flex;
   flex-direction: column;
+  flex-shrink: 0;
   width: ${({ $isExpanded, $isCollapsible }) =>
     $isCollapsible
       ? $isExpanded

--- a/frontend/src/components/threads/styles/contextSidebarStyles.ts
+++ b/frontend/src/components/threads/styles/contextSidebarStyles.ts
@@ -1,0 +1,430 @@
+/**
+ * Styled components for the CorpusContextSidebar
+ * Used when viewing thread details inline within the Discussions tab
+ */
+
+import styled from "styled-components";
+import { motion } from "framer-motion";
+import {
+  CORPUS_COLORS,
+  CORPUS_FONTS,
+  CORPUS_RADII,
+  CORPUS_SHADOWS,
+  CORPUS_TRANSITIONS,
+  CORPUS_BREAKPOINTS,
+} from "../../corpuses/styles/corpusDesignTokens";
+
+// ============================================================================
+// LAYOUT CONSTANTS
+// ============================================================================
+
+export const SIDEBAR_WIDTH = 320;
+export const SIDEBAR_COLLAPSED_WIDTH = 48;
+export const SIDEBAR_BREAKPOINT_HIDE = 1024;
+export const SIDEBAR_BREAKPOINT_COLLAPSE = 1200;
+
+// ============================================================================
+// MAIN CONTAINERS
+// ============================================================================
+
+/** Main flex container for thread detail + sidebar layout */
+export const ThreadWithContextContainer = styled.div`
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+  background: ${CORPUS_COLORS.slate[50]};
+`;
+
+/** Thread detail pane - takes remaining space */
+export const ThreadDetailPane = styled.div`
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+`;
+
+/** Vertical divider between thread and sidebar */
+export const VerticalDivider = styled.div`
+  width: 1px;
+  background: ${CORPUS_COLORS.slate[200]};
+  flex-shrink: 0;
+
+  @media (max-width: ${SIDEBAR_BREAKPOINT_HIDE}px) {
+    display: none;
+  }
+`;
+
+// ============================================================================
+// SIDEBAR CONTAINER
+// ============================================================================
+
+/** Context sidebar container - fixed/collapsible width */
+export const ContextSidebarContainer = styled(motion.aside)<{
+  $isExpanded: boolean;
+  $isCollapsible: boolean;
+}>`
+  display: flex;
+  flex-direction: column;
+  width: ${({ $isExpanded, $isCollapsible }) =>
+    $isCollapsible
+      ? $isExpanded
+        ? `${SIDEBAR_WIDTH}px`
+        : `${SIDEBAR_COLLAPSED_WIDTH}px`
+      : `${SIDEBAR_WIDTH}px`};
+  min-width: ${({ $isExpanded, $isCollapsible }) =>
+    $isCollapsible
+      ? $isExpanded
+        ? `${SIDEBAR_WIDTH}px`
+        : `${SIDEBAR_COLLAPSED_WIDTH}px`
+      : `${SIDEBAR_WIDTH}px`};
+  max-width: ${SIDEBAR_WIDTH}px;
+  background: ${CORPUS_COLORS.white};
+  border-left: 1px solid ${CORPUS_COLORS.slate[200]};
+  overflow: hidden;
+  transition: all ${CORPUS_TRANSITIONS.normal};
+
+  /* Hide on small screens */
+  @media (max-width: ${SIDEBAR_BREAKPOINT_HIDE}px) {
+    display: none;
+  }
+`;
+
+/** Sidebar header */
+export const SidebarHeader = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid ${CORPUS_COLORS.slate[200]};
+  background: ${CORPUS_COLORS.white};
+  flex-shrink: 0;
+`;
+
+/** Sidebar title */
+export const SidebarTitle = styled.h3`
+  margin: 0;
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: ${CORPUS_COLORS.slate[700]};
+`;
+
+/** Close/toggle button */
+export const ContextSidebarToggle = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  padding: 0;
+  border: none;
+  border-radius: ${CORPUS_RADII.sm};
+  background: transparent;
+  color: ${CORPUS_COLORS.slate[400]};
+  cursor: pointer;
+  transition: all ${CORPUS_TRANSITIONS.fast};
+
+  &:hover {
+    background: ${CORPUS_COLORS.slate[100]};
+    color: ${CORPUS_COLORS.slate[600]};
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${CORPUS_COLORS.teal[500]};
+    outline-offset: 2px;
+  }
+
+  svg {
+    width: 1rem;
+    height: 1rem;
+  }
+`;
+
+/** Collapsed sidebar with toggle button */
+export const CollapsedSidebar = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 1rem 0;
+  gap: 0.5rem;
+`;
+
+/** Collapsed sidebar expand button */
+export const ExpandSidebarButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  border: 1px solid ${CORPUS_COLORS.slate[200]};
+  border-radius: ${CORPUS_RADII.md};
+  background: ${CORPUS_COLORS.white};
+  color: ${CORPUS_COLORS.slate[500]};
+  cursor: pointer;
+  transition: all ${CORPUS_TRANSITIONS.fast};
+
+  &:hover {
+    border-color: ${CORPUS_COLORS.teal[300]};
+    background: ${CORPUS_COLORS.teal[50]};
+    color: ${CORPUS_COLORS.teal[700]};
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${CORPUS_COLORS.teal[500]};
+    outline-offset: 2px;
+  }
+
+  svg {
+    width: 1rem;
+    height: 1rem;
+  }
+`;
+
+// ============================================================================
+// SIDEBAR CONTENT
+// ============================================================================
+
+/** Scrollable sidebar content */
+export const SidebarContent = styled.div`
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 0;
+
+  &::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: ${CORPUS_COLORS.slate[200]};
+    border-radius: 3px;
+
+    &:hover {
+      background: ${CORPUS_COLORS.slate[300]};
+    }
+  }
+`;
+
+/** Sidebar section */
+export const SidebarSection = styled.section`
+  border-bottom: 1px solid ${CORPUS_COLORS.slate[100]};
+
+  &:last-child {
+    border-bottom: none;
+  }
+`;
+
+/** Section header with toggle */
+export const SectionHeader = styled.button<{ $isExpanded?: boolean }>`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 0.875rem 1.25rem;
+  border: none;
+  background: ${({ $isExpanded }) =>
+    $isExpanded ? CORPUS_COLORS.slate[50] : CORPUS_COLORS.white};
+  cursor: pointer;
+  transition: background ${CORPUS_TRANSITIONS.fast};
+
+  &:hover {
+    background: ${CORPUS_COLORS.slate[50]};
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${CORPUS_COLORS.teal[500]};
+    outline-offset: -2px;
+  }
+`;
+
+/** Section title */
+export const SectionTitle = styled.span`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: ${CORPUS_COLORS.slate[700]};
+
+  svg {
+    width: 1rem;
+    height: 1rem;
+    color: ${CORPUS_COLORS.teal[600]};
+  }
+`;
+
+/** Section chevron */
+export const SectionChevron = styled.span<{ $isExpanded?: boolean }>`
+  display: flex;
+  align-items: center;
+  color: ${CORPUS_COLORS.slate[400]};
+  transition: transform ${CORPUS_TRANSITIONS.fast};
+  transform: rotate(${({ $isExpanded }) => ($isExpanded ? "180deg" : "0deg")});
+
+  svg {
+    width: 1rem;
+    height: 1rem;
+  }
+`;
+
+/** Section content (collapsible) */
+export const SectionContent = styled(motion.div)`
+  overflow: hidden;
+`;
+
+/** Section inner content with padding */
+export const SectionInner = styled.div`
+  padding: 0.5rem 1.25rem 1rem;
+`;
+
+// ============================================================================
+// QUICK STATS
+// ============================================================================
+
+/** Stats grid */
+export const StatsGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.75rem;
+`;
+
+/** Stat item */
+export const StatItem = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.75rem;
+  background: ${CORPUS_COLORS.slate[50]};
+  border-radius: ${CORPUS_RADII.md};
+  border: 1px solid ${CORPUS_COLORS.slate[100]};
+`;
+
+/** Stat value */
+export const StatValue = styled.span`
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: ${CORPUS_COLORS.slate[800]};
+`;
+
+/** Stat label */
+export const StatLabel = styled.span`
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: 0.6875rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: ${CORPUS_COLORS.slate[500]};
+`;
+
+// ============================================================================
+// ABOUT SECTION OVERRIDES
+// ============================================================================
+
+/** Compact about content wrapper */
+export const CompactAboutWrapper = styled.div`
+  /* Override AboutContent styles for compact sidebar display */
+  font-size: 0.875rem;
+  line-height: 1.6;
+  color: ${CORPUS_COLORS.slate[600]};
+
+  p {
+    margin-bottom: 0.75rem;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  /* Constrain markdown content */
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-size: 0.9375rem;
+    margin-top: 1rem;
+    margin-bottom: 0.5rem;
+    color: ${CORPUS_COLORS.teal[700]};
+  }
+
+  ul,
+  ol {
+    padding-left: 1.25rem;
+    margin-bottom: 0.75rem;
+  }
+
+  code {
+    font-size: 0.8125rem;
+    padding: 0.125rem 0.375rem;
+    background: ${CORPUS_COLORS.slate[100]};
+    border-radius: ${CORPUS_RADII.sm};
+  }
+
+  pre {
+    font-size: 0.75rem;
+    padding: 0.75rem;
+    background: ${CORPUS_COLORS.slate[100]};
+    border-radius: ${CORPUS_RADII.md};
+    overflow-x: auto;
+  }
+`;
+
+// ============================================================================
+// DOCUMENTS TOC SECTION OVERRIDES
+// ============================================================================
+
+/** Compact TOC wrapper */
+export const CompactTocWrapper = styled.div`
+  /* Override DocumentTableOfContents styles for compact sidebar display */
+  max-height: 300px;
+  overflow-y: auto;
+
+  &::-webkit-scrollbar {
+    width: 4px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: ${CORPUS_COLORS.slate[200]};
+    border-radius: 2px;
+  }
+`;
+
+// ============================================================================
+// EMPTY STATE
+// ============================================================================
+
+/** Empty section state */
+export const EmptySectionState = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 1.5rem 1rem;
+  text-align: center;
+  color: ${CORPUS_COLORS.slate[400]};
+
+  svg {
+    width: 2rem;
+    height: 2rem;
+    margin-bottom: 0.5rem;
+    opacity: 0.5;
+  }
+
+  p {
+    font-size: 0.8125rem;
+    margin: 0;
+  }
+`;

--- a/frontend/src/components/threads/styles/discussionStyles.ts
+++ b/frontend/src/components/threads/styles/discussionStyles.ts
@@ -1,0 +1,949 @@
+/**
+ * Shared styles for discussion thread components
+ * Following the OS-Legal-Style design system established in corpusDesignTokens.ts
+ *
+ * Design principles:
+ * - Typography-first: Serif headings (Georgia), sans-serif body (Inter)
+ * - Teal accent: teal-700 (#0f766e) for interactive elements
+ * - Generous whitespace: 2rem+ padding, 1-1.5rem gaps
+ * - Subtle shadows: Light card shadows, no heavy drops
+ * - Smooth transitions: 0.15s-0.3s ease for interactions
+ */
+
+import styled from "styled-components";
+
+// Re-export design tokens from corpusDesignTokens for consistency
+export {
+  CORPUS_COLORS,
+  CORPUS_FONTS,
+  CORPUS_FONT_SIZES,
+  CORPUS_SPACING,
+  CORPUS_RADII,
+  CORPUS_SHADOWS,
+  CORPUS_TRANSITIONS,
+  CORPUS_BREAKPOINTS,
+  mediaQuery,
+} from "../../corpuses/styles/corpusDesignTokens";
+
+import {
+  CORPUS_COLORS,
+  CORPUS_FONTS,
+  CORPUS_FONT_SIZES,
+  CORPUS_RADII,
+  CORPUS_SHADOWS,
+  CORPUS_TRANSITIONS,
+  mediaQuery,
+} from "../../corpuses/styles/corpusDesignTokens";
+
+// ============================================================================
+// Typography Components
+// ============================================================================
+
+/**
+ * Serif title for discussion headings
+ * Use for thread titles and major section headers
+ */
+export const DiscussionTitle = styled.h1<{ $size?: "sm" | "md" | "lg" }>`
+  font-family: ${CORPUS_FONTS.serif};
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  line-height: 1.3;
+  color: ${CORPUS_COLORS.slate[900]};
+  margin: 0;
+
+  ${({ $size = "md" }) => {
+    switch ($size) {
+      case "sm":
+        return `font-size: ${CORPUS_FONT_SIZES.xl};`; // 18px
+      case "lg":
+        return `font-size: ${CORPUS_FONT_SIZES["4xl"]};`; // 32px
+      default:
+        return `font-size: ${CORPUS_FONT_SIZES["3xl"]};`; // 24px
+    }
+  }}
+
+  ${mediaQuery.mobile} {
+    ${({ $size = "md" }) => {
+      switch ($size) {
+        case "sm":
+          return `font-size: ${CORPUS_FONT_SIZES.lg};`; // 16px
+        case "lg":
+          return `font-size: ${CORPUS_FONT_SIZES["3xl"]};`; // 24px
+        default:
+          return `font-size: ${CORPUS_FONT_SIZES["2xl"]};`; // 20px
+      }
+    }}
+  }
+`;
+
+/**
+ * Subtitle for discussion descriptions
+ */
+export const DiscussionSubtitle = styled.p`
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: ${CORPUS_FONT_SIZES.md};
+  font-weight: 400;
+  line-height: 1.65;
+  color: ${CORPUS_COLORS.slate[600]};
+  margin: 0;
+
+  ${mediaQuery.mobile} {
+    font-size: ${CORPUS_FONT_SIZES.base};
+  }
+`;
+
+/**
+ * Section header for grouping content
+ */
+export const DiscussionSectionHeader = styled.h2`
+  font-family: ${CORPUS_FONTS.serif};
+  font-size: ${CORPUS_FONT_SIZES["2xl"]};
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: ${CORPUS_COLORS.slate[800]};
+  margin: 0;
+
+  ${mediaQuery.mobile} {
+    font-size: ${CORPUS_FONT_SIZES.xl};
+  }
+`;
+
+// ============================================================================
+// Badge Components
+// ============================================================================
+
+/**
+ * Pill-shaped badge with teal accent
+ * Used for discussion types, status indicators
+ */
+export const DiscussionBadge = styled.span<{
+  $variant?: "teal" | "green" | "amber" | "red" | "slate";
+}>`
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem 0.75rem;
+  border-radius: ${CORPUS_RADII.full};
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: ${CORPUS_FONT_SIZES.xs};
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  transition: all ${CORPUS_TRANSITIONS.fast};
+
+  ${({ $variant = "teal" }) => {
+    switch ($variant) {
+      case "green":
+        return `
+          background: #dcfce7;
+          color: #166534;
+          border: 1px solid #86efac;
+        `;
+      case "amber":
+        return `
+          background: #fef3c7;
+          color: #92400e;
+          border: 1px solid #fcd34d;
+        `;
+      case "red":
+        return `
+          background: #fee2e2;
+          color: #991b1b;
+          border: 1px solid #fca5a5;
+        `;
+      case "slate":
+        return `
+          background: ${CORPUS_COLORS.slate[100]};
+          color: ${CORPUS_COLORS.slate[600]};
+          border: 1px solid ${CORPUS_COLORS.slate[300]};
+        `;
+      default: // teal
+        return `
+          background: ${CORPUS_COLORS.teal[50]};
+          color: ${CORPUS_COLORS.teal[700]};
+          border: 1px solid ${CORPUS_COLORS.teal[200]};
+        `;
+    }
+  }}
+
+  svg {
+    width: 0.75rem;
+    height: 0.75rem;
+    flex-shrink: 0;
+  }
+`;
+
+/**
+ * Compact status indicator badge
+ */
+export const StatusIndicator = styled.span<{
+  $status?: "pinned" | "locked" | "deleted";
+}>`
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.125rem 0.5rem;
+  border-radius: ${CORPUS_RADII.sm};
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+
+  ${({ $status = "pinned" }) => {
+    switch ($status) {
+      case "locked":
+        return `
+          background: #fef3c7;
+          color: #92400e;
+        `;
+      case "deleted":
+        return `
+          background: ${CORPUS_COLORS.slate[100]};
+          color: ${CORPUS_COLORS.slate[500]};
+        `;
+      default: // pinned
+        return `
+          background: ${CORPUS_COLORS.teal[50]};
+          color: ${CORPUS_COLORS.teal[700]};
+        `;
+    }
+  }}
+
+  svg {
+    width: 0.6875rem;
+    height: 0.6875rem;
+    flex-shrink: 0;
+  }
+`;
+
+// ============================================================================
+// Card Components
+// ============================================================================
+
+/**
+ * Base card component for discussion items
+ * White background, subtle border, hover shadow
+ */
+export const DiscussionCard = styled.div<{
+  $isSelected?: boolean;
+  $isHighlighted?: boolean;
+  $isDeleted?: boolean;
+}>`
+  background: ${CORPUS_COLORS.white};
+  border: 1px solid ${CORPUS_COLORS.slate[200]};
+  border-radius: ${CORPUS_RADII.lg};
+  padding: 1.25rem;
+  transition: all ${CORPUS_TRANSITIONS.normal};
+
+  ${({ $isSelected }) =>
+    $isSelected &&
+    `
+    border-left: 3px solid ${CORPUS_COLORS.teal[600]};
+    background: ${CORPUS_COLORS.teal[50]};
+  `}
+
+  ${({ $isHighlighted }) =>
+    $isHighlighted &&
+    `
+    border-color: ${CORPUS_COLORS.teal[300]};
+    background: ${CORPUS_COLORS.teal[50]};
+  `}
+
+  ${({ $isDeleted }) =>
+    $isDeleted &&
+    `
+    opacity: 0.6;
+    background: ${CORPUS_COLORS.slate[50]};
+  `}
+
+  &:hover {
+    border-color: ${CORPUS_COLORS.slate[300]};
+    box-shadow: ${CORPUS_SHADOWS.cardHover};
+    transform: translateY(-1px);
+  }
+
+  ${mediaQuery.mobile} {
+    padding: 1rem;
+    border-radius: ${CORPUS_RADII.md};
+  }
+`;
+
+/**
+ * Thread/message container card with left accent
+ */
+export const ThreadCard = styled(DiscussionCard)<{
+  $isPinned?: boolean;
+  $depth?: number;
+}>`
+  cursor: pointer;
+  display: flex;
+  gap: 1rem;
+
+  ${({ $isPinned }) =>
+    $isPinned &&
+    `
+    border-left: 3px solid ${CORPUS_COLORS.teal[500]};
+    background: linear-gradient(135deg, ${CORPUS_COLORS.teal[50]} 0%, ${CORPUS_COLORS.white} 100%);
+  `}
+
+  ${({ $depth = 0 }) =>
+    $depth > 0 &&
+    `
+    margin-left: ${Math.min($depth * 1.5, 6)}rem;
+    border-left: 2px solid ${CORPUS_COLORS.teal[200]};
+  `}
+
+  ${mediaQuery.mobile} {
+    gap: 0.75rem;
+    ${({ $depth = 0 }) =>
+      $depth > 0 &&
+      `
+      margin-left: ${Math.min($depth * 1, 3)}rem;
+    `}
+  }
+`;
+
+/**
+ * Message item card with agent styling support
+ */
+export const MessageCard = styled(DiscussionCard)<{
+  $isAgent?: boolean;
+  $agentColor?: string;
+}>`
+  display: flex;
+  gap: 0.75rem;
+
+  ${({ $isAgent, $agentColor }) =>
+    $isAgent &&
+    `
+    background: linear-gradient(135deg, ${
+      $agentColor || CORPUS_COLORS.teal[700]
+    }08 0%, ${$agentColor || CORPUS_COLORS.teal[700]}03 100%);
+    border-color: ${$agentColor || CORPUS_COLORS.teal[700]}40;
+    border-left: 3px solid ${$agentColor || CORPUS_COLORS.teal[700]};
+  `}
+`;
+
+// ============================================================================
+// Metadata Components
+// ============================================================================
+
+/**
+ * Metadata row for author info, timestamps, stats
+ */
+export const DiscussionMetadata = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: ${CORPUS_FONT_SIZES.sm};
+  color: ${CORPUS_COLORS.slate[500]};
+  flex-wrap: wrap;
+
+  svg {
+    width: 0.875rem;
+    height: 0.875rem;
+    color: ${CORPUS_COLORS.slate[400]};
+  }
+
+  ${mediaQuery.mobile} {
+    font-size: ${CORPUS_FONT_SIZES.xs};
+    gap: 0.5rem;
+  }
+`;
+
+/**
+ * Metadata item with icon
+ */
+export const MetadataItem = styled.span`
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  white-space: nowrap;
+
+  strong {
+    color: ${CORPUS_COLORS.slate[700]};
+    font-weight: 600;
+  }
+`;
+
+/**
+ * Dot separator for metadata
+ */
+export const MetadataDot = styled.span`
+  color: ${CORPUS_COLORS.slate[300]};
+  font-size: 0.5rem;
+`;
+
+// ============================================================================
+// Avatar Components
+// ============================================================================
+
+/**
+ * User avatar with teal gradient for humans
+ */
+export const UserAvatar = styled.div<{
+  $size?: "sm" | "md" | "lg";
+  $isAgent?: boolean;
+  $agentColor?: string;
+}>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  flex-shrink: 0;
+  color: ${CORPUS_COLORS.white};
+  font-weight: 600;
+
+  ${({ $size = "md" }) => {
+    switch ($size) {
+      case "sm":
+        return `
+          width: 1.5rem;
+          height: 1.5rem;
+          font-size: 0.625rem;
+        `;
+      case "lg":
+        return `
+          width: 2.5rem;
+          height: 2.5rem;
+          font-size: 0.875rem;
+        `;
+      default:
+        return `
+          width: 1.75rem;
+          height: 1.75rem;
+          font-size: 0.75rem;
+        `;
+    }
+  }}
+
+  ${({ $isAgent, $agentColor }) =>
+    $isAgent
+      ? `background: linear-gradient(135deg, ${$agentColor || "#4A90E2"} 0%, ${
+          $agentColor || "#4A90E2"
+        }dd 100%);`
+      : `background: linear-gradient(135deg, ${CORPUS_COLORS.teal[600]} 0%, ${CORPUS_COLORS.teal[700]} 100%);`}
+
+  svg {
+    ${({ $size = "md" }) => {
+      switch ($size) {
+        case "sm":
+          return `width: 0.75rem; height: 0.75rem;`;
+        case "lg":
+          return `width: 1.25rem; height: 1.25rem;`;
+        default:
+          return `width: 0.875rem; height: 0.875rem;`;
+      }
+    }}
+  }
+`;
+
+// ============================================================================
+// Button Components
+// ============================================================================
+
+/**
+ * Primary teal button with gradient
+ */
+export const PrimaryButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.625rem 1.25rem;
+  border: none;
+  border-radius: ${CORPUS_RADII.md};
+  background: linear-gradient(
+    135deg,
+    ${CORPUS_COLORS.teal[600]} 0%,
+    ${CORPUS_COLORS.teal[700]} 100%
+  );
+  color: ${CORPUS_COLORS.white};
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: ${CORPUS_FONT_SIZES.base};
+  font-weight: 600;
+  cursor: pointer;
+  transition: all ${CORPUS_TRANSITIONS.normal};
+  box-shadow: 0 4px 12px rgba(15, 118, 110, 0.35);
+
+  &:hover:not(:disabled) {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px rgba(15, 118, 110, 0.45);
+    background: linear-gradient(
+      135deg,
+      ${CORPUS_COLORS.teal[500]} 0%,
+      ${CORPUS_COLORS.teal[600]} 100%
+    );
+  }
+
+  &:active:not(:disabled) {
+    transform: translateY(0);
+    box-shadow: 0 2px 8px rgba(15, 118, 110, 0.3);
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    transform: none;
+  }
+
+  svg {
+    width: 1rem;
+    height: 1rem;
+  }
+`;
+
+/**
+ * Secondary ghost button
+ */
+export const SecondaryButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.375rem;
+  padding: 0.5rem 1rem;
+  border: 1px solid ${CORPUS_COLORS.slate[200]};
+  border-radius: ${CORPUS_RADII.md};
+  background: ${CORPUS_COLORS.white};
+  color: ${CORPUS_COLORS.slate[700]};
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: ${CORPUS_FONT_SIZES.sm};
+  font-weight: 500;
+  cursor: pointer;
+  transition: all ${CORPUS_TRANSITIONS.fast};
+
+  &:hover:not(:disabled) {
+    border-color: ${CORPUS_COLORS.teal[300]};
+    background: ${CORPUS_COLORS.teal[50]};
+    color: ${CORPUS_COLORS.teal[700]};
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  svg {
+    width: 0.875rem;
+    height: 0.875rem;
+  }
+`;
+
+/**
+ * Text-only button for inline actions
+ */
+export const TextButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem 0.5rem;
+  border: none;
+  border-radius: ${CORPUS_RADII.sm};
+  background: transparent;
+  color: ${CORPUS_COLORS.slate[600]};
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: ${CORPUS_FONT_SIZES.sm};
+  font-weight: 500;
+  cursor: pointer;
+  transition: all ${CORPUS_TRANSITIONS.fast};
+
+  &:hover:not(:disabled) {
+    background: ${CORPUS_COLORS.teal[50]};
+    color: ${CORPUS_COLORS.teal[700]};
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  svg {
+    width: 0.875rem;
+    height: 0.875rem;
+  }
+`;
+
+// ============================================================================
+// Vote Components
+// ============================================================================
+
+/**
+ * Vote button with teal upvote accent
+ */
+export const VoteButton = styled.button<{
+  $isActive?: boolean;
+  $variant?: "up" | "down";
+}>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  border: none;
+  border-radius: ${CORPUS_RADII.sm};
+  background: ${({ $isActive, $variant }) => {
+    if ($isActive && $variant === "up") return CORPUS_COLORS.teal[50];
+    if ($isActive && $variant === "down") return "#fee2e2";
+    return "transparent";
+  }};
+  color: ${({ $isActive, $variant }) => {
+    if ($isActive && $variant === "up") return CORPUS_COLORS.teal[700];
+    if ($isActive && $variant === "down") return "#dc2626";
+    return CORPUS_COLORS.slate[500];
+  }};
+  cursor: pointer;
+  transition: all ${CORPUS_TRANSITIONS.fast};
+
+  &:hover:not(:disabled) {
+    background: ${({ $variant }) =>
+      $variant === "up" ? CORPUS_COLORS.teal[50] : "#fee2e2"};
+    color: ${({ $variant }) =>
+      $variant === "up" ? CORPUS_COLORS.teal[700] : "#dc2626"};
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  svg {
+    width: 1.125rem;
+    height: 1.125rem;
+  }
+`;
+
+/**
+ * Vote count display
+ */
+export const VoteCount = styled.span<{ $score: number }>`
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: ${CORPUS_FONT_SIZES.sm};
+  font-weight: 600;
+  min-width: 1.5rem;
+  text-align: center;
+  color: ${({ $score }) => {
+    if ($score > 0) return CORPUS_COLORS.teal[700];
+    if ($score < 0) return "#dc2626";
+    return CORPUS_COLORS.slate[500];
+  }};
+`;
+
+// ============================================================================
+// Input Components
+// ============================================================================
+
+/**
+ * Text input with teal focus ring
+ */
+export const TextInput = styled.input`
+  width: 100%;
+  padding: 0.625rem 0.875rem;
+  border: 1px solid ${CORPUS_COLORS.slate[200]};
+  border-radius: ${CORPUS_RADII.md};
+  background: ${CORPUS_COLORS.white};
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: ${CORPUS_FONT_SIZES.base};
+  color: ${CORPUS_COLORS.slate[800]};
+  transition: all ${CORPUS_TRANSITIONS.fast};
+
+  &:focus {
+    outline: none;
+    border-color: ${CORPUS_COLORS.teal[500]};
+    box-shadow: 0 0 0 3px ${CORPUS_COLORS.teal[50]};
+  }
+
+  &::placeholder {
+    color: ${CORPUS_COLORS.slate[400]};
+  }
+
+  &:disabled {
+    background: ${CORPUS_COLORS.slate[50]};
+    cursor: not-allowed;
+  }
+`;
+
+/**
+ * Textarea with teal focus ring
+ */
+export const TextArea = styled.textarea`
+  width: 100%;
+  min-height: 6rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid ${CORPUS_COLORS.slate[200]};
+  border-radius: ${CORPUS_RADII.md};
+  background: ${CORPUS_COLORS.white};
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: ${CORPUS_FONT_SIZES.base};
+  color: ${CORPUS_COLORS.slate[800]};
+  resize: vertical;
+  transition: all ${CORPUS_TRANSITIONS.fast};
+
+  &:focus {
+    outline: none;
+    border-color: ${CORPUS_COLORS.teal[500]};
+    box-shadow: 0 0 0 3px ${CORPUS_COLORS.teal[50]};
+  }
+
+  &::placeholder {
+    color: ${CORPUS_COLORS.slate[400]};
+  }
+`;
+
+// ============================================================================
+// Container Components
+// ============================================================================
+
+/**
+ * Page container with max-width and padding
+ */
+export const DiscussionContainer = styled.div`
+  max-width: 64rem;
+  margin: 0 auto;
+  padding: 2rem;
+
+  ${mediaQuery.tablet} {
+    padding: 1.5rem;
+  }
+
+  ${mediaQuery.mobile} {
+    padding: 1rem;
+  }
+`;
+
+/**
+ * Section wrapper with bottom border
+ */
+export const DiscussionSection = styled.section`
+  padding-bottom: 1.5rem;
+  margin-bottom: 1.5rem;
+  border-bottom: 1px solid ${CORPUS_COLORS.slate[200]};
+
+  &:last-child {
+    border-bottom: none;
+    margin-bottom: 0;
+    padding-bottom: 0;
+  }
+`;
+
+/**
+ * Flex container for header rows
+ */
+export const HeaderRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+`;
+
+/**
+ * Grid container for thread lists
+ */
+export const ThreadGrid = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+
+  ${mediaQuery.mobile} {
+    gap: 0.5rem;
+  }
+`;
+
+// ============================================================================
+// Filter/Tab Components
+// ============================================================================
+
+/**
+ * Tab container for filter tabs
+ */
+export const TabContainer = styled.div`
+  display: flex;
+  gap: 0.25rem;
+  background: ${CORPUS_COLORS.slate[100]};
+  padding: 0.25rem;
+  border-radius: ${CORPUS_RADII.lg};
+  border: 1px solid ${CORPUS_COLORS.slate[200]};
+`;
+
+/**
+ * Individual tab button
+ */
+export const TabButton = styled.button<{ $isActive: boolean }>`
+  padding: 0.5rem 1rem;
+  border-radius: ${CORPUS_RADII.md};
+  border: none;
+  background: ${({ $isActive }) =>
+    $isActive ? CORPUS_COLORS.white : "transparent"};
+  color: ${({ $isActive }) =>
+    $isActive ? CORPUS_COLORS.slate[800] : CORPUS_COLORS.slate[600]};
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: ${CORPUS_FONT_SIZES.sm};
+  font-weight: ${({ $isActive }) => ($isActive ? 600 : 500)};
+  cursor: pointer;
+  transition: all ${CORPUS_TRANSITIONS.fast};
+  box-shadow: ${({ $isActive }) => ($isActive ? CORPUS_SHADOWS.sm : "none")};
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+
+  &:hover {
+    background: ${({ $isActive }) =>
+      $isActive ? CORPUS_COLORS.white : "rgba(255,255,255,0.6)"};
+  }
+
+  svg {
+    width: 1rem;
+    height: 1rem;
+  }
+`;
+
+/**
+ * Filter pill button
+ */
+export const FilterPill = styled.button<{ $isActive: boolean }>`
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.375rem 0.75rem;
+  border: 1px solid
+    ${({ $isActive }) =>
+      $isActive ? CORPUS_COLORS.teal[500] : CORPUS_COLORS.slate[200]};
+  border-radius: ${CORPUS_RADII.full};
+  background: ${({ $isActive }) =>
+    $isActive ? CORPUS_COLORS.teal[600] : CORPUS_COLORS.white};
+  color: ${({ $isActive }) =>
+    $isActive ? CORPUS_COLORS.white : CORPUS_COLORS.slate[600]};
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: ${CORPUS_FONT_SIZES.xs};
+  font-weight: 500;
+  cursor: pointer;
+  transition: all ${CORPUS_TRANSITIONS.fast};
+
+  &:hover {
+    border-color: ${CORPUS_COLORS.teal[400]};
+    background: ${({ $isActive }) =>
+      $isActive ? CORPUS_COLORS.teal[700] : CORPUS_COLORS.teal[50]};
+    color: ${({ $isActive }) =>
+      $isActive ? CORPUS_COLORS.white : CORPUS_COLORS.teal[700]};
+  }
+
+  svg {
+    width: 0.75rem;
+    height: 0.75rem;
+  }
+`;
+
+// ============================================================================
+// Search Components
+// ============================================================================
+
+/**
+ * Search input container
+ */
+export const SearchContainer = styled.div`
+  position: relative;
+  flex: 1;
+  min-width: 12rem;
+  max-width: 25rem;
+`;
+
+/**
+ * Search icon positioned inside input
+ */
+export const SearchIcon = styled.span`
+  position: absolute;
+  left: 0.75rem;
+  top: 50%;
+  transform: translateY(-50%);
+  color: ${CORPUS_COLORS.slate[400]};
+  pointer-events: none;
+  display: flex;
+
+  svg {
+    width: 1rem;
+    height: 1rem;
+  }
+`;
+
+/**
+ * Search input field
+ */
+export const SearchInput = styled.input`
+  width: 100%;
+  padding: 0.5rem 0.875rem 0.5rem 2.25rem;
+  border: 1px solid ${CORPUS_COLORS.slate[200]};
+  border-radius: ${CORPUS_RADII.md};
+  background: ${CORPUS_COLORS.white};
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: ${CORPUS_FONT_SIZES.sm};
+  color: ${CORPUS_COLORS.slate[800]};
+  transition: all ${CORPUS_TRANSITIONS.fast};
+
+  &:focus {
+    outline: none;
+    border-color: ${CORPUS_COLORS.teal[500]};
+    box-shadow: 0 0 0 3px ${CORPUS_COLORS.teal[50]};
+  }
+
+  &::placeholder {
+    color: ${CORPUS_COLORS.slate[400]};
+  }
+`;
+
+// ============================================================================
+// Timestamp Component
+// ============================================================================
+
+/**
+ * Relative time display
+ */
+export const Timestamp = styled.span`
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: ${CORPUS_FONT_SIZES.xs};
+  color: ${CORPUS_COLORS.slate[400]};
+  white-space: nowrap;
+`;
+
+// ============================================================================
+// Empty State Component
+// ============================================================================
+
+/**
+ * Empty state container
+ */
+export const EmptyState = styled.div`
+  text-align: center;
+  padding: 3rem 1.5rem;
+  color: ${CORPUS_COLORS.slate[500]};
+
+  h3 {
+    font-family: ${CORPUS_FONTS.serif};
+    font-size: ${CORPUS_FONT_SIZES.xl};
+    font-weight: 600;
+    color: ${CORPUS_COLORS.slate[700]};
+    margin: 0 0 0.5rem 0;
+  }
+
+  p {
+    font-family: ${CORPUS_FONTS.sans};
+    font-size: ${CORPUS_FONT_SIZES.base};
+    margin: 0;
+    line-height: 1.5;
+  }
+`;
+
+// ============================================================================
+// Loading State Component
+// ============================================================================
+
+/**
+ * Loading container
+ */
+export const LoadingContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+`;

--- a/frontend/src/components/threads/styles/discussionStyles.ts
+++ b/frontend/src/components/threads/styles/discussionStyles.ts
@@ -12,8 +12,8 @@
 
 import styled from "styled-components";
 
-// Re-export design tokens from corpusDesignTokens for consistency
-export {
+// Import design tokens from corpusDesignTokens for consistency
+import {
   CORPUS_COLORS,
   CORPUS_FONTS,
   CORPUS_FONT_SIZES,
@@ -25,15 +25,18 @@ export {
   mediaQuery,
 } from "../../corpuses/styles/corpusDesignTokens";
 
-import {
+// Re-export for external use
+export {
   CORPUS_COLORS,
   CORPUS_FONTS,
   CORPUS_FONT_SIZES,
+  CORPUS_SPACING,
   CORPUS_RADII,
   CORPUS_SHADOWS,
   CORPUS_TRANSITIONS,
+  CORPUS_BREAKPOINTS,
   mediaQuery,
-} from "../../corpuses/styles/corpusDesignTokens";
+};
 
 // ============================================================================
 // Typography Components

--- a/frontend/src/utils/colorUtils.ts
+++ b/frontend/src/utils/colorUtils.ts
@@ -1,0 +1,146 @@
+/**
+ * Color manipulation utilities
+ *
+ * Provides functions for working with hex colors, converting to RGB/RGBA,
+ * and validating color values. Used throughout the application for
+ * styling components with dynamic colors.
+ */
+
+/**
+ * Validates that a string is a valid hex color (3 or 6 digit format).
+ * Accepts formats: #RGB, #RRGGBB, RGB, RRGGBB
+ *
+ * @param value - The string to validate
+ * @returns True if the string is a valid hex color
+ *
+ * @example
+ * isValidHexColor("#fff")     // true
+ * isValidHexColor("#FF0000")  // true
+ * isValidHexColor("abc123")   // true
+ * isValidHexColor("invalid")  // false
+ */
+export function isValidHexColor(value: string): boolean {
+  return /^#?([A-Fa-f0-9]{3}|[A-Fa-f0-9]{6})$/.test(value);
+}
+
+/**
+ * Normalizes a 3-digit hex color to 6-digit format.
+ * Passes through 6-digit colors unchanged.
+ *
+ * @param hex - The hex color string (e.g., "#abc" or "#aabbcc")
+ * @returns Normalized 6-digit hex color (e.g., "#aabbcc")
+ *
+ * @example
+ * normalizeHexColor("#abc")    // "#aabbcc"
+ * normalizeHexColor("#FF0000") // "#FF0000"
+ * normalizeHexColor("abc")     // "#aabbcc"
+ */
+export function normalizeHexColor(hex: string): string {
+  // Remove # if present
+  let cleanHex = hex.startsWith("#") ? hex.slice(1) : hex;
+
+  // Expand 3-digit to 6-digit
+  if (cleanHex.length === 3) {
+    cleanHex = cleanHex
+      .split("")
+      .map((char) => char + char)
+      .join("");
+  }
+
+  return `#${cleanHex}`;
+}
+
+/**
+ * Converts a hex color string to an RGB object.
+ *
+ * @param hex - The hex color string (e.g., "#FF0000" or "#F00")
+ * @returns An object with r, g, b number values (0-255)
+ *
+ * @example
+ * hexToRgb("#FF0000") // { r: 255, g: 0, b: 0 }
+ * hexToRgb("#F00")    // { r: 255, g: 0, b: 0 }
+ */
+export function hexToRgb(hex: string): { r: number; g: number; b: number } {
+  // Remove # and normalize to 6 digits
+  let cleanHex = hex.startsWith("#") ? hex.slice(1) : hex;
+  if (cleanHex.length === 3) {
+    cleanHex = cleanHex
+      .split("")
+      .map((char) => char + char)
+      .join("");
+  }
+
+  const bigint = parseInt(cleanHex, 16);
+  return {
+    r: (bigint >> 16) & 255,
+    g: (bigint >> 8) & 255,
+    b: bigint & 255,
+  };
+}
+
+/**
+ * Converts a hex color to an RGBA color string.
+ * Handles null/undefined input gracefully with a fallback color.
+ * Supports both 3-digit (#abc) and 6-digit (#aabbcc) hex formats.
+ *
+ * @param hex - The hex color string, or null/undefined
+ * @param alpha - The opacity value (0 to 1)
+ * @param fallbackColor - RGB values to use if hex is invalid (default: blue)
+ * @returns An RGBA color string
+ *
+ * @example
+ * hexToRgba("#FF0000", 0.5)     // "rgba(255, 0, 0, 0.5)"
+ * hexToRgba("#F00", 1)          // "rgba(255, 0, 0, 1)"
+ * hexToRgba(null, 0.5)          // "rgba(74, 144, 226, 0.5)" (fallback blue)
+ * hexToRgba("invalid", 0.5)     // "rgba(74, 144, 226, 0.5)" (fallback blue)
+ */
+export function hexToRgba(
+  hex: string | null | undefined,
+  alpha: number,
+  fallbackColor: { r: number; g: number; b: number } = { r: 74, g: 144, b: 226 }
+): string {
+  // Guard against null/undefined
+  if (!hex) {
+    return `rgba(${fallbackColor.r}, ${fallbackColor.g}, ${fallbackColor.b}, ${alpha})`;
+  }
+
+  // Validate hex format
+  if (!isValidHexColor(hex)) {
+    return `rgba(${fallbackColor.r}, ${fallbackColor.g}, ${fallbackColor.b}, ${alpha})`;
+  }
+
+  const { r, g, b } = hexToRgb(hex);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+/**
+ * Blends multiple hex colors together by averaging their RGB values.
+ * Useful for creating overlay effects when multiple annotations overlap.
+ *
+ * @param colors - Array of hex color strings
+ * @returns An RGB color string (not RGBA)
+ *
+ * @example
+ * blendColors(["#FF0000", "#0000FF"]) // "rgb(127, 0, 127)"
+ */
+export function blendColors(colors: string[]): string {
+  if (colors.length === 0) return "rgb(0, 0, 0)";
+  if (colors.length === 1) return colors[0];
+
+  let r = 0;
+  let g = 0;
+  let b = 0;
+
+  for (const color of colors) {
+    const rgb = hexToRgb(color);
+    r += rgb.r;
+    g += rgb.g;
+    b += rgb.b;
+  }
+
+  r = Math.round(r / colors.length);
+  g = Math.round(g / colors.length);
+  b = Math.round(b / colors.length);
+
+  return `rgb(${r}, ${g}, ${b})`;
+}

--- a/frontend/src/views/Corpuses.tsx
+++ b/frontend/src/views/Corpuses.tsx
@@ -1577,6 +1577,11 @@ export const Corpuses = () => {
   // Used to hide parent navigation header when CorpusChat handles its own
   const [chatInConversation, setChatInConversation] = useState<boolean>(false);
 
+  // Track whether CorpusDiscussionsView is showing a thread detail (vs the list view)
+  // Used to hide parent navigation header when viewing inline thread detail
+  const [discussionInThreadView, setDiscussionInThreadView] =
+    useState<boolean>(false);
+
   // Debug: Log state changes
   console.log("[Corpuses] Current documentsViewMode:", documentsViewMode);
 
@@ -2374,25 +2379,33 @@ export const Corpuses = () => {
           <div
             style={{ display: "flex", flexDirection: "column", height: "100%" }}
           >
-            <TabNavigationHeader>
-              <BackNavButton
-                onClick={() => setActiveTab(0)}
-                whileHover={{ scale: 1.05 }}
-                whileTap={{ scale: 0.95 }}
-                title="Back to Home"
-              >
-                <ArrowLeft />
-              </BackNavButton>
-              <TabTitle>Discussions</TabTitle>
-              <MobileKebabButton
-                onClick={() => setMobileSidebarOpen(true)}
-                aria-label="Open navigation menu"
-              >
-                <MoreVertical />
-              </MobileKebabButton>
-            </TabNavigationHeader>
+            {/* Only show parent header when viewing thread list */}
+            {/* When viewing inline thread detail, CorpusDiscussionsView handles its own */}
+            {!discussionInThreadView && (
+              <TabNavigationHeader>
+                <BackNavButton
+                  onClick={() => setActiveTab(0)}
+                  whileHover={{ scale: 1.05 }}
+                  whileTap={{ scale: 0.95 }}
+                  title="Back to Home"
+                >
+                  <ArrowLeft />
+                </BackNavButton>
+                <TabTitle>Discussions</TabTitle>
+                <MobileKebabButton
+                  onClick={() => setMobileSidebarOpen(true)}
+                  aria-label="Open navigation menu"
+                >
+                  <MoreVertical />
+                </MobileKebabButton>
+              </TabNavigationHeader>
+            )}
             <div style={{ flex: 1, overflow: "hidden" }}>
-              <CorpusDiscussionsView corpusId={opened_corpus.id} hideHeader />
+              <CorpusDiscussionsView
+                corpusId={opened_corpus.id}
+                hideHeader
+                onViewModeChange={setDiscussionInThreadView}
+              />
             </div>
           </div>
         ) : null,
@@ -2550,6 +2563,7 @@ export const Corpuses = () => {
     canUpdateCorpus,
     documentsViewMode, // Required for view mode toggle to work
     chatInConversation, // Required for chat tab header visibility
+    discussionInThreadView, // Required for discussions tab header visibility
     // Note: corpusAtomPermissions is an array that changes, but canUpdateCorpus is derived from it
     // and is a stable boolean, so we don't need corpusAtomPermissions in deps
   ]);

--- a/frontend/src/views/GlobalDiscussions.tsx
+++ b/frontend/src/views/GlobalDiscussions.tsx
@@ -10,7 +10,14 @@ import {
   GetConversationsOutputs,
 } from "../graphql/queries";
 import { ThreadListItem } from "../components/threads/ThreadListItem";
-import { color } from "../theme/colors";
+import {
+  CORPUS_COLORS,
+  CORPUS_FONTS,
+  CORPUS_RADII,
+  CORPUS_SHADOWS,
+  CORPUS_TRANSITIONS,
+  mediaQuery,
+} from "../components/threads/styles/discussionStyles";
 import { ModernLoadingDisplay } from "../components/widgets/ModernLoadingDisplay";
 
 // Custom hook for debounced value
@@ -32,8 +39,9 @@ function useDebouncedValue<T>(value: T, delay: number): T {
 
 // Styled components
 const Container = styled.div`
+  max-width: 75rem;
   margin: 0 auto;
-  padding: 2rem 4rem;
+  padding: 2.5rem 4rem;
   height: 100%;
   overflow-y: auto;
   overflow-x: hidden;
@@ -46,31 +54,32 @@ const Container = styled.div`
     padding: 1.5rem 2rem;
   }
 
-  @media (max-width: 768px) {
+  ${mediaQuery.mobile} {
     padding: 1rem;
   }
 `;
 
 const Header = styled.div`
-  margin-bottom: 2rem;
+  margin-bottom: 2.5rem;
 `;
 
 const TitleRow = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 1.5rem;
+  margin-bottom: 2rem;
 `;
 
 const Title = styled.h1`
-  font-size: 2rem;
-  font-weight: 800;
-  color: ${color.N10};
+  font-family: ${CORPUS_FONTS.serif};
+  font-size: 2.25rem;
+  font-weight: 600;
+  color: ${CORPUS_COLORS.slate[900]};
   margin: 0;
-  letter-spacing: -0.025em;
+  letter-spacing: -0.02em;
 
-  @media (max-width: 768px) {
-    font-size: 1.5rem;
+  ${mediaQuery.mobile} {
+    font-size: 1.75rem;
   }
 `;
 
@@ -84,35 +93,37 @@ const FilterBar = styled.div`
 
 const TabContainer = styled.div`
   display: flex;
-  gap: 0.5rem;
-  background: ${color.N2};
-  padding: 0.375rem;
-  border-radius: 12px;
-  border: 1px solid ${color.N4};
+  gap: 0.25rem;
+  background: ${CORPUS_COLORS.slate[100]};
+  padding: 0.25rem;
+  border-radius: ${CORPUS_RADII.lg};
+  border: 1px solid ${CORPUS_COLORS.slate[200]};
 `;
 
 const Tab = styled(motion.button)<{ $isActive: boolean }>`
   padding: 0.625rem 1.25rem;
-  border-radius: 8px;
+  border-radius: ${CORPUS_RADII.md};
   border: none;
-  background: ${(props) => (props.$isActive ? "white" : "transparent")};
-  color: ${(props) => (props.$isActive ? color.N10 : color.N7)};
+  background: ${(props) =>
+    props.$isActive ? CORPUS_COLORS.white : "transparent"};
+  color: ${(props) =>
+    props.$isActive ? CORPUS_COLORS.slate[800] : CORPUS_COLORS.slate[600]};
+  font-family: ${CORPUS_FONTS.sans};
   font-weight: ${(props) => (props.$isActive ? "600" : "500")};
   font-size: 0.9375rem;
   cursor: pointer;
-  transition: all 0.2s ease;
-  box-shadow: ${(props) =>
-    props.$isActive ? "0 1px 3px rgba(0,0,0,0.1)" : "none"};
+  transition: all ${CORPUS_TRANSITIONS.fast};
+  box-shadow: ${(props) => (props.$isActive ? CORPUS_SHADOWS.sm : "none")};
   display: flex;
   align-items: center;
   gap: 0.5rem;
 
   &:hover {
     background: ${(props) =>
-      props.$isActive ? "white" : "rgba(255,255,255,0.6)"};
+      props.$isActive ? CORPUS_COLORS.white : "rgba(255,255,255,0.6)"};
   }
 
-  @media (max-width: 640px) {
+  ${mediaQuery.mobile} {
     padding: 0.5rem 0.875rem;
     font-size: 0.875rem;
   }
@@ -120,8 +131,8 @@ const Tab = styled(motion.button)<{ $isActive: boolean }>`
 
 const SearchInputContainer = styled.div`
   flex: 1;
-  min-width: 200px;
-  max-width: 400px;
+  min-width: 12.5rem;
+  max-width: 25rem;
   position: relative;
 `;
 
@@ -130,27 +141,29 @@ const SearchIconStyled = styled(Search)`
   left: 1rem;
   top: 50%;
   transform: translateY(-50%);
-  color: ${color.N6};
+  color: ${CORPUS_COLORS.slate[400]};
   pointer-events: none;
 `;
 
 const SearchInput = styled.input`
   width: 100%;
   padding: 0.625rem 1rem 0.625rem 2.75rem;
-  border: 1px solid ${color.N4};
-  border-radius: 8px;
+  border: 1px solid ${CORPUS_COLORS.slate[200]};
+  border-radius: ${CORPUS_RADII.md};
+  font-family: ${CORPUS_FONTS.sans};
   font-size: 0.9375rem;
-  color: ${color.N10};
-  background: white;
+  color: ${CORPUS_COLORS.slate[800]};
+  background: ${CORPUS_COLORS.white};
+  transition: all ${CORPUS_TRANSITIONS.fast};
 
   &:focus {
     outline: none;
-    border-color: ${color.B5};
-    box-shadow: 0 0 0 3px rgba(74, 144, 226, 0.1);
+    border-color: ${CORPUS_COLORS.teal[500]};
+    box-shadow: 0 0 0 3px ${CORPUS_COLORS.teal[50]};
   }
 
   &::placeholder {
-    color: ${color.N6};
+    color: ${CORPUS_COLORS.slate[400]};
   }
 `;
 
@@ -158,31 +171,35 @@ const FAB = styled(motion.button)`
   position: fixed;
   bottom: 2rem;
   right: 2rem;
-  width: 56px;
-  height: 56px;
-  border-radius: 16px;
-  background: linear-gradient(135deg, ${color.B6} 0%, ${color.B7} 100%);
+  width: 3.5rem;
+  height: 3.5rem;
+  border-radius: ${CORPUS_RADII.xl};
+  background: linear-gradient(
+    135deg,
+    ${CORPUS_COLORS.teal[600]} 0%,
+    ${CORPUS_COLORS.teal[700]} 100%
+  );
   border: none;
-  color: white;
+  color: ${CORPUS_COLORS.white};
   display: flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  box-shadow: 0 8px 24px rgba(74, 144, 226, 0.4);
+  box-shadow: 0 8px 24px rgba(15, 118, 110, 0.4);
   z-index: 100;
 
   &:hover {
-    box-shadow: 0 12px 32px rgba(74, 144, 226, 0.5);
+    box-shadow: 0 12px 32px rgba(15, 118, 110, 0.5);
   }
 
-  @media (max-width: 768px) {
+  ${mediaQuery.mobile} {
     bottom: 1rem;
     right: 1rem;
   }
 `;
 
 const SectionContainer = styled(motion.div)`
-  margin-bottom: 2.5rem;
+  margin-bottom: 3rem;
 `;
 
 const SectionHeader = styled.div`
@@ -191,31 +208,33 @@ const SectionHeader = styled.div`
   gap: 0.75rem;
   margin-bottom: 1rem;
   padding-bottom: 0.75rem;
-  border-bottom: 2px solid ${color.N4};
+  border-bottom: 1px solid ${CORPUS_COLORS.slate[200]};
 `;
 
 const SectionIcon = styled.div<{ $color: string }>`
-  width: 32px;
-  height: 32px;
-  border-radius: 8px;
+  width: 2rem;
+  height: 2rem;
+  border-radius: ${CORPUS_RADII.md};
   background: ${(props) => props.$color};
   display: flex;
   align-items: center;
   justify-content: center;
-  color: white;
+  color: ${CORPUS_COLORS.white};
   flex-shrink: 0;
 `;
 
 const SectionTitle = styled.h2`
+  font-family: ${CORPUS_FONTS.serif};
   font-size: 1.25rem;
-  font-weight: 700;
-  color: ${color.N10};
+  font-weight: 600;
+  color: ${CORPUS_COLORS.slate[800]};
   margin: 0;
 `;
 
 const SectionCount = styled.span`
+  font-family: ${CORPUS_FONTS.sans};
   font-size: 0.875rem;
-  color: ${color.N6};
+  color: ${CORPUS_COLORS.slate[500]};
   font-weight: 500;
   margin-left: auto;
 `;
@@ -228,8 +247,9 @@ const ThreadGrid = styled.div`
 
 const EmptyState = styled.div`
   text-align: center;
-  padding: 2rem 1rem;
-  color: ${color.N6};
+  padding: 3rem 1.5rem;
+  color: ${CORPUS_COLORS.slate[500]};
+  font-family: ${CORPUS_FONTS.sans};
   font-size: 0.9375rem;
 `;
 

--- a/frontend/tests/MentionRendering.ct.tsx
+++ b/frontend/tests/MentionRendering.ct.tsx
@@ -1,0 +1,212 @@
+/**
+ * Component Tests for Mention Rendering
+ *
+ * Tests the MarkdownMessageRenderer mention badge rendering:
+ * - User mentions render as styled badges
+ * - Corpus mentions render as styled badges
+ * - Document mentions render as styled badges
+ * - Annotation mentions render as styled badges
+ * - Agent mentions render as styled badges (non-navigable)
+ * - Regular links still work
+ * - Markdown formatting works with mentions
+ */
+import { test, expect } from "@playwright/experimental-ct-react";
+import { MentionTestWrapper } from "./MentionRenderingTestWrapper";
+
+test.describe("MentionRendering - User Mentions", () => {
+  test("renders user mention as styled badge", async ({ mount, page }) => {
+    await mount(
+      <MentionTestWrapper content="Hello [@testuser](/users/testuser), how are you?" />
+    );
+
+    // User mention should be visible as a link
+    const mentionLink = page.locator('a[href="/users/testuser"]');
+    await expect(mentionLink).toBeVisible();
+    await expect(mentionLink).toContainText("@testuser");
+  });
+
+  test("user mention has href for navigation", async ({ mount, page }) => {
+    await mount(
+      <MentionTestWrapper content="Check out [@testuser](/users/testuser)" />
+    );
+
+    // Should have href attribute (navigable)
+    const mention = page.locator('a[href="/users/testuser"]');
+    await expect(mention).toBeVisible();
+  });
+
+  test("user mention shows tooltip", async ({ mount, page }) => {
+    await mount(
+      <MentionTestWrapper content="Hello [@testuser](/users/testuser)" />
+    );
+
+    const mention = page.locator('a[href="/users/testuser"]');
+    await expect(mention).toHaveAttribute("title", /User:/);
+  });
+});
+
+test.describe("MentionRendering - Corpus Mentions", () => {
+  test("renders corpus mention as styled badge", async ({ mount, page }) => {
+    await mount(
+      <MentionTestWrapper content="See the [@test-corpus](/c/creator/test-corpus) for more info." />
+    );
+
+    const mention = page.locator('a[href="/c/creator/test-corpus"]');
+    await expect(mention).toBeVisible();
+    await expect(mention).toContainText("@test-corpus");
+  });
+
+  test("corpus mention has href for navigation", async ({ mount, page }) => {
+    await mount(
+      <MentionTestWrapper content="Check [@my-corpus](/c/user/my-corpus)" />
+    );
+
+    const mention = page.locator('a[href="/c/user/my-corpus"]');
+    await expect(mention).toBeVisible();
+  });
+});
+
+test.describe("MentionRendering - Document Mentions", () => {
+  test("renders document mention as styled badge", async ({ mount, page }) => {
+    await mount(
+      <MentionTestWrapper content="Read [@contract.pdf](/d/user/corpus/contract-pdf)" />
+    );
+
+    const mention = page.locator('a[href="/d/user/corpus/contract-pdf"]');
+    await expect(mention).toBeVisible();
+    await expect(mention).toContainText("@contract.pdf");
+  });
+
+  test("document mention has href for navigation", async ({ mount, page }) => {
+    await mount(
+      <MentionTestWrapper content="See [@doc](/d/user/corpus/doc)" />
+    );
+
+    const mention = page.locator('a[href="/d/user/corpus/doc"]');
+    await expect(mention).toBeVisible();
+  });
+});
+
+test.describe("MentionRendering - Annotation Mentions", () => {
+  test("renders annotation mention as styled badge", async ({
+    mount,
+    page,
+  }) => {
+    await mount(
+      <MentionTestWrapper content="See this [@annotation](/d/user/corpus/doc?ann=123&structural=true)" />
+    );
+
+    // Annotation mention should be visible (has ?ann= in URL)
+    const mention = page.locator("a").filter({ hasText: "@annotation" });
+    await expect(mention).toBeVisible();
+  });
+});
+
+test.describe("MentionRendering - Agent Mentions", () => {
+  test("renders global agent mention as styled badge", async ({
+    mount,
+    page,
+  }) => {
+    await mount(
+      <MentionTestWrapper content="Ask [@agent:helper-bot](/agents/helper-bot) for help" />
+    );
+
+    const mention = page.locator("a").filter({ hasText: "@agent:helper-bot" });
+    await expect(mention).toBeVisible();
+  });
+
+  test("renders corpus-scoped agent mention as styled badge", async ({
+    mount,
+    page,
+  }) => {
+    await mount(
+      <MentionTestWrapper content="Try [@agent:corpus-bot](/c/abc123/Test%20Corpus/agents/corpus-bot)" />
+    );
+
+    const mention = page.locator("a").filter({ hasText: "@agent:corpus-bot" });
+    await expect(mention).toBeVisible();
+  });
+
+  test("agent mention shows 'coming soon' in tooltip", async ({
+    mount,
+    page,
+  }) => {
+    await mount(
+      <MentionTestWrapper content="Ask [@agent:my-agent](/agents/my-agent)" />
+    );
+
+    const mention = page.locator("a").filter({ hasText: "@agent:my-agent" });
+    await expect(mention).toHaveAttribute("title", /coming soon/i);
+  });
+
+  test("agent mention does not have href (non-navigable)", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<MentionTestWrapper content="Ask [@agent:bot](/agents/bot)" />);
+
+    const mention = page.locator("a").filter({ hasText: "@agent:bot" });
+    // Non-navigable mentions don't have href
+    await expect(mention).not.toHaveAttribute("href");
+  });
+});
+
+test.describe("MentionRendering - Mixed Content", () => {
+  test("renders multiple mention types in same message", async ({
+    mount,
+    page,
+  }) => {
+    await mount(
+      <MentionTestWrapper content="Hey [@john](/users/john), check out the [@contract](/d/user/corpus/contract) in [@legal-corpus](/c/user/legal-corpus). You can ask [@agent:helper](/agents/helper) for assistance." />
+    );
+
+    // All mentions should be visible
+    await expect(page.locator("a").filter({ hasText: "@john" })).toBeVisible();
+    await expect(
+      page.locator("a").filter({ hasText: "@contract" })
+    ).toBeVisible();
+    await expect(
+      page.locator("a").filter({ hasText: "@legal-corpus" })
+    ).toBeVisible();
+    await expect(
+      page.locator("a").filter({ hasText: "@agent:helper" })
+    ).toBeVisible();
+  });
+
+  test("regular links still work normally", async ({ mount, page }) => {
+    await mount(
+      <MentionTestWrapper content="Check out [Google](https://google.com) for more info and [@user](/users/user) for contact." />
+    );
+
+    // Regular link should have target="_blank"
+    const googleLink = page.locator('a[href="https://google.com"]');
+    await expect(googleLink).toBeVisible();
+    await expect(googleLink).toHaveAttribute("target", "_blank");
+
+    // Mention should also be visible
+    const mention = page.locator('a[href="/users/user"]');
+    await expect(mention).toBeVisible();
+  });
+});
+
+test.describe("MentionRendering - Markdown Formatting", () => {
+  test("renders markdown with bold text", async ({ mount, page }) => {
+    await mount(
+      <MentionTestWrapper content="This is **bold** and this is a [@mention](/users/user)" />
+    );
+
+    await expect(page.locator("strong")).toContainText("bold");
+    await expect(
+      page.locator("a").filter({ hasText: "@mention" })
+    ).toBeVisible();
+  });
+
+  test("renders markdown with code blocks", async ({ mount, page }) => {
+    await mount(
+      <MentionTestWrapper content="Use `code` like this. Also see [@dev](/users/dev) for help." />
+    );
+
+    await expect(page.locator("code")).toContainText("code");
+    await expect(page.locator("a").filter({ hasText: "@dev" })).toBeVisible();
+  });
+});

--- a/frontend/tests/MentionRenderingTestWrapper.tsx
+++ b/frontend/tests/MentionRenderingTestWrapper.tsx
@@ -1,0 +1,28 @@
+/**
+ * Test wrapper for MarkdownMessageRenderer mention tests
+ */
+import React from "react";
+import { MockedProvider } from "@apollo/client/testing";
+import { Provider } from "jotai";
+import { MemoryRouter } from "react-router-dom";
+import { MarkdownMessageRenderer } from "../src/components/threads/MarkdownMessageRenderer";
+
+interface MentionTestWrapperProps {
+  content: string;
+}
+
+export const MentionTestWrapper: React.FC<MentionTestWrapperProps> = ({
+  content,
+}) => {
+  return (
+    <MockedProvider mocks={[]} addTypename={false}>
+      <Provider>
+        <MemoryRouter initialEntries={["/test"]}>
+          <div style={{ padding: "20px" }}>
+            <MarkdownMessageRenderer content={content} />
+          </div>
+        </MemoryRouter>
+      </Provider>
+    </MockedProvider>
+  );
+};

--- a/frontend/tests/VoteButtonsCompact.ct.tsx
+++ b/frontend/tests/VoteButtonsCompact.ct.tsx
@@ -1,0 +1,173 @@
+/**
+ * Component Tests for VoteButtons Compact Mode
+ *
+ * Tests the compact horizontal layout with thumbs icons:
+ * - Compact mode renders horizontally
+ * - Uses thumbs icons instead of chevrons
+ * - Smaller button size in compact mode
+ * - All voting functionality still works
+ */
+import { test, expect } from "@playwright/experimental-ct-react";
+import { MockedResponse } from "@apollo/client/testing";
+import { VoteButtonsTestWrapper } from "./VoteButtonsTestWrapper";
+import {
+  UPVOTE_MESSAGE,
+  DOWNVOTE_MESSAGE,
+  UpvoteMessageOutput,
+  DownvoteMessageOutput,
+} from "../src/graphql/mutations";
+
+test.describe("VoteButtons Compact Mode", () => {
+  test("renders in compact horizontal layout", async ({ mount, page }) => {
+    await mount(<VoteButtonsTestWrapper />);
+
+    // Both buttons should be visible
+    await expect(page.getByLabel("Upvote")).toBeVisible();
+    await expect(page.getByLabel("Downvote")).toBeVisible();
+
+    // Score should be visible
+    await expect(page.getByText("3")).toBeVisible();
+  });
+
+  test("shows correct score in compact mode", async ({ mount, page }) => {
+    await mount(<VoteButtonsTestWrapper upvoteCount={10} downvoteCount={3} />);
+
+    // Net score: 10 - 3 = 7
+    await expect(page.getByText("7")).toBeVisible();
+  });
+
+  test("shows negative score in compact mode", async ({ mount, page }) => {
+    await mount(<VoteButtonsTestWrapper upvoteCount={1} downvoteCount={5} />);
+
+    // Net score: 1 - 5 = -4
+    await expect(page.getByText("-4")).toBeVisible();
+  });
+
+  test("upvote works in compact mode", async ({ mount, page }) => {
+    const mocks: MockedResponse[] = [
+      {
+        request: {
+          query: UPVOTE_MESSAGE,
+          variables: { messageId: "msg-1" },
+        },
+        result: {
+          data: {
+            voteMessage: {
+              ok: true,
+              message: "Upvoted",
+              obj: {
+                id: "msg-1",
+                upvoteCount: 6,
+                downvoteCount: 2,
+                userVote: "UPVOTE",
+              },
+            },
+          } as UpvoteMessageOutput,
+        },
+      },
+    ];
+
+    await mount(<VoteButtonsTestWrapper mocks={mocks} />);
+
+    await page.getByLabel("Upvote").click();
+
+    // Wait for optimistic update
+    await page.waitForTimeout(200);
+
+    // Score should change from 3 to 4 after upvote
+    // Just verify the mutation was triggered (button still works)
+  });
+
+  test("downvote works in compact mode", async ({ mount, page }) => {
+    const mocks: MockedResponse[] = [
+      {
+        request: {
+          query: DOWNVOTE_MESSAGE,
+          variables: { messageId: "msg-1" },
+        },
+        result: {
+          data: {
+            voteMessage: {
+              ok: true,
+              message: "Downvoted",
+              obj: {
+                id: "msg-1",
+                upvoteCount: 5,
+                downvoteCount: 3,
+                userVote: "DOWNVOTE",
+              },
+            },
+          } as DownvoteMessageOutput,
+        },
+      },
+    ];
+
+    await mount(<VoteButtonsTestWrapper mocks={mocks} />);
+
+    await page.getByLabel("Downvote").click();
+
+    // Wait for optimistic update
+    await page.waitForTimeout(200);
+
+    // Just verify mutation was triggered (button still works)
+  });
+
+  test("shows upvoted state in compact mode", async ({ mount, page }) => {
+    await mount(<VoteButtonsTestWrapper userVote="UPVOTE" />);
+
+    const upvoteButton = page.getByLabel("Upvote");
+    await expect(upvoteButton).toBeVisible();
+  });
+
+  test("shows downvoted state in compact mode", async ({ mount, page }) => {
+    await mount(<VoteButtonsTestWrapper userVote="DOWNVOTE" />);
+
+    const downvoteButton = page.getByLabel("Downvote");
+    await expect(downvoteButton).toBeVisible();
+  });
+
+  test("disabled state works in compact mode", async ({ mount, page }) => {
+    await mount(<VoteButtonsTestWrapper disabled={true} />);
+
+    await expect(page.getByLabel("Upvote")).toBeDisabled();
+    await expect(page.getByLabel("Downvote")).toBeDisabled();
+  });
+
+  test("prevents voting on own message in compact mode", async ({
+    mount,
+    page,
+  }) => {
+    await mount(
+      <VoteButtonsTestWrapper senderId="user-1" currentUserId="user-1" />
+    );
+
+    await page.getByLabel("Upvote").click();
+    await page.waitForTimeout(100);
+
+    // Should show error message
+    await expect(
+      page.getByText(/cannot vote on your own messages/i)
+    ).toBeVisible();
+  });
+});
+
+test.describe("VoteButtons - Compact vs Standard Comparison", () => {
+  test("standard mode renders vertically", async ({ mount, page }) => {
+    await mount(<VoteButtonsTestWrapper compact={false} />);
+
+    // Standard mode should render (just verify it renders)
+    await expect(page.getByLabel("Upvote")).toBeVisible();
+    await expect(page.getByLabel("Downvote")).toBeVisible();
+    await expect(page.getByText("3")).toBeVisible();
+  });
+
+  test("compact mode defaults to false", async ({ mount, page }) => {
+    // Note: wrapper defaults to compact=true for these tests
+    // For this test, we explicitly set compact=false to test standard mode
+    await mount(<VoteButtonsTestWrapper compact={false} />);
+
+    // Should render in standard mode
+    await expect(page.getByLabel("Upvote")).toBeVisible();
+    await expect(page.getByLabel("Downvote")).toBeVisible();
+  });
+});

--- a/frontend/tests/VoteButtonsTestWrapper.tsx
+++ b/frontend/tests/VoteButtonsTestWrapper.tsx
@@ -1,0 +1,45 @@
+/**
+ * Test wrapper for VoteButtons tests
+ */
+import React from "react";
+import { MockedProvider, MockedResponse } from "@apollo/client/testing";
+import { VoteButtons } from "../src/components/threads/VoteButtons";
+
+export interface VoteButtonsTestWrapperProps {
+  mocks?: MockedResponse[];
+  messageId?: string;
+  upvoteCount?: number;
+  downvoteCount?: number;
+  userVote?: "UPVOTE" | "DOWNVOTE" | null;
+  senderId?: string;
+  currentUserId?: string;
+  compact?: boolean;
+  disabled?: boolean;
+}
+
+export const VoteButtonsTestWrapper: React.FC<VoteButtonsTestWrapperProps> = ({
+  mocks = [],
+  messageId = "msg-1",
+  upvoteCount = 5,
+  downvoteCount = 2,
+  userVote = null,
+  senderId = "user-1",
+  currentUserId = "user-2",
+  compact = true,
+  disabled = false,
+}) => {
+  return (
+    <MockedProvider mocks={mocks} addTypename={false}>
+      <VoteButtons
+        messageId={messageId}
+        upvoteCount={upvoteCount}
+        downvoteCount={downvoteCount}
+        userVote={userVote}
+        senderId={senderId}
+        currentUserId={currentUserId}
+        compact={compact}
+        disabled={disabled}
+      />
+    </MockedProvider>
+  );
+};


### PR DESCRIPTION
## Summary

- View thread details inline within Discussions tab instead of navigating away
- Corpus context sidebar displays description, document TOC, and quick stats alongside threads
- Modernized message UI with cleaner, borderless layout following ChatGPT/Claude patterns
- Enhanced mention system with agent support and navigability configuration

## Features

### Inline Thread Viewing
- Click thread in Discussions tab → shows thread detail inline (no URL change)
- Back button returns to thread list without page navigation
- Tab header hides when viewing thread (like Chats tab pattern)

### Corpus Context Sidebar
- Shows corpus description (markdown rendered), document TOC, and quick stats
- Responsive: expanded on large screens, collapsible on medium, hidden on small
- Sidebar state persists to localStorage

### Message UI Modernization
- Remove heavy borders - use subtle background/spacing instead
- Move vote buttons to footer alongside Reply (horizontal layout)
- Actions appear on hover (always visible on mobile)
- Add `compact` mode to VoteButtons with thumbs icons

### Mention System Improvements
- Add agent mention detection (`/agents/` and `/c/.../agents/` URL patterns)
- Purple badge styling with Bot icon for agent mentions
- URL-encode agent paths to handle spaces in corpus names
- Add `MENTION_TYPES` constant to configure navigable vs non-navigable types
- Non-navigable mentions (agents) show "Detail page coming soon" tooltip

## New Components

| Component | Description |
|-----------|-------------|
| `CorpusContextSidebar` | Collapsible sidebar with corpus info sections |
| `ThreadDetailWithContext` | Wrapper combining ThreadDetail + sidebar |
| `contextSidebarStyles.ts` | Styled components for sidebar layout |

## Test plan

- [ ] Click thread in Discussions tab → shows inline (no URL change)
- [ ] Back button returns to thread list
- [ ] Sidebar shows corpus description, documents, stats
- [ ] Sidebar collapse/expand works on medium screens
- [ ] Message actions appear on hover
- [ ] Vote buttons show in footer with thumbs icons
- [ ] Agent mentions render as purple badges
- [ ] Agent mention click shows tooltip (no navigation)
- [ ] User/corpus/document mentions still navigate correctly