### PR TITLE
Fix sync-to-async boundary for Django ORM in PydanticAI tools

### DIFF
--- a/opencontractserver/llms/tools/pydantic_ai_tools.py
+++ b/opencontractserver/llms/tools/pydantic_ai_tools.py
@@ -3,6 +3,7 @@
 import inspect
 import logging
 from collections.abc import Awaitable
+from functools import partial
 from typing import Any, Callable, Optional, get_type_hints
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -15,6 +16,25 @@ from opencontractserver.llms.vector_stores.core_vector_stores import (
 )
 
 logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Async-safe wrapper for synchronous database operations
+# ---------------------------------------------------------------------------
+# When sync tools are registered with PydanticAI agents, they get called from
+# an async context. Django's ORM is not async-safe by default and will raise
+# "You cannot call this from an async context" errors. We use database_sync_to_async
+# (from channels) or sync_to_async (from asgiref) to run sync functions in a
+# thread pool, making them safe to call from async contexts.
+# ---------------------------------------------------------------------------
+
+try:
+    from channels.db import database_sync_to_async as _database_sync_to_async
+
+    _db_sync_to_async = partial(_database_sync_to_async, thread_sensitive=False)
+except ModuleNotFoundError:  # Channels not installed – fall back gracefully
+    from asgiref.sync import sync_to_async as _sync_to_async
+
+    _db_sync_to_async = partial(_sync_to_async, thread_sensitive=False)
 
 
 async def _check_user_permissions(
@@ -383,7 +403,10 @@ class PydanticAIToolWrapper:
             async_wrapper.requires_approval = self.core_tool.requires_approval
             return async_wrapper
         else:
-            # Convert sync function to async
+            # Convert sync function to async using database_sync_to_async
+            # This wraps the sync function to run in a thread pool, making it
+            # safe to call Django ORM operations from async contexts
+            async_original_func = _db_sync_to_async(original_func)
 
             async def sync_to_async_wrapper(
                 ctx: RunContext[PydanticAIDependencies], *args, **kwargs
@@ -406,7 +429,7 @@ class PydanticAIToolWrapper:
                 _maybe_raise(ctx, *args, **kwargs)
 
                 try:
-                    return original_func(*args, **kwargs)
+                    return await async_original_func(*args, **kwargs)
                 except Exception as e:
                     logger.error(f"Error in tool {func_name}: {e}")
                     raise

--- a/opencontractserver/tests/test_pydantic_ai_tools_module.py
+++ b/opencontractserver/tests/test_pydantic_ai_tools_module.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from django.contrib.auth import get_user_model
-from django.test import TestCase
+from django.test import TestCase, TransactionTestCase
 
 from opencontractserver.corpuses.models import Corpus
 from opencontractserver.documents.models import Document
@@ -772,3 +772,132 @@ class TestContextInjectionIntegration(TestCase):
 
         self.assertEqual(result["document_id"], 42)
         self.assertEqual(result["query"], "unified test")
+
+
+# ---------------------------------------------------------------------------
+# Tests for sync-to-async database wrapping
+# ---------------------------------------------------------------------------
+
+
+def sync_db_read_tool(document_id: int) -> dict:
+    """A sync tool that reads from the database."""
+    doc = Document.objects.get(pk=document_id)
+    return {"id": doc.id, "title": doc.title}
+
+
+def sync_db_write_tool(document_id: int, new_title: str) -> dict:
+    """A sync tool that writes to the database."""
+    doc = Document.objects.get(pk=document_id)
+    old_title = doc.title
+    doc.title = new_title
+    doc.save(update_fields=["title"])
+    return {"id": doc.id, "old_title": old_title, "new_title": new_title}
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+class TestSyncToAsyncDatabaseWrapping(TransactionTestCase):
+    """Tests verifying that sync database tools work correctly in async context.
+
+    These tests ensure that the PydanticAI tool wrapper properly handles
+    synchronous Django ORM operations when called from async contexts.
+    Issue #841: sync tools were failing with "You cannot call this from an
+    async context" errors.
+
+    NOTE: We use TransactionTestCase because these tests use sync_to_async
+    which runs code in a thread pool. The thread pool worker has a different
+    database connection that can't see uncommitted transactions from TestCase.
+    TransactionTestCase commits data to the database, making it visible to
+    all connections.
+    """
+
+    def setUp(self):
+        # Create test data in setUp so it's committed to DB and visible
+        # to thread pool workers used by sync_to_async
+        self.user = User.objects.create_user(
+            username="sync_async_test_user",
+            password="password",
+            email="syncasync@test.com",
+        )
+        self.corpus = Corpus.objects.create(
+            title="Sync Async Test Corpus", creator=self.user, is_public=False
+        )
+        self.doc = Document.objects.create(
+            title="Sync Async Test Doc",
+            corpus=self.corpus,
+            creator=self.user,
+            is_public=False,
+        )
+
+    async def test_sync_db_read_tool_works_in_async_context(self):
+        """Test that a sync tool performing DB reads works when wrapped for async.
+
+        This verifies that sync Django ORM .get() calls are properly wrapped
+        with sync_to_async when the tool is called from an async PydanticAI agent.
+        """
+        core_tool = CoreTool.from_function(sync_db_read_tool)
+        wrapped = PydanticAIToolWrapper(
+            core_tool, inject_params={"document_id": self.doc.id}
+        ).callable_function
+
+        ctx = MagicMock(deps=None)
+        result = await wrapped(ctx)
+
+        self.assertEqual(result["id"], self.doc.id)
+        self.assertEqual(result["title"], "Sync Async Test Doc")
+
+    async def test_sync_db_write_tool_works_in_async_context(self):
+        """Test that a sync tool performing DB writes works when wrapped for async.
+
+        This verifies that sync Django ORM .save() calls are properly wrapped
+        with sync_to_async when the tool is called from an async PydanticAI agent.
+        """
+        core_tool = CoreTool.from_function(sync_db_write_tool)
+        wrapped = PydanticAIToolWrapper(
+            core_tool, inject_params={"document_id": self.doc.id}
+        ).callable_function
+
+        ctx = MagicMock(deps=None)
+        result = await wrapped(ctx, new_title="Updated Title")
+
+        self.assertEqual(result["id"], self.doc.id)
+        self.assertEqual(result["old_title"], "Sync Async Test Doc")
+        self.assertEqual(result["new_title"], "Updated Title")
+
+        # Verify the change was persisted
+        from channels.db import database_sync_to_async
+
+        doc = await database_sync_to_async(Document.objects.get)(pk=self.doc.id)
+        self.assertEqual(doc.title, "Updated Title")
+
+    async def test_sync_tool_with_core_tool_wrapper(self):
+        """Test sync tool wrapping through the full CoreTool -> PydanticAI pipeline.
+
+        This tests the complete flow that would be used by agent factory,
+        ensuring sync tools work when converted through UnifiedToolFactory.
+        """
+        # Create a fresh document for this test
+        from channels.db import database_sync_to_async
+
+        from opencontractserver.llms.tools.tool_factory import UnifiedToolFactory
+        from opencontractserver.llms.types import AgentFramework
+
+        fresh_doc = await database_sync_to_async(Document.objects.create)(
+            title="Fresh Test Doc",
+            corpus=self.corpus,
+            creator=self.user,
+            is_public=False,
+        )
+
+        core_tool = CoreTool.from_function(sync_db_read_tool)
+        wrapped = UnifiedToolFactory.create_tool(
+            core_tool,
+            AgentFramework.PYDANTIC_AI,
+            inject_params={"document_id": fresh_doc.id},
+        )
+
+        ctx = MagicMock(deps=None)
+        result = await wrapped(ctx)
+
+        self.assertEqual(result["id"], fresh_doc.id)
+        self.assertEqual(result["title"], "Fresh Test Doc")


### PR DESCRIPTION
## Summary
Fixes Issue #841 where sync functions performing Django ORM operations would fail with "You cannot call this from an async context" when invoked by PydanticAI agents. The fix properly wraps sync tool functions with `database_sync_to_async` to ensure thread isolation for database operations.

## Changes

- **Added sync-to-async database wrapper**: Introduced `_db_sync_to_async` helper that wraps sync functions with Django's `database_sync_to_async` (or `asgiref.sync_to_async` as fallback) with `thread_sensitive=False` to prevent stale database connections between tool invocations

- **Updated PydanticAIToolWrapper**: Modified the `sync_to_async_wrapper` method to use `_db_sync_to_async` when calling sync tool functions, ensuring Django ORM operations run in a proper thread pool context rather than directly in the async event loop

- **Added comprehensive tests**: Created `TestSyncToAsyncDatabaseWrapping` test class with three test cases covering:
  - Sync tools with database read operations
  - Sync tools with database write operations  
  - Sync tools wrapped through both CoreTool and PydanticAIToolWrapper

## Implementation Details

The fix uses `functools.partial` to create a reusable wrapper that:
1. Attempts to import `database_sync_to_async` from `channels.db` (preferred for Django Channels projects)
2. Falls back to `asgiref.sync_to_async` if Channels is not installed
3. Sets `thread_sensitive=False` to ensure each tool invocation gets a fresh worker thread, preventing connection pool issues

This allows tools like `update_document_description` to work correctly when invoked by PydanticAI agents during corpus actions, while maintaining backward compatibility with projects that may not have Channels installed.

https://claude.ai/code/session_018hsEGD6TF1KuUoaMpTvUKh