### PR TITLE
Add runtime-configurable pipeline settings with encrypted secrets storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,32 @@ If rollback is required after deployment, you must write a custom migration to h
 
 ### Added
 
+#### Runtime-Configurable Pipeline Settings (Superuser Only)
+- **PipelineSettings singleton model**: Database-backed configuration for document processing pipeline
+  - Stores preferred parsers, embedders, and thumbnailers per MIME type
+  - Stores parser-specific kwargs and component settings overrides
+  - Falls back to Django settings when database values are not configured
+  - Singleton pattern: only one instance exists, cannot be deleted
+  - Files: `opencontractserver/documents/models.py:734-986`
+- **GraphQL query `pipelineSettings`**: Any authenticated user can read current pipeline configuration
+  - Returns preferred components, parser kwargs, component settings
+  - Includes audit fields (modified, modified_by)
+  - Files: `config/graphql/queries.py:4214-4246`
+- **GraphQL mutation `updatePipelineSettings`**: Superusers can modify pipeline configuration at runtime
+  - Validates component class paths exist in the pipeline registry
+  - Tracks who made changes (modified_by field)
+  - Changes take effect immediately for new document processing tasks
+  - Files: `config/graphql/pipeline_settings_mutations.py:20-193`
+- **GraphQL mutation `resetPipelineSettings`**: Superusers can reset to Django settings defaults
+  - Restores all values from PREFERRED_PARSERS, PREFERRED_EMBEDDERS, etc.
+  - Files: `config/graphql/pipeline_settings_mutations.py:196-270`
+- **Migration 0031**: Creates PipelineSettings table and initializes singleton with Django settings defaults
+  - Files: `opencontractserver/documents/migrations/0031_add_pipeline_settings.py`
+- **Integration with doc_tasks**: `ingest_doc` and `extract_thumbnail` now read from PipelineSettings
+  - Files: `opencontractserver/tasks/doc_tasks.py:355-374`, `opencontractserver/tasks/doc_tasks.py:686-721`
+- **Integration with pipeline/utils**: `get_preferred_embedder` and `get_default_embedder` use PipelineSettings
+  - Files: `opencontractserver/pipeline/utils.py:303-361`
+
 #### Personal Corpus ("My Documents") Feature
 - **Personal corpus auto-creation**: Each user now automatically receives a personal "My Documents" corpus
   - Created via signal handler when user account is created

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,20 +28,33 @@ If rollback is required after deployment, you must write a custom migration to h
   - Stores parser-specific kwargs and component settings overrides
   - Falls back to Django settings when database values are not configured
   - Singleton pattern: only one instance exists, cannot be deleted
-  - Files: `opencontractserver/documents/models.py:734-986`
+  - Files: `opencontractserver/documents/models.py:734-1140`
+- **Encrypted secrets storage**: Secure storage for API keys and sensitive credentials
+  - Uses Fernet symmetric encryption (key derived from Django SECRET_KEY)
+  - Secrets are never exposed via GraphQL responses
+  - GraphQL only returns list of components that have secrets configured
+  - Methods: `set_secrets()`, `get_secrets()`, `update_secrets()`, `get_full_component_settings()`
+  - Files: `opencontractserver/documents/models.py:1012-1139`
 - **GraphQL query `pipelineSettings`**: Any authenticated user can read current pipeline configuration
   - Returns preferred components, parser kwargs, component settings
+  - Includes `componentsWithSecrets` field (list of paths, not actual secrets)
   - Includes audit fields (modified, modified_by)
-  - Files: `config/graphql/queries.py:4214-4246`
+  - Files: `config/graphql/queries.py:4214-4250`
 - **GraphQL mutation `updatePipelineSettings`**: Superusers can modify pipeline configuration at runtime
   - Validates component class paths exist in the pipeline registry
   - Tracks who made changes (modified_by field)
   - Changes take effect immediately for new document processing tasks
-  - Files: `config/graphql/pipeline_settings_mutations.py:20-193`
+  - Files: `config/graphql/pipeline_settings_mutations.py:20-220`
 - **GraphQL mutation `resetPipelineSettings`**: Superusers can reset to Django settings defaults
   - Restores all values from PREFERRED_PARSERS, PREFERRED_EMBEDDERS, etc.
-  - Files: `config/graphql/pipeline_settings_mutations.py:196-270`
-- **Migration 0031**: Creates PipelineSettings table and initializes singleton with Django settings defaults
+  - Files: `config/graphql/pipeline_settings_mutations.py:223-302`
+- **GraphQL mutation `updateComponentSecrets`**: Superusers can securely store API keys per component
+  - Accepts component path and secrets dict, encrypts and stores in database
+  - Supports merge mode (add to existing) or replace mode
+  - Files: `config/graphql/pipeline_settings_mutations.py:305-411`
+- **GraphQL mutation `deleteComponentSecrets`**: Superusers can remove secrets for a component
+  - Files: `config/graphql/pipeline_settings_mutations.py:414-481`
+- **Migration 0031**: Creates PipelineSettings table with encrypted_secrets field
   - Files: `opencontractserver/documents/migrations/0031_add_pipeline_settings.py`
 - **Integration with doc_tasks**: `ingest_doc` and `extract_thumbnail` now read from PipelineSettings
   - Files: `opencontractserver/tasks/doc_tasks.py:355-374`, `opencontractserver/tasks/doc_tasks.py:686-721`

--- a/config/graphql/graphene_types.py
+++ b/config/graphql/graphene_types.py
@@ -3505,6 +3505,13 @@ class PipelineSettingsType(graphene.ObjectType):
         description="Default embedder class path when no MIME-specific embedder is found"
     )
 
+    # Secrets indicator (actual secrets are never exposed via GraphQL)
+    components_with_secrets = graphene.List(
+        graphene.String,
+        description="List of component paths that have encrypted secrets configured. "
+        "Actual secret values are never exposed via GraphQL.",
+    )
+
     # Audit fields
     modified = graphene.DateTime(description="When these settings were last modified")
     modified_by = graphene.Field(

--- a/config/graphql/graphene_types.py
+++ b/config/graphql/graphene_types.py
@@ -3466,3 +3466,47 @@ class SemanticSearchResultType(graphene.ObjectType):
         if self.annotation:
             return self.annotation.corpus
         return None
+
+
+# ==============================================================================
+# PIPELINE SETTINGS TYPES (Runtime-configurable document processing settings)
+# ==============================================================================
+
+
+class PipelineSettingsType(graphene.ObjectType):
+    """
+    GraphQL type for PipelineSettings singleton.
+
+    Exposes the runtime-configurable document processing pipeline settings.
+    Only superusers can modify these settings via mutation.
+    """
+
+    # Preferred components per MIME type
+    preferred_parsers = GenericScalar(
+        description="Mapping of MIME types to preferred parser class paths"
+    )
+    preferred_embedders = GenericScalar(
+        description="Mapping of MIME types to preferred embedder class paths"
+    )
+    preferred_thumbnailers = GenericScalar(
+        description="Mapping of MIME types to preferred thumbnailer class paths"
+    )
+
+    # Component configuration
+    parser_kwargs = GenericScalar(
+        description="Mapping of parser class paths to their configuration kwargs"
+    )
+    component_settings = GenericScalar(
+        description="Mapping of component class paths to settings overrides"
+    )
+
+    # Default embedder
+    default_embedder = graphene.String(
+        description="Default embedder class path when no MIME-specific embedder is found"
+    )
+
+    # Audit fields
+    modified = graphene.DateTime(description="When these settings were last modified")
+    modified_by = graphene.Field(
+        UserType, description="User who last modified these settings"
+    )

--- a/config/graphql/mutations.py
+++ b/config/graphql/mutations.py
@@ -95,6 +95,12 @@ from config.graphql.notification_mutations import (
     MarkNotificationReadMutation,
     MarkNotificationUnreadMutation,
 )
+
+# Import pipeline settings mutations
+from config.graphql.pipeline_settings_mutations import (
+    ResetPipelineSettingsMutation,
+    UpdatePipelineSettingsMutation,
+)
 from config.graphql.ratelimits import (
     RateLimits,
     get_user_tier_rate,
@@ -5956,3 +5962,7 @@ class Mutation(graphene.ObjectType):
     create_agent_configuration = CreateAgentConfigurationMutation.Field()
     update_agent_configuration = UpdateAgentConfigurationMutation.Field()
     delete_agent_configuration = DeleteAgentConfigurationMutation.Field()
+
+    # PIPELINE SETTINGS MUTATIONS (Superuser only) ###############################
+    update_pipeline_settings = UpdatePipelineSettingsMutation.Field()
+    reset_pipeline_settings = ResetPipelineSettingsMutation.Field()

--- a/config/graphql/mutations.py
+++ b/config/graphql/mutations.py
@@ -98,7 +98,9 @@ from config.graphql.notification_mutations import (
 
 # Import pipeline settings mutations
 from config.graphql.pipeline_settings_mutations import (
+    DeleteComponentSecretsMutation,
     ResetPipelineSettingsMutation,
+    UpdateComponentSecretsMutation,
     UpdatePipelineSettingsMutation,
 )
 from config.graphql.ratelimits import (
@@ -5966,3 +5968,5 @@ class Mutation(graphene.ObjectType):
     # PIPELINE SETTINGS MUTATIONS (Superuser only) ###############################
     update_pipeline_settings = UpdatePipelineSettingsMutation.Field()
     reset_pipeline_settings = ResetPipelineSettingsMutation.Field()
+    update_component_secrets = UpdateComponentSecretsMutation.Field()
+    delete_component_secrets = DeleteComponentSecretsMutation.Field()

--- a/config/graphql/pipeline_settings_mutations.py
+++ b/config/graphql/pipeline_settings_mutations.py
@@ -5,6 +5,8 @@ Superuser-only mutations to configure document processing pipeline at runtime.
 """
 
 import logging
+import re
+from typing import Optional
 
 import graphene
 from graphene.types.generic import GenericScalar
@@ -14,6 +16,111 @@ from config.graphql.graphene_types import PipelineSettingsType
 from config.graphql.ratelimits import RateLimits, graphql_ratelimit
 
 logger = logging.getLogger(__name__)
+
+# Validation constants
+MAX_COMPONENT_PATH_LENGTH = 256
+MAX_MIME_TYPE_LENGTH = 128
+VALID_COMPONENT_PATH_PATTERN = re.compile(
+    r"^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)+$"
+)
+VALID_MIME_TYPE_PATTERN = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9!#$&\-^_.+]*\/[a-zA-Z0-9][a-zA-Z0-9!#$&\-^_.+]*$")
+
+
+def validate_component_path(path: str) -> Optional[str]:
+    """
+    Validate a component class path.
+
+    Args:
+        path: The component class path to validate
+
+    Returns:
+        Error message if invalid, None if valid
+    """
+    if not path:
+        return "Component path cannot be empty"
+    if len(path) > MAX_COMPONENT_PATH_LENGTH:
+        return f"Component path exceeds maximum length of {MAX_COMPONENT_PATH_LENGTH}"
+    if not VALID_COMPONENT_PATH_PATTERN.match(path):
+        return f"Invalid component path format: '{path}'. Must be a valid Python module path."
+    return None
+
+
+def validate_mime_type(mime_type: str) -> Optional[str]:
+    """
+    Validate a MIME type string.
+
+    Args:
+        mime_type: The MIME type to validate
+
+    Returns:
+        Error message if invalid, None if valid
+    """
+    if not mime_type:
+        return "MIME type cannot be empty"
+    if len(mime_type) > MAX_MIME_TYPE_LENGTH:
+        return f"MIME type exceeds maximum length of {MAX_MIME_TYPE_LENGTH}"
+    if not VALID_MIME_TYPE_PATTERN.match(mime_type):
+        return f"Invalid MIME type format: '{mime_type}'"
+    return None
+
+
+def validate_component_mapping(
+    mapping: dict, registry, component_type: str
+) -> Optional[str]:
+    """
+    Validate a mapping of MIME types to component paths.
+
+    Args:
+        mapping: Dict mapping MIME types to component class paths
+        registry: Pipeline component registry for validation
+        component_type: Type name for error messages (e.g., "Parser")
+
+    Returns:
+        Error message if invalid, None if valid
+    """
+    if not isinstance(mapping, dict):
+        return f"{component_type} mapping must be a dictionary"
+
+    for mime_type, component_path in mapping.items():
+        # Validate MIME type
+        error = validate_mime_type(mime_type)
+        if error:
+            return error
+
+        # Validate component path format
+        error = validate_component_path(component_path)
+        if error:
+            return error
+
+        # Validate component exists in registry
+        if not registry.get_by_class_name(component_path):
+            return f"{component_type} '{component_path}' not found in registry"
+
+    return None
+
+
+def validate_secrets_input(secrets: dict) -> Optional[str]:
+    """
+    Validate secrets input structure.
+
+    Args:
+        secrets: Dict of secret key-value pairs
+
+    Returns:
+        Error message if invalid, None if valid
+    """
+    if not isinstance(secrets, dict):
+        return "Secrets must be a dictionary"
+
+    for key, value in secrets.items():
+        if not isinstance(key, str):
+            return f"Secret key must be a string, got {type(key).__name__}"
+        if len(key) > 256:
+            return f"Secret key '{key[:50]}...' exceeds maximum length of 256"
+        if not isinstance(value, (str, int, float, bool, type(None))):
+            return f"Secret value for '{key}' must be a primitive type (string, number, boolean, null)"
+
+    return None
 
 
 class UpdatePipelineSettingsMutation(graphene.Mutation):
@@ -103,61 +210,38 @@ class UpdatePipelineSettingsMutation(graphene.Mutation):
             settings_instance = PipelineSettings.get_instance()
             registry = get_registry()
 
-            # Validate preferred_parsers if provided
+            # Validate and apply preferred_parsers
             if preferred_parsers is not None:
-                if not isinstance(preferred_parsers, dict):
+                error = validate_component_mapping(preferred_parsers, registry, "Parser")
+                if error:
                     return UpdatePipelineSettingsMutation(
-                        ok=False,
-                        message="preferred_parsers must be a dictionary.",
-                        pipeline_settings=None,
+                        ok=False, message=error, pipeline_settings=None
                     )
-                # Validate parser class paths exist in registry
-                for mimetype, parser_path in preferred_parsers.items():
-                    if not registry.get_by_class_name(parser_path):
-                        return UpdatePipelineSettingsMutation(
-                            ok=False,
-                            message=f"Parser '{parser_path}' not found in registry.",
-                            pipeline_settings=None,
-                        )
                 settings_instance.preferred_parsers = preferred_parsers
 
-            # Validate preferred_embedders if provided
+            # Validate and apply preferred_embedders
             if preferred_embedders is not None:
-                if not isinstance(preferred_embedders, dict):
+                error = validate_component_mapping(
+                    preferred_embedders, registry, "Embedder"
+                )
+                if error:
                     return UpdatePipelineSettingsMutation(
-                        ok=False,
-                        message="preferred_embedders must be a dictionary.",
-                        pipeline_settings=None,
+                        ok=False, message=error, pipeline_settings=None
                     )
-                # Validate embedder class paths exist in registry
-                for mimetype, embedder_path in preferred_embedders.items():
-                    if not registry.get_by_class_name(embedder_path):
-                        return UpdatePipelineSettingsMutation(
-                            ok=False,
-                            message=f"Embedder '{embedder_path}' not found in registry.",
-                            pipeline_settings=None,
-                        )
                 settings_instance.preferred_embedders = preferred_embedders
 
-            # Validate preferred_thumbnailers if provided
+            # Validate and apply preferred_thumbnailers
             if preferred_thumbnailers is not None:
-                if not isinstance(preferred_thumbnailers, dict):
+                error = validate_component_mapping(
+                    preferred_thumbnailers, registry, "Thumbnailer"
+                )
+                if error:
                     return UpdatePipelineSettingsMutation(
-                        ok=False,
-                        message="preferred_thumbnailers must be a dictionary.",
-                        pipeline_settings=None,
+                        ok=False, message=error, pipeline_settings=None
                     )
-                # Validate thumbnailer class paths exist in registry
-                for mimetype, thumbnailer_path in preferred_thumbnailers.items():
-                    if not registry.get_by_class_name(thumbnailer_path):
-                        return UpdatePipelineSettingsMutation(
-                            ok=False,
-                            message=f"Thumbnailer '{thumbnailer_path}' not found in registry.",
-                            pipeline_settings=None,
-                        )
                 settings_instance.preferred_thumbnailers = preferred_thumbnailers
 
-            # Validate parser_kwargs if provided
+            # Validate parser_kwargs
             if parser_kwargs is not None:
                 if not isinstance(parser_kwargs, dict):
                     return UpdatePipelineSettingsMutation(
@@ -167,7 +251,7 @@ class UpdatePipelineSettingsMutation(graphene.Mutation):
                     )
                 settings_instance.parser_kwargs = parser_kwargs
 
-            # Validate component_settings if provided
+            # Validate component_settings
             if component_settings is not None:
                 if not isinstance(component_settings, dict):
                     return UpdatePipelineSettingsMutation(
@@ -177,14 +261,20 @@ class UpdatePipelineSettingsMutation(graphene.Mutation):
                     )
                 settings_instance.component_settings = component_settings
 
-            # Validate default_embedder if provided
+            # Validate default_embedder
             if default_embedder is not None:
-                if default_embedder and not registry.get_by_class_name(default_embedder):
-                    return UpdatePipelineSettingsMutation(
-                        ok=False,
-                        message=f"Default embedder '{default_embedder}' not found in registry.",
-                        pipeline_settings=None,
-                    )
+                if default_embedder:
+                    error = validate_component_path(default_embedder)
+                    if error:
+                        return UpdatePipelineSettingsMutation(
+                            ok=False, message=error, pipeline_settings=None
+                        )
+                    if not registry.get_by_class_name(default_embedder):
+                        return UpdatePipelineSettingsMutation(
+                            ok=False,
+                            message=f"Default embedder '{default_embedder}' not found in registry.",
+                            pipeline_settings=None,
+                        )
                 settings_instance.default_embedder = default_embedder
 
             # Record who made the change
@@ -365,12 +455,18 @@ class UpdateComponentSecretsMutation(graphene.Mutation):
                 components_with_secrets=None,
             )
 
-        # Validate secrets is a dict
-        if not isinstance(secrets, dict):
+        # Validate component path
+        error = validate_component_path(component_path)
+        if error:
             return UpdateComponentSecretsMutation(
-                ok=False,
-                message="secrets must be a dictionary.",
-                components_with_secrets=None,
+                ok=False, message=error, components_with_secrets=None
+            )
+
+        # Validate secrets structure
+        error = validate_secrets_input(secrets)
+        if error:
+            return UpdateComponentSecretsMutation(
+                ok=False, message=error, components_with_secrets=None
             )
 
         try:

--- a/config/graphql/pipeline_settings_mutations.py
+++ b/config/graphql/pipeline_settings_mutations.py
@@ -23,7 +23,9 @@ MAX_MIME_TYPE_LENGTH = 128
 VALID_COMPONENT_PATH_PATTERN = re.compile(
     r"^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)+$"
 )
-VALID_MIME_TYPE_PATTERN = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9!#$&\-^_.+]*\/[a-zA-Z0-9][a-zA-Z0-9!#$&\-^_.+]*$")
+VALID_MIME_TYPE_PATTERN = re.compile(
+    r"^[a-zA-Z0-9][a-zA-Z0-9!#$&\-^_.+]*\/[a-zA-Z0-9][a-zA-Z0-9!#$&\-^_.+]*$"
+)
 
 
 def validate_component_path(path: str) -> Optional[str]:
@@ -212,7 +214,9 @@ class UpdatePipelineSettingsMutation(graphene.Mutation):
 
             # Validate and apply preferred_parsers
             if preferred_parsers is not None:
-                error = validate_component_mapping(preferred_parsers, registry, "Parser")
+                error = validate_component_mapping(
+                    preferred_parsers, registry, "Parser"
+                )
                 if error:
                     return UpdatePipelineSettingsMutation(
                         ok=False, message=error, pipeline_settings=None
@@ -296,6 +300,9 @@ class UpdatePipelineSettingsMutation(graphene.Mutation):
                     parser_kwargs=settings_instance.parser_kwargs or {},
                     component_settings=settings_instance.component_settings or {},
                     default_embedder=settings_instance.default_embedder or "",
+                    components_with_secrets=list(
+                        settings_instance.get_secrets().keys()
+                    ),
                     modified=settings_instance.modified,
                     modified_by=settings_instance.modified_by,
                 ),
@@ -378,6 +385,9 @@ class ResetPipelineSettingsMutation(graphene.Mutation):
                     parser_kwargs=settings_instance.parser_kwargs or {},
                     component_settings=settings_instance.component_settings or {},
                     default_embedder=settings_instance.default_embedder or "",
+                    components_with_secrets=list(
+                        settings_instance.get_secrets().keys()
+                    ),
                     modified=settings_instance.modified,
                     modified_by=settings_instance.modified_by,
                 ),

--- a/config/graphql/pipeline_settings_mutations.py
+++ b/config/graphql/pipeline_settings_mutations.py
@@ -1,0 +1,302 @@
+"""
+GraphQL mutations for the pipeline settings system.
+
+Superuser-only mutations to configure document processing pipeline at runtime.
+"""
+
+import logging
+
+import graphene
+from graphene.types.generic import GenericScalar
+from graphql_jwt.decorators import login_required
+
+from config.graphql.graphene_types import PipelineSettingsType
+from config.graphql.ratelimits import RateLimits, graphql_ratelimit
+
+logger = logging.getLogger(__name__)
+
+
+class UpdatePipelineSettingsMutation(graphene.Mutation):
+    """
+    Update the singleton pipeline settings.
+
+    Only superusers can modify these settings. Changes take effect immediately
+    for all new document processing tasks.
+
+    Arguments:
+        preferred_parsers: Dict mapping MIME types to parser class paths
+        preferred_embedders: Dict mapping MIME types to embedder class paths
+        preferred_thumbnailers: Dict mapping MIME types to thumbnailer class paths
+        parser_kwargs: Dict mapping parser class paths to their configuration kwargs
+        component_settings: Dict mapping component class paths to settings overrides
+        default_embedder: Default embedder class path
+
+    Returns:
+        ok: Whether the update succeeded
+        message: Status message
+        pipeline_settings: The updated settings
+    """
+
+    class Arguments:
+        preferred_parsers = GenericScalar(
+            required=False,
+            description="Mapping of MIME types to preferred parser class paths. "
+            "Example: {'application/pdf': 'opencontractserver.pipeline.parsers.docling_parser_rest.DoclingParser'}",
+        )
+        preferred_embedders = GenericScalar(
+            required=False,
+            description="Mapping of MIME types to preferred embedder class paths.",
+        )
+        preferred_thumbnailers = GenericScalar(
+            required=False,
+            description="Mapping of MIME types to preferred thumbnailer class paths.",
+        )
+        parser_kwargs = GenericScalar(
+            required=False,
+            description="Mapping of parser class paths to their configuration kwargs. "
+            "Example: {'DoclingParser': {'force_ocr': true}}",
+        )
+        component_settings = GenericScalar(
+            required=False,
+            description="Mapping of component class paths to settings overrides.",
+        )
+        default_embedder = graphene.String(
+            required=False,
+            description="Default embedder class path when no MIME-specific embedder is found.",
+        )
+
+    ok = graphene.Boolean()
+    message = graphene.String()
+    pipeline_settings = graphene.Field(PipelineSettingsType)
+
+    @login_required
+    @graphql_ratelimit(rate=RateLimits.WRITE_LIGHT)
+    def mutate(
+        root,
+        info,
+        preferred_parsers=None,
+        preferred_embedders=None,
+        preferred_thumbnailers=None,
+        parser_kwargs=None,
+        component_settings=None,
+        default_embedder=None,
+    ):
+        """
+        Update the pipeline settings.
+
+        Security: Only superusers can update these settings.
+        """
+        from opencontractserver.documents.models import PipelineSettings
+        from opencontractserver.pipeline.registry import get_registry
+
+        user = info.context.user
+
+        # SECURITY: Only superusers can update pipeline settings
+        if not user.is_superuser:
+            return UpdatePipelineSettingsMutation(
+                ok=False,
+                message="Only superusers can update pipeline settings.",
+                pipeline_settings=None,
+            )
+
+        try:
+            settings_instance = PipelineSettings.get_instance()
+            registry = get_registry()
+
+            # Validate preferred_parsers if provided
+            if preferred_parsers is not None:
+                if not isinstance(preferred_parsers, dict):
+                    return UpdatePipelineSettingsMutation(
+                        ok=False,
+                        message="preferred_parsers must be a dictionary.",
+                        pipeline_settings=None,
+                    )
+                # Validate parser class paths exist in registry
+                for mimetype, parser_path in preferred_parsers.items():
+                    if not registry.get_by_class_name(parser_path):
+                        return UpdatePipelineSettingsMutation(
+                            ok=False,
+                            message=f"Parser '{parser_path}' not found in registry.",
+                            pipeline_settings=None,
+                        )
+                settings_instance.preferred_parsers = preferred_parsers
+
+            # Validate preferred_embedders if provided
+            if preferred_embedders is not None:
+                if not isinstance(preferred_embedders, dict):
+                    return UpdatePipelineSettingsMutation(
+                        ok=False,
+                        message="preferred_embedders must be a dictionary.",
+                        pipeline_settings=None,
+                    )
+                # Validate embedder class paths exist in registry
+                for mimetype, embedder_path in preferred_embedders.items():
+                    if not registry.get_by_class_name(embedder_path):
+                        return UpdatePipelineSettingsMutation(
+                            ok=False,
+                            message=f"Embedder '{embedder_path}' not found in registry.",
+                            pipeline_settings=None,
+                        )
+                settings_instance.preferred_embedders = preferred_embedders
+
+            # Validate preferred_thumbnailers if provided
+            if preferred_thumbnailers is not None:
+                if not isinstance(preferred_thumbnailers, dict):
+                    return UpdatePipelineSettingsMutation(
+                        ok=False,
+                        message="preferred_thumbnailers must be a dictionary.",
+                        pipeline_settings=None,
+                    )
+                # Validate thumbnailer class paths exist in registry
+                for mimetype, thumbnailer_path in preferred_thumbnailers.items():
+                    if not registry.get_by_class_name(thumbnailer_path):
+                        return UpdatePipelineSettingsMutation(
+                            ok=False,
+                            message=f"Thumbnailer '{thumbnailer_path}' not found in registry.",
+                            pipeline_settings=None,
+                        )
+                settings_instance.preferred_thumbnailers = preferred_thumbnailers
+
+            # Validate parser_kwargs if provided
+            if parser_kwargs is not None:
+                if not isinstance(parser_kwargs, dict):
+                    return UpdatePipelineSettingsMutation(
+                        ok=False,
+                        message="parser_kwargs must be a dictionary.",
+                        pipeline_settings=None,
+                    )
+                settings_instance.parser_kwargs = parser_kwargs
+
+            # Validate component_settings if provided
+            if component_settings is not None:
+                if not isinstance(component_settings, dict):
+                    return UpdatePipelineSettingsMutation(
+                        ok=False,
+                        message="component_settings must be a dictionary.",
+                        pipeline_settings=None,
+                    )
+                settings_instance.component_settings = component_settings
+
+            # Validate default_embedder if provided
+            if default_embedder is not None:
+                if default_embedder and not registry.get_by_class_name(default_embedder):
+                    return UpdatePipelineSettingsMutation(
+                        ok=False,
+                        message=f"Default embedder '{default_embedder}' not found in registry.",
+                        pipeline_settings=None,
+                    )
+                settings_instance.default_embedder = default_embedder
+
+            # Record who made the change
+            settings_instance.modified_by = user
+            settings_instance.save()
+
+            logger.info(
+                f"Pipeline settings updated by {user.username} (superuser={user.is_superuser})"
+            )
+
+            return UpdatePipelineSettingsMutation(
+                ok=True,
+                message="Pipeline settings updated successfully.",
+                pipeline_settings=PipelineSettingsType(
+                    preferred_parsers=settings_instance.preferred_parsers or {},
+                    preferred_embedders=settings_instance.preferred_embedders or {},
+                    preferred_thumbnailers=settings_instance.preferred_thumbnailers
+                    or {},
+                    parser_kwargs=settings_instance.parser_kwargs or {},
+                    component_settings=settings_instance.component_settings or {},
+                    default_embedder=settings_instance.default_embedder or "",
+                    modified=settings_instance.modified,
+                    modified_by=settings_instance.modified_by,
+                ),
+            )
+
+        except Exception as e:
+            logger.exception("Error updating pipeline settings")
+            return UpdatePipelineSettingsMutation(
+                ok=False,
+                message=f"Failed to update pipeline settings: {str(e)}",
+                pipeline_settings=None,
+            )
+
+
+class ResetPipelineSettingsMutation(graphene.Mutation):
+    """
+    Reset pipeline settings to Django settings defaults.
+
+    This mutation resets all pipeline settings to their default values from
+    Django settings (PREFERRED_PARSERS, PREFERRED_EMBEDDERS, etc.).
+
+    Only superusers can perform this operation.
+    """
+
+    ok = graphene.Boolean()
+    message = graphene.String()
+    pipeline_settings = graphene.Field(PipelineSettingsType)
+
+    @login_required
+    @graphql_ratelimit(rate=RateLimits.WRITE_LIGHT)
+    def mutate(root, info):
+        """Reset pipeline settings to Django settings defaults."""
+        from django.conf import settings as django_settings
+
+        from opencontractserver.documents.models import PipelineSettings
+
+        user = info.context.user
+
+        # SECURITY: Only superusers can reset pipeline settings
+        if not user.is_superuser:
+            return ResetPipelineSettingsMutation(
+                ok=False,
+                message="Only superusers can reset pipeline settings.",
+                pipeline_settings=None,
+            )
+
+        try:
+            settings_instance = PipelineSettings.get_instance()
+
+            # Reset to Django settings defaults
+            settings_instance.preferred_parsers = getattr(
+                django_settings, "PREFERRED_PARSERS", {}
+            )
+            settings_instance.preferred_embedders = getattr(
+                django_settings, "PREFERRED_EMBEDDERS", {}
+            )
+            settings_instance.preferred_thumbnailers = {}
+            settings_instance.parser_kwargs = getattr(
+                django_settings, "PARSER_KWARGS", {}
+            )
+            settings_instance.component_settings = getattr(
+                django_settings, "PIPELINE_SETTINGS", {}
+            )
+            settings_instance.default_embedder = getattr(
+                django_settings, "DEFAULT_EMBEDDER", ""
+            )
+            settings_instance.modified_by = user
+            settings_instance.save()
+
+            logger.info(f"Pipeline settings reset to defaults by {user.username}")
+
+            return ResetPipelineSettingsMutation(
+                ok=True,
+                message="Pipeline settings reset to defaults successfully.",
+                pipeline_settings=PipelineSettingsType(
+                    preferred_parsers=settings_instance.preferred_parsers or {},
+                    preferred_embedders=settings_instance.preferred_embedders or {},
+                    preferred_thumbnailers=settings_instance.preferred_thumbnailers
+                    or {},
+                    parser_kwargs=settings_instance.parser_kwargs or {},
+                    component_settings=settings_instance.component_settings or {},
+                    default_embedder=settings_instance.default_embedder or "",
+                    modified=settings_instance.modified,
+                    modified_by=settings_instance.modified_by,
+                ),
+            )
+
+        except Exception as e:
+            logger.exception("Error resetting pipeline settings")
+            return ResetPipelineSettingsMutation(
+                ok=False,
+                message=f"Failed to reset pipeline settings: {str(e)}",
+                pipeline_settings=None,
+            )

--- a/config/graphql/pipeline_settings_mutations.py
+++ b/config/graphql/pipeline_settings_mutations.py
@@ -300,3 +300,182 @@ class ResetPipelineSettingsMutation(graphene.Mutation):
                 message=f"Failed to reset pipeline settings: {str(e)}",
                 pipeline_settings=None,
             )
+
+
+class UpdateComponentSecretsMutation(graphene.Mutation):
+    """
+    Update encrypted secrets for a specific pipeline component.
+
+    This mutation allows superusers to securely store API keys, tokens, and
+    other credentials for pipeline components. The secrets are encrypted at
+    rest using Fernet symmetric encryption.
+
+    Only superusers can perform this operation.
+
+    Arguments:
+        component_path: Full class path of the component (e.g.,
+            'opencontractserver.pipeline.parsers.llamaparse_parser.LlamaParseParser')
+        secrets: Dict of secret key-value pairs to store (e.g., {'api_key': '...'})
+        merge: If True, merge with existing secrets. If False, replace all secrets
+            for this component. Default: True
+
+    Returns:
+        ok: Whether the update succeeded
+        message: Status message
+        components_with_secrets: List of component paths that have secrets stored
+    """
+
+    class Arguments:
+        component_path = graphene.String(
+            required=True,
+            description="Full class path of the component.",
+        )
+        secrets = GenericScalar(
+            required=True,
+            description="Dict of secret key-value pairs to store. "
+            "Example: {'api_key': 'sk-...', 'secret_token': '...'}",
+        )
+        merge = graphene.Boolean(
+            required=False,
+            default_value=True,
+            description="If True, merge with existing secrets. "
+            "If False, replace all secrets for this component.",
+        )
+
+    ok = graphene.Boolean()
+    message = graphene.String()
+    components_with_secrets = graphene.List(
+        graphene.String,
+        description="List of component paths that have secrets stored.",
+    )
+
+    @login_required
+    @graphql_ratelimit(rate=RateLimits.WRITE_LIGHT)
+    def mutate(root, info, component_path, secrets, merge=True):
+        """Update encrypted secrets for a component."""
+        from opencontractserver.documents.models import PipelineSettings
+
+        user = info.context.user
+
+        # SECURITY: Only superusers can update secrets
+        if not user.is_superuser:
+            return UpdateComponentSecretsMutation(
+                ok=False,
+                message="Only superusers can update component secrets.",
+                components_with_secrets=None,
+            )
+
+        # Validate secrets is a dict
+        if not isinstance(secrets, dict):
+            return UpdateComponentSecretsMutation(
+                ok=False,
+                message="secrets must be a dictionary.",
+                components_with_secrets=None,
+            )
+
+        try:
+            settings_instance = PipelineSettings.get_instance()
+
+            if merge:
+                # Merge with existing secrets
+                settings_instance.update_secrets(component_path, secrets)
+            else:
+                # Replace all secrets for this component
+                all_secrets = settings_instance.get_secrets()
+                all_secrets[component_path] = secrets
+                settings_instance.set_secrets(all_secrets)
+
+            settings_instance.modified_by = user
+            settings_instance.save()
+
+            # Return list of components that have secrets (don't return actual secrets)
+            all_secrets = settings_instance.get_secrets()
+            components_with_secrets = list(all_secrets.keys())
+
+            logger.info(
+                f"Secrets updated for component '{component_path}' by {user.username}"
+            )
+
+            return UpdateComponentSecretsMutation(
+                ok=True,
+                message=f"Secrets updated successfully for '{component_path}'.",
+                components_with_secrets=components_with_secrets,
+            )
+
+        except Exception as e:
+            logger.exception("Error updating component secrets")
+            return UpdateComponentSecretsMutation(
+                ok=False,
+                message=f"Failed to update secrets: {str(e)}",
+                components_with_secrets=None,
+            )
+
+
+class DeleteComponentSecretsMutation(graphene.Mutation):
+    """
+    Delete all encrypted secrets for a specific pipeline component.
+
+    Only superusers can perform this operation.
+
+    Arguments:
+        component_path: Full class path of the component
+
+    Returns:
+        ok: Whether the deletion succeeded
+        message: Status message
+        components_with_secrets: Updated list of component paths that have secrets
+    """
+
+    class Arguments:
+        component_path = graphene.String(
+            required=True,
+            description="Full class path of the component.",
+        )
+
+    ok = graphene.Boolean()
+    message = graphene.String()
+    components_with_secrets = graphene.List(graphene.String)
+
+    @login_required
+    @graphql_ratelimit(rate=RateLimits.WRITE_LIGHT)
+    def mutate(root, info, component_path):
+        """Delete all secrets for a component."""
+        from opencontractserver.documents.models import PipelineSettings
+
+        user = info.context.user
+
+        # SECURITY: Only superusers can delete secrets
+        if not user.is_superuser:
+            return DeleteComponentSecretsMutation(
+                ok=False,
+                message="Only superusers can delete component secrets.",
+                components_with_secrets=None,
+            )
+
+        try:
+            settings_instance = PipelineSettings.get_instance()
+            settings_instance.delete_component_secrets(component_path)
+            settings_instance.modified_by = user
+            settings_instance.save()
+
+            # Return updated list of components with secrets
+            all_secrets = settings_instance.get_secrets()
+            components_with_secrets = list(all_secrets.keys())
+
+            logger.info(
+                f"Secrets deleted for component '{component_path}' by {user.username}"
+            )
+
+            return DeleteComponentSecretsMutation(
+                ok=True,
+                message=f"Secrets deleted for '{component_path}'.",
+                components_with_secrets=components_with_secrets,
+            )
+
+        except Exception as e:
+            logger.exception("Error deleting component secrets")
+            return DeleteComponentSecretsMutation(
+                ok=False,
+                message=f"Failed to delete secrets: {str(e)}",
+                components_with_secrets=None,
+            )

--- a/config/graphql/queries.py
+++ b/config/graphql/queries.py
@@ -4234,6 +4234,9 @@ class Query(graphene.ObjectType):
 
         settings_instance = PipelineSettings.get_instance()
 
+        # Get list of components that have secrets (don't expose actual secrets)
+        components_with_secrets = list(settings_instance.get_secrets().keys())
+
         return PipelineSettingsType(
             preferred_parsers=settings_instance.preferred_parsers or {},
             preferred_embedders=settings_instance.preferred_embedders or {},
@@ -4241,6 +4244,7 @@ class Query(graphene.ObjectType):
             parser_kwargs=settings_instance.parser_kwargs or {},
             component_settings=settings_instance.component_settings or {},
             default_embedder=settings_instance.default_embedder or "",
+            components_with_secrets=components_with_secrets,
             modified=settings_instance.modified,
             modified_by=settings_instance.modified_by,
         )

--- a/config/graphql/queries.py
+++ b/config/graphql/queries.py
@@ -4211,6 +4211,40 @@ class Query(graphene.ObjectType):
         except Extract.DoesNotExist:
             return None
 
+    # PIPELINE SETTINGS ########################################
+    pipeline_settings = graphene.Field(
+        "config.graphql.graphene_types.PipelineSettingsType",
+        description="Retrieve the singleton pipeline settings for document processing configuration.",
+    )
+
+    @login_required
+    def resolve_pipeline_settings(self, info):
+        """
+        Resolve the singleton PipelineSettings instance.
+
+        This query returns the runtime-configurable document processing settings.
+        Any authenticated user can read these settings, but only superusers can
+        modify them via the UpdatePipelineSettings mutation.
+
+        Returns:
+            PipelineSettingsType: The singleton pipeline settings.
+        """
+        from config.graphql.graphene_types import PipelineSettingsType
+        from opencontractserver.documents.models import PipelineSettings
+
+        settings_instance = PipelineSettings.get_instance()
+
+        return PipelineSettingsType(
+            preferred_parsers=settings_instance.preferred_parsers or {},
+            preferred_embedders=settings_instance.preferred_embedders or {},
+            preferred_thumbnailers=settings_instance.preferred_thumbnailers or {},
+            parser_kwargs=settings_instance.parser_kwargs or {},
+            component_settings=settings_instance.component_settings or {},
+            default_embedder=settings_instance.default_embedder or "",
+            modified=settings_instance.modified,
+            modified_by=settings_instance.modified_by,
+        )
+
     # DEBUG FIELD ########################################
     if settings.ALLOW_GRAPHQL_DEBUG:
         debug = graphene.Field(DjangoDebug, name="_debug")

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -912,6 +912,33 @@ PIPELINE_SETTINGS = {
     # Currently no overrides - all components use global settings which read from env vars
 }
 
+# Pipeline Settings Encryption Configuration
+# ------------------------------------------------------------------------------
+# These settings control how sensitive pipeline configuration (API keys, etc.)
+# is encrypted at rest in the PipelineSettings model.
+
+# Length of random salt prepended to encrypted secrets (in bytes)
+# 16 bytes = 128 bits, recommended minimum for secure encryption
+PIPELINE_SETTINGS_ENCRYPTION_SALT_LENGTH = 16
+
+# PBKDF2 iterations for key derivation from SECRET_KEY
+# OWASP 2023 recommends 480,000 iterations for PBKDF2-HMAC-SHA256
+# Higher = more secure but slower; only impacts save/load of secrets
+PIPELINE_SETTINGS_ENCRYPTION_ITERATIONS = env.int(
+    "PIPELINE_SETTINGS_ENCRYPTION_ITERATIONS", default=480000
+)
+
+# Maximum size for secrets payload (in bytes)
+# Prevents storage abuse; 10KB is generous for API keys/tokens
+PIPELINE_SETTINGS_MAX_SECRET_SIZE_BYTES = 10240
+
+# Cache TTL for PipelineSettings singleton (in seconds)
+# Reduces database queries during document processing
+# Cache is invalidated on any settings update
+PIPELINE_SETTINGS_CACHE_TTL_SECONDS = env.int(
+    "PIPELINE_SETTINGS_CACHE_TTL_SECONDS", default=300
+)
+
 LLMS_DEFAULT_AGENT_FRAMEWORK = "pydantic_ai"
 
 # Default Agent Instructions

--- a/opencontractserver/documents/migrations/0031_add_pipeline_settings.py
+++ b/opencontractserver/documents/migrations/0031_add_pipeline_settings.py
@@ -109,6 +109,14 @@ class Migration(migrations.Migration):
                         max_length=512,
                     ),
                 ),
+                (
+                    "encrypted_secrets",
+                    models.BinaryField(
+                        blank=True,
+                        null=True,
+                        help_text="Encrypted storage for sensitive configuration (API keys, credentials)",
+                    ),
+                ),
                 ("modified", models.DateTimeField(auto_now=True)),
                 (
                     "modified_by",

--- a/opencontractserver/documents/migrations/0031_add_pipeline_settings.py
+++ b/opencontractserver/documents/migrations/0031_add_pipeline_settings.py
@@ -1,0 +1,135 @@
+# Generated migration for PipelineSettings singleton model
+
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+import opencontractserver.shared.fields
+
+
+def create_pipeline_settings_singleton(apps, schema_editor):
+    """
+    Create the singleton PipelineSettings instance with defaults from Django settings.
+
+    This ensures the singleton exists after migration, populated with the current
+    Django settings values so existing deployments continue to work unchanged.
+    """
+    from django.conf import settings as django_settings
+
+    PipelineSettings = apps.get_model("documents", "PipelineSettings")
+
+    # Only create if doesn't exist (idempotent)
+    if not PipelineSettings.objects.exists():
+        PipelineSettings.objects.create(
+            id=1,
+            preferred_parsers=getattr(django_settings, "PREFERRED_PARSERS", {}),
+            preferred_embedders=getattr(django_settings, "PREFERRED_EMBEDDERS", {}),
+            preferred_thumbnailers={},  # No default in Django settings
+            parser_kwargs=getattr(django_settings, "PARSER_KWARGS", {}),
+            component_settings=getattr(django_settings, "PIPELINE_SETTINGS", {}),
+            default_embedder=getattr(django_settings, "DEFAULT_EMBEDDER", ""),
+        )
+
+
+def reverse_create_singleton(apps, schema_editor):
+    """
+    Reverse the singleton creation.
+
+    Note: This removes all pipeline settings data.
+    """
+    PipelineSettings = apps.get_model("documents", "PipelineSettings")
+    PipelineSettings.objects.all().delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ("documents", "0030_document_processing_error_and_more"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="PipelineSettings",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "preferred_parsers",
+                    opencontractserver.shared.fields.NullableJSONField(
+                        blank=True,
+                        default=dict,
+                        help_text="Mapping of MIME types to preferred parser class paths",
+                    ),
+                ),
+                (
+                    "preferred_embedders",
+                    opencontractserver.shared.fields.NullableJSONField(
+                        blank=True,
+                        default=dict,
+                        help_text="Mapping of MIME types to preferred embedder class paths",
+                    ),
+                ),
+                (
+                    "preferred_thumbnailers",
+                    opencontractserver.shared.fields.NullableJSONField(
+                        blank=True,
+                        default=dict,
+                        help_text="Mapping of MIME types to preferred thumbnailer class paths",
+                    ),
+                ),
+                (
+                    "parser_kwargs",
+                    opencontractserver.shared.fields.NullableJSONField(
+                        blank=True,
+                        default=dict,
+                        help_text="Mapping of parser class paths to configuration kwargs",
+                    ),
+                ),
+                (
+                    "component_settings",
+                    opencontractserver.shared.fields.NullableJSONField(
+                        blank=True,
+                        default=dict,
+                        help_text="Mapping of component class paths to settings overrides",
+                    ),
+                ),
+                (
+                    "default_embedder",
+                    models.CharField(
+                        blank=True,
+                        default="",
+                        help_text="Default embedder class path",
+                        max_length=512,
+                    ),
+                ),
+                ("modified", models.DateTimeField(auto_now=True)),
+                (
+                    "modified_by",
+                    models.ForeignKey(
+                        blank=True,
+                        help_text="User who last modified these settings",
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="pipeline_settings_modifications",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "Pipeline Settings",
+                "verbose_name_plural": "Pipeline Settings",
+            },
+        ),
+        # Create the singleton instance with defaults from Django settings
+        migrations.RunPython(
+            create_pipeline_settings_singleton,
+            reverse_create_singleton,
+        ),
+    ]

--- a/opencontractserver/documents/models.py
+++ b/opencontractserver/documents/models.py
@@ -760,17 +760,21 @@ class PipelineSettings(django.db.models.Model):
 
         default_embedder: Default embedder class path when no MIME-specific embedder is found
 
-    Security Note - API Keys and Secrets:
-        This model is intended for non-sensitive configuration only. Sensitive values
-        like API keys should be stored in environment variables, not in this model.
+    Security - Encrypted Secrets Storage:
+        Sensitive values (API keys, credentials) can be stored in the `encrypted_secrets`
+        field, which is encrypted at rest using Fernet symmetric encryption. The encryption
+        key is derived from Django's SECRET_KEY.
 
-        The recommended pattern is:
-        1. Store API keys in environment variables (LLAMAPARSE_API_KEY, etc.)
-        2. Pipeline components read from environment variables first
-        3. Use component_settings only for non-sensitive overrides (timeouts, batch sizes)
+        Structure of encrypted_secrets (after decryption):
+            {
+                "component_class_path": {
+                    "api_key": "...",
+                    "secret_token": "...",
+                }
+            }
 
-        This keeps secrets out of the database and allows them to be managed via
-        deployment configuration (environment variables, secrets managers, etc.).
+        Use set_secrets() and get_secrets() methods to access encrypted data.
+        The GraphQL mutations handle encryption/decryption transparently.
     """
 
     # Preferred parsers per MIME type
@@ -814,6 +818,14 @@ class PipelineSettings(django.db.models.Model):
         blank=True,
         default="",
         help_text="Default embedder class path",
+    )
+
+    # Encrypted secrets storage (API keys, tokens, credentials)
+    # Stored as Fernet-encrypted JSON blob
+    encrypted_secrets = django.db.models.BinaryField(
+        blank=True,
+        null=True,
+        help_text="Encrypted storage for sensitive configuration (API keys, credentials)",
     )
 
     # Audit fields
@@ -996,3 +1008,132 @@ class PipelineSettings(django.db.models.Model):
             return self.default_embedder
 
         return getattr(django_settings, "DEFAULT_EMBEDDER", "")
+
+    # =====================================================================
+    # Encrypted Secrets Management
+    # =====================================================================
+
+    @staticmethod
+    def _get_fernet() -> "Fernet":
+        """
+        Get a Fernet instance for encryption/decryption.
+
+        Uses Django's SECRET_KEY to derive the encryption key.
+        """
+        import base64
+        import hashlib
+
+        from cryptography.fernet import Fernet
+        from django.conf import settings as django_settings
+
+        # Derive a 32-byte key from SECRET_KEY using SHA256
+        key = hashlib.sha256(django_settings.SECRET_KEY.encode()).digest()
+        # Fernet requires base64-encoded 32-byte key
+        fernet_key = base64.urlsafe_b64encode(key)
+        return Fernet(fernet_key)
+
+    def get_secrets(self) -> dict:
+        """
+        Get the decrypted secrets dictionary.
+
+        Returns:
+            Dict mapping component class paths to their secrets:
+            {
+                "opencontractserver.pipeline.parsers.llamaparse_parser.LlamaParseParser": {
+                    "api_key": "...",
+                },
+                ...
+            }
+        """
+        import json
+
+        if not self.encrypted_secrets:
+            return {}
+
+        try:
+            fernet = self._get_fernet()
+            decrypted = fernet.decrypt(bytes(self.encrypted_secrets))
+            return json.loads(decrypted.decode("utf-8"))
+        except Exception:
+            # If decryption fails (e.g., key changed), return empty dict
+            return {}
+
+    def set_secrets(self, secrets: dict) -> None:
+        """
+        Encrypt and store secrets.
+
+        Args:
+            secrets: Dict mapping component class paths to their secrets:
+            {
+                "opencontractserver.pipeline.parsers.llamaparse_parser.LlamaParseParser": {
+                    "api_key": "...",
+                },
+            }
+        """
+        import json
+
+        fernet = self._get_fernet()
+        json_bytes = json.dumps(secrets).encode("utf-8")
+        self.encrypted_secrets = fernet.encrypt(json_bytes)
+
+    def update_secrets(self, component_path: str, secret_values: dict) -> None:
+        """
+        Update secrets for a specific component (merge with existing).
+
+        Args:
+            component_path: Full class path of the component
+            secret_values: Dict of secret key-value pairs to set
+        """
+        secrets = self.get_secrets()
+        if component_path not in secrets:
+            secrets[component_path] = {}
+        secrets[component_path].update(secret_values)
+        self.set_secrets(secrets)
+
+    def get_component_secrets(self, component_path: str) -> dict:
+        """
+        Get secrets for a specific component.
+
+        Args:
+            component_path: Full class path of the component
+
+        Returns:
+            Dict of secret key-value pairs for the component.
+        """
+        secrets = self.get_secrets()
+        return secrets.get(component_path, {})
+
+    def delete_component_secrets(self, component_path: str) -> None:
+        """
+        Delete all secrets for a specific component.
+
+        Args:
+            component_path: Full class path of the component
+        """
+        secrets = self.get_secrets()
+        if component_path in secrets:
+            del secrets[component_path]
+            self.set_secrets(secrets)
+
+    def get_full_component_settings(self, component_class_path: str) -> dict:
+        """
+        Get full settings for a component, merging non-sensitive settings
+        with decrypted secrets.
+
+        This is the method pipeline components should use to get their
+        complete configuration.
+
+        Args:
+            component_class_path: Full class path of the component
+
+        Returns:
+            Dict of all settings (non-sensitive + secrets) for the component.
+        """
+        # Get non-sensitive settings
+        settings = dict(self.get_component_settings(component_class_path))
+
+        # Merge with secrets (secrets take precedence)
+        secrets = self.get_component_secrets(component_class_path)
+        settings.update(secrets)
+
+        return settings

--- a/opencontractserver/documents/models.py
+++ b/opencontractserver/documents/models.py
@@ -742,15 +742,27 @@ class PipelineSettings(django.db.models.Model):
     The singleton instance is created via migration and cannot be deleted.
     Only superusers can modify these settings via the GraphQL API.
 
+    ⚠️  CRITICAL: SECRET_KEY Dependency
+    ----------------------------------
+    Encrypted secrets (API keys, credentials) are tied to Django's SECRET_KEY.
+    If you rotate SECRET_KEY, ALL encrypted secrets become PERMANENTLY UNRECOVERABLE.
+
+    Before rotating SECRET_KEY:
+    1. Export secrets via Django shell: PipelineSettings.get_instance().get_secrets()
+    2. Store exported secrets securely
+    3. After rotation, re-import via: instance.set_secrets(exported_secrets); instance.save()
+
     Settings Structure:
         preferred_parsers: Dict mapping MIME types to parser class paths
             Example: {"application/pdf": "opencontractserver.pipeline.parsers.docling_parser_rest.DoclingParser"}
 
         preferred_embedders: Dict mapping MIME types to embedder class paths
-            Example: {"application/pdf": "opencontractserver.pipeline.embedders.sent_transformer_microservice.MicroserviceEmbedder"}
+            Example: {"application/pdf":
+                "opencontractserver.pipeline.embedders...MicroserviceEmbedder"}
 
         preferred_thumbnailers: Dict mapping MIME types to thumbnailer class paths
-            Example: {"application/pdf": "opencontractserver.pipeline.thumbnailers.pdf_thumbnailer.PdfThumbnailGenerator"}
+            Example: {"application/pdf":
+                "opencontractserver.pipeline.thumbnailers...PdfThumbnailGenerator"}
 
         parser_kwargs: Dict mapping parser class paths to their configuration kwargs
             Example: {"opencontractserver.pipeline.parsers.docling_parser_rest.DoclingParser": {"force_ocr": false}}
@@ -868,14 +880,18 @@ class PipelineSettings(django.db.models.Model):
         """Get PBKDF2 iteration count from Django settings."""
         from django.conf import settings as django_settings
 
-        return getattr(django_settings, "PIPELINE_SETTINGS_ENCRYPTION_ITERATIONS", 480000)
+        return getattr(
+            django_settings, "PIPELINE_SETTINGS_ENCRYPTION_ITERATIONS", 480000
+        )
 
     @classmethod
     def _get_max_secret_size(cls) -> int:
         """Get maximum secret payload size from Django settings."""
         from django.conf import settings as django_settings
 
-        return getattr(django_settings, "PIPELINE_SETTINGS_MAX_SECRET_SIZE_BYTES", 10240)
+        return getattr(
+            django_settings, "PIPELINE_SETTINGS_MAX_SECRET_SIZE_BYTES", 10240
+        )
 
     def save(self, *args, **kwargs):
         """Ensure singleton pattern and invalidate cache on save."""
@@ -925,8 +941,8 @@ class PipelineSettings(django.db.models.Model):
             if cached is not None:
                 return cached
 
-        # Get from database
-        instance, created = cls.objects.get_or_create(
+        # Get from database (select_related for modified_by to avoid N+1 query)
+        instance, created = cls.objects.select_related("modified_by").get_or_create(
             pk=1,
             defaults={
                 "preferred_parsers": getattr(django_settings, "PREFERRED_PARSERS", {}),
@@ -935,9 +951,7 @@ class PipelineSettings(django.db.models.Model):
                 ),
                 "preferred_thumbnailers": {},  # No default in Django settings
                 "parser_kwargs": getattr(django_settings, "PARSER_KWARGS", {}),
-                "component_settings": getattr(
-                    django_settings, "PIPELINE_SETTINGS", {}
-                ),
+                "component_settings": getattr(django_settings, "PIPELINE_SETTINGS", {}),
                 "default_embedder": getattr(django_settings, "DEFAULT_EMBEDDER", ""),
             },
         )
@@ -1026,9 +1040,7 @@ class PipelineSettings(django.db.models.Model):
             return self.parser_kwargs[parser_class_path]
 
         # Fall back to Django settings
-        return getattr(django_settings, "PARSER_KWARGS", {}).get(
-            parser_class_path, {}
-        )
+        return getattr(django_settings, "PARSER_KWARGS", {}).get(parser_class_path, {})
 
     def get_component_settings(self, component_class_path: str) -> dict:
         """
@@ -1189,7 +1201,9 @@ class PipelineSettings(django.db.models.Model):
         # Validate size
         max_size = self._get_max_secret_size()
         if len(json_bytes) > max_size:
-            raise ValueError(f"Secrets payload exceeds maximum size of {max_size} bytes")
+            raise ValueError(
+                f"Secrets payload exceeds maximum size of {max_size} bytes"
+            )
 
         # Generate random salt for this encryption
         salt = os.urandom(self._get_encryption_salt_length())

--- a/opencontractserver/documents/models.py
+++ b/opencontractserver/documents/models.py
@@ -726,3 +726,273 @@ class DocumentSummaryRevision(django.db.models.Model):
         return (
             f"DocumentSummaryRevision(document_id={self.document_id}, v={self.version})"
         )
+
+
+# -------------------- PipelineSettings (Singleton) -------------------- #
+
+
+class PipelineSettings(django.db.models.Model):
+    """
+    Singleton model for configurable document processing pipeline settings.
+
+    This model stores runtime-configurable settings for the document ingestion
+    pipeline, allowing superusers to change parsers, embedders, and thumbnailers
+    without code deployment.
+
+    The singleton instance is created via migration and cannot be deleted.
+    Only superusers can modify these settings via the GraphQL API.
+
+    Settings Structure:
+        preferred_parsers: Dict mapping MIME types to parser class paths
+            Example: {"application/pdf": "opencontractserver.pipeline.parsers.docling_parser_rest.DoclingParser"}
+
+        preferred_embedders: Dict mapping MIME types to embedder class paths
+            Example: {"application/pdf": "opencontractserver.pipeline.embedders.sent_transformer_microservice.MicroserviceEmbedder"}
+
+        preferred_thumbnailers: Dict mapping MIME types to thumbnailer class paths
+            Example: {"application/pdf": "opencontractserver.pipeline.thumbnailers.pdf_thumbnailer.PdfThumbnailGenerator"}
+
+        parser_kwargs: Dict mapping parser class paths to their configuration kwargs
+            Example: {"opencontractserver.pipeline.parsers.docling_parser_rest.DoclingParser": {"force_ocr": false}}
+
+        component_settings: Dict mapping component class paths to their settings overrides
+            Example: {"opencontractserver.pipeline.embedders.MicroserviceEmbedder": {"timeout": 30}}
+
+        default_embedder: Default embedder class path when no MIME-specific embedder is found
+
+    Security Note - API Keys and Secrets:
+        This model is intended for non-sensitive configuration only. Sensitive values
+        like API keys should be stored in environment variables, not in this model.
+
+        The recommended pattern is:
+        1. Store API keys in environment variables (LLAMAPARSE_API_KEY, etc.)
+        2. Pipeline components read from environment variables first
+        3. Use component_settings only for non-sensitive overrides (timeouts, batch sizes)
+
+        This keeps secrets out of the database and allows them to be managed via
+        deployment configuration (environment variables, secrets managers, etc.).
+    """
+
+    # Preferred parsers per MIME type
+    preferred_parsers = NullableJSONField(
+        default=dict,
+        blank=True,
+        help_text="Mapping of MIME types to preferred parser class paths",
+    )
+
+    # Preferred embedders per MIME type
+    preferred_embedders = NullableJSONField(
+        default=dict,
+        blank=True,
+        help_text="Mapping of MIME types to preferred embedder class paths",
+    )
+
+    # Preferred thumbnailers per MIME type
+    preferred_thumbnailers = NullableJSONField(
+        default=dict,
+        blank=True,
+        help_text="Mapping of MIME types to preferred thumbnailer class paths",
+    )
+
+    # Parser-specific kwargs
+    parser_kwargs = NullableJSONField(
+        default=dict,
+        blank=True,
+        help_text="Mapping of parser class paths to configuration kwargs",
+    )
+
+    # Component-specific settings overrides
+    component_settings = NullableJSONField(
+        default=dict,
+        blank=True,
+        help_text="Mapping of component class paths to settings overrides",
+    )
+
+    # Default embedder when no MIME-specific one is found
+    default_embedder = django.db.models.CharField(
+        max_length=512,
+        blank=True,
+        default="",
+        help_text="Default embedder class path",
+    )
+
+    # Audit fields
+    modified = django.db.models.DateTimeField(auto_now=True)
+    modified_by = django.db.models.ForeignKey(
+        get_user_model(),
+        on_delete=django.db.models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="pipeline_settings_modifications",
+        help_text="User who last modified these settings",
+    )
+
+    class Meta:
+        verbose_name = "Pipeline Settings"
+        verbose_name_plural = "Pipeline Settings"
+
+    def __str__(self):
+        return "PipelineSettings (Singleton)"
+
+    def save(self, *args, **kwargs):
+        """Ensure singleton pattern - only allow one instance."""
+        if not self.pk and PipelineSettings.objects.exists():
+            raise ValidationError(
+                "PipelineSettings is a singleton. Use PipelineSettings.get_instance() instead."
+            )
+        super().save(*args, **kwargs)
+
+    def delete(self, *args, **kwargs):
+        """Prevent deletion of the singleton instance."""
+        raise ValidationError("PipelineSettings singleton cannot be deleted.")
+
+    @classmethod
+    def get_instance(cls) -> "PipelineSettings":
+        """
+        Get the singleton PipelineSettings instance.
+
+        If no instance exists (shouldn't happen after migration), creates one
+        with default values from Django settings.
+
+        Returns:
+            PipelineSettings: The singleton instance.
+        """
+        from django.conf import settings as django_settings
+
+        instance, created = cls.objects.get_or_create(
+            pk=1,
+            defaults={
+                "preferred_parsers": getattr(django_settings, "PREFERRED_PARSERS", {}),
+                "preferred_embedders": getattr(
+                    django_settings, "PREFERRED_EMBEDDERS", {}
+                ),
+                "preferred_thumbnailers": {},  # No default in Django settings
+                "parser_kwargs": getattr(django_settings, "PARSER_KWARGS", {}),
+                "component_settings": getattr(
+                    django_settings, "PIPELINE_SETTINGS", {}
+                ),
+                "default_embedder": getattr(django_settings, "DEFAULT_EMBEDDER", ""),
+            },
+        )
+        return instance
+
+    def get_preferred_parser(self, mimetype: str) -> str | None:
+        """
+        Get the preferred parser class path for a MIME type.
+
+        Falls back to Django settings if not configured in database.
+
+        Args:
+            mimetype: The MIME type (e.g., "application/pdf")
+
+        Returns:
+            Parser class path or None if not found.
+        """
+        from django.conf import settings as django_settings
+
+        # First check database settings
+        if self.preferred_parsers and mimetype in self.preferred_parsers:
+            return self.preferred_parsers[mimetype]
+
+        # Fall back to Django settings
+        return getattr(django_settings, "PREFERRED_PARSERS", {}).get(mimetype)
+
+    def get_preferred_embedder(self, mimetype: str) -> str | None:
+        """
+        Get the preferred embedder class path for a MIME type.
+
+        Falls back to Django settings if not configured in database.
+
+        Args:
+            mimetype: The MIME type (e.g., "application/pdf")
+
+        Returns:
+            Embedder class path or None if not found.
+        """
+        from django.conf import settings as django_settings
+
+        # First check database settings
+        if self.preferred_embedders and mimetype in self.preferred_embedders:
+            return self.preferred_embedders[mimetype]
+
+        # Fall back to Django settings
+        return getattr(django_settings, "PREFERRED_EMBEDDERS", {}).get(mimetype)
+
+    def get_preferred_thumbnailer(self, mimetype: str) -> str | None:
+        """
+        Get the preferred thumbnailer class path for a MIME type.
+
+        Note: No fallback to Django settings as thumbnailers are dynamically
+        selected by default.
+
+        Args:
+            mimetype: The MIME type (e.g., "application/pdf")
+
+        Returns:
+            Thumbnailer class path or None if not found.
+        """
+        if self.preferred_thumbnailers and mimetype in self.preferred_thumbnailers:
+            return self.preferred_thumbnailers[mimetype]
+        return None
+
+    def get_parser_kwargs(self, parser_class_path: str) -> dict:
+        """
+        Get configuration kwargs for a specific parser.
+
+        Falls back to Django settings if not configured in database.
+
+        Args:
+            parser_class_path: Full class path of the parser
+
+        Returns:
+            Dict of kwargs for the parser.
+        """
+        from django.conf import settings as django_settings
+
+        # First check database settings
+        if self.parser_kwargs and parser_class_path in self.parser_kwargs:
+            return self.parser_kwargs[parser_class_path]
+
+        # Fall back to Django settings
+        return getattr(django_settings, "PARSER_KWARGS", {}).get(
+            parser_class_path, {}
+        )
+
+    def get_component_settings(self, component_class_path: str) -> dict:
+        """
+        Get settings overrides for a specific component.
+
+        Falls back to Django settings if not configured in database.
+
+        Args:
+            component_class_path: Full class path of the component
+
+        Returns:
+            Dict of settings for the component.
+        """
+        from django.conf import settings as django_settings
+
+        # First check database settings
+        if self.component_settings and component_class_path in self.component_settings:
+            return self.component_settings[component_class_path]
+
+        # Fall back to Django settings
+        return getattr(django_settings, "PIPELINE_SETTINGS", {}).get(
+            component_class_path, {}
+        )
+
+    def get_default_embedder(self) -> str:
+        """
+        Get the default embedder class path.
+
+        Falls back to Django settings if not configured in database.
+
+        Returns:
+            Default embedder class path.
+        """
+        from django.conf import settings as django_settings
+
+        if self.default_embedder:
+            return self.default_embedder
+
+        return getattr(django_settings, "DEFAULT_EMBEDDER", "")

--- a/opencontractserver/documents/models.py
+++ b/opencontractserver/documents/models.py
@@ -846,31 +846,59 @@ class PipelineSettings(django.db.models.Model):
     def __str__(self):
         return "PipelineSettings (Singleton)"
 
+    # Cache settings
+    CACHE_KEY = "pipeline_settings_singleton"
+    CACHE_TTL_SECONDS = 300  # 5 minutes
+
     def save(self, *args, **kwargs):
-        """Ensure singleton pattern - only allow one instance."""
+        """Ensure singleton pattern and invalidate cache on save."""
         if not self.pk and PipelineSettings.objects.exists():
             raise ValidationError(
                 "PipelineSettings is a singleton. Use PipelineSettings.get_instance() instead."
             )
         super().save(*args, **kwargs)
+        # Invalidate cache on save
+        self._invalidate_cache()
 
     def delete(self, *args, **kwargs):
         """Prevent deletion of the singleton instance."""
         raise ValidationError("PipelineSettings singleton cannot be deleted.")
 
     @classmethod
-    def get_instance(cls) -> "PipelineSettings":
+    def _invalidate_cache(cls) -> None:
+        """Invalidate the cached instance."""
+        from django.core.cache import cache
+
+        cache.delete(cls.CACHE_KEY)
+
+    @classmethod
+    def get_instance(cls, use_cache: bool = True) -> "PipelineSettings":
         """
         Get the singleton PipelineSettings instance.
 
+        Uses Django's cache framework with a 5-minute TTL to reduce database
+        queries during document processing.
+
         If no instance exists (shouldn't happen after migration), creates one
         with default values from Django settings.
+
+        Args:
+            use_cache: If True (default), use cached instance. Set to False
+                to bypass cache and get fresh data from database.
 
         Returns:
             PipelineSettings: The singleton instance.
         """
         from django.conf import settings as django_settings
+        from django.core.cache import cache
 
+        # Try cache first (if enabled)
+        if use_cache:
+            cached = cache.get(cls.CACHE_KEY)
+            if cached is not None:
+                return cached
+
+        # Get from database
         instance, created = cls.objects.get_or_create(
             pk=1,
             defaults={
@@ -886,6 +914,11 @@ class PipelineSettings(django.db.models.Model):
                 "default_embedder": getattr(django_settings, "DEFAULT_EMBEDDER", ""),
             },
         )
+
+        # Cache the instance
+        if use_cache:
+            cache.set(cls.CACHE_KEY, instance, cls.CACHE_TTL_SECONDS)
+
         return instance
 
     def get_preferred_parser(self, mimetype: str) -> str | None:
@@ -1013,24 +1046,39 @@ class PipelineSettings(django.db.models.Model):
     # Encrypted Secrets Management
     # =====================================================================
 
-    @staticmethod
-    def _get_fernet() -> "Fernet":
-        """
-        Get a Fernet instance for encryption/decryption.
+    # Constants for encryption
+    ENCRYPTION_SALT_LENGTH = 16  # 128-bit salt
+    ENCRYPTION_ITERATIONS = 480000  # OWASP 2023 recommendation for PBKDF2-SHA256
+    MAX_SECRET_SIZE_BYTES = 10240  # 10KB limit per secret payload
 
-        Uses Django's SECRET_KEY to derive the encryption key.
+    @staticmethod
+    def _derive_key(salt: bytes) -> bytes:
+        """
+        Derive encryption key from Django SECRET_KEY using PBKDF2.
+
+        Uses PBKDF2-HMAC-SHA256 with high iteration count as recommended
+        by OWASP for secure key derivation.
+
+        Args:
+            salt: Random salt bytes (16 bytes recommended)
+
+        Returns:
+            32-byte derived key suitable for Fernet
         """
         import base64
         import hashlib
 
-        from cryptography.fernet import Fernet
         from django.conf import settings as django_settings
 
-        # Derive a 32-byte key from SECRET_KEY using SHA256
-        key = hashlib.sha256(django_settings.SECRET_KEY.encode()).digest()
-        # Fernet requires base64-encoded 32-byte key
-        fernet_key = base64.urlsafe_b64encode(key)
-        return Fernet(fernet_key)
+        # Use PBKDF2 with SHA256 for secure key derivation
+        key = hashlib.pbkdf2_hmac(
+            "sha256",
+            django_settings.SECRET_KEY.encode(),
+            salt,
+            PipelineSettings.ENCRYPTION_ITERATIONS,
+            dklen=32,
+        )
+        return base64.urlsafe_b64encode(key)
 
     def get_secrets(self) -> dict:
         """
@@ -1046,16 +1094,51 @@ class PipelineSettings(django.db.models.Model):
             }
         """
         import json
+        import logging
+
+        from cryptography.fernet import Fernet, InvalidToken
+
+        logger = logging.getLogger(__name__)
 
         if not self.encrypted_secrets:
             return {}
 
         try:
-            fernet = self._get_fernet()
-            decrypted = fernet.decrypt(bytes(self.encrypted_secrets))
+            raw_data = bytes(self.encrypted_secrets)
+
+            # Extract salt (first 16 bytes) and ciphertext
+            if len(raw_data) < self.ENCRYPTION_SALT_LENGTH:
+                logger.error(
+                    "PipelineSettings: encrypted_secrets too short to contain salt"
+                )
+                return {}
+
+            salt = raw_data[: self.ENCRYPTION_SALT_LENGTH]
+            ciphertext = raw_data[self.ENCRYPTION_SALT_LENGTH :]
+
+            # Derive key from salt and decrypt
+            key = self._derive_key(salt)
+            fernet = Fernet(key)
+            decrypted = fernet.decrypt(ciphertext)
             return json.loads(decrypted.decode("utf-8"))
-        except Exception:
-            # If decryption fails (e.g., key changed), return empty dict
+
+        except InvalidToken:
+            logger.critical(
+                "PipelineSettings: Failed to decrypt secrets - InvalidToken. "
+                "This may indicate SECRET_KEY has changed. Secrets are unrecoverable "
+                "without the original SECRET_KEY."
+            )
+            return {}
+        except json.JSONDecodeError as e:
+            logger.error(
+                f"PipelineSettings: Decrypted secrets contain invalid JSON: {e}"
+            )
+            return {}
+        except Exception as e:
+            logger.critical(
+                f"PipelineSettings: Unexpected error decrypting secrets: {e}. "
+                "Secrets may be corrupted or SECRET_KEY may have changed."
+            )
             return {}
 
     def set_secrets(self, secrets: dict) -> None:
@@ -1069,12 +1152,33 @@ class PipelineSettings(django.db.models.Model):
                     "api_key": "...",
                 },
             }
+
+        Raises:
+            ValueError: If secrets payload exceeds size limit
         """
         import json
+        import os
 
-        fernet = self._get_fernet()
+        from cryptography.fernet import Fernet
+
         json_bytes = json.dumps(secrets).encode("utf-8")
-        self.encrypted_secrets = fernet.encrypt(json_bytes)
+
+        # Validate size
+        if len(json_bytes) > self.MAX_SECRET_SIZE_BYTES:
+            raise ValueError(
+                f"Secrets payload exceeds maximum size of {self.MAX_SECRET_SIZE_BYTES} bytes"
+            )
+
+        # Generate random salt for this encryption
+        salt = os.urandom(self.ENCRYPTION_SALT_LENGTH)
+
+        # Derive key and encrypt
+        key = self._derive_key(salt)
+        fernet = Fernet(key)
+        ciphertext = fernet.encrypt(json_bytes)
+
+        # Store salt + ciphertext
+        self.encrypted_secrets = salt + ciphertext
 
     def update_secrets(self, component_path: str, secret_values: dict) -> None:
         """

--- a/opencontractserver/documents/models.py
+++ b/opencontractserver/documents/models.py
@@ -848,7 +848,34 @@ class PipelineSettings(django.db.models.Model):
 
     # Cache settings
     CACHE_KEY = "pipeline_settings_singleton"
-    CACHE_TTL_SECONDS = 300  # 5 minutes
+
+    @classmethod
+    def _get_cache_ttl(cls) -> int:
+        """Get cache TTL from Django settings."""
+        from django.conf import settings as django_settings
+
+        return getattr(django_settings, "PIPELINE_SETTINGS_CACHE_TTL_SECONDS", 300)
+
+    @classmethod
+    def _get_encryption_salt_length(cls) -> int:
+        """Get encryption salt length from Django settings."""
+        from django.conf import settings as django_settings
+
+        return getattr(django_settings, "PIPELINE_SETTINGS_ENCRYPTION_SALT_LENGTH", 16)
+
+    @classmethod
+    def _get_encryption_iterations(cls) -> int:
+        """Get PBKDF2 iteration count from Django settings."""
+        from django.conf import settings as django_settings
+
+        return getattr(django_settings, "PIPELINE_SETTINGS_ENCRYPTION_ITERATIONS", 480000)
+
+    @classmethod
+    def _get_max_secret_size(cls) -> int:
+        """Get maximum secret payload size from Django settings."""
+        from django.conf import settings as django_settings
+
+        return getattr(django_settings, "PIPELINE_SETTINGS_MAX_SECRET_SIZE_BYTES", 10240)
 
     def save(self, *args, **kwargs):
         """Ensure singleton pattern and invalidate cache on save."""
@@ -917,7 +944,7 @@ class PipelineSettings(django.db.models.Model):
 
         # Cache the instance
         if use_cache:
-            cache.set(cls.CACHE_KEY, instance, cls.CACHE_TTL_SECONDS)
+            cache.set(cls.CACHE_KEY, instance, cls._get_cache_ttl())
 
         return instance
 
@@ -1046,13 +1073,8 @@ class PipelineSettings(django.db.models.Model):
     # Encrypted Secrets Management
     # =====================================================================
 
-    # Constants for encryption
-    ENCRYPTION_SALT_LENGTH = 16  # 128-bit salt
-    ENCRYPTION_ITERATIONS = 480000  # OWASP 2023 recommendation for PBKDF2-SHA256
-    MAX_SECRET_SIZE_BYTES = 10240  # 10KB limit per secret payload
-
-    @staticmethod
-    def _derive_key(salt: bytes) -> bytes:
+    @classmethod
+    def _derive_key(cls, salt: bytes) -> bytes:
         """
         Derive encryption key from Django SECRET_KEY using PBKDF2.
 
@@ -1075,7 +1097,7 @@ class PipelineSettings(django.db.models.Model):
             "sha256",
             django_settings.SECRET_KEY.encode(),
             salt,
-            PipelineSettings.ENCRYPTION_ITERATIONS,
+            cls._get_encryption_iterations(),
             dklen=32,
         )
         return base64.urlsafe_b64encode(key)
@@ -1106,15 +1128,16 @@ class PipelineSettings(django.db.models.Model):
         try:
             raw_data = bytes(self.encrypted_secrets)
 
-            # Extract salt (first 16 bytes) and ciphertext
-            if len(raw_data) < self.ENCRYPTION_SALT_LENGTH:
+            # Extract salt and ciphertext
+            salt_length = self._get_encryption_salt_length()
+            if len(raw_data) < salt_length:
                 logger.error(
                     "PipelineSettings: encrypted_secrets too short to contain salt"
                 )
                 return {}
 
-            salt = raw_data[: self.ENCRYPTION_SALT_LENGTH]
-            ciphertext = raw_data[self.ENCRYPTION_SALT_LENGTH :]
+            salt = raw_data[:salt_length]
+            ciphertext = raw_data[salt_length:]
 
             # Derive key from salt and decrypt
             key = self._derive_key(salt)
@@ -1164,13 +1187,12 @@ class PipelineSettings(django.db.models.Model):
         json_bytes = json.dumps(secrets).encode("utf-8")
 
         # Validate size
-        if len(json_bytes) > self.MAX_SECRET_SIZE_BYTES:
-            raise ValueError(
-                f"Secrets payload exceeds maximum size of {self.MAX_SECRET_SIZE_BYTES} bytes"
-            )
+        max_size = self._get_max_secret_size()
+        if len(json_bytes) > max_size:
+            raise ValueError(f"Secrets payload exceeds maximum size of {max_size} bytes")
 
         # Generate random salt for this encryption
-        salt = os.urandom(self.ENCRYPTION_SALT_LENGTH)
+        salt = os.urandom(self._get_encryption_salt_length())
 
         # Derive key and encrypt
         key = self._derive_key(salt)

--- a/opencontractserver/documents/models.py
+++ b/opencontractserver/documents/models.py
@@ -1044,26 +1044,24 @@ class PipelineSettings(django.db.models.Model):
 
     def get_component_settings(self, component_class_path: str) -> dict:
         """
-        Get settings overrides for a specific component.
+        Get settings overrides for a specific component from database.
 
-        Falls back to Django settings if not configured in database.
+        This method only returns database settings, not Django settings fallback.
+        The Django settings fallback (with proper simple name vs full path
+        precedence) is handled by PipelineComponentBase.get_component_settings().
 
         Args:
             component_class_path: Full class path of the component
 
         Returns:
-            Dict of settings for the component.
+            Dict of settings for the component from database, or empty dict.
         """
-        from django.conf import settings as django_settings
-
-        # First check database settings
+        # Only return database settings - no Django fallback here
+        # The fallback chain is handled by PipelineComponentBase
         if self.component_settings and component_class_path in self.component_settings:
             return self.component_settings[component_class_path]
 
-        # Fall back to Django settings
-        return getattr(django_settings, "PIPELINE_SETTINGS", {}).get(
-            component_class_path, {}
-        )
+        return {}
 
     def get_default_embedder(self) -> str:
         """

--- a/opencontractserver/llms/vector_stores/pydantic_ai_conversation_vector_stores.py
+++ b/opencontractserver/llms/vector_stores/pydantic_ai_conversation_vector_stores.py
@@ -1,5 +1,6 @@
 """PydanticAI-specific vector store implementations for conversations and messages."""
 
+import asyncio
 import logging
 from typing import Any, Optional, Union
 
@@ -311,7 +312,11 @@ async def create_conversation_search_tool(
     Returns:
         Async function that can be used as a PydanticAI tool
     """
-    vector_store = PydanticAIConversationVectorStore(
+    # The PydanticAIConversationVectorStore constructor makes synchronous ORM calls
+    # (via CoreConversationVectorStore -> get_embedder -> PipelineSettings.get_instance).
+    # Wrap in to_thread to avoid SynchronousOnlyOperation in async context.
+    vector_store = await asyncio.to_thread(
+        PydanticAIConversationVectorStore,
         user_id=user_id,
         corpus_id=corpus_id,
         document_id=document_id,
@@ -375,7 +380,11 @@ async def create_message_search_tool(
     Returns:
         Async function that can be used as a PydanticAI tool
     """
-    vector_store = PydanticAIChatMessageVectorStore(
+    # The PydanticAIChatMessageVectorStore constructor makes synchronous ORM calls
+    # (via CoreChatMessageVectorStore -> get_embedder -> PipelineSettings.get_instance).
+    # Wrap in to_thread to avoid SynchronousOnlyOperation in async context.
+    vector_store = await asyncio.to_thread(
+        PydanticAIChatMessageVectorStore,
         user_id=user_id,
         corpus_id=corpus_id,
         conversation_id=conversation_id,

--- a/opencontractserver/pipeline/base/base_component.py
+++ b/opencontractserver/pipeline/base/base_component.py
@@ -84,7 +84,9 @@ class PipelineComponentBase(ABC):
         """
         Load settings from Django settings.PIPELINE_SETTINGS as fallback.
 
-        Tries the full class path first, then falls back to simple class name.
+        Tries the simple class name first (higher precedence), then falls back
+        to the full class path. This allows simple configuration keys like
+        "MyComponent" to override more specific "mymodule.MyComponent" paths.
 
         Returns:
             Dict of settings for this component from Django settings.
@@ -97,20 +99,20 @@ class PipelineComponentBase(ABC):
 
         simple_class_name = self.__class__.__name__
 
-        # Try full class path first (more specific)
-        component_settings = pipeline_settings_dict.get(self._full_class_path)
-        if isinstance(component_settings, dict) and component_settings:
-            logger.debug(f"Loaded Django settings for '{self._full_class_path}'")
-            return component_settings.copy()
-
-        # Fallback to simple class name
+        # Try simple class name first (higher precedence for user convenience)
         component_settings = pipeline_settings_dict.get(simple_class_name)
         if isinstance(component_settings, dict) and component_settings:
             logger.debug(f"Loaded Django settings for '{simple_class_name}'")
             return component_settings.copy()
 
+        # Fallback to full class path
+        component_settings = pipeline_settings_dict.get(self._full_class_path)
+        if isinstance(component_settings, dict) and component_settings:
+            logger.debug(f"Loaded Django settings for '{self._full_class_path}'")
+            return component_settings.copy()
+
         logger.debug(
-            f"No settings found for '{self._full_class_path}' or "
-            f"'{simple_class_name}' in PIPELINE_SETTINGS."
+            f"No settings found for '{simple_class_name}' or "
+            f"'{self._full_class_path}' in PIPELINE_SETTINGS."
         )
         return {}

--- a/opencontractserver/pipeline/base/base_component.py
+++ b/opencontractserver/pipeline/base/base_component.py
@@ -11,11 +11,15 @@ class PipelineComponentBase(ABC):
     Base class for pipeline components, providing automatic settings injection.
 
     Pipeline components inheriting from this class will have settings
-    defined in Django's `settings.PIPELINE_SETTINGS` dictionary automatically
-    made available to their operative methods.
+    automatically loaded from:
+    1. The PipelineSettings database singleton (includes encrypted secrets)
+    2. Django's `settings.PIPELINE_SETTINGS` as fallback
 
-    The `PIPELINE_SETTINGS` dictionary should be structured as follows:
-    PIPELINE_SETTINGS = {
+    Settings are loaded fresh on each call to get_component_settings() to
+    ensure runtime changes are reflected without restarting workers.
+
+    The settings dictionary should be structured as follows:
+    {
         "full.python.path.to.ComponentClass": {
             "setting_key_1": "value1",
             "setting_key_2": True,
@@ -32,67 +36,81 @@ class PipelineComponentBase(ABC):
         or can be used by subclasses after calling super().__init__().
         """
         super().__init__()  # Ensures MRO is handled correctly, e.g. if ABC has __init__
-        self._component_settings: dict = {}
-        self._load_component_settings()
-
-    def _load_component_settings(self):
-        """
-        Loads settings for this component from Django settings.
-        It first tries the simple class name, then the full class path.
-        """
-        simple_class_name = self.__class__.__name__
-        full_class_path = f"{self.__class__.__module__}.{self.__class__.__name__}"
-
-        # Ensure settings are loaded, especially in non-Django managed scripts or tests
-        if not settings.configured:
-            logger.warning(
-                "Django settings not configured. PIPELINE_SETTINGS will not be available."
-            )
-            # Depending on strictness, you might want to raise an error or allow proceeding
-            # For now, we'll allow proceeding, _component_settings will remain empty.
-            # In a typical Django app flow, settings would be configured.
-            # Consider if `settings.configure()` needs to be called in specific entry points
-            # if this code runs outside the standard manage.py/WSGI/ASGI flow.
-            return  # Return early if settings aren't configured, _component_settings remains {}
-
-        pipeline_settings_dict = getattr(settings, "PIPELINE_SETTINGS", {})
-
-        if not isinstance(pipeline_settings_dict, dict):
-            logger.warning(
-                f"PIPELINE_SETTINGS is defined but is not a dictionary. "
-                f"Settings for {simple_class_name} (or {full_class_path}) will not be loaded."
-            )
-            return
-
-        # Try simple class name first
-        component_settings = pipeline_settings_dict.get(simple_class_name)
-        if (
-            isinstance(component_settings, dict) and component_settings
-        ):  # Check if it's a non-empty dict
-            self._component_settings = component_settings
-            logger.debug(
-                f"Loaded settings for component using simple name '{simple_class_name}': {self._component_settings}"
-            )
-        else:
-            # Fallback to full class path
-            component_settings_fallback = pipeline_settings_dict.get(full_class_path)
-            if (
-                isinstance(component_settings_fallback, dict)
-                and component_settings_fallback
-            ):
-                self._component_settings = component_settings_fallback
-                logger.debug(
-                    f"Loaded settings for component using full path '{full_class_path}': {self._component_settings}"
-                )
-            else:
-                logger.debug(
-                    f"No specific settings found for component using simple name '{simple_class_name}' "
-                    f"or full path '{full_class_path}' in PIPELINE_SETTINGS."
-                )
-        # If neither key yields settings, self._component_settings remains the default {}
+        # Cache the class path for efficient lookups
+        self._full_class_path = f"{self.__class__.__module__}.{self.__class__.__name__}"
 
     def get_component_settings(self) -> dict:
         """
-        Returns a copy of the settings loaded for this component.
+        Get settings for this component from PipelineSettings DB or Django settings.
+
+        This method fetches settings fresh on each call to support runtime
+        configuration changes. It checks the PipelineSettings database model
+        first (which includes encrypted secrets), then falls back to Django
+        settings.PIPELINE_SETTINGS.
+
+        Returns:
+            Dict of settings for this component, including decrypted secrets.
         """
-        return self._component_settings.copy()
+        # Ensure Django settings are configured
+        if not settings.configured:
+            logger.warning(
+                "Django settings not configured. Component settings unavailable."
+            )
+            return {}
+
+        # Try to get settings from PipelineSettings DB model (includes secrets)
+        try:
+            from opencontractserver.documents.models import PipelineSettings
+
+            pipeline_settings = PipelineSettings.get_instance()
+            # get_full_component_settings merges component_settings with secrets
+            db_settings = pipeline_settings.get_full_component_settings(
+                self._full_class_path
+            )
+            if db_settings:
+                logger.debug(f"Loaded settings from DB for '{self._full_class_path}'")
+                return db_settings
+        except Exception as e:
+            # DB not available (e.g., during migrations or early startup)
+            logger.debug(
+                f"Could not load settings from PipelineSettings DB: {e}. "
+                "Falling back to Django settings."
+            )
+
+        # Fallback to Django settings.PIPELINE_SETTINGS
+        return self._get_django_settings_fallback()
+
+    def _get_django_settings_fallback(self) -> dict:
+        """
+        Load settings from Django settings.PIPELINE_SETTINGS as fallback.
+
+        Tries the full class path first, then falls back to simple class name.
+
+        Returns:
+            Dict of settings for this component from Django settings.
+        """
+        pipeline_settings_dict = getattr(settings, "PIPELINE_SETTINGS", {})
+
+        if not isinstance(pipeline_settings_dict, dict):
+            logger.warning("PIPELINE_SETTINGS is defined but is not a dictionary.")
+            return {}
+
+        simple_class_name = self.__class__.__name__
+
+        # Try full class path first (more specific)
+        component_settings = pipeline_settings_dict.get(self._full_class_path)
+        if isinstance(component_settings, dict) and component_settings:
+            logger.debug(f"Loaded Django settings for '{self._full_class_path}'")
+            return component_settings.copy()
+
+        # Fallback to simple class name
+        component_settings = pipeline_settings_dict.get(simple_class_name)
+        if isinstance(component_settings, dict) and component_settings:
+            logger.debug(f"Loaded Django settings for '{simple_class_name}'")
+            return component_settings.copy()
+
+        logger.debug(
+            f"No settings found for '{self._full_class_path}' or "
+            f"'{simple_class_name}' in PIPELINE_SETTINGS."
+        )
+        return {}

--- a/opencontractserver/pipeline/utils.py
+++ b/opencontractserver/pipeline/utils.py
@@ -304,13 +304,20 @@ def get_preferred_embedder(mimetype: str) -> Optional[type[BaseEmbedder]]:
     """
     Get the preferred embedder class for a given mimetype.
 
+    First checks the database PipelineSettings, then falls back to Django settings.
+
     Args:
         mimetype (str): The mimetype of the file.
 
     Returns:
         Optional[Type[BaseEmbedder]]: The preferred embedder class, or None if not found.
     """
-    embedder_path = settings.PREFERRED_EMBEDDERS.get(mimetype)
+    # Import here to avoid circular imports
+    from opencontractserver.documents.models import PipelineSettings
+
+    pipeline_settings = PipelineSettings.get_instance()
+    embedder_path = pipeline_settings.get_preferred_embedder(mimetype)
+
     if embedder_path:
         try:
             module_path, class_name = embedder_path.rsplit(".", 1)
@@ -329,10 +336,17 @@ def get_default_embedder() -> Optional[type[BaseEmbedder]]:
     """
     Get the default embedder class.
 
+    First checks the database PipelineSettings, then falls back to Django settings.
+
     Returns:
         Optional[Type[BaseEmbedder]]: The default embedder class, or None if not found.
     """
-    embedder_path = settings.DEFAULT_EMBEDDER
+    # Import here to avoid circular imports
+    from opencontractserver.documents.models import PipelineSettings
+
+    pipeline_settings = PipelineSettings.get_instance()
+    embedder_path = pipeline_settings.get_default_embedder()
+
     if embedder_path:
         try:
             module_path, class_name = embedder_path.rsplit(".", 1)

--- a/opencontractserver/tasks/doc_tasks.py
+++ b/opencontractserver/tasks/doc_tasks.py
@@ -352,21 +352,22 @@ def ingest_doc(self, user_id: int, doc_id: int) -> dict[str, Any]:
     if corpus_id:
         logger.info(f"[ingest_doc] Document {doc_id} is in corpus {corpus_id}")
 
-    parser_name: str | None = getattr(settings, "PREFERRED_PARSERS", {}).get(
-        document.file_type
-    )
+    # Get preferred parser from database settings (with fallback to Django settings)
+    from opencontractserver.documents.models import PipelineSettings
+
+    pipeline_settings = PipelineSettings.get_instance()
+    parser_name: str | None = pipeline_settings.get_preferred_parser(document.file_type)
+
     if not parser_name:
         error_msg = f"No parser defined for MIME type '{document.file_type}'"
         _mark_document_failed(document, error_msg)
         return {"status": "failed", "doc_id": doc_id, "error": error_msg}
 
-    # Attempt to load parser kwargs
-    parser_kwargs = {}
-    if hasattr(settings, "PARSER_KWARGS"):
-        from opencontractserver.utils.logging import redact_sensitive_kwargs
+    # Attempt to load parser kwargs from database settings (with fallback)
+    from opencontractserver.utils.logging import redact_sensitive_kwargs
 
-        kwargs = getattr(settings, "PARSER_KWARGS", {})
-        parser_kwargs = kwargs.get(parser_name, {})
+    parser_kwargs = pipeline_settings.get_parser_kwargs(parser_name)
+    if parser_kwargs:
         logger.debug(
             f"Resolved parser kwargs for '{parser_name}': "
             f"{redact_sensitive_kwargs(parser_kwargs)}"
@@ -682,17 +683,42 @@ def extract_thumbnail(self, doc_id: int) -> None:
 
     file_type: str = document.file_type
 
-    # Get compatible thumbnailers for the document's MIME type
-    components = get_components_by_mimetype(file_type)
-    thumbnailers = components.get("thumbnailers", [])
+    # Check for preferred thumbnailer in database settings first
+    from opencontractserver.documents.models import PipelineSettings
 
-    if not thumbnailers:
-        logger.error(f"No thumbnailer found for file type '{file_type}'.")
-        return
+    pipeline_settings = PipelineSettings.get_instance()
+    preferred_thumbnailer = pipeline_settings.get_preferred_thumbnailer(file_type)
 
-    # Use the first available thumbnailer
-    thumbnailer_class = thumbnailers[0]
-    logger.info(f"Using thumbnailer '{thumbnailer_class.__name__}' for doc {doc_id}")
+    thumbnailer_class = None
+
+    if preferred_thumbnailer:
+        # Try to load the preferred thumbnailer
+        try:
+            thumbnailer_class = get_component_by_name(preferred_thumbnailer)
+            logger.info(
+                f"Using preferred thumbnailer '{preferred_thumbnailer}' for doc {doc_id}"
+            )
+        except ValueError:
+            logger.warning(
+                f"Preferred thumbnailer '{preferred_thumbnailer}' not found, "
+                "falling back to auto-discovery"
+            )
+
+    if not thumbnailer_class:
+        # Fall back to auto-discovered thumbnailers for the MIME type
+        components = get_components_by_mimetype(file_type)
+        thumbnailers = components.get("thumbnailers", [])
+
+        if not thumbnailers:
+            logger.error(f"No thumbnailer found for file type '{file_type}'.")
+            return
+
+        # Use the first available thumbnailer
+        thumbnailer_class = thumbnailers[0]
+        logger.info(
+            f"Using auto-discovered thumbnailer '{thumbnailer_class.__name__}' "
+            f"for doc {doc_id}"
+        )
 
     try:
         thumbnailer: BaseThumbnailGenerator = thumbnailer_class()

--- a/opencontractserver/tasks/doc_tasks.py
+++ b/opencontractserver/tasks/doc_tasks.py
@@ -8,7 +8,6 @@ from typing import Any
 
 from celery import shared_task
 from celery.utils.log import get_task_logger
-from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.files.storage import default_storage
 from django.db.models import Q

--- a/opencontractserver/tests/test_pipeline_component_base.py
+++ b/opencontractserver/tests/test_pipeline_component_base.py
@@ -102,12 +102,23 @@ class TestPipelineComponentBaseSettings(TestCase):
 
     def test_pipeline_settings_is_not_a_dictionary(self):
         """Tests that a warning is logged if PIPELINE_SETTINGS is not a dict."""
-        with self.assertLogs(logger=BASE_COMPONENT_LOGGER, level="WARNING") as cm:
-            # The override_settings context manager will apply this setting
-            with self.settings(PIPELINE_SETTINGS="this_is_not_a_dictionary"):
-                component = DummyComponent()
+        # The new implementation loads settings lazily when get_component_settings()
+        # is called, so we need to call it to trigger the warning.
+        # Also, we need to ensure DB settings are empty so the fallback is used.
+        with self.settings(PIPELINE_SETTINGS="this_is_not_a_dictionary"):
+            component = DummyComponent()
+            # Clear DB settings so fallback to Django settings is used
+            from opencontractserver.documents.models import PipelineSettings
 
-        self.assertEqual(component.get_component_settings(), {})
+            pipeline_settings = PipelineSettings.get_instance(use_cache=False)
+            pipeline_settings.component_settings = {}
+            pipeline_settings.save()
+            PipelineSettings._invalidate_cache()
+
+            with self.assertLogs(logger=BASE_COMPONENT_LOGGER, level="WARNING") as cm:
+                result = component.get_component_settings()
+
+        self.assertEqual(result, {})
         self.assertIn(
             "PIPELINE_SETTINGS is defined but is not a dictionary", cm.output[0]
         )

--- a/opencontractserver/tests/test_pipeline_settings.py
+++ b/opencontractserver/tests/test_pipeline_settings.py
@@ -786,7 +786,7 @@ class PipelineSettingsEdgeCasesTestCase(TestCase):
         cache.set(
             PipelineSettings.CACHE_KEY,
             "not_a_valid_instance",
-            PipelineSettings.CACHE_TTL_SECONDS,
+            PipelineSettings._get_cache_ttl(),
         )
 
         # With use_cache=False, should get real instance from DB

--- a/opencontractserver/tests/test_pipeline_settings.py
+++ b/opencontractserver/tests/test_pipeline_settings.py
@@ -667,3 +667,173 @@ class PipelineSettingsSecretsTestCase(TestCase):
         components = result["data"]["pipelineSettings"]["componentsWithSecrets"]
         self.assertIn("parser1.path", components)
         self.assertIn("parser2.path", components)
+
+
+class PipelineSettingsEdgeCasesTestCase(TestCase):
+    """Tests for edge cases and error handling."""
+
+    def setUp(self):
+        self.superuser = User.objects.create_superuser(
+            username="admin", password="admin", email="admin@test.com"
+        )
+        self.superuser_client = Client(
+            schema, context_value=TestContext(self.superuser)
+        )
+        PipelineSettings.objects.all().delete()
+
+    def test_secrets_size_limit(self):
+        """Test that oversized secrets are rejected."""
+        instance = PipelineSettings.get_instance()
+
+        # Create a secret payload that exceeds the 10KB limit
+        large_value = "x" * 15000  # 15KB
+        with self.assertRaises(ValueError) as context:
+            instance.set_secrets({"test.parser": {"api_key": large_value}})
+
+        self.assertIn("exceeds maximum size", str(context.exception))
+
+    def test_invalid_component_path_format(self):
+        """Test that invalid component paths are rejected."""
+        mutation = """
+            mutation UpdateComponentSecrets(
+                $componentPath: String!,
+                $secrets: GenericScalar!
+            ) {
+                updateComponentSecrets(
+                    componentPath: $componentPath,
+                    secrets: $secrets
+                ) {
+                    ok
+                    message
+                }
+            }
+        """
+
+        # Test path with invalid characters
+        variables = {
+            "componentPath": "invalid path with spaces",
+            "secrets": {"api_key": "test"},
+        }
+        result = self.superuser_client.execute(mutation, variables=variables)
+        self.assertFalse(result["data"]["updateComponentSecrets"]["ok"])
+        self.assertIn("Invalid component path", result["data"]["updateComponentSecrets"]["message"])
+
+        # Test path that's too long
+        variables = {
+            "componentPath": "a" * 300 + ".module.Class",
+            "secrets": {"api_key": "test"},
+        }
+        result = self.superuser_client.execute(mutation, variables=variables)
+        self.assertFalse(result["data"]["updateComponentSecrets"]["ok"])
+        self.assertIn("exceeds maximum length", result["data"]["updateComponentSecrets"]["message"])
+
+    def test_invalid_secret_value_types(self):
+        """Test that non-primitive secret values are rejected."""
+        mutation = """
+            mutation UpdateComponentSecrets(
+                $componentPath: String!,
+                $secrets: GenericScalar!
+            ) {
+                updateComponentSecrets(
+                    componentPath: $componentPath,
+                    secrets: $secrets
+                ) {
+                    ok
+                    message
+                }
+            }
+        """
+
+        # Test nested dict (should be rejected)
+        variables = {
+            "componentPath": "valid.module.Class",
+            "secrets": {"nested": {"key": "value"}},
+        }
+        result = self.superuser_client.execute(mutation, variables=variables)
+        self.assertFalse(result["data"]["updateComponentSecrets"]["ok"])
+        self.assertIn("primitive type", result["data"]["updateComponentSecrets"]["message"])
+
+    def test_caching_invalidation_on_save(self):
+        """Test that cache is invalidated when settings are saved."""
+        from django.core.cache import cache
+
+        instance = PipelineSettings.get_instance()
+
+        # Verify cache is populated
+        cached = cache.get(PipelineSettings.CACHE_KEY)
+        self.assertIsNotNone(cached)
+
+        # Modify and save
+        instance.default_embedder = "new.embedder.Class"
+        instance.save()
+
+        # Cache should be invalidated
+        cached_after_save = cache.get(PipelineSettings.CACHE_KEY)
+        self.assertIsNone(cached_after_save)
+
+        # Get instance again - should hit database
+        new_instance = PipelineSettings.get_instance()
+        self.assertEqual(new_instance.default_embedder, "new.embedder.Class")
+
+    def test_bypass_cache_flag(self):
+        """Test that use_cache=False bypasses the cache."""
+        from django.core.cache import cache
+
+        # Get instance with cache
+        instance1 = PipelineSettings.get_instance(use_cache=True)
+
+        # Manually modify cache entry to test bypass
+        cache.set(
+            PipelineSettings.CACHE_KEY,
+            "not_a_valid_instance",
+            PipelineSettings.CACHE_TTL_SECONDS,
+        )
+
+        # With use_cache=False, should get real instance from DB
+        instance2 = PipelineSettings.get_instance(use_cache=False)
+        self.assertIsInstance(instance2, PipelineSettings)
+
+    def test_primitive_secret_types_accepted(self):
+        """Test that all primitive types are accepted as secret values."""
+        instance = PipelineSettings.get_instance()
+
+        # All primitive types should work
+        secrets = {
+            "test.component": {
+                "string_val": "test",
+                "int_val": 42,
+                "float_val": 3.14,
+                "bool_val": True,
+                "null_val": None,
+            }
+        }
+
+        instance.set_secrets(secrets)
+        instance.save()
+
+        retrieved = instance.get_secrets()
+        self.assertEqual(retrieved["test.component"]["string_val"], "test")
+        self.assertEqual(retrieved["test.component"]["int_val"], 42)
+        self.assertEqual(retrieved["test.component"]["float_val"], 3.14)
+        self.assertEqual(retrieved["test.component"]["bool_val"], True)
+        self.assertIsNone(retrieved["test.component"]["null_val"])
+
+    def test_pbkdf2_encryption_uses_unique_salt(self):
+        """Test that each encryption uses a unique salt."""
+        instance = PipelineSettings.get_instance()
+
+        # Encrypt same data twice
+        instance.set_secrets({"test": {"key": "value"}})
+        encrypted1 = bytes(instance.encrypted_secrets)
+
+        instance.set_secrets({"test": {"key": "value"}})
+        encrypted2 = bytes(instance.encrypted_secrets)
+
+        # Salt is first 16 bytes - should be different each time
+        salt1 = encrypted1[:16]
+        salt2 = encrypted2[:16]
+        self.assertNotEqual(salt1, salt2)
+
+        # But decryption should still work
+        decrypted = instance.get_secrets()
+        self.assertEqual(decrypted["test"]["key"], "value")

--- a/opencontractserver/tests/test_pipeline_settings.py
+++ b/opencontractserver/tests/test_pipeline_settings.py
@@ -1,0 +1,419 @@
+"""
+Tests for the PipelineSettings singleton model and GraphQL endpoints.
+"""
+
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
+from django.test import TestCase, override_settings
+from graphene.test import Client
+
+from config.graphql.schema import schema
+from opencontractserver.documents.models import PipelineSettings
+
+User = get_user_model()
+
+
+class TestContext:
+    """Mock context for GraphQL tests."""
+
+    def __init__(self, user):
+        self.user = user
+
+
+class PipelineSettingsModelTestCase(TestCase):
+    """Tests for the PipelineSettings model."""
+
+    def setUp(self):
+        self.superuser = User.objects.create_superuser(
+            username="admin", password="admin", email="admin@test.com"
+        )
+        self.regular_user = User.objects.create_user(
+            username="regular", password="regular"
+        )
+
+    def test_get_instance_creates_singleton(self):
+        """Test that get_instance creates a singleton if it doesn't exist."""
+        # Ensure no instance exists
+        PipelineSettings.objects.all().delete()
+
+        instance = PipelineSettings.get_instance()
+        self.assertIsNotNone(instance)
+        self.assertEqual(instance.pk, 1)
+
+        # Getting instance again should return the same object
+        instance2 = PipelineSettings.get_instance()
+        self.assertEqual(instance.pk, instance2.pk)
+
+    def test_cannot_create_second_instance(self):
+        """Test that creating a second instance raises ValidationError."""
+        # Create the first instance
+        PipelineSettings.get_instance()
+
+        # Attempting to create a second instance should fail
+        with self.assertRaises(ValidationError):
+            PipelineSettings.objects.create(
+                preferred_parsers={"test": "test"},
+            )
+
+    def test_cannot_delete_singleton(self):
+        """Test that deleting the singleton raises ValidationError."""
+        instance = PipelineSettings.get_instance()
+
+        with self.assertRaises(ValidationError):
+            instance.delete()
+
+    @override_settings(
+        PREFERRED_PARSERS={"application/pdf": "test.parser.TestParser"},
+        PREFERRED_EMBEDDERS={"application/pdf": "test.embedder.TestEmbedder"},
+        PARSER_KWARGS={"test.parser.TestParser": {"option1": True}},
+        DEFAULT_EMBEDDER="test.embedder.DefaultEmbedder",
+    )
+    def test_get_preferred_parser_uses_db_then_fallback(self):
+        """Test that get_preferred_parser uses DB first, then Django settings."""
+        # Delete existing instance and create new one to pick up test settings
+        PipelineSettings.objects.all().delete()
+        instance = PipelineSettings.get_instance()
+
+        # Initially should fallback to Django settings
+        self.assertEqual(
+            instance.get_preferred_parser("application/pdf"),
+            "test.parser.TestParser",
+        )
+
+        # Set a value in the database
+        instance.preferred_parsers = {
+            "application/pdf": "db.parser.DBParser",
+        }
+        instance.save()
+
+        # Now should use the database value
+        self.assertEqual(
+            instance.get_preferred_parser("application/pdf"),
+            "db.parser.DBParser",
+        )
+
+        # Unlisted MIME type should fallback to Django settings
+        self.assertIsNone(instance.get_preferred_parser("text/plain"))
+
+    @override_settings(
+        DEFAULT_EMBEDDER="test.embedder.DefaultEmbedder",
+    )
+    def test_get_default_embedder_uses_db_then_fallback(self):
+        """Test that get_default_embedder uses DB first, then Django settings."""
+        # Delete existing instance to test creation with settings
+        PipelineSettings.objects.all().delete()
+        instance = PipelineSettings.get_instance()
+
+        # Initially should fallback to Django settings
+        self.assertEqual(
+            instance.get_default_embedder(),
+            "test.embedder.DefaultEmbedder",
+        )
+
+        # Set a value in the database
+        instance.default_embedder = "db.embedder.NewDefault"
+        instance.save()
+
+        # Now should use the database value
+        self.assertEqual(instance.get_default_embedder(), "db.embedder.NewDefault")
+
+    def test_get_parser_kwargs_uses_db_then_fallback(self):
+        """Test that get_parser_kwargs uses DB first, then Django settings."""
+        PipelineSettings.objects.all().delete()
+        instance = PipelineSettings.get_instance()
+
+        # Set a value in the database
+        instance.parser_kwargs = {
+            "my.parser.TestParser": {"force_ocr": True, "timeout": 60},
+        }
+        instance.save()
+
+        # Should use the database value
+        kwargs = instance.get_parser_kwargs("my.parser.TestParser")
+        self.assertEqual(kwargs["force_ocr"], True)
+        self.assertEqual(kwargs["timeout"], 60)
+
+    def test_get_preferred_thumbnailer(self):
+        """Test that get_preferred_thumbnailer uses DB only (no fallback)."""
+        PipelineSettings.objects.all().delete()
+        instance = PipelineSettings.get_instance()
+
+        # Initially should return None (no Django settings fallback)
+        self.assertIsNone(instance.get_preferred_thumbnailer("application/pdf"))
+
+        # Set a value in the database
+        instance.preferred_thumbnailers = {
+            "application/pdf": "my.thumbnailer.PdfThumb",
+        }
+        instance.save()
+
+        # Now should use the database value
+        self.assertEqual(
+            instance.get_preferred_thumbnailer("application/pdf"),
+            "my.thumbnailer.PdfThumb",
+        )
+
+    def test_modified_by_tracks_user(self):
+        """Test that modified_by is updated when a user modifies settings."""
+        instance = PipelineSettings.get_instance()
+
+        instance.modified_by = self.superuser
+        instance.preferred_parsers = {"test/mime": "test.parser.Parser"}
+        instance.save()
+
+        instance.refresh_from_db()
+        self.assertEqual(instance.modified_by, self.superuser)
+
+
+class PipelineSettingsGraphQLTestCase(TestCase):
+    """Tests for the PipelineSettings GraphQL endpoints."""
+
+    def setUp(self):
+        self.superuser = User.objects.create_superuser(
+            username="admin", password="admin", email="admin@test.com"
+        )
+        self.regular_user = User.objects.create_user(
+            username="regular", password="regular"
+        )
+        self.superuser_client = Client(
+            schema, context_value=TestContext(self.superuser)
+        )
+        self.regular_client = Client(
+            schema, context_value=TestContext(self.regular_user)
+        )
+
+        # Ensure the singleton exists
+        PipelineSettings.get_instance()
+
+    def test_query_pipeline_settings_as_regular_user(self):
+        """Test that regular users can read pipeline settings."""
+        query = """
+            query {
+                pipelineSettings {
+                    preferredParsers
+                    preferredEmbedders
+                    preferredThumbnailers
+                    parserKwargs
+                    componentSettings
+                    defaultEmbedder
+                    modified
+                }
+            }
+        """
+
+        result = self.regular_client.execute(query)
+        self.assertIsNone(result.get("errors"))
+        self.assertIsNotNone(result["data"]["pipelineSettings"])
+
+    def test_update_pipeline_settings_as_superuser(self):
+        """Test that superusers can update pipeline settings."""
+        mutation = """
+            mutation UpdatePipelineSettings(
+                $preferredParsers: GenericScalar
+            ) {
+                updatePipelineSettings(
+                    preferredParsers: $preferredParsers
+                ) {
+                    ok
+                    message
+                    pipelineSettings {
+                        preferredParsers
+                    }
+                }
+            }
+        """
+
+        # Use a real parser that exists in the registry
+        from opencontractserver.pipeline.registry import get_registry
+
+        registry = get_registry()
+        if registry.parsers:
+            parser = registry.parsers[0]
+            variables = {
+                "preferredParsers": {
+                    "application/pdf": parser.class_name,
+                }
+            }
+
+            result = self.superuser_client.execute(mutation, variables=variables)
+            self.assertIsNone(result.get("errors"))
+            self.assertTrue(result["data"]["updatePipelineSettings"]["ok"])
+            self.assertEqual(
+                result["data"]["updatePipelineSettings"]["pipelineSettings"][
+                    "preferredParsers"
+                ]["application/pdf"],
+                parser.class_name,
+            )
+
+    def test_update_pipeline_settings_as_regular_user_fails(self):
+        """Test that regular users cannot update pipeline settings."""
+        mutation = """
+            mutation UpdatePipelineSettings(
+                $preferredParsers: GenericScalar
+            ) {
+                updatePipelineSettings(
+                    preferredParsers: $preferredParsers
+                ) {
+                    ok
+                    message
+                }
+            }
+        """
+
+        variables = {
+            "preferredParsers": {
+                "application/pdf": "some.parser.TestParser",
+            }
+        }
+
+        result = self.regular_client.execute(mutation, variables=variables)
+        self.assertIsNone(result.get("errors"))
+        self.assertFalse(result["data"]["updatePipelineSettings"]["ok"])
+        self.assertIn(
+            "superuser",
+            result["data"]["updatePipelineSettings"]["message"].lower(),
+        )
+
+    def test_update_with_invalid_parser_fails(self):
+        """Test that updating with an invalid parser class path fails."""
+        mutation = """
+            mutation UpdatePipelineSettings(
+                $preferredParsers: GenericScalar
+            ) {
+                updatePipelineSettings(
+                    preferredParsers: $preferredParsers
+                ) {
+                    ok
+                    message
+                }
+            }
+        """
+
+        variables = {
+            "preferredParsers": {
+                "application/pdf": "nonexistent.parser.FakeParser",
+            }
+        }
+
+        result = self.superuser_client.execute(mutation, variables=variables)
+        self.assertIsNone(result.get("errors"))
+        self.assertFalse(result["data"]["updatePipelineSettings"]["ok"])
+        self.assertIn(
+            "not found",
+            result["data"]["updatePipelineSettings"]["message"].lower(),
+        )
+
+    def test_reset_pipeline_settings_as_superuser(self):
+        """Test that superusers can reset pipeline settings to defaults."""
+        mutation = """
+            mutation {
+                resetPipelineSettings {
+                    ok
+                    message
+                    pipelineSettings {
+                        preferredParsers
+                    }
+                }
+            }
+        """
+
+        result = self.superuser_client.execute(mutation)
+        self.assertIsNone(result.get("errors"))
+        self.assertTrue(result["data"]["resetPipelineSettings"]["ok"])
+
+    def test_reset_pipeline_settings_as_regular_user_fails(self):
+        """Test that regular users cannot reset pipeline settings."""
+        mutation = """
+            mutation {
+                resetPipelineSettings {
+                    ok
+                    message
+                }
+            }
+        """
+
+        result = self.regular_client.execute(mutation)
+        self.assertIsNone(result.get("errors"))
+        self.assertFalse(result["data"]["resetPipelineSettings"]["ok"])
+        self.assertIn(
+            "superuser",
+            result["data"]["resetPipelineSettings"]["message"].lower(),
+        )
+
+    def test_update_parser_kwargs(self):
+        """Test updating parser kwargs via GraphQL."""
+        mutation = """
+            mutation UpdatePipelineSettings(
+                $parserKwargs: GenericScalar
+            ) {
+                updatePipelineSettings(
+                    parserKwargs: $parserKwargs
+                ) {
+                    ok
+                    message
+                    pipelineSettings {
+                        parserKwargs
+                    }
+                }
+            }
+        """
+
+        variables = {
+            "parserKwargs": {
+                "some.parser.TestParser": {
+                    "force_ocr": True,
+                    "timeout": 120,
+                }
+            }
+        }
+
+        result = self.superuser_client.execute(mutation, variables=variables)
+        self.assertIsNone(result.get("errors"))
+        self.assertTrue(result["data"]["updatePipelineSettings"]["ok"])
+
+        returned_kwargs = result["data"]["updatePipelineSettings"]["pipelineSettings"][
+            "parserKwargs"
+        ]
+        self.assertEqual(
+            returned_kwargs["some.parser.TestParser"]["force_ocr"], True
+        )
+        self.assertEqual(
+            returned_kwargs["some.parser.TestParser"]["timeout"], 120
+        )
+
+    def test_update_default_embedder(self):
+        """Test updating default embedder via GraphQL."""
+        # Use a real embedder that exists in the registry
+        from opencontractserver.pipeline.registry import get_registry
+
+        registry = get_registry()
+        if registry.embedders:
+            embedder = registry.embedders[0]
+
+            mutation = """
+                mutation UpdatePipelineSettings(
+                    $defaultEmbedder: String
+                ) {
+                    updatePipelineSettings(
+                        defaultEmbedder: $defaultEmbedder
+                    ) {
+                        ok
+                        message
+                        pipelineSettings {
+                            defaultEmbedder
+                        }
+                    }
+                }
+            """
+
+            variables = {"defaultEmbedder": embedder.class_name}
+
+            result = self.superuser_client.execute(mutation, variables=variables)
+            self.assertIsNone(result.get("errors"))
+            self.assertTrue(result["data"]["updatePipelineSettings"]["ok"])
+            self.assertEqual(
+                result["data"]["updatePipelineSettings"]["pipelineSettings"][
+                    "defaultEmbedder"
+                ],
+                embedder.class_name,
+            )

--- a/opencontractserver/tests/test_pipeline_settings.py
+++ b/opencontractserver/tests/test_pipeline_settings.py
@@ -24,6 +24,11 @@ class PipelineSettingsModelTestCase(TestCase):
     """Tests for the PipelineSettings model."""
 
     def setUp(self):
+        from django.core.cache import cache
+
+        # Clear cache to ensure clean state between tests
+        cache.delete(PipelineSettings.CACHE_KEY)
+
         self.superuser = User.objects.create_superuser(
             username="admin", password="admin", email="admin@test.com"
         )
@@ -169,6 +174,11 @@ class PipelineSettingsGraphQLTestCase(TestCase):
     """Tests for the PipelineSettings GraphQL endpoints."""
 
     def setUp(self):
+        from django.core.cache import cache
+
+        # Clear cache to ensure clean state between tests
+        cache.delete(PipelineSettings.CACHE_KEY)
+
         self.superuser = User.objects.create_superuser(
             username="admin", password="admin", email="admin@test.com"
         )
@@ -374,12 +384,8 @@ class PipelineSettingsGraphQLTestCase(TestCase):
         returned_kwargs = result["data"]["updatePipelineSettings"]["pipelineSettings"][
             "parserKwargs"
         ]
-        self.assertEqual(
-            returned_kwargs["some.parser.TestParser"]["force_ocr"], True
-        )
-        self.assertEqual(
-            returned_kwargs["some.parser.TestParser"]["timeout"], 120
-        )
+        self.assertEqual(returned_kwargs["some.parser.TestParser"]["force_ocr"], True)
+        self.assertEqual(returned_kwargs["some.parser.TestParser"]["timeout"], 120)
 
     def test_update_default_embedder(self):
         """Test updating default embedder via GraphQL."""
@@ -423,6 +429,11 @@ class PipelineSettingsSecretsTestCase(TestCase):
     """Tests for encrypted secrets storage in PipelineSettings."""
 
     def setUp(self):
+        from django.core.cache import cache
+
+        # Clear cache to ensure clean state between tests
+        cache.delete(PipelineSettings.CACHE_KEY)
+
         self.superuser = User.objects.create_superuser(
             username="admin", password="admin", email="admin@test.com"
         )
@@ -455,7 +466,9 @@ class PipelineSettingsSecretsTestCase(TestCase):
         instance.refresh_from_db()
         retrieved = instance.get_secrets()
 
-        self.assertEqual(retrieved["component.path.TestParser"]["api_key"], "sk-test-12345")
+        self.assertEqual(
+            retrieved["component.path.TestParser"]["api_key"], "sk-test-12345"
+        )
         self.assertEqual(
             retrieved["component.path.TestParser"]["secret_token"], "tok-abcdef"
         )
@@ -465,9 +478,7 @@ class PipelineSettingsSecretsTestCase(TestCase):
         instance = PipelineSettings.get_instance()
 
         # Set initial secrets
-        instance.set_secrets(
-            {"component.path.Parser1": {"key1": "value1"}}
-        )
+        instance.set_secrets({"component.path.Parser1": {"key1": "value1"}})
         instance.save()
 
         # Update with new secret for same component
@@ -531,7 +542,9 @@ class PipelineSettingsSecretsTestCase(TestCase):
         )
         instance.save()
 
-        full_settings = instance.get_full_component_settings("component.path.TestParser")
+        full_settings = instance.get_full_component_settings(
+            "component.path.TestParser"
+        )
 
         self.assertEqual(full_settings["timeout"], 60)
         self.assertEqual(full_settings["batch_size"], 10)
@@ -673,6 +686,11 @@ class PipelineSettingsEdgeCasesTestCase(TestCase):
     """Tests for edge cases and error handling."""
 
     def setUp(self):
+        from django.core.cache import cache
+
+        # Clear cache to ensure clean state between tests
+        cache.delete(PipelineSettings.CACHE_KEY)
+
         self.superuser = User.objects.create_superuser(
             username="admin", password="admin", email="admin@test.com"
         )
@@ -716,7 +734,10 @@ class PipelineSettingsEdgeCasesTestCase(TestCase):
         }
         result = self.superuser_client.execute(mutation, variables=variables)
         self.assertFalse(result["data"]["updateComponentSecrets"]["ok"])
-        self.assertIn("Invalid component path", result["data"]["updateComponentSecrets"]["message"])
+        self.assertIn(
+            "Invalid component path",
+            result["data"]["updateComponentSecrets"]["message"],
+        )
 
         # Test path that's too long
         variables = {
@@ -725,7 +746,10 @@ class PipelineSettingsEdgeCasesTestCase(TestCase):
         }
         result = self.superuser_client.execute(mutation, variables=variables)
         self.assertFalse(result["data"]["updateComponentSecrets"]["ok"])
-        self.assertIn("exceeds maximum length", result["data"]["updateComponentSecrets"]["message"])
+        self.assertIn(
+            "exceeds maximum length",
+            result["data"]["updateComponentSecrets"]["message"],
+        )
 
     def test_invalid_secret_value_types(self):
         """Test that non-primitive secret values are rejected."""
@@ -751,7 +775,9 @@ class PipelineSettingsEdgeCasesTestCase(TestCase):
         }
         result = self.superuser_client.execute(mutation, variables=variables)
         self.assertFalse(result["data"]["updateComponentSecrets"]["ok"])
-        self.assertIn("primitive type", result["data"]["updateComponentSecrets"]["message"])
+        self.assertIn(
+            "primitive type", result["data"]["updateComponentSecrets"]["message"]
+        )
 
     def test_caching_invalidation_on_save(self):
         """Test that cache is invalidated when settings are saved."""
@@ -779,8 +805,8 @@ class PipelineSettingsEdgeCasesTestCase(TestCase):
         """Test that use_cache=False bypasses the cache."""
         from django.core.cache import cache
 
-        # Get instance with cache
-        instance1 = PipelineSettings.get_instance(use_cache=True)
+        # Populate the cache by getting instance
+        PipelineSettings.get_instance(use_cache=True)
 
         # Manually modify cache entry to test bypass
         cache.set(

--- a/opencontractserver/tests/test_pipeline_settings.py
+++ b/opencontractserver/tests/test_pipeline_settings.py
@@ -417,3 +417,253 @@ class PipelineSettingsGraphQLTestCase(TestCase):
                 ],
                 embedder.class_name,
             )
+
+
+class PipelineSettingsSecretsTestCase(TestCase):
+    """Tests for encrypted secrets storage in PipelineSettings."""
+
+    def setUp(self):
+        self.superuser = User.objects.create_superuser(
+            username="admin", password="admin", email="admin@test.com"
+        )
+        self.regular_user = User.objects.create_user(
+            username="regular", password="regular"
+        )
+        self.superuser_client = Client(
+            schema, context_value=TestContext(self.superuser)
+        )
+        self.regular_client = Client(
+            schema, context_value=TestContext(self.regular_user)
+        )
+        PipelineSettings.objects.all().delete()
+
+    def test_set_and_get_secrets(self):
+        """Test basic encryption/decryption of secrets."""
+        instance = PipelineSettings.get_instance()
+
+        secrets = {
+            "component.path.TestParser": {
+                "api_key": "sk-test-12345",
+                "secret_token": "tok-abcdef",
+            }
+        }
+
+        instance.set_secrets(secrets)
+        instance.save()
+
+        # Retrieve and verify
+        instance.refresh_from_db()
+        retrieved = instance.get_secrets()
+
+        self.assertEqual(retrieved["component.path.TestParser"]["api_key"], "sk-test-12345")
+        self.assertEqual(
+            retrieved["component.path.TestParser"]["secret_token"], "tok-abcdef"
+        )
+
+    def test_update_secrets_merges_with_existing(self):
+        """Test that update_secrets merges with existing secrets."""
+        instance = PipelineSettings.get_instance()
+
+        # Set initial secrets
+        instance.set_secrets(
+            {"component.path.Parser1": {"key1": "value1"}}
+        )
+        instance.save()
+
+        # Update with new secret for same component
+        instance.update_secrets("component.path.Parser1", {"key2": "value2"})
+        instance.save()
+
+        secrets = instance.get_secrets()
+        self.assertEqual(secrets["component.path.Parser1"]["key1"], "value1")
+        self.assertEqual(secrets["component.path.Parser1"]["key2"], "value2")
+
+    def test_get_component_secrets(self):
+        """Test getting secrets for a specific component."""
+        instance = PipelineSettings.get_instance()
+
+        instance.set_secrets(
+            {
+                "component.path.Parser1": {"api_key": "key1"},
+                "component.path.Parser2": {"api_key": "key2"},
+            }
+        )
+        instance.save()
+
+        parser1_secrets = instance.get_component_secrets("component.path.Parser1")
+        self.assertEqual(parser1_secrets["api_key"], "key1")
+
+        # Non-existent component returns empty dict
+        empty_secrets = instance.get_component_secrets("component.path.NonExistent")
+        self.assertEqual(empty_secrets, {})
+
+    def test_delete_component_secrets(self):
+        """Test deleting secrets for a component."""
+        instance = PipelineSettings.get_instance()
+
+        instance.set_secrets(
+            {
+                "component.path.Parser1": {"api_key": "key1"},
+                "component.path.Parser2": {"api_key": "key2"},
+            }
+        )
+        instance.save()
+
+        instance.delete_component_secrets("component.path.Parser1")
+        instance.save()
+
+        secrets = instance.get_secrets()
+        self.assertNotIn("component.path.Parser1", secrets)
+        self.assertIn("component.path.Parser2", secrets)
+
+    def test_get_full_component_settings_merges_secrets(self):
+        """Test that get_full_component_settings merges non-sensitive and secrets."""
+        instance = PipelineSettings.get_instance()
+
+        # Set non-sensitive settings
+        instance.component_settings = {
+            "component.path.TestParser": {"timeout": 60, "batch_size": 10}
+        }
+
+        # Set secrets
+        instance.set_secrets(
+            {"component.path.TestParser": {"api_key": "secret-key-123"}}
+        )
+        instance.save()
+
+        full_settings = instance.get_full_component_settings("component.path.TestParser")
+
+        self.assertEqual(full_settings["timeout"], 60)
+        self.assertEqual(full_settings["batch_size"], 10)
+        self.assertEqual(full_settings["api_key"], "secret-key-123")
+
+    def test_encrypted_secrets_not_readable_as_plaintext(self):
+        """Test that encrypted secrets are not stored as plaintext."""
+        instance = PipelineSettings.get_instance()
+
+        secret_value = "super-secret-api-key-12345"
+        instance.set_secrets({"test.parser": {"api_key": secret_value}})
+        instance.save()
+        instance.refresh_from_db()
+
+        # The encrypted_secrets field should contain binary data
+        self.assertIsNotNone(instance.encrypted_secrets)
+
+        # The secret value should NOT appear in the raw binary
+        raw_bytes = bytes(instance.encrypted_secrets)
+        self.assertNotIn(secret_value.encode(), raw_bytes)
+
+    def test_update_component_secrets_mutation_as_superuser(self):
+        """Test updating secrets via GraphQL mutation."""
+        mutation = """
+            mutation UpdateComponentSecrets(
+                $componentPath: String!,
+                $secrets: GenericScalar!
+            ) {
+                updateComponentSecrets(
+                    componentPath: $componentPath,
+                    secrets: $secrets
+                ) {
+                    ok
+                    message
+                    componentsWithSecrets
+                }
+            }
+        """
+
+        variables = {
+            "componentPath": "test.parser.TestParser",
+            "secrets": {"api_key": "test-key-123"},
+        }
+
+        result = self.superuser_client.execute(mutation, variables=variables)
+        self.assertIsNone(result.get("errors"))
+        self.assertTrue(result["data"]["updateComponentSecrets"]["ok"])
+        self.assertIn(
+            "test.parser.TestParser",
+            result["data"]["updateComponentSecrets"]["componentsWithSecrets"],
+        )
+
+    def test_update_component_secrets_mutation_as_regular_user_fails(self):
+        """Test that regular users cannot update secrets."""
+        mutation = """
+            mutation UpdateComponentSecrets(
+                $componentPath: String!,
+                $secrets: GenericScalar!
+            ) {
+                updateComponentSecrets(
+                    componentPath: $componentPath,
+                    secrets: $secrets
+                ) {
+                    ok
+                    message
+                }
+            }
+        """
+
+        variables = {
+            "componentPath": "test.parser.TestParser",
+            "secrets": {"api_key": "test-key-123"},
+        }
+
+        result = self.regular_client.execute(mutation, variables=variables)
+        self.assertIsNone(result.get("errors"))
+        self.assertFalse(result["data"]["updateComponentSecrets"]["ok"])
+        self.assertIn(
+            "superuser",
+            result["data"]["updateComponentSecrets"]["message"].lower(),
+        )
+
+    def test_delete_component_secrets_mutation(self):
+        """Test deleting secrets via GraphQL mutation."""
+        # First set some secrets
+        instance = PipelineSettings.get_instance()
+        instance.set_secrets({"test.parser.TestParser": {"api_key": "key"}})
+        instance.save()
+
+        mutation = """
+            mutation DeleteComponentSecrets($componentPath: String!) {
+                deleteComponentSecrets(componentPath: $componentPath) {
+                    ok
+                    message
+                    componentsWithSecrets
+                }
+            }
+        """
+
+        variables = {"componentPath": "test.parser.TestParser"}
+
+        result = self.superuser_client.execute(mutation, variables=variables)
+        self.assertIsNone(result.get("errors"))
+        self.assertTrue(result["data"]["deleteComponentSecrets"]["ok"])
+        self.assertNotIn(
+            "test.parser.TestParser",
+            result["data"]["deleteComponentSecrets"]["componentsWithSecrets"],
+        )
+
+    def test_pipeline_settings_query_includes_components_with_secrets(self):
+        """Test that the query returns list of components with secrets."""
+        # Set some secrets
+        instance = PipelineSettings.get_instance()
+        instance.set_secrets(
+            {
+                "parser1.path": {"key": "value1"},
+                "parser2.path": {"key": "value2"},
+            }
+        )
+        instance.save()
+
+        query = """
+            query {
+                pipelineSettings {
+                    componentsWithSecrets
+                }
+            }
+        """
+
+        result = self.superuser_client.execute(query)
+        self.assertIsNone(result.get("errors"))
+
+        components = result["data"]["pipelineSettings"]["componentsWithSecrets"]
+        self.assertIn("parser1.path", components)
+        self.assertIn("parser2.path", components)

--- a/opencontractserver/tests/test_pipeline_utils.py
+++ b/opencontractserver/tests/test_pipeline_utils.py
@@ -593,12 +593,23 @@ class TestPostProcessor(BasePostProcessor):
     def test_find_embedder_for_filetype(self) -> None:
         """
         Test find_embedder_for_filetype function with different input types and scenarios.
+
+        Note: We clear PipelineSettings DB values to ensure Django settings fallback is used,
+        since the functions now check DB first before Django settings.
         """
+        from opencontractserver.documents.models import PipelineSettings
         from opencontractserver.pipeline.base.file_types import FileTypeEnum
         from opencontractserver.pipeline.utils import (
             find_embedder_for_filetype,
             get_default_embedder,
         )
+
+        # Clear PipelineSettings DB values so Django settings fallback is used
+        pipeline_settings = PipelineSettings.get_instance(use_cache=False)
+        pipeline_settings.preferred_embedders = {}
+        pipeline_settings.default_embedder = ""
+        pipeline_settings.save()
+        PipelineSettings._invalidate_cache()
 
         # Get the default embedder for comparison
         default_embedder = get_default_embedder()
@@ -640,8 +651,18 @@ class TestPostProcessor(BasePostProcessor):
     def test_find_embedder_for_filetype_error_handling(self) -> None:
         """
         Test find_embedder_for_filetype error handling when embedder path can't be loaded.
+
+        Note: We clear PipelineSettings DB values to ensure Django settings fallback is used.
         """
+        from opencontractserver.documents.models import PipelineSettings
         from opencontractserver.pipeline.utils import find_embedder_for_filetype
+
+        # Clear PipelineSettings DB values so Django settings fallback is used
+        pipeline_settings = PipelineSettings.get_instance(use_cache=False)
+        pipeline_settings.preferred_embedders = {}
+        pipeline_settings.default_embedder = ""
+        pipeline_settings.save()
+        PipelineSettings._invalidate_cache()
 
         # When a preferred embedder can't be loaded, the function should return None
         embedder = find_embedder_for_filetype("application/pdf")


### PR DESCRIPTION
## Summary

This PR introduces a new `PipelineSettings` singleton model that allows superusers to configure document processing pipeline components (parsers, embedders, thumbnailers) at runtime without code deployment. Settings are stored in the database with fallback to Django settings, and sensitive credentials are encrypted at rest using Fernet symmetric encryption.

## Key Changes

- **PipelineSettings Singleton Model** (`opencontractserver/documents/models.py`)
  - Database-backed configuration for preferred parsers, embedders, and thumbnailers per MIME type
  - Stores parser-specific kwargs and component settings overrides
  - Singleton pattern: only one instance exists, cannot be deleted
  - Automatic fallback to Django settings when database values are not configured

- **Encrypted Secrets Storage**
  - Fernet symmetric encryption (key derived from Django SECRET_KEY)
  - Methods: `set_secrets()`, `get_secrets()`, `update_secrets()`, `delete_component_secrets()`
  - Secrets never exposed via GraphQL responses
  - GraphQL only returns list of components that have secrets configured

- **GraphQL Query `pipelineSettings`** (`config/graphql/queries.py`)
  - Any authenticated user can read current pipeline configuration
  - Returns preferred components, parser kwargs, component settings
  - Includes `componentsWithSecrets` field (list of paths, not actual secrets)
  - Includes audit fields (modified, modified_by)

- **GraphQL Mutations** (`config/graphql/pipeline_settings_mutations.py`)
  - `updatePipelineSettings`: Superusers modify pipeline configuration at runtime
    - Validates component class paths exist in pipeline registry
    - Changes take effect immediately for new document processing tasks
  - `resetPipelineSettings`: Superusers reset to Django settings defaults
  - `updateComponentSecrets`: Superusers securely store API keys per component
    - Supports merge mode (add to existing) or replace mode
  - `deleteComponentSecrets`: Superusers remove secrets for a component

- **GraphQL Type** (`config/graphql/graphene_types.py`)
  - `PipelineSettingsType` exposes all configuration fields and audit information

- **Database Migration** (`opencontractserver/documents/migrations/0031_add_pipeline_settings.py`)
  - Creates PipelineSettings table with encrypted_secrets field
  - Automatically creates singleton instance populated with Django settings defaults

- **Pipeline Integration**
  - `doc_tasks.py`: `ingest_doc` and `extract_thumbnail` now read from PipelineSettings
  - `pipeline/utils.py`: `get_preferred_embedder` and `get_default_embedder` use PipelineSettings

## Security Considerations

- All mutations restricted to superusers only
- Secrets encrypted at rest using Fernet symmetric encryption
- Secrets never exposed via GraphQL API
- Audit trail maintained (modified_by field tracks who made changes)
- Singleton pattern prevents accidental deletion of configuration

## Backward Compatibility

- Existing deployments continue to work unchanged
- Django settings remain as fallback when database values not configured
- Migration automatically populates singleton with current Django settings

https://claude.ai/code/session_019D6cTBBTfSbYYYPjfsVY92