### PR TITLE
Fix structural annotations not appearing in corpus-wide queries

### DIFF
--- a/config/graphql/queries.py
+++ b/config/graphql/queries.py
@@ -325,16 +325,16 @@ class Query(graphene.ObjectType):
     def resolve_annotations(
         self, info, analysis_isnull=None, structural=None, **kwargs
     ):
-        # Check if we should use the query optimizer (when document_id is provided)
+        # Import the query optimizer
+        from opencontractserver.annotations.query_optimizer import (
+            AnnotationQueryOptimizer,
+        )
+
         document_id = kwargs.get("document_id")
         corpus_id = kwargs.get("corpus_id")
 
         if document_id:
-            # Import the query optimizer
-            from opencontractserver.annotations.query_optimizer import (
-                AnnotationQueryOptimizer,
-            )
-
+            # Use document-specific query optimizer
             doc_django_pk = int(from_global_id(document_id)[1])
             corpus_django_pk = int(from_global_id(corpus_id)[1]) if corpus_id else None
 
@@ -348,8 +348,23 @@ class Query(graphene.ObjectType):
                 use_cache=False,
             )
 
+        elif corpus_id:
+            # Use corpus-wide query optimizer (handles structural annotations correctly)
+            # This optimizer already applies structural, analysis_isnull, and corpus filters
+            corpus_django_pk = int(from_global_id(corpus_id)[1])
+            queryset = AnnotationQueryOptimizer.get_corpus_annotations(
+                corpus_id=corpus_django_pk,
+                user=info.context.user,
+                structural=structural,
+                analysis_isnull=analysis_isnull,
+            )
+            # Mark filters already applied by optimizer to prevent double-filtering
+            corpus_id = None
+            structural = None
+            analysis_isnull = None
+
         else:
-            # Fallback to old behavior for non-document queries
+            # Fallback to visible_to_user for queries without document or corpus
             queryset = Annotation.objects.visible_to_user(info.context.user)
             logger.info(
                 f"Using visible_to_user for annotations query, found {queryset.count()} annotations"

--- a/opencontractserver/annotations/query_optimizer.py
+++ b/opencontractserver/annotations/query_optimizer.py
@@ -492,6 +492,179 @@ class AnnotationQueryOptimizer:
         # Simply filter by corpus since permissions are already checked
         return qs.filter(corpus_id=corpus_id)
 
+    @classmethod
+    def get_corpus_annotations(
+        cls,
+        corpus_id: int,
+        user,
+        structural: Optional[bool] = None,
+        analysis_isnull: Optional[bool] = None,
+    ) -> QuerySet:
+        """
+        Get annotations for a corpus with proper permission filtering.
+        Handles BOTH document-attached AND structural annotations correctly.
+
+        This method is for corpus-wide queries where no specific document_id is provided.
+        It properly includes structural annotations which have:
+        - document_id = NULL (linked via structural_set instead)
+        - corpus_id = NULL (shared across corpuses via structural_set)
+
+        Permission model:
+        - User must have READ permission on corpus
+        - Annotations are filtered to only those on documents user can see
+        - Structural annotations are included if their structural_set is linked
+          to any visible document in the corpus
+
+        Args:
+            corpus_id: The corpus ID to query annotations for
+            user: The requesting user
+            structural: Optional filter for structural annotations (True/False/None)
+            analysis_isnull: Optional filter for analysis field (True=manual only)
+
+        Returns:
+            QuerySet of annotations with permission filtering applied
+        """
+        from opencontractserver.analyzer.models import (
+            Analysis,
+            AnalysisUserObjectPermission,
+        )
+        from opencontractserver.annotations.models import Annotation
+        from opencontractserver.corpuses.models import Corpus
+        from opencontractserver.documents.models import Document
+        from opencontractserver.extracts.models import (
+            Extract,
+            ExtractUserObjectPermission,
+        )
+        from opencontractserver.types.enums import PermissionTypes
+        from opencontractserver.utils.permissioning import user_has_permission_for_obj
+
+        # Superusers see everything
+        if user.is_superuser:
+            qs = Annotation.objects.filter(corpus_id=corpus_id)
+
+            # For structural annotations, include those linked via structural_set
+            # to documents in this corpus
+            visible_doc_ids = Document.objects.filter(
+                path_records__corpus_id=corpus_id,
+                path_records__is_current=True,
+                path_records__is_deleted=False,
+            ).values_list("id", flat=True)
+
+            structural_set_ids = Document.objects.filter(
+                id__in=visible_doc_ids,
+                structural_annotation_set_id__isnull=False,
+            ).values_list("structural_annotation_set_id", flat=True)
+
+            # Combine: corpus annotations OR structural annotations from visible docs
+            qs = Annotation.objects.filter(
+                Q(corpus_id=corpus_id)
+                | Q(structural_set_id__in=structural_set_ids, structural=True)
+            )
+
+            if structural is not None:
+                qs = qs.filter(structural=structural)
+            if analysis_isnull is not None:
+                qs = qs.filter(analysis__isnull=analysis_isnull)
+
+            return qs.distinct()
+
+        # Check corpus permission first
+        try:
+            corpus = Corpus.objects.get(id=corpus_id)
+        except Corpus.DoesNotExist:
+            return Annotation.objects.none()
+
+        # Anonymous users: corpus must be public
+        if user.is_anonymous:
+            if not corpus.is_public:
+                return Annotation.objects.none()
+            # Get public documents in this corpus
+            visible_doc_ids = Document.objects.filter(
+                is_public=True,
+                path_records__corpus_id=corpus_id,
+                path_records__is_current=True,
+                path_records__is_deleted=False,
+            ).values_list("id", flat=True)
+        else:
+            # Check if user has READ permission on corpus
+            has_corpus_read = user_has_permission_for_obj(
+                user, corpus, PermissionTypes.READ, include_group_permissions=True
+            )
+            if not has_corpus_read:
+                return Annotation.objects.none()
+
+            # Get documents visible to user in this corpus
+            visible_doc_ids = (
+                Document.objects.visible_to_user(user)
+                .filter(
+                    path_records__corpus_id=corpus_id,
+                    path_records__is_current=True,
+                    path_records__is_deleted=False,
+                )
+                .values_list("id", flat=True)
+            )
+
+        if not visible_doc_ids:
+            return Annotation.objects.none()
+
+        # Get structural_annotation_set IDs from visible documents
+        structural_set_ids = Document.objects.filter(
+            id__in=visible_doc_ids,
+            structural_annotation_set_id__isnull=False,
+        ).values_list("structural_annotation_set_id", flat=True)
+
+        # Build query for BOTH types of annotations:
+        # 1. Document-attached annotations: corpus_id matches AND document is visible
+        # 2. Structural annotations: structural_set_id is from a visible document
+        base_filter = Q(corpus_id=corpus_id, document_id__in=visible_doc_ids)
+
+        if structural_set_ids:
+            base_filter |= Q(structural_set_id__in=structural_set_ids, structural=True)
+
+        qs = Annotation.objects.filter(base_filter)
+
+        # Apply privacy filtering for created_by_* fields (non-superuser, non-anonymous)
+        if not user.is_anonymous:
+            # Get analyses user can access
+            visible_analyses = Analysis.objects.filter(
+                Q(is_public=True) | Q(creator=user)
+            )
+            analyses_with_permission = AnalysisUserObjectPermission.objects.filter(
+                user=user
+            ).values_list("content_object_id", flat=True)
+            visible_analyses = visible_analyses | Analysis.objects.filter(
+                id__in=analyses_with_permission
+            )
+
+            # Get extracts user can access
+            visible_extracts = Extract.objects.filter(Q(creator=user))
+            extracts_with_permission = ExtractUserObjectPermission.objects.filter(
+                user=user
+            ).values_list("content_object_id", flat=True)
+            visible_extracts = visible_extracts | Extract.objects.filter(
+                id__in=extracts_with_permission
+            )
+
+            # Filter: exclude private annotations user can't see
+            # BUT always include structural annotations (bypass privacy)
+            qs = qs.exclude(
+                Q(created_by_analysis__isnull=False)
+                & Q(structural=False)
+                & ~Q(created_by_analysis__in=visible_analyses)
+            ).exclude(
+                Q(created_by_extract__isnull=False)
+                & Q(structural=False)
+                & ~Q(created_by_extract__in=visible_extracts)
+            )
+
+        # Apply optional filters
+        if structural is not None:
+            qs = qs.filter(structural=structural)
+        if analysis_isnull is not None:
+            qs = qs.filter(analysis__isnull=analysis_isnull)
+
+        return qs.distinct()
+
 
 class RelationshipQueryOptimizer:
     """

--- a/opencontractserver/shared/QuerySets.py
+++ b/opencontractserver/shared/QuerySets.py
@@ -234,11 +234,20 @@ class AnnotationQuerySet(
 
         # For anonymous users, only show public structural annotations
         if user.is_anonymous:
+            # Handle both document-attached and structural_set-linked annotations
+            doc_attached_public = Q(document__isnull=False) & Q(
+                document__is_public=True
+            )
+            structural_set_public = (
+                Q(document__isnull=True)
+                & Q(structural_set__isnull=False)
+                & Q(structural_set__documents__is_public=True)
+            )
             return qs.filter(
                 Q(structural=True)
-                & Q(document__is_public=True)
+                & (doc_attached_public | structural_set_public)
                 & (Q(corpus__isnull=True) | Q(corpus__is_public=True))
-            )
+            ).distinct()
 
         # Build visibility filters for analyses
         visible_analyses = Analysis.objects.filter(Q(is_public=True) | Q(creator=user))
@@ -282,13 +291,35 @@ class AnnotationQuerySet(
         )
 
         # Also need document/corpus visibility
-        doc_corpus_filter = (
+        # Handle TWO types of annotations:
+        # 1. Document-attached: have document FK set, check document visibility
+        # 2. Structural via structural_set: have document=NULL, check via structural_set__documents
+        doc_attached_filter = Q(document__isnull=False) & (
             Q(document__is_public=True) | Q(document__creator=user)
-        ) & (
+        )
+
+        # Structural annotations linked via structural_set (document FK is NULL)
+        # These are visible if ANY document using that structural_set is visible to user
+        structural_set_filter = (
+            Q(document__isnull=True)
+            & Q(structural_set__isnull=False)
+            & Q(structural=True)
+            & (
+                Q(structural_set__documents__is_public=True)
+                | Q(structural_set__documents__creator=user)
+            )
+        )
+
+        doc_visibility_filter = doc_attached_filter | structural_set_filter
+
+        # Corpus visibility (for document-attached annotations with corpus)
+        corpus_filter = (
             Q(corpus__isnull=True) | Q(corpus__is_public=True) | Q(corpus__creator=user)
         )
 
-        return qs.filter(visibility_filter & doc_corpus_filter).distinct()
+        return qs.filter(
+            visibility_filter & doc_visibility_filter & corpus_filter
+        ).distinct()
 
 
 class NoteQuerySet(CTEQuerySet, PermissionQuerySet, VectorSearchViaEmbeddingMixin):

--- a/opencontractserver/tests/test_corpus_annotations_query.py
+++ b/opencontractserver/tests/test_corpus_annotations_query.py
@@ -279,3 +279,161 @@ class TestAnnotationQuerySetVisibleToUser(TestCase):
 
         # Structural annotation should be visible via structural_set relationship
         self.assertIn(self.structural_annotation, result)
+
+
+class TestCorpusAnnotationsQueryEdgeCases(TestCase):
+    """Test edge cases for AnnotationQueryOptimizer.get_corpus_annotations."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """Set up test data."""
+        cls.owner = User.objects.create_user(
+            username="edge_owner", email="edge_owner@test.com", password="test123"
+        )
+        cls.superuser = User.objects.create_superuser(
+            username="edge_admin", email="edge_admin@test.com", password="admin123"
+        )
+
+        # Create a private corpus
+        cls.private_corpus = Corpus.objects.create(
+            title="Private Corpus",
+            creator=cls.owner,
+            is_public=False,
+        )
+
+        # Create structural annotation set and document
+        cls.structural_set = StructuralAnnotationSet.objects.create()
+        cls.document = Document.objects.create(
+            title="Edge Test Doc",
+            creator=cls.owner,
+            structural_annotation_set=cls.structural_set,
+        )
+
+        # Link document to corpus
+        DocumentPath.objects.create(
+            document=cls.document,
+            corpus=cls.private_corpus,
+            path="/edge_test.pdf",
+            is_current=True,
+            is_deleted=False,
+            version_number=1,
+            creator=cls.owner,
+        )
+
+        cls.label = AnnotationLabel.objects.create(
+            text="EdgeLabel",
+            label_type=LabelType.TOKEN_LABEL,
+            creator=cls.owner,
+        )
+
+        # Create annotations
+        cls.structural_annotation = Annotation.objects.create(
+            annotation_label=cls.label,
+            structural_set=cls.structural_set,
+            document=None,
+            corpus=None,
+            structural=True,
+            creator=cls.owner,
+        )
+        cls.user_annotation = Annotation.objects.create(
+            annotation_label=cls.label,
+            document=cls.document,
+            corpus=cls.private_corpus,
+            structural=False,
+            creator=cls.owner,
+        )
+
+        # Grant permissions to owner
+        set_permissions_for_obj_to_user(
+            cls.owner, cls.private_corpus, [PermissionTypes.CRUD]
+        )
+        set_permissions_for_obj_to_user(cls.owner, cls.document, [PermissionTypes.CRUD])
+
+    def test_nonexistent_corpus_returns_empty(self):
+        """Querying a non-existent corpus should return empty queryset."""
+        result = AnnotationQueryOptimizer.get_corpus_annotations(
+            corpus_id=999999,  # Non-existent
+            user=self.owner,
+        )
+
+        self.assertEqual(result.count(), 0)
+
+    def test_anonymous_user_private_corpus_returns_empty(self):
+        """Anonymous user cannot access private corpus annotations."""
+        from django.contrib.auth.models import AnonymousUser
+
+        anon_user = AnonymousUser()
+
+        result = AnnotationQueryOptimizer.get_corpus_annotations(
+            corpus_id=self.private_corpus.id,
+            user=anon_user,
+        )
+
+        self.assertEqual(result.count(), 0)
+
+    def test_superuser_with_structural_filter(self):
+        """Superuser can filter by structural=True."""
+        result = AnnotationQueryOptimizer.get_corpus_annotations(
+            corpus_id=self.private_corpus.id,
+            user=self.superuser,
+            structural=True,
+        )
+
+        self.assertIn(self.structural_annotation, result)
+        self.assertNotIn(self.user_annotation, result)
+
+    def test_superuser_with_analysis_isnull_filter(self):
+        """Superuser can filter by analysis_isnull=True."""
+        result = AnnotationQueryOptimizer.get_corpus_annotations(
+            corpus_id=self.private_corpus.id,
+            user=self.superuser,
+            analysis_isnull=True,
+        )
+
+        # Both annotations have analysis=NULL (manual annotations)
+        self.assertIn(self.structural_annotation, result)
+        self.assertIn(self.user_annotation, result)
+
+    def test_regular_user_with_analysis_isnull_filter(self):
+        """Regular user can filter by analysis_isnull=True."""
+        result = AnnotationQueryOptimizer.get_corpus_annotations(
+            corpus_id=self.private_corpus.id,
+            user=self.owner,
+            analysis_isnull=True,
+        )
+
+        # Both annotations have analysis=NULL (manual annotations)
+        self.assertIn(self.structural_annotation, result)
+        self.assertIn(self.user_annotation, result)
+
+    def test_user_with_corpus_access_but_no_document_access(self):
+        """User with corpus access but no visible documents sees nothing."""
+        # Create a user with corpus access but no document access
+        limited_user = User.objects.create_user(
+            username="limited", email="limited@test.com", password="test123"
+        )
+        set_permissions_for_obj_to_user(
+            limited_user, self.private_corpus, [PermissionTypes.READ]
+        )
+        # Deliberately NOT granting document permissions
+
+        result = AnnotationQueryOptimizer.get_corpus_annotations(
+            corpus_id=self.private_corpus.id,
+            user=limited_user,
+        )
+
+        # No visible documents = no annotations
+        self.assertEqual(result.count(), 0)
+
+    def test_apply_permission_filter_deprecated_method(self):
+        """Test the deprecated _apply_permission_filter method."""
+        from opencontractserver.annotations.models import Annotation
+
+        qs = Annotation.objects.all()
+        result = AnnotationQueryOptimizer._apply_permission_filter(
+            qs, self.owner, self.private_corpus.id
+        )
+
+        # Should filter by corpus_id
+        for annotation in result:
+            self.assertEqual(annotation.corpus_id, self.private_corpus.id)

--- a/opencontractserver/tests/test_corpus_annotations_query.py
+++ b/opencontractserver/tests/test_corpus_annotations_query.py
@@ -1,0 +1,281 @@
+"""
+Tests for corpus-wide annotation queries including structural annotations.
+
+These tests verify that the GetAnnotationsForCards query correctly returns
+both document-attached annotations and structural annotations when querying
+by corpus_id without a document_id.
+"""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from opencontractserver.annotations.models import (
+    Annotation,
+    AnnotationLabel,
+    StructuralAnnotationSet,
+)
+from opencontractserver.annotations.query_optimizer import AnnotationQueryOptimizer
+from opencontractserver.corpuses.models import Corpus
+from opencontractserver.documents.models import Document, DocumentPath
+from opencontractserver.types.enums import LabelType, PermissionTypes
+from opencontractserver.utils.permissioning import set_permissions_for_obj_to_user
+
+User = get_user_model()
+
+
+class TestCorpusAnnotationsQuery(TestCase):
+    """Test the AnnotationQueryOptimizer.get_corpus_annotations method."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """Set up test data once for all tests in this class."""
+        # Create users
+        cls.owner = User.objects.create_user(
+            username="owner", email="owner@test.com", password="test123"
+        )
+        cls.viewer = User.objects.create_user(
+            username="viewer", email="viewer@test.com", password="test123"
+        )
+        cls.superuser = User.objects.create_superuser(
+            username="admin", email="admin@test.com", password="admin123"
+        )
+
+        # Create corpus
+        cls.corpus = Corpus.objects.create(
+            title="Test Corpus",
+            creator=cls.owner,
+        )
+
+        # Create a structural annotation set (shared across documents)
+        cls.structural_set = StructuralAnnotationSet.objects.create()
+
+        # Create documents - one with structural_set, one without
+        cls.doc_with_structural = Document.objects.create(
+            title="Document with Structural Annotations",
+            creator=cls.owner,
+            structural_annotation_set=cls.structural_set,
+        )
+        cls.doc_without_structural = Document.objects.create(
+            title="Document without Structural Annotations",
+            creator=cls.owner,
+        )
+
+        # Create DocumentPaths to link documents to corpus
+        DocumentPath.objects.create(
+            document=cls.doc_with_structural,
+            corpus=cls.corpus,
+            path="/doc_with_structural.pdf",
+            is_current=True,
+            is_deleted=False,
+            version_number=1,
+            creator=cls.owner,
+        )
+        DocumentPath.objects.create(
+            document=cls.doc_without_structural,
+            corpus=cls.corpus,
+            path="/doc_without_structural.pdf",
+            is_current=True,
+            is_deleted=False,
+            version_number=1,
+            creator=cls.owner,
+        )
+
+        # Create annotation labels
+        cls.structural_label = AnnotationLabel.objects.create(
+            text="Paragraph",
+            label_type=LabelType.TOKEN_LABEL,
+            creator=cls.owner,
+        )
+        cls.user_label = AnnotationLabel.objects.create(
+            text="Important",
+            label_type=LabelType.TOKEN_LABEL,
+            creator=cls.owner,
+        )
+
+        # Create structural annotations (linked via structural_set, NOT document)
+        # These have document=NULL and corpus=NULL
+        cls.structural_annotation = Annotation.objects.create(
+            annotation_label=cls.structural_label,
+            structural_set=cls.structural_set,
+            document=None,  # NULL - linked via structural_set instead
+            corpus=None,  # NULL - shared across corpuses
+            structural=True,
+            creator=cls.owner,
+            raw_text="This is a structural annotation",
+        )
+
+        # Create document-attached user annotations (corpus-specific)
+        cls.user_annotation = Annotation.objects.create(
+            annotation_label=cls.user_label,
+            document=cls.doc_with_structural,
+            corpus=cls.corpus,
+            structural=False,
+            creator=cls.owner,
+            raw_text="This is a user annotation",
+        )
+
+        # Grant permissions to owner (creator also needs explicit permissions for the test)
+        set_permissions_for_obj_to_user(cls.owner, cls.corpus, [PermissionTypes.CRUD])
+        set_permissions_for_obj_to_user(
+            cls.owner, cls.doc_with_structural, [PermissionTypes.CRUD]
+        )
+        set_permissions_for_obj_to_user(
+            cls.owner, cls.doc_without_structural, [PermissionTypes.CRUD]
+        )
+
+        # Grant permissions to viewer
+        set_permissions_for_obj_to_user(cls.viewer, cls.corpus, [PermissionTypes.READ])
+        set_permissions_for_obj_to_user(
+            cls.viewer, cls.doc_with_structural, [PermissionTypes.READ]
+        )
+        set_permissions_for_obj_to_user(
+            cls.viewer, cls.doc_without_structural, [PermissionTypes.READ]
+        )
+
+    def test_superuser_sees_all_annotations(self):
+        """Superuser should see both structural and document-attached annotations."""
+        result = AnnotationQueryOptimizer.get_corpus_annotations(
+            corpus_id=self.corpus.id,
+            user=self.superuser,
+        )
+
+        self.assertIn(self.structural_annotation, result)
+        self.assertIn(self.user_annotation, result)
+
+    def test_owner_sees_all_annotations(self):
+        """Owner should see both structural and document-attached annotations."""
+        result = AnnotationQueryOptimizer.get_corpus_annotations(
+            corpus_id=self.corpus.id,
+            user=self.owner,
+        )
+
+        self.assertIn(self.structural_annotation, result)
+        self.assertIn(self.user_annotation, result)
+
+    def test_viewer_with_permission_sees_annotations(self):
+        """Viewer with corpus and document permissions should see annotations."""
+        result = AnnotationQueryOptimizer.get_corpus_annotations(
+            corpus_id=self.corpus.id,
+            user=self.viewer,
+        )
+
+        # Viewer should see both types
+        self.assertIn(self.structural_annotation, result)
+        self.assertIn(self.user_annotation, result)
+
+    def test_filter_structural_only(self):
+        """Filtering by structural=True should return only structural annotations."""
+        result = AnnotationQueryOptimizer.get_corpus_annotations(
+            corpus_id=self.corpus.id,
+            user=self.owner,
+            structural=True,
+        )
+
+        self.assertIn(self.structural_annotation, result)
+        self.assertNotIn(self.user_annotation, result)
+
+    def test_filter_non_structural_only(self):
+        """Filtering by structural=False should return only user annotations."""
+        result = AnnotationQueryOptimizer.get_corpus_annotations(
+            corpus_id=self.corpus.id,
+            user=self.owner,
+            structural=False,
+        )
+
+        self.assertNotIn(self.structural_annotation, result)
+        self.assertIn(self.user_annotation, result)
+
+    def test_user_without_corpus_permission_sees_nothing(self):
+        """User without corpus permission should see no annotations."""
+        no_access_user = User.objects.create_user(
+            username="no_access", email="no_access@test.com", password="test123"
+        )
+
+        result = AnnotationQueryOptimizer.get_corpus_annotations(
+            corpus_id=self.corpus.id,
+            user=no_access_user,
+        )
+
+        self.assertEqual(result.count(), 0)
+
+    def test_structural_annotation_with_document_null(self):
+        """Verify that structural annotations have document=NULL but are still found."""
+        # Verify our test data is correct
+        self.assertIsNone(self.structural_annotation.document)
+        self.assertIsNotNone(self.structural_annotation.structural_set)
+        self.assertTrue(self.structural_annotation.structural)
+
+        # Query should still find it
+        result = AnnotationQueryOptimizer.get_corpus_annotations(
+            corpus_id=self.corpus.id,
+            user=self.owner,
+            structural=True,
+        )
+
+        self.assertIn(self.structural_annotation, result)
+
+    def test_deleted_document_path_excludes_annotations(self):
+        """Annotations for documents with deleted paths should not be returned."""
+        # Mark the document path as deleted
+        path = DocumentPath.objects.get(
+            document=self.doc_with_structural, corpus=self.corpus
+        )
+        path.is_deleted = True
+        path.save()
+
+        try:
+            result = AnnotationQueryOptimizer.get_corpus_annotations(
+                corpus_id=self.corpus.id,
+                user=self.owner,
+            )
+
+            # User annotation should be excluded (document path is deleted)
+            self.assertNotIn(self.user_annotation, result)
+            # Structural annotation should also be excluded (linked document path is deleted)
+            self.assertNotIn(self.structural_annotation, result)
+        finally:
+            # Restore for other tests
+            path.is_deleted = False
+            path.save()
+
+
+class TestAnnotationQuerySetVisibleToUser(TestCase):
+    """Test the AnnotationQuerySet.visible_to_user method with structural annotations."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """Set up test data."""
+        cls.owner = User.objects.create_user(
+            username="owner2", email="owner2@test.com", password="test123"
+        )
+
+        # Create structural annotation set and document
+        cls.structural_set = StructuralAnnotationSet.objects.create()
+        cls.document = Document.objects.create(
+            title="Test Doc",
+            creator=cls.owner,
+            structural_annotation_set=cls.structural_set,
+        )
+
+        cls.label = AnnotationLabel.objects.create(
+            text="Token",
+            label_type=LabelType.TOKEN_LABEL,
+            creator=cls.owner,
+        )
+
+        # Create structural annotation with document=NULL
+        cls.structural_annotation = Annotation.objects.create(
+            annotation_label=cls.label,
+            structural_set=cls.structural_set,
+            document=None,
+            corpus=None,
+            structural=True,
+            creator=cls.owner,
+        )
+
+    def test_visible_to_user_includes_structural_annotations(self):
+        """visible_to_user should include structural annotations with document=NULL."""
+        result = Annotation.objects.visible_to_user(self.owner)
+
+        # Structural annotation should be visible via structural_set relationship
+        self.assertIn(self.structural_annotation, result)


### PR DESCRIPTION
## Summary

Fixes an issue where the `GetAnnotationsForCards` query (and similar corpus-wide annotation queries) returned 0 structural annotations when querying by `corpusId` without a `documentId`.

**Root Cause:**
1. `AnnotationQuerySet.visible_to_user()` filtered out structural annotations because they have `document=NULL` (linked via `structural_set` instead) and the filter checked `document__is_public`/`document__creator` which fails on NULL relations
2. `resolve_annotations()` filtered by `corpus_id=X`, but structural annotations have `corpus_id=NULL` since they're shared across corpuses via `structural_set`

**Changes:**
- Added `AnnotationQueryOptimizer.get_corpus_annotations()` method for corpus-wide annotation queries that properly includes structural annotations by checking their `structural_set__documents` relationship
- Updated `resolve_annotations()` to use the new optimizer when querying by corpus without a document
- Fixed `AnnotationQuerySet.visible_to_user()` to handle structural annotations with `document=NULL` by checking `structural_set__documents`
- Added comprehensive tests for the new functionality

## Test plan

- [x] All 17 annotation-related tests pass
- [x] New test file `test_corpus_annotations_query.py` with 9 tests covering:
  - Superuser sees all annotations
  - Owner sees all annotations  
  - Viewer with permissions sees annotations
  - Filtering by structural=True/False
  - User without corpus permission sees nothing
  - Structural annotations with document=NULL are found
  - Deleted document paths exclude annotations
  - `visible_to_user()` includes structural annotations
- [ ] Manual testing: Verify `GetAnnotationsForCards` query returns structural annotations when querying by corpusId