### PR TITLE
Add rate limiting to admin login and fix logout redirect

### DIFF
--- a/config/admin_auth/views.py
+++ b/config/admin_auth/views.py
@@ -12,15 +12,36 @@ from urllib.parse import urlencode
 from django.conf import settings
 from django.contrib import admin, messages
 from django.contrib.auth import authenticate, login, logout
-from django.http import HttpResponseNotAllowed
+from django.http import HttpResponse, HttpResponseNotAllowed, JsonResponse
 from django.shortcuts import redirect, render
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.http import url_has_allowed_host_and_scheme
 from django.views import View
 from django.views.decorators.csrf import csrf_protect
+from django_ratelimit.decorators import ratelimit
 
 logger = logging.getLogger(__name__)
+
+# Rate limits for admin login endpoints.
+# Can be overridden via RATELIMIT_AUTH_LOGIN and RATELIMIT_ADMIN_LOGIN_PAGE
+# environment variables through the RATE_LIMIT_OVERRIDES mechanism.
+_overrides = getattr(settings, "RATE_LIMIT_OVERRIDES", {})
+ADMIN_LOGIN_RATE = _overrides.get("AUTH_LOGIN", "5/m")
+ADMIN_LOGIN_PAGE_RATE = _overrides.get("ADMIN_LOGIN_PAGE", "20/m")
+
+
+def _ratelimit_ip_key(group: str, request) -> str:
+    """
+    Extract client IP for rate-limit keying.
+
+    Falls back to REMOTE_ADDR when the X-Forwarded-For header is absent
+    (e.g. in tests or direct connections without a reverse proxy).
+    """
+    forwarded_for = request.META.get("HTTP_X_FORWARDED_FOR")
+    if forwarded_for:
+        return forwarded_for.split(",")[0].strip()
+    return request.META.get("REMOTE_ADDR", "unknown")
 
 
 def _get_login_url():
@@ -144,8 +165,17 @@ class Auth0AdminLoginView(View):
     template_name = "admin/auth0_login.html"
 
     @method_decorator(csrf_protect)
+    @method_decorator(ratelimit(key=_ratelimit_ip_key, rate=ADMIN_LOGIN_PAGE_RATE, block=False))
     def get(self, request):
         """Display the appropriate login form."""
+        if getattr(request, "limited", False):
+            logger.warning("Rate limit exceeded for admin login page GET")
+            return HttpResponse(
+                "Too many requests. Please try again later.",
+                status=429,
+                content_type="text/plain",
+            )
+
         # Check if user is already authenticated
         if request.user.is_authenticated and request.user.is_staff:
             return redirect(_get_admin_index_url())
@@ -174,8 +204,21 @@ class Auth0AdminLoginView(View):
         return render(request, self.template_name, context)
 
     @method_decorator(csrf_protect)
+    @method_decorator(ratelimit(key=_ratelimit_ip_key, rate=ADMIN_LOGIN_RATE, block=False))
     def post(self, request):
         """Handle token-based login via POST or password authentication."""
+        if getattr(request, "limited", False):
+            logger.warning("Rate limit exceeded for admin login POST")
+            return JsonResponse(
+                {
+                    "error": (
+                        "Too many login attempts. "
+                        "Please wait a minute and try again."
+                    )
+                },
+                status=429,
+            )
+
         token = request.POST.get("token")
         if token:
             return self._authenticate_with_token(request, token)

--- a/config/admin_auth/views.py
+++ b/config/admin_auth/views.py
@@ -165,7 +165,9 @@ class Auth0AdminLoginView(View):
     template_name = "admin/auth0_login.html"
 
     @method_decorator(csrf_protect)
-    @method_decorator(ratelimit(key=_ratelimit_ip_key, rate=ADMIN_LOGIN_PAGE_RATE, block=False))
+    @method_decorator(
+        ratelimit(key=_ratelimit_ip_key, rate=ADMIN_LOGIN_PAGE_RATE, block=False)
+    )
     def get(self, request):
         """Display the appropriate login form."""
         if getattr(request, "limited", False):
@@ -204,7 +206,9 @@ class Auth0AdminLoginView(View):
         return render(request, self.template_name, context)
 
     @method_decorator(csrf_protect)
-    @method_decorator(ratelimit(key=_ratelimit_ip_key, rate=ADMIN_LOGIN_RATE, block=False))
+    @method_decorator(
+        ratelimit(key=_ratelimit_ip_key, rate=ADMIN_LOGIN_RATE, block=False)
+    )
     def post(self, request):
         """Handle token-based login via POST or password authentication."""
         if getattr(request, "limited", False):

--- a/config/settings/ratelimit.py
+++ b/config/settings/ratelimit.py
@@ -32,6 +32,7 @@ RATELIMIT_FAIL_OPEN = False
 # Override specific rate limits from environment if provided
 RATE_LIMIT_OVERRIDES = {
     "AUTH_LOGIN": os.environ.get("RATELIMIT_AUTH_LOGIN"),
+    "ADMIN_LOGIN_PAGE": os.environ.get("RATELIMIT_ADMIN_LOGIN_PAGE"),
     "AUTH_REGISTER": os.environ.get("RATELIMIT_AUTH_REGISTER"),
     "AUTH_PASSWORD_RESET": os.environ.get("RATELIMIT_AUTH_PASSWORD_RESET"),
     "READ_LIGHT": os.environ.get("RATELIMIT_READ_LIGHT"),

--- a/opencontractserver/templates/admin/auth0_login.html
+++ b/opencontractserver/templates/admin/auth0_login.html
@@ -187,6 +187,8 @@
                 <span>Authenticating...</span>
             </div>
 
+            <ul id="client-messages" class="messages" style="display:none;"></ul>
+
             <form id="login-form" method="post">
                 {% csrf_token %}
                 <input type="hidden" name="next" value="{{ next }}">
@@ -217,6 +219,93 @@
         </div>
     </main>
 
+    <!-- Shared helpers for rate-limit handling (always available) -->
+    <script>
+        function showMessage(text, type) {
+            var container = document.getElementById('client-messages');
+            container.style.display = '';
+            var li = document.createElement('li');
+            li.className = type || 'error';
+            li.textContent = text;
+            container.appendChild(li);
+        }
+
+        function clearClientMessages() {
+            var container = document.getElementById('client-messages');
+            container.innerHTML = '';
+            container.style.display = 'none';
+        }
+
+        function showLoading(show) {
+            var loading = document.getElementById('loading');
+            var form = document.getElementById('login-form');
+            if (show) {
+                loading.classList.add('active');
+                form.style.display = 'none';
+            } else {
+                loading.classList.remove('active');
+                form.style.display = 'block';
+            }
+        }
+
+        /**
+         * Submit form data via fetch and handle rate-limit (429) responses.
+         * On success the browser is navigated to the redirect target.
+         * On 429 a user-friendly message is shown in-page.
+         */
+        async function submitFormViaFetch(formData) {
+            var form = document.getElementById('login-form');
+            var url = form.action || window.location.pathname;
+
+            try {
+                var response = await fetch(url, {
+                    method: 'POST',
+                    body: formData,
+                });
+
+                if (response.status === 429) {
+                    try {
+                        var data = await response.json();
+                        showMessage(data.error || 'Too many login attempts. Please wait and try again.', 'error');
+                    } catch (e) {
+                        showMessage('Too many login attempts. Please wait and try again.', 'error');
+                    }
+                    showLoading(false);
+                    return;
+                }
+
+                // fetch follows redirects automatically.
+                // On success the server redirects to /admin/ and response.url
+                // reflects the final destination. On auth failure it redirects
+                // back to /admin/login/ where server-set messages are displayed.
+                if (response.redirected && response.url) {
+                    window.location.href = response.url;
+                } else {
+                    window.location.reload();
+                }
+            } catch (error) {
+                console.error('Form submission error:', error);
+                showMessage('An error occurred. Please try again.', 'error');
+                showLoading(false);
+            }
+        }
+
+        // Intercept the standard password form submission so we can
+        // inspect the response status and show rate-limit errors in-page
+        // instead of displaying raw JSON.
+        document.getElementById('login-form').addEventListener('submit', function(e) {
+            // Skip interception when the token field is populated because
+            // that path is handled by submitToken() directly.
+            if (document.getElementById('token-input').value) {
+                return;
+            }
+
+            e.preventDefault();
+            clearClientMessages();
+            submitFormViaFetch(new FormData(this));
+        });
+    </script>
+
     {% if use_auth0 %}
     <!-- Define error handler before loading Auth0 SDK -->
     <script>
@@ -236,7 +325,7 @@
             crossorigin="anonymous"
             onerror="handleScriptError()"></script>
     <script>
-        let auth0Client = null;
+        var auth0Client = null;
 
         async function initAuth0() {
             // Check if Auth0 SDK loaded successfully
@@ -261,9 +350,9 @@
                     showLoading(true);
                     try {
                         await auth0Client.handleRedirectCallback();
-                        const token = await auth0Client.getTokenSilently();
+                        var token = await auth0Client.getTokenSilently();
                         // Restore the next URL from localStorage
-                        const nextUrl = localStorage.getItem('admin_auth0_next') || '/admin/';
+                        var nextUrl = localStorage.getItem('admin_auth0_next') || '/admin/';
                         localStorage.removeItem('admin_auth0_next');
                         submitToken(token, nextUrl);
                     } catch (error) {
@@ -277,7 +366,7 @@
             } catch (error) {
                 console.error('Auth0 initialization error:', error);
                 // Disable Auth0 button if initialization fails
-                const btn = document.getElementById('auth0-login-btn');
+                var btn = document.getElementById('auth0-login-btn');
                 if (btn) {
                     btn.disabled = true;
                     btn.textContent = 'Auth0 unavailable';
@@ -306,24 +395,14 @@
             }
         }
 
-        function submitToken(token, nextUrl) {
+        async function submitToken(token, nextUrl) {
+            var form = document.getElementById('login-form');
             document.getElementById('token-input').value = token;
             if (nextUrl) {
-                document.querySelector('input[name="next"]').value = nextUrl;
+                form.querySelector('input[name="next"]').value = nextUrl;
             }
-            document.getElementById('login-form').submit();
-        }
-
-        function showLoading(show) {
-            const loading = document.getElementById('loading');
-            const form = document.getElementById('login-form');
-            if (show) {
-                loading.classList.add('active');
-                form.style.display = 'none';
-            } else {
-                loading.classList.remove('active');
-                form.style.display = 'block';
-            }
+            clearClientMessages();
+            await submitFormViaFetch(new FormData(form));
         }
 
         // Initialize Auth0 when page loads

--- a/opencontractserver/tests/test_admin_auth.py
+++ b/opencontractserver/tests/test_admin_auth.py
@@ -5,11 +5,13 @@ This module tests:
 - Admin claims sync from Auth0 tokens
 - Auth0AdminBackend authentication
 - Auth0AdminLoginView and Auth0AdminLogoutView
+- Rate limiting on admin login endpoints
 """
 
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
+from django.core.cache import cache
 from django.test import Client, TestCase, override_settings
 
 User = get_user_model()
@@ -568,6 +570,8 @@ class TestAdminLoginView(TestCase):
 
     def setUp(self):
         self.client = Client()
+        # Clear the rate-limit cache so each test starts with a fresh budget
+        cache.clear()
 
     def test_get_login_page(self):
         """GET request should return login page."""
@@ -950,3 +954,102 @@ class TestGetUserByPayloadWithClaimSync(TestCase):
         self.user.refresh_from_db()
         self.assertTrue(self.user.is_staff)
         self.assertTrue(self.user.is_superuser)
+
+
+@override_settings(
+    RATELIMIT_ENABLE=True,
+    RATELIMIT_DISABLE=False,
+    CACHES={
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "admin-login-ratelimit-test",
+        }
+    },
+)
+class TestAdminLoginRateLimit(TestCase):
+    """Tests for rate limiting on the admin login endpoint."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.staff_user = User.objects.create_user(
+            username="ratelimit_test",
+            email="ratelimit@example.com",
+            password="testpass123",
+            is_staff=True,
+        )
+
+    def setUp(self):
+        self.client = Client()
+        # Clear the rate-limit cache before each test to ensure isolation
+        cache.clear()
+
+    def test_post_rate_limit_returns_429(self):
+        """Login POST should return 429 after exceeding the rate limit."""
+        # Default rate is 5/m. Send 5 requests to exhaust the limit.
+        for _ in range(5):
+            self.client.post(
+                "/admin/login/",
+                {"username": "wrong", "password": "wrong"},
+            )
+
+        # The 6th request should be rate-limited
+        response = self.client.post(
+            "/admin/login/",
+            {"username": "wrong", "password": "wrong"},
+        )
+
+        self.assertEqual(response.status_code, 429)
+        data = response.json()
+        self.assertIn("error", data)
+        self.assertIn("Too many login attempts", data["error"])
+
+    def test_post_rate_limit_json_content_type(self):
+        """Rate-limited POST should return application/json."""
+        for _ in range(5):
+            self.client.post(
+                "/admin/login/",
+                {"username": "wrong", "password": "wrong"},
+            )
+
+        response = self.client.post(
+            "/admin/login/",
+            {"username": "wrong", "password": "wrong"},
+        )
+
+        self.assertEqual(response.status_code, 429)
+        self.assertEqual(response["Content-Type"], "application/json")
+
+    def test_successful_login_still_works_within_limit(self):
+        """Valid credentials should still succeed within the rate limit."""
+        response = self.client.post(
+            "/admin/login/",
+            {"username": "ratelimit_test", "password": "testpass123"},
+            follow=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.wsgi_request.user.is_authenticated)
+
+    def test_get_rate_limit_returns_429(self):
+        """Login page GET should return 429 after exceeding the rate limit."""
+        # Default GET rate is 20/m. Send 20 requests to exhaust.
+        for _ in range(20):
+            self.client.get("/admin/login/")
+
+        response = self.client.get("/admin/login/")
+
+        self.assertEqual(response.status_code, 429)
+        self.assertIn(
+            "Too many requests",
+            response.content.decode(),
+        )
+
+    def test_get_rate_limit_plain_text(self):
+        """Rate-limited GET should return text/plain."""
+        for _ in range(20):
+            self.client.get("/admin/login/")
+
+        response = self.client.get("/admin/login/")
+
+        self.assertEqual(response.status_code, 429)
+        self.assertEqual(response["Content-Type"], "text/plain")


### PR DESCRIPTION
## Summary
- Add IP-based rate limiting to admin login endpoints using `django-ratelimit` (5/m POST, 20/m GET), configurable via `RATE_LIMIT_OVERRIDES` setting
- Fix Auth0 logout `returnTo` URL to redirect to `/admin/login/` instead of root `/`, which caused users to land on the frontend app at port 3000 instead of the admin login page
- Handle 429 responses in the login template via `fetch()` so rate-limit errors display inline instead of showing raw JSON
- Update Auth0 Allowed Logout URLs in docs to include `/admin/login/`

## Test plan
- [ ] Verify admin logout redirects back to `/admin/login/` (not `localhost:3000`)
- [ ] Verify rate limiting triggers 429 after 5 failed POST login attempts within a minute
- [ ] Verify rate limiting triggers 429 after 20 GET requests to login page within a minute
- [ ] Verify rate-limit error messages display inline in the login page (not raw JSON)
- [ ] Verify successful login still works within rate limits
- [ ] Verify Auth0 `returnTo` URL is accepted (must be in Auth0 dashboard Allowed Logout URLs)
- [ ] Run `TestAdminLoginRateLimit` test class to confirm all rate-limit tests pass