### PR TITLE
Prevent deletion of personal 'My Documents' corpus

### DIFF
--- a/config/graphql/mutations.py
+++ b/config/graphql/mutations.py
@@ -3838,6 +3838,21 @@ class DeleteCorpusMutation(DRFDeletion):
     class Arguments:
         id = graphene.String(required=True)
 
+    @classmethod
+    @login_required
+    @graphql_ratelimit(rate=RateLimits.WRITE_LIGHT)
+    def mutate(cls, root, info, *args, **kwargs):
+        id = from_global_id(kwargs.get(cls.IOSettings.lookup_field, None))[1]
+        obj = cls.IOSettings.model.objects.get(pk=id)
+
+        if obj.is_personal:
+            raise GraphQLError(
+                "Cannot delete your personal 'My Documents' corpus. "
+                "This corpus is automatically managed and stores your uploaded documents."
+            )
+
+        return super().mutate(root, info, *args, **kwargs)
+
 
 class CreateLabelMutation(DRFMutation):
     class IOSettings:

--- a/frontend/src/components/corpuses/CorpusListView.tsx
+++ b/frontend/src/components/corpuses/CorpusListView.tsx
@@ -777,7 +777,7 @@ export const CorpusListView: React.FC<CorpusListViewProps> = ({
                             }}
                           />
                         )}
-                        {canRemove && (
+                        {canRemove && !corpus.isPersonal && (
                           <Menu.Item
                             className="danger"
                             icon="trash"

--- a/frontend/src/graphql/queries.ts
+++ b/frontend/src/graphql/queries.ts
@@ -605,6 +605,7 @@ export const GET_CORPUSES = gql`
           }
           description
           isPublic
+          isPersonal
           is_selected @client
           is_open @client
           myPermissions

--- a/frontend/src/types/graphql-api.ts
+++ b/frontend/src/types/graphql-api.ts
@@ -306,6 +306,7 @@ export type RawCorpusType = Node & {
   allAnnotationSummaries?: ServerAnnotationType[];
   analyses: AnalysisTypeConnection;
   isPublic?: Scalars["Boolean"];
+  isPersonal?: Scalars["Boolean"];
   myPermissions?: string[];
   conversations?: ConversationTypeConnection;
   // Note: categories is returned as a List (array), not a Connection, from the backend

--- a/opencontractserver/tests/test_personal_corpus.py
+++ b/opencontractserver/tests/test_personal_corpus.py
@@ -905,3 +905,76 @@ class TestDocumentVersioningHelpers(TestCase):
         self.assertIsNotNone(result)
         # Should have a .bin extension for unknown type
         self.assertTrue(result.name.endswith(".bin"))
+
+
+class TestPersonalCorpusDeletionProtection(TestCase):
+    """Tests that personal corpus cannot be deleted via GraphQL mutation."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username=f"testuser_{uuid.uuid4().hex[:8]}",
+            email=f"test_{uuid.uuid4().hex[:8]}@example.com",
+            password="testpass123",
+        )
+        self.client = Client(schema, context_value=TestContext(self.user))
+
+        self.delete_mutation = """
+            mutation($id: String!) {
+                deleteCorpus(id: $id) {
+                    ok
+                    message
+                }
+            }
+        """
+
+    def test_cannot_delete_personal_corpus(self):
+        """Deleting a personal corpus via GraphQL should be blocked."""
+        from graphql_relay import to_global_id
+
+        from opencontractserver.utils.permissioning import (
+            set_permissions_for_obj_to_user,
+        )
+
+        personal_corpus = Corpus.objects.get(creator=self.user, is_personal=True)
+        set_permissions_for_obj_to_user(
+            self.user, personal_corpus, [PermissionTypes.CRUD]
+        )
+
+        variables = {"id": to_global_id("CorpusType", personal_corpus.pk)}
+        result = self.client.execute(self.delete_mutation, variable_values=variables)
+
+        # Should return an error
+        self.assertIn("errors", result)
+        error_message = result["errors"][0]["message"]
+        self.assertIn("Cannot delete", error_message)
+        self.assertIn("My Documents", error_message)
+
+        # Corpus should still exist
+        self.assertTrue(Corpus.objects.filter(pk=personal_corpus.pk).exists())
+
+    def test_can_delete_non_personal_corpus(self):
+        """Deleting a non-personal corpus should still work normally."""
+        from graphql_relay import to_global_id
+
+        from opencontractserver.utils.permissioning import (
+            set_permissions_for_obj_to_user,
+        )
+
+        regular_corpus = Corpus.objects.create(
+            title="Regular Corpus",
+            creator=self.user,
+            is_personal=False,
+        )
+        set_permissions_for_obj_to_user(
+            self.user, regular_corpus, [PermissionTypes.CRUD]
+        )
+
+        variables = {"id": to_global_id("CorpusType", regular_corpus.pk)}
+        result = self.client.execute(self.delete_mutation, variable_values=variables)
+
+        # Should succeed
+        self.assertNotIn("errors", result)
+        self.assertTrue(result["data"]["deleteCorpus"]["ok"])
+
+        # Corpus should be deleted
+        self.assertFalse(Corpus.objects.filter(pk=regular_corpus.pk).exists())


### PR DESCRIPTION
## Summary
This PR adds protection against accidental deletion of the personal "My Documents" corpus by blocking deletion attempts at both the GraphQL API and UI levels.

## Key Changes
- **Backend Protection**: Added validation in the `deleteCorpus` GraphQL mutation to reject deletion requests for personal corpora with a clear error message
- **Frontend Protection**: Updated the corpus list view to hide the delete button for personal corpora
- **GraphQL Schema**: Added `isPersonal` field to the corpus type to expose personal corpus status to the frontend
- **Tests**: Added comprehensive test coverage for the deletion protection logic, including:
  - Test that personal corpus deletion is blocked via GraphQL
  - Test that non-personal corpus deletion still works normally

## Implementation Details
- The backend validation uses the existing `is_personal` flag on the Corpus model to determine if a corpus is the user's personal corpus
- Error message clearly explains that the personal corpus is automatically managed and stores uploaded documents
- Frontend conditionally renders the delete menu item based on both `canRemove` permission and `!corpus.isPersonal` status
- Tests verify both the error case (personal corpus) and the success case (regular corpus) to ensure the feature doesn't break normal deletion workflows

https://claude.ai/code/session_01YDfXCjUK7ARgfobeyYZXs9