### PR TITLE
Address PR review feedback for nested approval gates

### DIFF
--- a/frontend/src/components/corpuses/CorpusChat.tsx
+++ b/frontend/src/components/corpuses/CorpusChat.tsx
@@ -842,6 +842,27 @@ export const CorpusChat: React.FC<CorpusChatProps> = ({
   } | null>(null);
   const [showApprovalModal, setShowApprovalModal] = useState<boolean>(false);
 
+  /**
+   * Update approval status on a message in both chat and serverMessages arrays.
+   * Mirrors the updateMessageApprovalStatus helper in ChatTray / useAgentChat.
+   */
+  const updateMessageApprovalStatus = useCallback(
+    (
+      messageId: string,
+      status: "awaiting" | "approved" | "rejected",
+      opts?: { isComplete?: boolean }
+    ): void => {
+      const patch: Partial<ChatMessageProps> = { approvalStatus: status };
+      if (opts?.isComplete) patch.isComplete = true;
+
+      const mapper = (msg: ChatMessageProps) =>
+        msg.messageId === messageId ? { ...msg, ...patch } : msg;
+      setChat((prev) => prev.map(mapper));
+      setServerMessages((prev) => prev.map(mapper));
+    },
+    []
+  );
+
   // Query for listing CORPUS conversations
   const {
     data,
@@ -1048,20 +1069,7 @@ export const CorpusChat: React.FC<CorpusChatProps> = ({
               setShowApprovalModal(true);
 
               // Mark the message as awaiting approval
-              setChat((prev) =>
-                prev.map((msg) =>
-                  msg.messageId === data.message_id
-                    ? { ...msg, approvalStatus: "awaiting" as const }
-                    : msg
-                )
-              );
-              setServerMessages((prev) =>
-                prev.map((msg) =>
-                  msg.messageId === data.message_id
-                    ? { ...msg, approvalStatus: "awaiting" as const }
-                    : msg
-                )
-              );
+              updateMessageApprovalStatus(data.message_id, "awaiting");
             }
             break;
           case "ASYNC_APPROVAL_RESULT":
@@ -1073,20 +1081,10 @@ export const CorpusChat: React.FC<CorpusChatProps> = ({
               setPendingApproval(null);
               setShowApprovalModal(false);
               if (data?.decision) {
-                const status = data.decision as "approved" | "rejected";
-                setChat((prev) =>
-                  prev.map((msg) =>
-                    msg.messageId === data.message_id
-                      ? { ...msg, approvalStatus: status, isComplete: true }
-                      : msg
-                  )
-                );
-                setServerMessages((prev) =>
-                  prev.map((msg) =>
-                    msg.messageId === data.message_id
-                      ? { ...msg, approvalStatus: status, isComplete: true }
-                      : msg
-                  )
+                updateMessageApprovalStatus(
+                  data.message_id,
+                  data.decision as "approved" | "rejected",
+                  { isComplete: true }
                 );
               }
             }

--- a/frontend/src/components/corpuses/CorpusChat.tsx
+++ b/frontend/src/components/corpuses/CorpusChat.tsx
@@ -860,7 +860,7 @@ export const CorpusChat: React.FC<CorpusChatProps> = ({
       setChat((prev) => prev.map(mapper));
       setServerMessages((prev) => prev.map(mapper));
     },
-    []
+    [setChat, setServerMessages]
   );
 
   // Query for listing CORPUS conversations

--- a/frontend/src/components/knowledge_base/document/right_tray/ChatTray.tsx
+++ b/frontend/src/components/knowledge_base/document/right_tray/ChatTray.tsx
@@ -912,6 +912,11 @@ export const ChatTray: React.FC<ChatTrayProps> = ({
             mergeSourcesIntoMessage(data?.sources, data?.message_id);
             break;
           case "ASYNC_APPROVAL_NEEDED":
+            // NOTE: No sub-tool unwrapping (_sub_tool_name) needed here.
+            // ChatTray handles document-level chat which talks to a document
+            // agent directly — it never goes through ask_document, so nested
+            // sub-agent approvals don't occur. Sub-tool unwrapping is only
+            // relevant in CorpusChat.
             if (data?.pending_tool_call && data?.message_id) {
               setPendingApproval({
                 messageId: data.message_id,

--- a/frontend/src/hooks/useAgentChat.ts
+++ b/frontend/src/hooks/useAgentChat.ts
@@ -655,6 +655,11 @@ export function useAgentChat(options: UseAgentChatOptions): UseAgentChatReturn {
             break;
 
           case "ASYNC_APPROVAL_NEEDED":
+            // NOTE: No sub-tool unwrapping (_sub_tool_name) needed here.
+            // This hook is used for document-level and generic chat contexts
+            // that talk to agents directly — never via ask_document. Sub-tool
+            // unwrapping for nested corpus→document approvals lives only in
+            // CorpusChat.
             if (data?.pending_tool_call && data?.message_id) {
               setPendingApproval({
                 messageId: data.message_id,

--- a/opencontractserver/llms/agents/core_agents.py
+++ b/opencontractserver/llms/agents/core_agents.py
@@ -278,6 +278,12 @@ class AgentConfig:
     # Tool configuration
     tools: list[Any] = field(default_factory=list)
 
+    # Transient flag set by resume_with_approval() so that sub-agent closures
+    # (e.g. ask_document_tool) can bypass nested approval gates after the user
+    # has already approved.  Safe to mutate: AgentConfig is instantiated
+    # per-request via UnifiedAgentFactory, never shared across sessions.
+    _approval_bypass_allowed: bool = False
+
 
 @dataclass
 class DocumentAgentContext:

--- a/opencontractserver/llms/agents/pydantic_ai_agents.py
+++ b/opencontractserver/llms/agents/pydantic_ai_agents.py
@@ -320,7 +320,8 @@ class PydanticAICoreAgent(CoreAgentBase, TimelineStreamMixin):
         force_llm_id: int | None = None,
         force_user_msg_id: int | None = None,
         initial_timeline: list[dict] | None = None,
-        **kwargs,
+        deps: Any | None = None,
+        message_history: list[Any] | None = None,
     ) -> AsyncGenerator[UnifiedStreamEvent, None]:
         """Internal streaming generator – TimelineStreamMixin adds timeline."""
 
@@ -356,30 +357,33 @@ class PydanticAICoreAgent(CoreAgentBase, TimelineStreamMixin):
         final_usage_data: dict[str, Any] | None = None
 
         # Re-hydrate the historical context for Pydantic-AI, if any exists.
-        message_history = await self._get_message_history()
+        # Callers (e.g. resume_with_approval) may override via the explicit
+        # ``message_history`` param; otherwise we load from the DB.
+        effective_history = message_history
+        if effective_history is None:
+            effective_history = await self._get_message_history()
 
         # CRITICAL FIX: Exclude the most recent HUMAN message from history since
         # pydantic_ai.iter() will automatically add the current `message` parameter.
         # This prevents duplicate consecutive user messages which violate OpenAI's API contract.
-        if message_history:
+        if effective_history:
             # Remove the last message if it's a user prompt (HUMAN message)
-            if message_history and isinstance(message_history[-1], ModelRequest):
-                last_parts = message_history[-1].parts
+            if effective_history and isinstance(effective_history[-1], ModelRequest):
+                last_parts = effective_history[-1].parts
                 if last_parts and isinstance(last_parts[0], UserPromptPart):
                     logger.debug(
                         f"[Session {self.session_id if hasattr(self, 'session_id') else 'N/A'}] "
                         "Removing duplicate user message from history to prevent API error"
                     )
-                    message_history = message_history[:-1]
+                    effective_history = effective_history[:-1]
 
             # If history is now empty, set to None for pydantic_ai
-            if not message_history:
-                message_history = None
+            if not effective_history:
+                effective_history = None
 
-        stream_kwargs: dict[str, Any] = {"deps": self.agent_deps}
-        if message_history:
-            stream_kwargs["message_history"] = message_history
-        stream_kwargs.update(kwargs)
+        stream_kwargs: dict[str, Any] = {"deps": deps or self.agent_deps}
+        if effective_history:
+            stream_kwargs["message_history"] = effective_history
 
         # Timeline builder – captures reasoning steps for persistence/UI
         builder = TimelineBuilder()

--- a/opencontractserver/llms/agents/pydantic_ai_agents.py
+++ b/opencontractserver/llms/agents/pydantic_ai_agents.py
@@ -314,15 +314,17 @@ class PydanticAICoreAgent(CoreAgentBase, TimelineStreamMixin):
     # care of collecting the reasoning timeline.
 
     async def _stream_core(
-        self, message: str, **kwargs
+        self,
+        message: str,
+        *,
+        force_llm_id: int | None = None,
+        force_user_msg_id: int | None = None,
+        initial_timeline: list[dict] | None = None,
+        **kwargs,
     ) -> AsyncGenerator[UnifiedStreamEvent, None]:
         """Internal streaming generator – TimelineStreamMixin adds timeline."""
 
         logger.info(f"[PydanticAI stream] Starting stream with message: {message!r}")
-
-        # Extract optional overrides (used by resume_with_approval)
-        force_llm_id: int | None = kwargs.pop("force_llm_id", None)
-        force_user_msg_id: int | None = kwargs.pop("force_user_msg_id", None)
 
         user_msg_id: int | None = force_user_msg_id
         llm_msg_id: int | None = force_llm_id
@@ -385,9 +387,6 @@ class PydanticAICoreAgent(CoreAgentBase, TimelineStreamMixin):
         # Allow callers (e.g. resume_with_approval) to inject pre-built
         # timeline entries so they appear in both the persisted DB record
         # and the FinalEvent sent to the frontend.
-        initial_timeline: list[dict] | None = stream_kwargs.pop(
-            "initial_timeline", None
-        )
         if initial_timeline:
             for entry in initial_timeline:
                 builder.add(entry)
@@ -1251,7 +1250,7 @@ class PydanticAICoreAgent(CoreAgentBase, TimelineStreamMixin):
             # Signal post-approval context so closures (e.g. ask_document_tool)
             # can bypass sub-agent approval gates without exposing a parameter
             # that the LLM could abuse.
-            self.config._approval_bypass_allowed = True  # type: ignore[attr-defined]
+            self.config._approval_bypass_allowed = True
 
             # Try to execute the tool
             tool_executed = False
@@ -1327,7 +1326,7 @@ class PydanticAICoreAgent(CoreAgentBase, TimelineStreamMixin):
                         )
                         raise
             finally:
-                self.config._approval_bypass_allowed = False  # type: ignore[attr-defined]
+                self.config._approval_bypass_allowed = False
 
             tool_result = {"result": result}
             status_str = "approved"
@@ -1373,6 +1372,12 @@ class PydanticAICoreAgent(CoreAgentBase, TimelineStreamMixin):
         # so the LLM sees a proper tool-call / tool-return pair when it resumes.
         # Without this the LLM receives a text continuation prompt and often
         # re-invokes the same tool, creating an infinite approval loop.
+        #
+        # NOTE: These entries are injected as *historical context*, not live
+        # tool calls.  pydantic-ai's iter() treats message_history entries as
+        # past state and does NOT re-evaluate requires_approval for them.
+        # The actual tool execution has already completed above, so there is
+        # no risk of re-triggering the approval gate here.
         tool_call_id = pending.get("tool_call_id") or str(uuid4())
         if approved:
             resume_history = await self._get_message_history() or []

--- a/opencontractserver/tests/test_nested_approval_gates.py
+++ b/opencontractserver/tests/test_nested_approval_gates.py
@@ -219,6 +219,20 @@ class TestNestedApprovalGates(TransactionTestCase):
         self.assertIsNotNone(fn, "ask_document tool not found in effective_tools")
         return fn
 
+    def _make_ctx(self, *, skip_approval_gate: bool = False):
+        """Build a lightweight tool-call context stub for ask_document tests."""
+
+        class _Ctx:
+            tool_call_id = "test-call"
+            deps = types.SimpleNamespace(
+                skip_approval_gate=skip_approval_gate,
+                user_id=self.user.id,
+                document_id=self.document.id,
+                corpus_id=self.corpus.id,
+            )
+
+        return _Ctx()
+
     # ------------------------------------------------------------------
     # Tests: ask_document_tool approval propagation
     # ------------------------------------------------------------------
@@ -234,19 +248,11 @@ class TestNestedApprovalGates(TransactionTestCase):
             new_callable=AsyncMock,
             return_value=agent._mock_sub_agent,
         ):
-
-            class _Ctx:
-                tool_call_id = "test-call"
-                deps = types.SimpleNamespace(
-                    skip_approval_gate=False,
-                    user_id=self.user.id,
-                    document_id=self.document.id,
-                    corpus_id=self.corpus.id,
-                )
+            ctx = self._make_ctx()
 
             with self.assertRaises(ToolConfirmationRequired) as cm:
                 await ask_doc_fn(
-                    _Ctx(),
+                    ctx,
                     document_id=self.document.id,
                     question="What is this document about?",
                 )
@@ -277,18 +283,10 @@ class TestNestedApprovalGates(TransactionTestCase):
             new_callable=AsyncMock,
             return_value=agent._mock_sub_agent,
         ):
-
-            class _Ctx:
-                tool_call_id = "test-call"
-                deps = types.SimpleNamespace(
-                    skip_approval_gate=False,
-                    user_id=self.user.id,
-                    document_id=self.document.id,
-                    corpus_id=self.corpus.id,
-                )
+            ctx = self._make_ctx()
 
             result = await ask_doc_fn(
-                _Ctx(),
+                ctx,
                 document_id=self.document.id,
                 question="What is this document about?",
             )
@@ -321,18 +319,10 @@ class TestNestedApprovalGates(TransactionTestCase):
             new_callable=AsyncMock,
             return_value=agent._mock_sub_agent,
         ):
-
-            class _Ctx:
-                tool_call_id = "test-call"
-                deps = types.SimpleNamespace(
-                    skip_approval_gate=False,
-                    user_id=self.user.id,
-                    document_id=self.document.id,
-                    corpus_id=self.corpus.id,
-                )
+            ctx = self._make_ctx()
 
             result = await ask_doc_fn(
-                _Ctx(),
+                ctx,
                 document_id=self.document.id,
                 question="Test",
             )
@@ -360,18 +350,10 @@ class TestNestedApprovalGates(TransactionTestCase):
             new_callable=AsyncMock,
             return_value=agent._mock_sub_agent,
         ):
-
-            class _Ctx:
-                tool_call_id = "test-call"
-                deps = types.SimpleNamespace(
-                    skip_approval_gate=False,
-                    user_id=self.user.id,
-                    document_id=self.document.id,
-                    corpus_id=self.corpus.id,
-                )
+            ctx = self._make_ctx()
 
             result = await ask_doc_fn(
-                _Ctx(),
+                ctx,
                 document_id=self.document.id,
                 question="Test",
             )
@@ -392,18 +374,10 @@ class TestNestedApprovalGates(TransactionTestCase):
             new_callable=AsyncMock,
             return_value=agent._mock_sub_agent,
         ):
-
-            class _Ctx:
-                tool_call_id = "test-call"
-                deps = types.SimpleNamespace(
-                    skip_approval_gate=False,
-                    user_id=self.user.id,
-                    document_id=self.document.id,
-                    corpus_id=self.corpus.id,
-                )
+            ctx = self._make_ctx()
 
             result = await ask_doc_fn(
-                _Ctx(),
+                ctx,
                 document_id=self.document.id,
                 question="Test",
             )
@@ -819,21 +793,13 @@ class TestNestedApprovalGates(TransactionTestCase):
             new_callable=AsyncMock,
             return_value=_MockSubAgent(normal_events),
         ) as mock_for_doc:
-
-            class _Ctx:
-                tool_call_id = "test-call"
-                deps = types.SimpleNamespace(
-                    skip_approval_gate=False,
-                    user_id=self.user.id,
-                    document_id=self.document.id,
-                    corpus_id=self.corpus.id,
-                )
+            ctx = self._make_ctx()
 
             # Simulate post-approval context
             agent.config._approval_bypass_allowed = True
             try:
                 await ask_doc_fn(
-                    _Ctx(),
+                    ctx,
                     document_id=self.document.id,
                     question="Test",
                 )
@@ -863,20 +829,12 @@ class TestNestedApprovalGates(TransactionTestCase):
             new_callable=AsyncMock,
             return_value=_MockSubAgent(normal_events),
         ) as mock_for_doc:
-
-            class _Ctx:
-                tool_call_id = "test-call"
-                deps = types.SimpleNamespace(
-                    skip_approval_gate=False,
-                    user_id=self.user.id,
-                    document_id=self.document.id,
-                    corpus_id=self.corpus.id,
-                )
+            ctx = self._make_ctx()
 
             self.assertFalse(getattr(agent.config, "_approval_bypass_allowed", False))
 
             await ask_doc_fn(
-                _Ctx(),
+                ctx,
                 document_id=self.document.id,
                 question="Test",
             )
@@ -1002,3 +960,24 @@ class TestNestedApprovalGates(TransactionTestCase):
         # Non-existent tool should return False
         result_missing = agent._check_tool_requires_approval("nonexistent_tool")
         self.assertFalse(result_missing)
+
+    async def test_update_corpus_description_requires_approval(self):
+        """update_corpus_description should be gated by requires_approval=True."""
+        agent = await self._create_corpus_agent()
+        tool_fn = _extract_tool(agent._effective_tools, "update_corpus_description")
+        self.assertIsNotNone(
+            tool_fn, "update_corpus_description tool not found in effective_tools"
+        )
+
+        # The tool callable should carry requires_approval via core_tool
+        core_tool = getattr(tool_fn, "core_tool", None)
+        if core_tool is not None:
+            self.assertTrue(
+                core_tool.requires_approval,
+                "update_corpus_description core_tool.requires_approval should be True",
+            )
+        # Also check the direct attribute set by the wrapper
+        self.assertTrue(
+            getattr(tool_fn, "requires_approval", False),
+            "update_corpus_description should have requires_approval=True",
+        )

--- a/opencontractserver/tests/test_nested_approval_gates.py
+++ b/opencontractserver/tests/test_nested_approval_gates.py
@@ -969,15 +969,18 @@ class TestNestedApprovalGates(TransactionTestCase):
             tool_fn, "update_corpus_description tool not found in effective_tools"
         )
 
-        # The tool callable should carry requires_approval via core_tool
+        # Both the underlying core_tool and the wrapper must carry the flag.
+        # Assert unconditionally so a regression where either is dropped is caught.
         core_tool = getattr(tool_fn, "core_tool", None)
-        if core_tool is not None:
-            self.assertTrue(
-                core_tool.requires_approval,
-                "update_corpus_description core_tool.requires_approval should be True",
-            )
-        # Also check the direct attribute set by the wrapper
+        self.assertIsNotNone(
+            core_tool,
+            "update_corpus_description wrapper should expose .core_tool attribute",
+        )
+        self.assertTrue(
+            core_tool.requires_approval,
+            "update_corpus_description core_tool.requires_approval should be True",
+        )
         self.assertTrue(
             getattr(tool_fn, "requires_approval", False),
-            "update_corpus_description should have requires_approval=True",
+            "update_corpus_description wrapper should have requires_approval=True",
         )


### PR DESCRIPTION
## Summary
Follow-up to the nested approval gates feature branch, addressing PR review feedback:

- Add `_approval_bypass_allowed` as a typed field on `AgentConfig`, removing `type: ignore` suppressions and documenting request-scoped safety
- Make `initial_timeline`, `force_llm_id`, `force_user_msg_id` explicit keyword params on `_stream_core` instead of fragile `kwargs.pop()` pattern
- Add safety comment on `ToolCallPart`/`ToolReturnPart` history injection explaining why it doesn't re-trigger approval gates
- Add test asserting `update_corpus_description` has `requires_approval=True`
- Extract `updateMessageApprovalStatus` helper in CorpusChat, replacing duplicated `setChat`/`setServerMessages` mapping logic (DRY)
- Document why ChatTray and useAgentChat don't need sub-tool unwrapping (`_sub_tool_name`)
- Extract `_make_ctx()` helper in tests, replacing 7 identical inline `_Ctx` class definitions

## Test plan
- [x] Pre-commit hooks pass (black, isort, flake8, prettier)
- [x] TypeScript compiles (`npx tsc --noEmit`)
- [ ] Backend tests pass: `docker compose -f test.yml run django pytest opencontractserver/tests/test_nested_approval_gates.py -n 4 --dist loadscope`
- [ ] New `test_update_corpus_description_requires_approval` test passes
- [ ] Frontend component tests pass: `yarn test:ct --reporter=list`