### PR TITLE
Store LLM model name in ChatMessage metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,15 @@ All notable changes to OpenContracts will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2026-02-12
+## [Unreleased] - 2026-02-19
+
+### Added
+
+#### Store Model Name in ChatMessage Metadata (#897)
+- **Automatic model name persistence**: The LLM model name from `AgentConfig` is now stored in the `data` JSON field of every `ChatMessage` produced by an agent, enabling debugging, auditing, and reproducibility
+  - `opencontractserver/llms/agents/core_agents.py` — `CoreConversationManager.complete_message()`, `store_llm_message()`, and `create_placeholder_message()` all write `data["model_name"]` from `self.config.model_name`
+- **Tests**: Four new async tests verifying model name storage across all message lifecycle paths
+  - `opencontractserver/tests/test_core_agents.py` — `test_complete_message_stores_model_name`, `test_complete_message_uses_default_model_name`, `test_store_llm_message_stores_model_name`, `test_placeholder_message_stores_model_name`
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Store Model Name in ChatMessage Metadata (#897)
 - **Automatic model name persistence**: The LLM model name from `AgentConfig` is now stored in the `data` JSON field of every `ChatMessage` produced by an agent, enabling debugging, auditing, and reproducibility
-  - `opencontractserver/llms/agents/core_agents.py` — `CoreConversationManager.complete_message()`, `store_llm_message()`, and `create_placeholder_message()` all write `data["model_name"]` from `self.config.model_name`
-- **Tests**: Four new async tests verifying model name storage across all message lifecycle paths
-  - `opencontractserver/tests/test_core_agents.py` — `test_complete_message_stores_model_name`, `test_complete_message_uses_default_model_name`, `test_store_llm_message_stores_model_name`, `test_placeholder_message_stores_model_name`
+  - `opencontractserver/llms/agents/core_agents.py` — all five `CoreConversationManager` message-writing methods now persist `data["model_name"]`:
+    - `create_placeholder_message()` and `store_llm_message()` — unconditional write at creation time
+    - `complete_message()`, `update_message()`, `mark_message_error()` — use `setdefault` to backfill without overwriting placeholder values
+- **Tests**: Seven new async tests verifying model name storage across all message lifecycle paths
+  - `opencontractserver/tests/test_core_agents.py` — covers explicit model name, default model name, all five methods, and `setdefault` preservation semantics
 
 ### Added
 

--- a/opencontractserver/llms/agents/core_agents.py
+++ b/opencontractserver/llms/agents/core_agents.py
@@ -1287,7 +1287,7 @@ class CoreConversationManager:
 
         data = message.data or {}
         data["completed_at"] = timezone.now().isoformat()
-        data["model_name"] = self.config.model_name
+        data.setdefault("model_name", self.config.model_name)
 
         if sources:
             data["sources"] = [source.to_dict() for source in sources]
@@ -1386,6 +1386,7 @@ class CoreConversationManager:
 
         data = message.data or {}
         data["updated_at"] = timezone.now().isoformat()
+        data.setdefault("model_name", self.config.model_name)
 
         if sources:
             data["sources"] = [source.to_dict() for source in sources]
@@ -1417,6 +1418,7 @@ class CoreConversationManager:
         data = message.data or {}
         data["error"] = error
         data["errored_at"] = timezone.now().isoformat()
+        data.setdefault("model_name", self.config.model_name)
         message.data = data
 
         await message.asave()

--- a/opencontractserver/llms/agents/core_agents.py
+++ b/opencontractserver/llms/agents/core_agents.py
@@ -1250,6 +1250,7 @@ class CoreConversationManager:
             data={
                 "state": MessageState.IN_PROGRESS,
                 "created_at": timezone.now().isoformat(),
+                "model_name": self.config.model_name,
             },
             state=MessageState.IN_PROGRESS,
         )
@@ -1286,6 +1287,7 @@ class CoreConversationManager:
 
         data = message.data or {}
         data["completed_at"] = timezone.now().isoformat()
+        data["model_name"] = self.config.model_name
 
         if sources:
             data["sources"] = [source.to_dict() for source in sources]
@@ -1348,6 +1350,7 @@ class CoreConversationManager:
         data = {
             "state": MessageState.COMPLETED,
             "created_at": timezone.now().isoformat(),
+            "model_name": self.config.model_name,
         }
 
         if sources:

--- a/opencontractserver/tests/test_core_agents.py
+++ b/opencontractserver/tests/test_core_agents.py
@@ -290,7 +290,7 @@ class TestCoreConversationManager(TestCoreAgentComponentsSetup):
         msg_id = await manager.create_placeholder_message("LLM")
         await manager.complete_message(msg_id, "Response text")
         message = await ChatMessage.objects.aget(id=msg_id)
-        self.assertEqual(message.data["model_name"], "gpt-4o-mini")
+        self.assertEqual(message.data["model_name"], config.model_name)
 
     async def test_store_llm_message_stores_model_name(self):
         """store_llm_message() should persist the model name from AgentConfig."""
@@ -311,6 +311,45 @@ class TestCoreConversationManager(TestCoreAgentComponentsSetup):
         msg_id = await manager.create_placeholder_message("LLM")
         message = await ChatMessage.objects.aget(id=msg_id)
         self.assertEqual(message.data["model_name"], "gpt-4-turbo")
+
+    async def test_update_message_stores_model_name(self):
+        """update_message() should backfill model_name when absent."""
+        config = AgentConfig(user_id=self.user.id, model_name="gpt-4o")
+        manager = CoreConversationManager(
+            conversation=self.conversation1, user_id=self.user.id, config=config
+        )
+        msg_id = await manager.store_user_message("Original content")
+        await manager.update_message(msg_id, "Updated content")
+        message = await ChatMessage.objects.aget(id=msg_id)
+        self.assertEqual(message.data["model_name"], "gpt-4o")
+
+    async def test_mark_message_error_stores_model_name(self):
+        """mark_message_error() should backfill model_name when absent."""
+        config = AgentConfig(user_id=self.user.id, model_name="claude-3-opus")
+        manager = CoreConversationManager(
+            conversation=self.conversation1, user_id=self.user.id, config=config
+        )
+        msg_id = await manager.create_placeholder_message("LLM")
+        await manager.mark_message_error(msg_id, "Something went wrong")
+        message = await ChatMessage.objects.aget(id=msg_id)
+        self.assertEqual(message.data["model_name"], "claude-3-opus")
+        self.assertEqual(message.data["error"], "Something went wrong")
+
+    async def test_complete_message_preserves_placeholder_model_name(self):
+        """complete_message() should not overwrite model_name set by create_placeholder_message()."""
+        config = AgentConfig(user_id=self.user.id, model_name="gpt-4o")
+        manager = CoreConversationManager(
+            conversation=self.conversation1, user_id=self.user.id, config=config
+        )
+        msg_id = await manager.create_placeholder_message("LLM")
+
+        # Simulate config change between placeholder creation and completion
+        manager.config.model_name = "gpt-4o-mini"
+        await manager.complete_message(msg_id, "Response text")
+
+        message = await ChatMessage.objects.aget(id=msg_id)
+        # Placeholder value ("gpt-4o") should be preserved via setdefault
+        self.assertEqual(message.data["model_name"], "gpt-4o")
 
 
 class TestCoreAgentFactoriesDefaults(TestCoreAgentComponentsSetup):

--- a/opencontractserver/tests/test_core_agents.py
+++ b/opencontractserver/tests/test_core_agents.py
@@ -270,6 +270,48 @@ class TestCoreConversationManager(TestCoreAgentComponentsSetup):
         self.assertEqual(message.content, "Updated content")
         self.assertEqual(message.data["status"], "edited")
 
+    async def test_complete_message_stores_model_name(self):
+        """complete_message() should persist the model name from AgentConfig."""
+        config = AgentConfig(user_id=self.user.id, model_name="gpt-4o")
+        manager = CoreConversationManager(
+            conversation=self.conversation1, user_id=self.user.id, config=config
+        )
+        msg_id = await manager.create_placeholder_message("LLM")
+        await manager.complete_message(msg_id, "Response text")
+        message = await ChatMessage.objects.aget(id=msg_id)
+        self.assertEqual(message.data["model_name"], "gpt-4o")
+
+    async def test_complete_message_uses_default_model_name(self):
+        """complete_message() should use the default model name when none is explicitly set."""
+        config = AgentConfig(user_id=self.user.id)
+        manager = CoreConversationManager(
+            conversation=self.conversation1, user_id=self.user.id, config=config
+        )
+        msg_id = await manager.create_placeholder_message("LLM")
+        await manager.complete_message(msg_id, "Response text")
+        message = await ChatMessage.objects.aget(id=msg_id)
+        self.assertEqual(message.data["model_name"], "gpt-4o-mini")
+
+    async def test_store_llm_message_stores_model_name(self):
+        """store_llm_message() should persist the model name from AgentConfig."""
+        config = AgentConfig(user_id=self.user.id, model_name="claude-3-opus")
+        manager = CoreConversationManager(
+            conversation=self.conversation1, user_id=self.user.id, config=config
+        )
+        msg_id = await manager.store_llm_message("LLM response")
+        message = await ChatMessage.objects.aget(id=msg_id)
+        self.assertEqual(message.data["model_name"], "claude-3-opus")
+
+    async def test_placeholder_message_stores_model_name(self):
+        """create_placeholder_message() should persist the model name for traceability."""
+        config = AgentConfig(user_id=self.user.id, model_name="gpt-4-turbo")
+        manager = CoreConversationManager(
+            conversation=self.conversation1, user_id=self.user.id, config=config
+        )
+        msg_id = await manager.create_placeholder_message("LLM")
+        message = await ChatMessage.objects.aget(id=msg_id)
+        self.assertEqual(message.data["model_name"], "gpt-4-turbo")
+
 
 class TestCoreAgentFactoriesDefaults(TestCoreAgentComponentsSetup):
     # These test the default prompt generation, not full context creation


### PR DESCRIPTION
## Summary
This PR adds automatic persistence of the LLM model name from `AgentConfig` to the `data` JSON field of every `ChatMessage` created by agents. This enables better debugging, auditing, and reproducibility of agent interactions.

## Changes
- **Core functionality**: Modified `CoreConversationManager` to store `model_name` in message metadata across all message lifecycle paths:
  - `create_placeholder_message()` — stores model name when creating placeholder messages
  - `complete_message()` — stores model name when completing messages
  - `store_llm_message()` — stores model name when storing LLM responses

- **Test coverage**: Added four comprehensive async tests to verify model name storage:
  - `test_complete_message_stores_model_name()` — verifies explicit model name is persisted
  - `test_complete_message_uses_default_model_name()` — verifies default model name fallback
  - `test_store_llm_message_stores_model_name()` — verifies model name in direct LLM message storage
  - `test_placeholder_message_stores_model_name()` — verifies model name in placeholder creation

## Implementation Details
- Model name is sourced from `self.config.model_name` in all three methods
- The model name is stored in the `data["model_name"]` field alongside other metadata like timestamps and state
- This provides full traceability of which model generated each message without requiring schema changes

https://claude.ai/code/session_01TcZeYwDsKLqzCKRCexsg5E