### PR TITLE
Fix: Consolidate document edit modal and implement save functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to OpenContracts will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - 2026-02-19
+
+### Fixed
+
+#### Edit Description Modal Does Not Save on Update (Issue #899)
+- **Root cause**: The edit document CRUDModal in `App.tsx` had a no-op `onSubmit` handler that only closed the modal without calling the `UPDATE_DOCUMENT` mutation, so changes were silently discarded
+  - File: `frontend/src/App.tsx` (lines 128-149, 398)
+- **Fix**: Added `useMutation` hook for `UPDATE_DOCUMENT` in `App.tsx` with proper `onCompleted`/`onError` handlers and `refetchQueries: "active"` to refresh displayed data
+- **Removed duplicate modals**: `Documents.tsx` rendered its own edit/view CRUDModals controlled by the same `editingDocument` reactive var as `App.tsx`, causing potential double-modal rendering. Removed the duplicates from `Documents.tsx` and consolidated into the global `App.tsx` handler
+  - File: `frontend/src/views/Documents.tsx` (removed ~45 lines of duplicate modal + mutation code)
+
 ## [Unreleased] - 2026-02-12
 
 ### Added

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,7 +16,7 @@ import { Container } from "semantic-ui-react";
 
 import { toast, ToastContainer } from "react-toastify";
 
-import { useQuery, useReactiveVar } from "@apollo/client";
+import { useMutation, useQuery, useReactiveVar } from "@apollo/client";
 
 import {
   authToken,
@@ -38,6 +38,11 @@ import {
   selectedFolderId,
 } from "./graphql/cache";
 import { GET_ME, GetMeOutputs } from "./graphql/queries";
+import {
+  UPDATE_DOCUMENT,
+  UpdateDocumentInputs,
+  UpdateDocumentOutputs,
+} from "./graphql/mutations";
 
 import { NavMenu } from "./components/layout/NavMenu";
 import { Footer } from "./components/layout/Footer";
@@ -119,6 +124,29 @@ export const App = () => {
 
   // Auth0 hooks for conditional rendering only
   const { isLoading } = useAuth0();
+
+  const [tryUpdateDocument] = useMutation<
+    UpdateDocumentOutputs,
+    UpdateDocumentInputs
+  >(UPDATE_DOCUMENT, {
+    onCompleted: () => {
+      toast.success("Document updated successfully");
+      editingDocument(null);
+    },
+    onError: (error) => {
+      toast.error(`Failed to update document: ${error.message}`);
+    },
+    refetchQueries: "active",
+  });
+
+  const handleUpdateDocument = useCallback(
+    (document_obj: Record<string, unknown>) => {
+      tryUpdateDocument({
+        variables: document_obj as unknown as UpdateDocumentInputs,
+      });
+    },
+    [tryUpdateDocument]
+  );
 
   const handleKnowledgeBaseModalClose = useCallback(() => {
     showKnowledgeBaseModal({
@@ -367,9 +395,7 @@ export const App = () => {
                 modelName="document"
                 uiSchema={editDocForm_Ui_Schema}
                 dataSchema={editDocForm_Schema}
-                onSubmit={() => {
-                  editingDocument(null);
-                }}
+                onSubmit={handleUpdateDocument}
                 onClose={() => editingDocument(null)}
                 acceptedFileTypes="pdf"
                 hasFile={true}

--- a/frontend/src/views/Documents.tsx
+++ b/frontend/src/views/Documents.tsx
@@ -33,9 +33,6 @@ import {
   DeleteMultipleDocumentsInputs,
   DeleteMultipleDocumentsOutputs,
   DELETE_MULTIPLE_DOCUMENTS,
-  UpdateDocumentInputs,
-  UpdateDocumentOutputs,
-  UPDATE_DOCUMENT,
 } from "../graphql/mutations";
 import {
   RequestDocumentsInputs,
@@ -58,15 +55,10 @@ import {
   backendUserObj,
 } from "../graphql/cache";
 
-import { CRUDModal } from "../components/widgets/CRUD/CRUDModal";
 import { FilterToLabelSelector } from "../components/widgets/model-filters/FilterToLabelSelector";
 import { DocumentType, LabelType } from "../types/graphql-api";
 import { AddToCorpusModal } from "../components/modals/AddToCorpusModal";
 import { ConfirmModal } from "../components/widgets/modals/ConfirmModal";
-import {
-  editDocForm_Schema,
-  editDocForm_Ui_Schema,
-} from "../components/forms/schemas";
 import { FilterToLabelsetSelector } from "../components/widgets/model-filters/FilterToLabelsetSelector";
 import { FilterToCorpusSelector } from "../components/widgets/model-filters/FilterToCorpusSelector";
 import { BulkUploadModal } from "../components/widgets/modals/BulkUploadModal";
@@ -876,8 +868,6 @@ function getDocumentType(doc: DocumentType): string {
 export const Documents = () => {
   const current_user = useReactiveVar(userObj);
   const backend_user = useReactiveVar(backendUserObj);
-  const document_to_edit = useReactiveVar(editingDocument);
-  const document_to_view = useReactiveVar(viewingDocument);
   const show_bulk_upload_modal = useReactiveVar(showBulkUploadModal);
   const show_upload_new_documents_modal = useReactiveVar(
     showUploadNewDocumentsModal
@@ -1075,25 +1065,6 @@ export const Documents = () => {
     }
   };
 
-  const [tryUpdateDocument] = useMutation<
-    UpdateDocumentOutputs,
-    UpdateDocumentInputs
-  >(UPDATE_DOCUMENT, {
-    onCompleted: () => {
-      toast.success("Document updated successfully");
-      refetchDocuments();
-    },
-    onError: (error) => {
-      toast.error(`Failed to update document: ${error.message}`);
-    },
-  });
-
-  const handleUpdateDocument = (document_obj: Record<string, unknown>) => {
-    tryUpdateDocument({
-      variables: document_obj as unknown as UpdateDocumentInputs,
-    });
-  };
-
   // Infinite scroll
   const handleFetchMore = useCallback(() => {
     if (
@@ -1246,36 +1217,6 @@ export const Documents = () => {
           toggleModal={() => showDeleteDocumentsModal(false)}
           visible={show_delete_documents_modal}
         />
-        <CRUDModal
-          open={document_to_edit !== null}
-          mode="EDIT"
-          oldInstance={document_to_edit ? document_to_edit : {}}
-          modelName="document"
-          uiSchema={editDocForm_Ui_Schema}
-          dataSchema={editDocForm_Schema}
-          onSubmit={handleUpdateDocument}
-          onClose={() => editingDocument(null)}
-          hasFile={true}
-          fileField="pdfFile"
-          fileLabel="PDF File"
-          fileIsImage={false}
-          acceptedFileTypes="pdf"
-        />
-        <CRUDModal
-          open={document_to_view !== null}
-          mode="VIEW"
-          oldInstance={document_to_view ? document_to_view : {}}
-          modelName="document"
-          uiSchema={editDocForm_Ui_Schema}
-          dataSchema={editDocForm_Schema}
-          onClose={() => viewingDocument(null)}
-          hasFile={true}
-          fileField="pdfFile"
-          fileLabel="PDF File"
-          fileIsImage={false}
-          acceptedFileTypes="pdf"
-        />
-
         {/* Hero Section */}
         <HeroSection>
           <HeroTitle>


### PR DESCRIPTION
## Summary
Fixed issue #899 where the edit document modal was not saving changes. The root cause was a no-op `onSubmit` handler in the modal that only closed the dialog without executing the `UPDATE_DOCUMENT` mutation. Additionally, duplicate modal implementations were consolidated to prevent potential conflicts.

## Key Changes
- **Moved document update logic to `App.tsx`**: Implemented `useMutation` hook for `UPDATE_DOCUMENT` with proper `onCompleted` and `onError` handlers, including `refetchQueries: "active"` to refresh displayed data after successful updates
- **Implemented `handleUpdateDocument` callback**: Created a memoized callback that properly executes the mutation with the document data
- **Removed duplicate modals from `Documents.tsx`**: Eliminated redundant edit/view CRUDModal components that were controlled by the same reactive variables (`editingDocument`, `viewingDocument`) as the `App.tsx` implementation, preventing potential double-modal rendering
- **Removed unused imports**: Cleaned up imports from `Documents.tsx` including `CRUDModal`, form schemas, and reactive variable subscriptions that are no longer needed

## Implementation Details
- The edit modal in `App.tsx` now properly calls `handleUpdateDocument` on form submission instead of a no-op handler
- The mutation includes proper error handling with toast notifications for both success and failure cases
- Used `useCallback` to memoize the update handler for optimal performance
- The consolidated approach ensures a single source of truth for document editing across the application

https://claude.ai/code/session_013ZajrwcqvLVP9Ln1TvT3Fk