### PR TITLE
Enable GeoIP resolution in PostHog client initialization

### DIFF
--- a/config/telemetry.py
+++ b/config/telemetry.py
@@ -40,6 +40,7 @@ def _get_posthog_client() -> Posthog | None:
         _posthog_client = Posthog(
             project_api_key=settings.POSTHOG_API_KEY,
             host=settings.POSTHOG_HOST,
+            disable_geoip=False,
         )
 
         # Register shutdown handler to flush events on process exit

--- a/opencontractserver/tests/test_telemetry.py
+++ b/opencontractserver/tests/test_telemetry.py
@@ -65,6 +65,26 @@ class TelemetryTestCase(TestCase):
         timestamp = datetime.fromisoformat(call_args["properties"]["timestamp"])
         self.assertIsNotNone(timestamp.tzinfo)
 
+    def test_posthog_client_initialized_with_geoip_enabled(self):
+        """Test that PostHog client is initialized with disable_geoip=False.
+
+        Server-side PostHog SDKs default to disable_geoip=True, which prevents
+        GeoIP resolution on events. We explicitly set disable_geoip=False so
+        PostHog can resolve geographic data from the server's IP.
+        """
+        with override_settings(
+            MODE="DEV",
+            TELEMETRY_ENABLED=True,
+            POSTHOG_API_KEY="test-key",
+            POSTHOG_HOST="https://test.host",
+        ):
+            record_event("test_event")
+
+        # Verify PostHog client was created with disable_geoip=False
+        init_kwargs = self.mock_posthog_class.call_args[1]
+        self.assertIn("disable_geoip", init_kwargs)
+        self.assertFalse(init_kwargs["disable_geoip"])
+
     def test_record_event_telemetry_disabled(self):
         """Test when telemetry is disabled"""
 

--- a/opencontractserver/tests/test_telemetry.py
+++ b/opencontractserver/tests/test_telemetry.py
@@ -81,7 +81,7 @@ class TelemetryTestCase(TestCase):
             record_event("test_event")
 
         # Verify PostHog client was created with disable_geoip=False
-        init_kwargs = self.mock_posthog_class.call_args[1]
+        init_kwargs = self.mock_posthog_class.call_args.kwargs
         self.assertIn("disable_geoip", init_kwargs)
         self.assertFalse(init_kwargs["disable_geoip"])
 
@@ -126,6 +126,32 @@ class TelemetryTestCase(TestCase):
         self.assertEqual(
             set(properties.keys()), {"package", "timestamp", "installation_id"}
         )
+
+
+class UsersAppGeoIPTestCase(TestCase):
+    """Tests that the UsersConfig.ready() method configures GeoIP on the
+    module-level posthog instance (the official Django integration path)."""
+
+    def test_ready_sets_geoip_enabled(self):
+        """Test that UsersConfig.ready() sets posthog.disable_geoip = False."""
+        import posthog
+
+        from opencontractserver.users.apps import UsersConfig
+
+        # Set a known bad state so we can verify the ready() method changes it
+        posthog.disable_geoip = True
+
+        app_config = UsersConfig(
+            "opencontractserver.users", __import__("opencontractserver.users")
+        )
+        with override_settings(
+            TELEMETRY_ENABLED=True,
+            POSTHOG_API_KEY="test-key",
+            POSTHOG_HOST="https://test.host",
+        ):
+            app_config.ready()
+
+        self.assertFalse(posthog.disable_geoip)
 
 
 class UsageHeartbeatTestCase(TestCase):

--- a/opencontractserver/users/apps.py
+++ b/opencontractserver/users/apps.py
@@ -18,6 +18,7 @@ class UsersConfig(AppConfig):
         if settings.TELEMETRY_ENABLED:
             posthog.api_key = settings.POSTHOG_API_KEY
             posthog.host = settings.POSTHOG_HOST
+            posthog.disable_geoip = False
 
         try:
             import opencontractserver.users.signals  # noqa F401


### PR DESCRIPTION
## Summary
This PR enables GeoIP resolution in the PostHog client by explicitly setting `disable_geoip=False` during initialization. By default, PostHog's server-side SDKs disable GeoIP resolution, but we want to allow PostHog to resolve geographic data from the server's IP address.

## Key Changes
- **config/telemetry.py**: Added `disable_geoip=False` parameter when initializing the PostHog client in `_get_posthog_client()`
- **opencontractserver/users/apps.py**: Added `posthog.disable_geoip = False` configuration in the `ready()` method to ensure GeoIP is enabled for the module-level PostHog instance
- **opencontractserver/tests/test_telemetry.py**: Added comprehensive test `test_posthog_client_initialized_with_geoip_enabled()` to verify that the PostHog client is initialized with GeoIP enabled

## Implementation Details
The changes ensure that GeoIP resolution is enabled in both initialization paths:
1. When creating a new PostHog client instance in the telemetry module
2. When configuring the module-level PostHog instance in the users app

The test validates that the `disable_geoip` parameter is explicitly set to `False` during client initialization, preventing regression of this behavior.

https://claude.ai/code/session_01YGVkYhBaCeunwnYGWxLoVN