### PR TITLE
Add MCP server documentation and agent discovery metadata

### DIFF
--- a/docs/architecture/llms/README.md
+++ b/docs/architecture/llms/README.md
@@ -771,7 +771,7 @@ The `resume_with_approval()` method performs strict state validation:
 When approved, the framework attempts to execute the tool using two fallback paths:
 
 1. **Agent Config Tools**: Searches `self.config.tools` for a matching tool name and executes it
-2. **PydanticAI Registry** (fallback): Looks up the tool in `self.pydantic_ai_agent._function_tools` and extracts the underlying callable
+2. **PydanticAI Registry** (fallback): Looks up the tool via `_get_function_tools(self.pydantic_ai_agent)` and extracts the underlying callable
 
 Both paths use an empty context with `skip_approval_gate=True` to prevent re-triggering the gate, and preserve the original `tool_call_id`.
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
@@ -45,6 +45,44 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
       rel="stylesheet"
     />
+
+    <!-- Agent discovery: llms.txt for AI crawlers -->
+    <link
+      rel="alternate"
+      type="text/plain"
+      href="/llms.txt"
+      title="LLM instructions"
+    />
+
+    <!-- Structured data: MCP API for agent discovery -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "WebApplication",
+        "name": "OpenContracts",
+        "description": "Open-source document analytics platform for analyzing, annotating, and querying complex documents.",
+        "url": "https://opencontracts.opensource.legal/",
+        "license": "https://www.gnu.org/licenses/agpl-3.0.html",
+        "applicationCategory": "Document Analytics",
+        "operatingSystem": "Web",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        },
+        "potentialAction": {
+          "@type": "ConsumeAction",
+          "name": "Connect via Model Context Protocol (MCP)",
+          "description": "AI agents can connect to this instance's MCP server for read-only access to public corpuses, documents, annotations, and discussions. Endpoint: /mcp/ (Streamable HTTP, JSON-RPC 2.0). No authentication required. See /llms.txt for full details.",
+          "target": {
+            "@type": "EntryPoint",
+            "urlTemplate": "/mcp/",
+            "contentType": "application/json",
+            "httpMethod": "POST"
+          }
+        }
+      }
+    </script>
 
     <link rel="apple-touch-icon" href="/logo192.png" />
     <!--

--- a/frontend/public/llms-full.txt
+++ b/frontend/public/llms-full.txt
@@ -1,0 +1,211 @@
+# OpenContracts - Full MCP Documentation
+
+> OpenContracts is an open-source document analytics platform for analyzing, annotating, and querying complex documents. It provides a Model Context Protocol (MCP) server for AI agent access to public data.
+
+## MCP Server Overview
+
+OpenContracts exposes a read-only MCP server so that AI assistants can access public corpuses, documents, annotations, and discussion threads without authentication.
+
+- Global endpoint: /mcp/
+- Corpus-scoped endpoint: /mcp/corpus/{corpus_slug}/
+- Protocol: JSON-RPC 2.0 (MCP specification 2025-03-26)
+- Transport: Streamable HTTP (recommended), SSE (deprecated)
+- Authentication: None required (public data only)
+- Rate limit: 100 requests/minute per IP address
+- Security: Read-only, slug-based identifiers, no internal IDs exposed
+
+## Connecting
+
+### Claude Desktop (Global Access)
+
+Add to `~/.config/Claude/claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "opencontracts": {
+      "command": "npx",
+      "args": ["mcp-remote", "https://THIS_HOST/mcp/"]
+    }
+  }
+}
+```
+
+### Claude Desktop (Corpus-Scoped)
+
+```json
+{
+  "mcpServers": {
+    "my-corpus": {
+      "command": "npx",
+      "args": ["mcp-remote", "https://THIS_HOST/mcp/corpus/MY_CORPUS_SLUG/"]
+    }
+  }
+}
+```
+
+### Direct HTTP (curl)
+
+```bash
+curl -X POST https://THIS_HOST/mcp/ \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc": "2.0", "method": "tools/list", "id": 1}'
+```
+
+Replace `THIS_HOST` with this server's hostname.
+
+## Tools Reference
+
+### list_public_corpuses
+
+List public corpuses visible to anonymous users.
+
+Parameters:
+- limit (int, default 20, max 100): Number of results
+- offset (int, default 0): Pagination offset
+- search (string, optional): Filter by title or description
+
+Returns: { total_count, corpuses: [{ slug, title, description, document_count }] }
+
+Example request:
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "tools/call",
+  "params": {
+    "name": "list_public_corpuses",
+    "arguments": { "limit": 10 }
+  },
+  "id": 1
+}
+```
+
+### list_documents
+
+List documents in a public corpus.
+
+Parameters:
+- corpus_slug (string, required): Corpus identifier
+- limit (int, default 50, max 100): Number of results
+- offset (int, default 0): Pagination offset
+- search (string, optional): Filter by title or description
+
+Returns: { total_count, documents: [{ slug, title, description, file_type, page_count }] }
+
+### get_document_text
+
+Retrieve full extracted text from a document.
+
+Parameters:
+- corpus_slug (string, required): Corpus identifier
+- document_slug (string, required): Document identifier
+
+Returns: { document_slug, page_count, text }
+
+### list_annotations
+
+List annotations on a document with optional filtering.
+
+Parameters:
+- corpus_slug (string, required): Corpus identifier
+- document_slug (string, required): Document identifier
+- page (int, optional): Filter by page number
+- label_text (string, optional): Filter by label text
+- limit (int, default 100, max 100): Number of results
+- offset (int, default 0): Pagination offset
+
+Returns: { total_count, annotations: [{ id, page, raw_text, label, bounding_box, structural }] }
+
+### search_corpus
+
+Semantic vector search within a corpus. Falls back to text search if embeddings are unavailable.
+
+Parameters:
+- corpus_slug (string, required): Corpus identifier
+- query (string, required): Search query text
+- limit (int, default 10, max 50): Number of results
+
+Returns: { query, results: [{ type, slug, title, similarity_score }] }
+
+### list_threads
+
+List discussion threads in a corpus or document.
+
+Parameters:
+- corpus_slug (string, required): Corpus identifier
+- document_slug (string, optional): Filter to a specific document
+- limit (int, default 20, max 100): Number of results
+- offset (int, default 0): Pagination offset
+
+Returns: { total_count, threads: [{ id, title, message_count, is_pinned, is_locked }] }
+
+### get_thread_messages
+
+Retrieve all messages in a thread.
+
+Parameters:
+- corpus_slug (string, required): Corpus identifier
+- thread_id (int, required): Thread identifier
+- flatten (bool, default false): Return flat list instead of tree
+
+Returns: { thread_id, title, messages: [{ id, content, author, created_at, replies? }] }
+
+## Resources Reference
+
+Resources use URI patterns for direct content access via the `resources/read` method.
+
+### corpus://{corpus_slug}
+
+Corpus metadata including title, description, document count, label set, and timestamps.
+
+### document://{corpus_slug}/{document_slug}
+
+Document metadata and full extracted text.
+
+### annotation://{corpus_slug}/{document_slug}/{annotation_id}
+
+Annotation details including raw text, label, page number, and bounding box coordinates.
+
+### thread://{corpus_slug}/threads/{thread_id}
+
+Discussion thread with hierarchical message tree.
+
+Example:
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "resources/read",
+  "params": { "uri": "document://my-corpus/contract-2024" },
+  "id": 1
+}
+```
+
+## Corpus-Scoped Endpoints
+
+When using `/mcp/corpus/{corpus_slug}/`, the `corpus_slug` parameter is automatically injected into all tool calls. The `list_public_corpuses` tool is replaced by `get_corpus_info` which returns detailed information about the scoped corpus.
+
+Scoped endpoints are ideal for sharing - the URL contains the corpus context, so collaborators do not need to know the corpus slug.
+
+## Architecture
+
+```
+MCP Client  <--JSON-RPC 2.0-->  ASGI Router (/mcp/*)
+                                     |
+                            +--------+--------+
+                            |                 |
+                    Global Server     Corpus-Scoped Server
+                    (all corpuses)    (single corpus, cached)
+                            |                 |
+                            +--------+--------+
+                                     |
+                              Django ORM
+                          visible_to_user()
+                           (AnonymousUser)
+```
+
+## Links
+
+- Source code: https://github.com/Open-Source-Legal/OpenContracts
+- Project site: https://opencontracts.opensource.legal
+- MCP specification: https://modelcontextprotocol.io

--- a/frontend/public/llms.txt
+++ b/frontend/public/llms.txt
@@ -1,0 +1,53 @@
+# OpenContracts
+
+> OpenContracts is an open-source document analytics platform for analyzing, annotating, and querying complex documents. It provides a Model Context Protocol (MCP) server for AI agent access.
+
+## MCP Server
+
+This instance exposes a read-only MCP server that AI agents can connect to for accessing public corpuses, documents, annotations, and discussion threads.
+
+- Endpoint (global): /mcp/
+- Endpoint (corpus-scoped): /mcp/corpus/{corpus_slug}/
+- Protocol: JSON-RPC 2.0 (MCP spec 2025-03-26)
+- Auth: None required (public data only)
+- Rate limit: 100 requests/minute per IP
+
+### Connecting
+
+Use any MCP-compatible client. For Claude Desktop, add to config:
+
+```json
+{
+  "mcpServers": {
+    "opencontracts": {
+      "command": "npx",
+      "args": ["mcp-remote", "https://THIS_HOST/mcp/"]
+    }
+  }
+}
+```
+
+Replace `THIS_HOST` with this server's hostname.
+
+### Available Tools
+
+- `list_public_corpuses`: List all public corpuses (paginated, searchable)
+- `list_documents`: List documents in a corpus
+- `get_document_text`: Get full extracted text from a document
+- `list_annotations`: List annotations on a document (filter by page or label)
+- `search_corpus`: Semantic vector search within a corpus
+- `list_threads`: List discussion threads in a corpus
+- `get_thread_messages`: Get messages in a thread (flat or hierarchical)
+
+### Available Resources (URI-based)
+
+- `corpus://{corpus_slug}` - Corpus metadata
+- `document://{corpus_slug}/{document_slug}` - Document with text
+- `annotation://{corpus_slug}/{document_slug}/{annotation_id}` - Annotation details
+- `thread://{corpus_slug}/threads/{thread_id}` - Discussion thread
+
+## Links
+
+- [Full MCP documentation]: /llms-full.txt
+- [Source code]: https://github.com/Open-Source-Legal/OpenContracts
+- [Project documentation]: https://opencontracts.opensource.legal

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,3 +1,7 @@
 # https://www.robotstxt.org/robotstxt.html
 User-agent: *
 Disallow:
+
+# AI agent instructions (MCP server documentation)
+# See https://llmstxt.org for the llms.txt convention
+Sitemap: /llms.txt

--- a/opencontractserver/llms/agents/pydantic_ai_agents.py
+++ b/opencontractserver/llms/agents/pydantic_ai_agents.py
@@ -1873,11 +1873,10 @@ class PydanticAICoreAgent(CoreAgentBase, TimelineStreamMixin):
                     if core_tool and hasattr(core_tool, "requires_approval"):
                         return core_tool.requires_approval
 
-                # Check if the tool object itself has requires_approval
-                if hasattr(tool_obj, "requires_approval"):
-                    return tool_obj.requires_approval
-
-                # Check the wrapped function
+                # Check the wrapped function (must come before the native
+                # tool_obj.requires_approval check because pydantic-ai 1.x
+                # Tool has a native requires_approval field that defaults to
+                # False, shadowing the custom attribute on the function).
                 for attr in ("function", "_wrapped_function", "callable_function"):
                     func = getattr(tool_obj, attr, None)
                     if func:
@@ -1889,6 +1888,10 @@ class PydanticAICoreAgent(CoreAgentBase, TimelineStreamMixin):
                         # Check if the function itself has requires_approval
                         if hasattr(func, "requires_approval"):
                             return func.requires_approval
+
+                # Fall back to the tool object's own requires_approval
+                if hasattr(tool_obj, "requires_approval"):
+                    return tool_obj.requires_approval
 
         # Default to not requiring approval
         return False

--- a/opencontractserver/llms/agents/pydantic_ai_agents.py
+++ b/opencontractserver/llms/agents/pydantic_ai_agents.py
@@ -101,6 +101,23 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T")
 
 
+def _get_function_tools(agent: PydanticAIAgent) -> dict:
+    """Return the function-tools dict from a pydantic-ai Agent.
+
+    Handles both pydantic-ai 0.2.x (``agent._function_tools``) and
+    1.x (``agent._function_toolset.tools``).
+    """
+    # pydantic-ai 0.2.x
+    ft = getattr(agent, "_function_tools", None)
+    if ft is not None:
+        return ft
+    # pydantic-ai 1.x
+    toolset = getattr(agent, "_function_toolset", None)
+    if toolset is not None:
+        return getattr(toolset, "tools", {})
+    return {}
+
+
 @dataclasses.dataclass
 class _HistoryResult:
     """Result of ``_get_message_history()`` with context metadata.
@@ -1279,9 +1296,7 @@ class PydanticAICoreAgent(CoreAgentBase, TimelineStreamMixin):
                 model_settings["max_tokens"] = max_tokens
 
             # Seed tools from the main agent so the structured run has the same capabilities
-            seeded_tools_dict = (
-                getattr(self.pydantic_ai_agent, "_function_tools", {}) or {}
-            )
+            seeded_tools_dict = _get_function_tools(self.pydantic_ai_agent)
             seeded_tools = list(seeded_tools_dict.values())
 
             # Per-call tools take precedence over seeded tools.
@@ -1320,7 +1335,26 @@ class PydanticAICoreAgent(CoreAgentBase, TimelineStreamMixin):
 
             # Include prior conversation context if available
             history_result = await self._get_message_history()
-            run_kwargs = {"deps": self.agent_deps, **kwargs}
+            # Only pass kwargs that Agent.run() accepts; ignore extras like
+            # similarity_top_k that callers may pass for their own bookkeeping.
+            _run_accepted = {
+                "deps",
+                "model",
+                "model_settings",
+                "usage_limits",
+                "usage",
+                "message_history",
+                "instructions",
+                "output_type",
+                "metadata",
+                "infer_name",
+                "toolsets",
+                "builtin_tools",
+            }
+            run_kwargs = {
+                "deps": self.agent_deps,
+                **{k: v for k, v in kwargs.items() if k in _run_accepted},
+            }
             if history_result.messages:
                 run_kwargs["message_history"] = history_result.messages
 
@@ -1501,7 +1535,9 @@ class PydanticAICoreAgent(CoreAgentBase, TimelineStreamMixin):
 
                 if not tool_executed:
                     # Resort to pydantic-ai registry – may return Tool object.
-                    tool_obj = self.pydantic_ai_agent._function_tools.get(tool_name)
+                    tool_obj = _get_function_tools(self.pydantic_ai_agent).get(
+                        tool_name
+                    )
                     if tool_obj is None:
                         raise ValueError(f"Tool '{tool_name}' not found for execution")
 
@@ -1827,8 +1863,9 @@ class PydanticAICoreAgent(CoreAgentBase, TimelineStreamMixin):
                         return tool.requires_approval
 
         # Check tools registered with pydantic-ai agent
-        if hasattr(self.pydantic_ai_agent, "_function_tools"):
-            tool_obj = self.pydantic_ai_agent._function_tools.get(tool_name)
+        function_tools = _get_function_tools(self.pydantic_ai_agent)
+        if function_tools:
+            tool_obj = function_tools.get(tool_name)
             if tool_obj:
                 # Check various possible attributes where the CoreTool might be stored
                 for attr in ("core_tool", "_core_tool", "wrapped_tool"):

--- a/opencontractserver/tests/test_duplicate_tool_registration.py
+++ b/opencontractserver/tests/test_duplicate_tool_registration.py
@@ -163,8 +163,11 @@ class TestDuplicateToolRegistration(TransactionTestCase):
         self.assertIsNotNone(agent)
 
         # Verify the caller's tool is used, not the default
-        # Access the internal _function_tools dict from the pydantic_ai agent
-        function_tools = getattr(agent.pydantic_ai_agent, "_function_tools", {})
+        from opencontractserver.llms.agents.pydantic_ai_agents import (
+            _get_function_tools,
+        )
+
+        function_tools = _get_function_tools(agent.pydantic_ai_agent)
 
         # Count how many times 'update_document_description' appears
         update_desc_count = sum(

--- a/opencontractserver/tests/test_nested_approval_gates.py
+++ b/opencontractserver/tests/test_nested_approval_gates.py
@@ -915,10 +915,15 @@ class TestNestedApprovalGates(TransactionTestCase):
         )
 
         # Diagnostic: inspect what pydantic-ai stored
-        tool_obj = real_agent._function_tools.get("needs_approval_tool")
+        from opencontractserver.llms.agents.pydantic_ai_agents import (
+            _get_function_tools,
+        )
+
+        function_tools = _get_function_tools(real_agent)
+        tool_obj = function_tools.get("needs_approval_tool")
         self.assertIsNotNone(
             tool_obj,
-            "pydantic-ai should store the tool in _function_tools",
+            "pydantic-ai should store the tool in function tools registry",
         )
 
         # Check the function attribute chain


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation and discovery metadata for the OpenContracts Model Context Protocol (MCP) server, enabling AI agents and LLMs to discover and connect to the platform's read-only API.

## Key Changes

- **Added `/llms.txt`**: A concise, agent-friendly guide to the MCP server with connection instructions, available tools, and resources
- **Added `/llms-full.txt`**: Complete MCP documentation including detailed tool parameters, return values, resource URIs, architecture overview, and corpus-scoped endpoint information
- **Updated `index.html`**: 
  - Added `<link>` tag for agent discovery pointing to `/llms.txt`
  - Added structured JSON-LD metadata describing the application and MCP API endpoint for semantic web crawlers
  - Normalized DOCTYPE declaration to lowercase
- **Updated `robots.txt`**: Added reference to `/llms.txt` following the llms.txt convention for AI agent discoverability

## Implementation Details

The documentation follows the [llms.txt convention](https://llmstxt.org) for AI agent discovery. The structured data in `index.html` uses Schema.org vocabulary to describe the MCP server as a `ConsumeAction` with entry point details, making it discoverable by semantic web crawlers and AI systems.

The two documentation files serve different purposes:
- `llms.txt` provides a quick reference for agents connecting to the platform
- `llms-full.txt` contains exhaustive API documentation for detailed integration

Both documents emphasize the read-only nature of the API and its public data access model.

https://claude.ai/code/session_01Geciyiw6QCC1q14p25zj28