### PR TITLE
Fix selectedChatSourceId condition to handle zero index

### DIFF
--- a/frontend/src/components/annotator/components/wrappers/TxtAnnotatorWrapper.tsx
+++ b/frontend/src/components/annotator/components/wrappers/TxtAnnotatorWrapper.tsx
@@ -158,7 +158,7 @@ export const TxtAnnotatorWrapper: React.FC<TxtAnnotatorWrapperProps> = ({
         searchResults={filteredSearchResults}
         chatSources={chatSourceMatches}
         selectedChatSourceId={
-          selectedMessageId && selectedSourceIndex
+          selectedMessageId && selectedSourceIndex !== null
             ? `${selectedMessageId}.${selectedSourceIndex}`
             : undefined
         }


### PR DESCRIPTION
## Summary
Fixed a bug in the TxtAnnotatorWrapper component where a `selectedSourceIndex` value of `0` was incorrectly treated as falsy, preventing the chat source ID from being properly constructed.

## Key Changes
- Updated the condition for `selectedChatSourceId` from `selectedMessageId && selectedSourceIndex` to `selectedMessageId && selectedSourceIndex !== null`
- This ensures that a `selectedSourceIndex` of `0` is correctly recognized as a valid value rather than being treated as falsy

## Implementation Details
The original condition would fail when `selectedSourceIndex` was `0` because JavaScript treats `0` as falsy in boolean contexts. By explicitly checking `!== null`, the code now properly distinguishes between:
- `0` (valid index, should construct the ID)
- `null` or `undefined` (no valid index, should return undefined)

This fix ensures that the first source item (index 0) can be properly selected and its chat source ID is correctly generated.
