### PR TITLE
Fix MCP documentation accuracy for tool returns and resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+#### MCP Documentation Accuracy (Closes #924)
+- **Missing `created` field in tool return docs**: `list_public_corpuses`, `list_documents`, and `list_annotations` all return a `created` ISO 8601 timestamp, but `llms-full.txt` omitted it from the documented return shapes
+- **Incorrect annotation label shape**: `list_annotations` return docs showed `label` (string) but the actual response uses `annotation_label: { text, color, label_type }` (object) — updated to match `format_annotation()` in `opencontractserver/mcp/formatters.py`
+- **Underdocumented `document://` resource**: The resource description only said "Document metadata and full extracted text" without listing the actual fields. Added field inventory including `text_preview` (first 500 chars), `full_text`, `corpus`, and `created` — critical for agents choosing between preview and full text under context window constraints
+- **File**: `frontend/public/llms-full.txt`
+
 #### BaseChunkedParser Cleanup (Closes #914)
 - **Duplicate test line**: Removed redundant `PdfReader` assignment in `test_pdf_splitting.py:95`
 - **Infinite loop guard**: Added input validation for `max_pages_per_chunk` and `min_pages_for_chunking` in `calculate_page_chunks()` (`opencontractserver/utils/pdf_splitting.py`); added `max_concurrent_chunks` validation in `_parse_document_impl` (`opencontractserver/pipeline/base/chunked_parser.py`)

--- a/frontend/public/llms-full.txt
+++ b/frontend/public/llms-full.txt
@@ -66,7 +66,7 @@ Parameters:
 - offset (int, default 0): Pagination offset
 - search (string, optional): Filter by title or description
 
-Returns: { total_count, corpuses: [{ slug, title, description, document_count }] }
+Returns: { total_count, corpuses: [{ slug, title, description, document_count, created }] }
 
 Example request:
 ```json
@@ -91,7 +91,7 @@ Parameters:
 - offset (int, default 0): Pagination offset
 - search (string, optional): Filter by title or description
 
-Returns: { total_count, documents: [{ slug, title, description, file_type, page_count }] }
+Returns: { total_count, documents: [{ slug, title, description, file_type, page_count, created }] }
 
 ### get_document_text
 
@@ -115,7 +115,7 @@ Parameters:
 - limit (int, default 100, max 100): Number of results
 - offset (int, default 0): Pagination offset
 
-Returns: { total_count, annotations: [{ id, page, raw_text, label, bounding_box, structural }] }
+Returns: { total_count, annotations: [{ id, page, raw_text, annotation_label: { text, color, label_type }, structural, created }] }
 
 ### search_corpus
 
@@ -161,11 +161,11 @@ Corpus metadata including title, description, document count, label set, and tim
 
 ### document://{corpus_slug}/{document_slug}
 
-Document metadata and full extracted text.
+Document metadata and full extracted text. Returns JSON with fields: slug, title, description, file_type, page_count, text_preview (first 500 characters of extracted text), full_text (complete extracted text), created (ISO 8601 timestamp), corpus (corpus slug). The text_preview field is useful for quick inspection without consuming the full text, which can be large.
 
 ### annotation://{corpus_slug}/{document_slug}/{annotation_id}
 
-Annotation details including raw text, label, page number, and bounding box coordinates.
+Annotation details including raw text, label, page number, bounding box coordinates, and created timestamp.
 
 ### thread://{corpus_slug}/threads/{thread_id}
 


### PR DESCRIPTION
## Summary
Updated `frontend/public/llms-full.txt` to accurately document the actual return shapes and fields for MCP tools and resources. The documentation was missing several fields that are actually returned by the API, and misrepresented the structure of annotation labels.

## Key Changes
- **Added `created` field to tool return documentation**: `list_public_corpuses`, `list_documents`, and `list_annotations` all return an ISO 8601 `created` timestamp, but this was omitted from the documented return shapes
- **Fixed annotation label structure**: Corrected `list_annotations` return docs from showing `label` (string) to the actual `annotation_label: { text, color, label_type }` (object) structure that matches the implementation in `opencontractserver/mcp/formatters.py`
- **Enhanced `document://` resource documentation**: Expanded the sparse "Document metadata and full extracted text" description to include the complete field inventory: `slug`, `title`, `description`, `file_type`, `page_count`, `text_preview` (first 500 characters), `full_text`, `created`, and `corpus`. Added clarification that `text_preview` is useful for agents to inspect content without consuming full text under context window constraints

## Implementation Details
These changes ensure that LLM agents using the MCP interface have accurate documentation of:
- What fields are available in paginated list responses
- The correct shape of nested objects (annotation labels)
- The complete set of fields in document resources, enabling smarter decisions about text preview vs. full text usage

Fixes #924

https://claude.ai/code/session_011C3WPXCFqF8VYJ4SonQZCF