### PR TITLE
Fix TxtAnnotator infinite re-render loop from unstable default parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+#### TxtAnnotator Infinite Re-render Loop (Closes #933)
+- **Unstable default parameter**: `chatSources = []` in `TxtAnnotator` component props created a new array reference on every render, triggering infinite re-renders via `useEffect` dependency arrays when the prop was not explicitly passed (`frontend/src/components/annotator/renderers/txt/TxtAnnotator.tsx:335`)
+- Extracted `ChatSourceHighlight` interface and defined module-level `EMPTY_CHAT_SOURCES` constant as the default value, ensuring referential stability across renders
+
 #### BaseChunkedParser Robustness and Consistency (Closes #926)
 - **Config ValueError not wrapped**: `calculate_page_chunks` raises `ValueError` for invalid `max_pages_per_chunk`/`min_pages_for_chunking`, but the call in `_parse_document_impl` was unwrapped. Now caught and re-raised as `DocumentParsingError(is_transient=False)` (`opencontractserver/pipeline/base/chunked_parser.py`)
 - **Small-document annotations unprefixed**: Single-chunk documents returned directly from `_parse_chunk_with_retry` without passing through `_reassemble_chunk_results`, resulting in unprefixed annotation/relationship IDs. Now all results consistently receive `c0_` prefixed IDs (`opencontractserver/pipeline/base/chunked_parser.py`)

--- a/frontend/src/components/annotator/renderers/txt/TxtAnnotator.tsx
+++ b/frontend/src/components/annotator/renderers/txt/TxtAnnotator.tsx
@@ -113,7 +113,7 @@ interface TxtAnnotatorProps {
   /** Callback to register/unregister annotation DOM refs for sidebar scroll-to. */
   onAnnotationRefChange?: (
     annotationId: string,
-    element: HTMLElement | null,
+    element: HTMLElement | null
   ) => void;
 }
 
@@ -165,9 +165,7 @@ const AnnotatedSpan = styled.span<{
   cursor: text;
   user-select: text;
   white-space: pre-wrap;
-  transition:
-    background-color 0.15s ease,
-    box-shadow 0.15s ease;
+  transition: background-color 0.15s ease, box-shadow 0.15s ease;
 
   ${(props) =>
     props.$hasAnnotation &&
@@ -267,7 +265,7 @@ const ChatSourceIcon = styled.div<{ isSelected: boolean }>`
 function getGlobalOffsetFromNode(
   node: Node | null,
   localOffset: number,
-  spans: TextSpan[],
+  spans: TextSpan[]
 ): number | null {
   if (!node) return null;
 
@@ -296,7 +294,7 @@ function getGlobalOffsetFromNode(
  * @returns A style object with background styling covering the highlights.
  */
 function buildCombinedBackgroundStyle(
-  highlightColors: string[],
+  highlightColors: string[]
 ): React.CSSProperties {
   if (highlightColors.length === 0) {
     return {};
@@ -308,7 +306,7 @@ function buildCombinedBackgroundStyle(
     // Combine them into a linear gradient to show multiple highlights.
     return {
       backgroundImage: `linear-gradient(to right, ${highlightColors.join(
-        ", ",
+        ", "
       )})`,
     };
   }
@@ -368,7 +366,7 @@ const TxtAnnotator: React.FC<TxtAnnotatorProps> = ({
 
     const visibleAnnotations = annotations.filter(
       (ann) =>
-        ann.annotationLabel?.text && isLabelVisible(ann.annotationLabel.text),
+        ann.annotationLabel?.text && isLabelVisible(ann.annotationLabel.text)
     );
 
     // Find and register the first DOM span for each visible annotation.
@@ -377,12 +375,12 @@ const TxtAnnotator: React.FC<TxtAnnotatorProps> = ({
     const currentIds = new Set<string>();
     for (const ann of visibleAnnotations) {
       const spanIndex = spans.findIndex(
-        (span) => ann.json.start >= span.start && ann.json.start < span.end,
+        (span) => ann.json.start >= span.start && ann.json.start < span.end
       );
       if (spanIndex < 0) continue;
 
       const el = containerRef.current.querySelector(
-        `span[data-span-index="${spanIndex}"]`,
+        `span[data-span-index="${spanIndex}"]`
       ) as HTMLElement | null;
       if (el) {
         onAnnotationRefChange(ann.id, el);
@@ -464,7 +462,7 @@ const TxtAnnotator: React.FC<TxtAnnotatorProps> = ({
         setSelectedAnnotations([annotation.id]);
       }
     },
-    [selectedAnnotations, setSelectedAnnotations],
+    [selectedAnnotations, setSelectedAnnotations]
   );
 
   /**
@@ -481,7 +479,7 @@ const TxtAnnotator: React.FC<TxtAnnotatorProps> = ({
     const validAnnotations = annotations
       .filter(
         (ann) =>
-          ann.annotationLabel?.text && isLabelVisible(ann.annotationLabel.text),
+          ann.annotationLabel?.text && isLabelVisible(ann.annotationLabel.text)
       )
       .sort((a, b) => a.json.start - b.json.start);
 
@@ -515,12 +513,12 @@ const TxtAnnotator: React.FC<TxtAnnotatorProps> = ({
 
       const sliceText = text.slice(spanStart, spanEnd);
       const spanAnnotations = validAnnotations.filter(
-        (ann) => ann.json.start < spanEnd && ann.json.end > spanStart,
+        (ann) => ann.json.start < spanEnd && ann.json.end > spanStart
       );
 
       // check search highlight info
       const matchedSearchResult = searchResults.find(
-        (sr) => sr.start_index <= spanStart && sr.end_index >= spanEnd,
+        (sr) => sr.start_index <= spanStart && sr.end_index >= spanEnd
       );
       const isSearchResult = Boolean(matchedSearchResult);
       const isSelectedSearchResult =
@@ -531,7 +529,7 @@ const TxtAnnotator: React.FC<TxtAnnotatorProps> = ({
 
       // check chat source info
       const matchingChatSource = chatSources.find(
-        (cs) => cs.start_index <= spanStart && cs.end_index >= spanEnd,
+        (cs) => cs.start_index <= spanStart && cs.end_index >= spanEnd
       );
       const isChatSource = Boolean(matchingChatSource);
       const isSelectedChatSource =
@@ -582,20 +580,20 @@ const TxtAnnotator: React.FC<TxtAnnotatorProps> = ({
       const annToRender =
         chatSources.length > 0
           ? hoveredSpan.annotations.filter((ann) =>
-              selectedAnnotations.includes(ann.id),
+              selectedAnnotations.includes(ann.id)
             )
           : selectedAnnotations.length > 0
-            ? hoveredSpan.annotations.filter((ann) =>
-                selectedAnnotations.includes(ann.id),
-              )
-            : hoveredSpan.annotations;
+          ? hoveredSpan.annotations.filter((ann) =>
+              selectedAnnotations.includes(ann.id)
+            )
+          : hoveredSpan.annotations;
 
       // Possibly filter out structural if not shown, unless it's selected
       const finalAnnotations = annToRender.filter(
         (ann) =>
           showStructuralAnnotations ||
           !ann.structural ||
-          selectedAnnotations.includes(ann.id),
+          selectedAnnotations.includes(ann.id)
       );
 
       if (finalAnnotations.length === 0) {
@@ -605,7 +603,7 @@ const TxtAnnotator: React.FC<TxtAnnotatorProps> = ({
 
       const containerElement = containerRef.current;
       const spanElement = containerElement?.querySelector(
-        `span[data-span-index="${hoveredSpanIndex}"]`,
+        `span[data-span-index="${hoveredSpanIndex}"]`
       ) as HTMLElement;
 
       if (!containerElement || !spanElement) {
@@ -650,7 +648,7 @@ const TxtAnnotator: React.FC<TxtAnnotatorProps> = ({
           width: 100,
           height: labelHeight,
           labelIndex: index,
-        }),
+        })
       );
       setLabelsToRender(newPositions);
     };
@@ -671,17 +669,17 @@ const TxtAnnotator: React.FC<TxtAnnotatorProps> = ({
     if (selectedAnnotations.length === 0) return;
 
     const selectedAnns = annotations.filter((ann) =>
-      selectedAnnotations.includes(ann.id),
+      selectedAnnotations.includes(ann.id)
     );
     if (selectedAnns.length === 0) return;
 
     const earliest = selectedAnns.reduce((acc, ann) =>
-      ann.json.start < acc.json.start ? ann : acc,
+      ann.json.start < acc.json.start ? ann : acc
     );
 
     const targetIndex = spans.findIndex(
       (span) =>
-        earliest.json.start >= span.start && earliest.json.start < span.end,
+        earliest.json.start >= span.start && earliest.json.start < span.end
     );
     if (targetIndex < 0) return;
 
@@ -689,7 +687,7 @@ const TxtAnnotator: React.FC<TxtAnnotatorProps> = ({
     if (!containerElement) return;
 
     const targetEl = containerElement.querySelector(
-      `span[data-span-index="${targetIndex}"]`,
+      `span[data-span-index="${targetIndex}"]`
     ) as HTMLElement | null;
 
     if (!targetEl) return;
@@ -726,12 +724,12 @@ const TxtAnnotator: React.FC<TxtAnnotatorProps> = ({
 
     // Find the first span whose sourceId matches the selectedChatSourceId
     const targetIndex = spans.findIndex(
-      (s) => s.sourceId === selectedChatSourceId,
+      (s) => s.sourceId === selectedChatSourceId
     );
     if (targetIndex === -1) return;
 
     const targetEl = containerElement.querySelector(
-      `span[data-span-index="${targetIndex}"]`,
+      `span[data-span-index="${targetIndex}"]`
     ) as HTMLElement | null;
     if (!targetEl) return;
 
@@ -766,12 +764,12 @@ const TxtAnnotator: React.FC<TxtAnnotatorProps> = ({
     const anchorGlobalOffset = getGlobalOffsetFromNode(
       anchorNode,
       selection.anchorOffset,
-      spans,
+      spans
     );
     const focusGlobalOffset = getGlobalOffsetFromNode(
       focusNode,
       selection.focusOffset,
-      spans,
+      spans
     );
 
     if (anchorGlobalOffset === null || focusGlobalOffset === null) {
@@ -819,19 +817,19 @@ const TxtAnnotator: React.FC<TxtAnnotatorProps> = ({
           const usedAnn =
             chatSources.length > 0
               ? spanAnnotations.filter((ann) =>
-                  selectedAnnotations.includes(ann.id),
+                  selectedAnnotations.includes(ann.id)
                 )
               : selectedAnnotations.length > 0
-                ? spanAnnotations.filter((ann) =>
-                    selectedAnnotations.includes(ann.id),
-                  )
-                : spanAnnotations;
+              ? spanAnnotations.filter((ann) =>
+                  selectedAnnotations.includes(ann.id)
+                )
+              : spanAnnotations;
 
           const finalAnnotations = usedAnn.filter(
             (ann) =>
               showStructuralAnnotations ||
               !ann.structural ||
-              selectedAnnotations.includes(ann.id),
+              selectedAnnotations.includes(ann.id)
           );
 
           // Evaluate approval/rejected status.
@@ -849,7 +847,7 @@ const TxtAnnotator: React.FC<TxtAnnotatorProps> = ({
             } else {
               // multiple annotation colors
               const colors = finalAnnotations.map((ann) =>
-                hexToRgba(ann.annotationLabel.color ?? "#cccccc", 0.3),
+                hexToRgba(ann.annotationLabel.color ?? "#cccccc", 0.3)
               );
               highlightColors.push(...colors);
             }
@@ -858,7 +856,7 @@ const TxtAnnotator: React.FC<TxtAnnotatorProps> = ({
           // If we have a search highlight (but not when chat sources are displayed)
           if (isSearchResult && chatSources.length === 0) {
             highlightColors.push(
-              isSelectedSearchResult ? "#FFFF00" : "#FFFF99",
+              isSelectedSearchResult ? "#FFFF00" : "#FFFF99"
             );
           }
 
@@ -1010,7 +1008,7 @@ const TxtAnnotator: React.FC<TxtAnnotatorProps> = ({
                 />
               </LabelContainer>
             );
-          },
+          }
         )}
       </PaperContainer>
 
@@ -1034,7 +1032,7 @@ const TxtAnnotator: React.FC<TxtAnnotatorProps> = ({
               value={annotationToEdit.annotationLabel.id}
               onChange={(e, { value }) => {
                 const newLabel = availableLabels.find(
-                  (lbl) => lbl.id === value,
+                  (lbl) => lbl.id === value
                 );
                 if (newLabel) {
                   const updatedAnnotation = annotationToEdit.update({

--- a/frontend/src/components/annotator/renderers/txt/TxtAnnotator.tsx
+++ b/frontend/src/components/annotator/renderers/txt/TxtAnnotator.tsx
@@ -41,6 +41,17 @@ interface TextSpan {
   sourceId?: string;
 }
 
+/** Shape of a single chat-source highlight boundary. */
+interface ChatSourceHighlight {
+  start_index: number;
+  end_index: number;
+  sourceId: string;
+  messageId: string;
+}
+
+/** Stable empty array used as default for `chatSources` to avoid re-render loops. */
+const EMPTY_CHAT_SOURCES: ChatSourceHighlight[] = [];
+
 /**
  * Props for the TxtAnnotator component.
  */
@@ -96,18 +107,13 @@ interface TxtAnnotatorProps {
   /** Which search result index is currently "selected." */
   selectedSearchResultIndex?: number;
   /** Array of chat source highlight boundaries. */
-  chatSources?: {
-    start_index: number;
-    end_index: number;
-    sourceId: string;
-    messageId: string;
-  }[];
+  chatSources?: ChatSourceHighlight[];
   /** Currently selected chat source ID, if any. */
   selectedChatSourceId?: string;
   /** Callback to register/unregister annotation DOM refs for sidebar scroll-to. */
   onAnnotationRefChange?: (
     annotationId: string,
-    element: HTMLElement | null
+    element: HTMLElement | null,
   ) => void;
 }
 
@@ -159,7 +165,9 @@ const AnnotatedSpan = styled.span<{
   cursor: text;
   user-select: text;
   white-space: pre-wrap;
-  transition: background-color 0.15s ease, box-shadow 0.15s ease;
+  transition:
+    background-color 0.15s ease,
+    box-shadow 0.15s ease;
 
   ${(props) =>
     props.$hasAnnotation &&
@@ -259,7 +267,7 @@ const ChatSourceIcon = styled.div<{ isSelected: boolean }>`
 function getGlobalOffsetFromNode(
   node: Node | null,
   localOffset: number,
-  spans: TextSpan[]
+  spans: TextSpan[],
 ): number | null {
   if (!node) return null;
 
@@ -288,7 +296,7 @@ function getGlobalOffsetFromNode(
  * @returns A style object with background styling covering the highlights.
  */
 function buildCombinedBackgroundStyle(
-  highlightColors: string[]
+  highlightColors: string[],
 ): React.CSSProperties {
   if (highlightColors.length === 0) {
     return {};
@@ -300,7 +308,7 @@ function buildCombinedBackgroundStyle(
     // Combine them into a linear gradient to show multiple highlights.
     return {
       backgroundImage: `linear-gradient(to right, ${highlightColors.join(
-        ", "
+        ", ",
       )})`,
     };
   }
@@ -326,7 +334,7 @@ const TxtAnnotator: React.FC<TxtAnnotatorProps> = ({
   setSelectedAnnotations,
   showStructuralAnnotations,
   selectedSearchResultIndex,
-  chatSources = [],
+  chatSources = EMPTY_CHAT_SOURCES,
   selectedChatSourceId,
   onAnnotationRefChange,
 }) => {
@@ -360,7 +368,7 @@ const TxtAnnotator: React.FC<TxtAnnotatorProps> = ({
 
     const visibleAnnotations = annotations.filter(
       (ann) =>
-        ann.annotationLabel?.text && isLabelVisible(ann.annotationLabel.text)
+        ann.annotationLabel?.text && isLabelVisible(ann.annotationLabel.text),
     );
 
     const currentIds = new Set<string>();
@@ -371,12 +379,12 @@ const TxtAnnotator: React.FC<TxtAnnotatorProps> = ({
     // Find and register the first DOM span for each visible annotation
     for (const ann of visibleAnnotations) {
       const spanIndex = spans.findIndex(
-        (span) => ann.json.start >= span.start && ann.json.start < span.end
+        (span) => ann.json.start >= span.start && ann.json.start < span.end,
       );
       if (spanIndex < 0) continue;
 
       const el = containerRef.current.querySelector(
-        `span[data-span-index="${spanIndex}"]`
+        `span[data-span-index="${spanIndex}"]`,
       ) as HTMLElement | null;
       if (el) {
         onAnnotationRefChange(ann.id, el);
@@ -456,7 +464,7 @@ const TxtAnnotator: React.FC<TxtAnnotatorProps> = ({
         setSelectedAnnotations([annotation.id]);
       }
     },
-    [selectedAnnotations, setSelectedAnnotations]
+    [selectedAnnotations, setSelectedAnnotations],
   );
 
   /**
@@ -473,7 +481,7 @@ const TxtAnnotator: React.FC<TxtAnnotatorProps> = ({
     const validAnnotations = annotations
       .filter(
         (ann) =>
-          ann.annotationLabel?.text && isLabelVisible(ann.annotationLabel.text)
+          ann.annotationLabel?.text && isLabelVisible(ann.annotationLabel.text),
       )
       .sort((a, b) => a.json.start - b.json.start);
 
@@ -507,12 +515,12 @@ const TxtAnnotator: React.FC<TxtAnnotatorProps> = ({
 
       const sliceText = text.slice(spanStart, spanEnd);
       const spanAnnotations = validAnnotations.filter(
-        (ann) => ann.json.start < spanEnd && ann.json.end > spanStart
+        (ann) => ann.json.start < spanEnd && ann.json.end > spanStart,
       );
 
       // check search highlight info
       const matchedSearchResult = searchResults.find(
-        (sr) => sr.start_index <= spanStart && sr.end_index >= spanEnd
+        (sr) => sr.start_index <= spanStart && sr.end_index >= spanEnd,
       );
       const isSearchResult = Boolean(matchedSearchResult);
       const isSelectedSearchResult =
@@ -523,7 +531,7 @@ const TxtAnnotator: React.FC<TxtAnnotatorProps> = ({
 
       // check chat source info
       const matchingChatSource = chatSources.find(
-        (cs) => cs.start_index <= spanStart && cs.end_index >= spanEnd
+        (cs) => cs.start_index <= spanStart && cs.end_index >= spanEnd,
       );
       const isChatSource = Boolean(matchingChatSource);
       const isSelectedChatSource =
@@ -574,20 +582,20 @@ const TxtAnnotator: React.FC<TxtAnnotatorProps> = ({
       const annToRender =
         chatSources.length > 0
           ? hoveredSpan.annotations.filter((ann) =>
-              selectedAnnotations.includes(ann.id)
+              selectedAnnotations.includes(ann.id),
             )
           : selectedAnnotations.length > 0
-          ? hoveredSpan.annotations.filter((ann) =>
-              selectedAnnotations.includes(ann.id)
-            )
-          : hoveredSpan.annotations;
+            ? hoveredSpan.annotations.filter((ann) =>
+                selectedAnnotations.includes(ann.id),
+              )
+            : hoveredSpan.annotations;
 
       // Possibly filter out structural if not shown, unless it's selected
       const finalAnnotations = annToRender.filter(
         (ann) =>
           showStructuralAnnotations ||
           !ann.structural ||
-          selectedAnnotations.includes(ann.id)
+          selectedAnnotations.includes(ann.id),
       );
 
       if (finalAnnotations.length === 0) {
@@ -597,7 +605,7 @@ const TxtAnnotator: React.FC<TxtAnnotatorProps> = ({
 
       const containerElement = containerRef.current;
       const spanElement = containerElement?.querySelector(
-        `span[data-span-index="${hoveredSpanIndex}"]`
+        `span[data-span-index="${hoveredSpanIndex}"]`,
       ) as HTMLElement;
 
       if (!containerElement || !spanElement) {
@@ -642,7 +650,7 @@ const TxtAnnotator: React.FC<TxtAnnotatorProps> = ({
           width: 100,
           height: labelHeight,
           labelIndex: index,
-        })
+        }),
       );
       setLabelsToRender(newPositions);
     };
@@ -663,17 +671,17 @@ const TxtAnnotator: React.FC<TxtAnnotatorProps> = ({
     if (selectedAnnotations.length === 0) return;
 
     const selectedAnns = annotations.filter((ann) =>
-      selectedAnnotations.includes(ann.id)
+      selectedAnnotations.includes(ann.id),
     );
     if (selectedAnns.length === 0) return;
 
     const earliest = selectedAnns.reduce((acc, ann) =>
-      ann.json.start < acc.json.start ? ann : acc
+      ann.json.start < acc.json.start ? ann : acc,
     );
 
     const targetIndex = spans.findIndex(
       (span) =>
-        earliest.json.start >= span.start && earliest.json.start < span.end
+        earliest.json.start >= span.start && earliest.json.start < span.end,
     );
     if (targetIndex < 0) return;
 
@@ -681,7 +689,7 @@ const TxtAnnotator: React.FC<TxtAnnotatorProps> = ({
     if (!containerElement) return;
 
     const targetEl = containerElement.querySelector(
-      `span[data-span-index="${targetIndex}"]`
+      `span[data-span-index="${targetIndex}"]`,
     ) as HTMLElement | null;
 
     if (!targetEl) return;
@@ -718,12 +726,12 @@ const TxtAnnotator: React.FC<TxtAnnotatorProps> = ({
 
     // Find the first span whose sourceId matches the selectedChatSourceId
     const targetIndex = spans.findIndex(
-      (s) => s.sourceId === selectedChatSourceId
+      (s) => s.sourceId === selectedChatSourceId,
     );
     if (targetIndex === -1) return;
 
     const targetEl = containerElement.querySelector(
-      `span[data-span-index="${targetIndex}"]`
+      `span[data-span-index="${targetIndex}"]`,
     ) as HTMLElement | null;
     if (!targetEl) return;
 
@@ -758,12 +766,12 @@ const TxtAnnotator: React.FC<TxtAnnotatorProps> = ({
     const anchorGlobalOffset = getGlobalOffsetFromNode(
       anchorNode,
       selection.anchorOffset,
-      spans
+      spans,
     );
     const focusGlobalOffset = getGlobalOffsetFromNode(
       focusNode,
       selection.focusOffset,
-      spans
+      spans,
     );
 
     if (anchorGlobalOffset === null || focusGlobalOffset === null) {
@@ -811,19 +819,19 @@ const TxtAnnotator: React.FC<TxtAnnotatorProps> = ({
           const usedAnn =
             chatSources.length > 0
               ? spanAnnotations.filter((ann) =>
-                  selectedAnnotations.includes(ann.id)
+                  selectedAnnotations.includes(ann.id),
                 )
               : selectedAnnotations.length > 0
-              ? spanAnnotations.filter((ann) =>
-                  selectedAnnotations.includes(ann.id)
-                )
-              : spanAnnotations;
+                ? spanAnnotations.filter((ann) =>
+                    selectedAnnotations.includes(ann.id),
+                  )
+                : spanAnnotations;
 
           const finalAnnotations = usedAnn.filter(
             (ann) =>
               showStructuralAnnotations ||
               !ann.structural ||
-              selectedAnnotations.includes(ann.id)
+              selectedAnnotations.includes(ann.id),
           );
 
           // Evaluate approval/rejected status.
@@ -841,7 +849,7 @@ const TxtAnnotator: React.FC<TxtAnnotatorProps> = ({
             } else {
               // multiple annotation colors
               const colors = finalAnnotations.map((ann) =>
-                hexToRgba(ann.annotationLabel.color ?? "#cccccc", 0.3)
+                hexToRgba(ann.annotationLabel.color ?? "#cccccc", 0.3),
               );
               highlightColors.push(...colors);
             }
@@ -850,7 +858,7 @@ const TxtAnnotator: React.FC<TxtAnnotatorProps> = ({
           // If we have a search highlight (but not when chat sources are displayed)
           if (isSearchResult && chatSources.length === 0) {
             highlightColors.push(
-              isSelectedSearchResult ? "#FFFF00" : "#FFFF99"
+              isSelectedSearchResult ? "#FFFF00" : "#FFFF99",
             );
           }
 
@@ -1002,7 +1010,7 @@ const TxtAnnotator: React.FC<TxtAnnotatorProps> = ({
                 />
               </LabelContainer>
             );
-          }
+          },
         )}
       </PaperContainer>
 
@@ -1026,7 +1034,7 @@ const TxtAnnotator: React.FC<TxtAnnotatorProps> = ({
               value={annotationToEdit.annotationLabel.id}
               onChange={(e, { value }) => {
                 const newLabel = availableLabels.find(
-                  (lbl) => lbl.id === value
+                  (lbl) => lbl.id === value,
                 );
                 if (newLabel) {
                   const updatedAnnotation = annotationToEdit.update({


### PR DESCRIPTION
## Summary
Fixed an infinite re-render loop in the `TxtAnnotator` component caused by an unstable default parameter for the `chatSources` prop. The issue occurred because `chatSources = []` created a new array reference on every render, triggering unnecessary re-renders in `useEffect` dependency arrays.

## Key Changes
- **Extracted `ChatSourceHighlight` interface**: Moved the inline object type definition for chat source highlights into a proper TypeScript interface for better type safety and reusability
- **Created module-level constant**: Defined `EMPTY_CHAT_SOURCES` as a stable, empty array constant to serve as the default value for the `chatSources` prop, ensuring referential equality across renders
- **Updated prop default**: Changed `chatSources = []` to `chatSources = EMPTY_CHAT_SOURCES` in the component destructuring
- **Code formatting improvements**: Applied consistent formatting to trailing commas in function parameters and array/object literals throughout the file for better code style consistency

## Implementation Details
The root cause was that JavaScript creates a new array object each time `[]` is evaluated, even though the contents are identical. When this default was used in `useEffect` dependency arrays, React detected a "change" and re-ran effects, which could trigger new renders, creating a loop. By using a module-level constant that's created once and reused, the reference remains stable across all renders where the prop isn't explicitly provided.

This fix ensures that the component only re-renders when actual prop values change, not due to reference instability in default parameters.

https://claude.ai/code/session_019rYAzRP7G7ZiNAFRu9C2KB