### PR TITLE
Update Pydantic decorator from validate_arguments to validate_call

### DIFF
--- a/opencontractserver/tasks/doc_tasks.py
+++ b/opencontractserver/tasks/doc_tasks.py
@@ -12,7 +12,7 @@ from django.contrib.auth import get_user_model
 from django.core.files.storage import default_storage
 from django.db.models import Q
 from django.utils import timezone
-from pydantic import validate_arguments
+from pydantic import validate_call
 
 from config import celery_app
 from opencontractserver.annotations.models import TOKEN_LABEL, Annotation
@@ -437,7 +437,7 @@ def ingest_doc(self, user_id: int, doc_id: int) -> dict[str, Any]:
 
 
 @celery_app.task()
-@validate_arguments
+@validate_call
 def burn_doc_annotations(
     label_lookups: LabelLookupPythonType,
     doc_id: int,


### PR DESCRIPTION
## Summary
Updated Pydantic decorator usage to reflect the latest Pydantic v2 API, replacing the deprecated `validate_arguments` with `validate_call`.

## Key Changes
- Replaced `from pydantic import validate_arguments` with `from pydantic import validate_call` in the imports
- Updated the `@validate_arguments` decorator on the `burn_doc_annotations` function to `@validate_call`

## Details
This change aligns with Pydantic v2's API changes where `validate_arguments` has been replaced with `validate_call`. The `validate_call` decorator provides the same functionality for runtime validation of function arguments and is the recommended approach in current Pydantic versions.

https://claude.ai/code/session_015MkNCdtU5mVx1HDTipp3Gv