### PR TITLE
Fix structural annotation set inheritance on document version updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,14 @@ All notable changes to OpenContracts will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2026-02-22
+## [Unreleased] - 2026-02-24
+
+### Fixed
+
+#### Document Version Structural Annotation Set Inheritance
+- **Bug**: When a document was updated with new content (different hash), `import_document()` unconditionally inherited the old version's `structural_annotation_set`. This caused the parser's `_create_structural_annotation_set()` to short-circuit (early return at `pipeline/base/parser.py:299`), leaving freshly-parsed structural annotations orphaned — never migrated into a set.
+- **Fix**: `opencontractserver/documents/versioning.py:224-231` — `structural_annotation_set` is now only inherited when the content hash is unchanged. When content changes, the field is set to `None` so the parser creates a fresh `StructuralAnnotationSet` during ingestion.
+- **Tests**: `opencontractserver/tests/test_structural_annotation_portability.py` — replaced single test with two: one verifying `None` on changed content, one verifying inheritance on identical content.
 
 ### Added
 

--- a/opencontractserver/documents/versioning.py
+++ b/opencontractserver/documents/versioning.py
@@ -221,6 +221,15 @@ def import_document(
                     )
                 effective_txt_file = None
 
+            # Inherit structural annotation set only when content is unchanged.
+            # When content changes (different hash), the parser will create a
+            # fresh StructuralAnnotationSet for the new content during ingestion.
+            old_set = old_doc.structural_annotation_set
+            if old_set and old_doc.pdf_file_hash == content_hash:
+                inherited_set = old_set
+            else:
+                inherited_set = None
+
             # Create new document version (isolated within corpus)
             new_doc = Document.objects.create(
                 title=doc_kwargs.get("title", old_doc.title),
@@ -232,7 +241,7 @@ def import_document(
                 version_tree_id=old_doc.version_tree_id,  # Same tree
                 parent=old_doc,
                 is_current=True,
-                structural_annotation_set=old_doc.structural_annotation_set,  # Inherit structural annotations
+                structural_annotation_set=inherited_set,
                 creator=user,
                 **{
                     k: v

--- a/opencontractserver/tests/test_structural_annotation_portability.py
+++ b/opencontractserver/tests/test_structural_annotation_portability.py
@@ -354,14 +354,13 @@ class ImportContentStructuralSetTests(TransactionTestCase):
         # import_document doesn't copy structural sets from existing docs
         self.assertIsNone(doc.structural_annotation_set)
 
-    def test_version_update_inherits_structural_set_from_previous_version(self):
-        """When content is updated, the new version INHERITS the structural set from previous version."""
+    def test_version_update_with_changed_content_gets_no_structural_set(self):
+        """When content changes, the new version gets NO structural set (parser creates fresh one)."""
         from opencontractserver.documents.versioning import import_document
 
         content_v1 = b"test pdf content v1"
         content_v2 = b"test pdf content v2"
         hash_v1 = hashlib.sha256(content_v1).hexdigest()
-        _hash_v2 = hashlib.sha256(content_v2).hexdigest()  # noqa: F841
 
         # Create structural set for v1
         structural_set_v1 = StructuralAnnotationSet.objects.create(
@@ -381,7 +380,7 @@ class ImportContentStructuralSetTests(TransactionTestCase):
         doc_v1.structural_annotation_set = structural_set_v1
         doc_v1.save()
 
-        # Import v2 at same path (version update)
+        # Import v2 at same path with DIFFERENT content (version update)
         doc_v2, status_v2, path_v2 = import_document(
             corpus=self.corpus_a,
             path="/documents/test.pdf",
@@ -390,10 +389,46 @@ class ImportContentStructuralSetTests(TransactionTestCase):
         )
         self.assertEqual(status_v2, "updated")
 
-        # v2 INHERITS structural set from v1 (version updates carry forward the set)
-        # This is different from add_document() which DUPLICATES the set
-        # The parser may later update the set if needed for new content
-        self.assertEqual(doc_v2.structural_annotation_set, structural_set_v1)
+        # v2 should NOT inherit v1's structural set because content changed.
+        # The parser will create a fresh StructuralAnnotationSet during ingestion.
+        self.assertIsNone(doc_v2.structural_annotation_set)
+
+    def test_version_update_with_same_content_inherits_structural_set(self):
+        """When content hash is unchanged, the new version reuses the existing structural set."""
+        from opencontractserver.documents.versioning import import_document
+
+        content = b"test pdf content unchanged"
+        content_hash = hashlib.sha256(content).hexdigest()
+
+        # Create structural set for this content
+        structural_set = StructuralAnnotationSet.objects.create(
+            content_hash=content_hash, creator=self.user
+        )
+
+        # Import v1
+        doc_v1, status_v1, path_v1 = import_document(
+            corpus=self.corpus_a,
+            path="/documents/test.pdf",
+            content=content,
+            user=self.user,
+        )
+        self.assertEqual(status_v1, "created")
+
+        # Manually set the structural set (simulating parser creating it)
+        doc_v1.structural_annotation_set = structural_set
+        doc_v1.save()
+
+        # Import same content again at same path (re-upload, same hash)
+        doc_v2, status_v2, path_v2 = import_document(
+            corpus=self.corpus_a,
+            path="/documents/test.pdf",
+            content=content,
+            user=self.user,
+        )
+        self.assertEqual(status_v2, "updated")
+
+        # v2 should inherit the structural set because content hash is identical
+        self.assertEqual(doc_v2.structural_annotation_set, structural_set)
 
     def test_brand_new_content_has_no_structural_set(self):
         """Brand new content should have no structural set (parser will create it later)."""


### PR DESCRIPTION
## Summary

Fixed a bug where document version updates with changed content would incorrectly inherit the previous version's structural annotation set, preventing the parser from creating a fresh set for the new content.

## Key Changes

- **versioning.py**: Modified `import_document()` to only inherit `structural_annotation_set` when the content hash is unchanged. When content changes (different hash), the field is now set to `None`, allowing the parser to create a fresh `StructuralAnnotationSet` during ingestion.

- **test_structural_annotation_portability.py**: Replaced the single test `test_version_update_inherits_structural_set_from_previous_version()` with two focused tests:
  - `test_version_update_with_changed_content_gets_no_structural_set()` — verifies that version updates with different content do not inherit the structural set
  - `test_version_update_with_same_content_inherits_structural_set()` — verifies that version updates with identical content do inherit the structural set

## Implementation Details

The fix adds a conditional check in `versioning.py` (lines 224-231) that compares the old document's `pdf_file_hash` with the new content hash. Only when hashes match is the structural annotation set inherited; otherwise it's set to `None`. This ensures the parser's `_create_structural_annotation_set()` method can execute normally instead of short-circuiting on an existing set, allowing freshly-parsed structural annotations to be properly migrated into a new set.

https://claude.ai/code/session_01G5x6UsdgMD7kbN3t3huChr