### PR TITLE
Add document versioning end-to-end documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,18 @@ All notable changes to OpenContracts will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2026-02-24
+## [Unreleased] - 2026-02-25
+
+### Added
+
+#### Document Version Selector End-to-End Documentation (Closes #954)
+- **User-facing guide**: `docs/features/document_versioning.md` — covers version creation workflow, visual status indicators (gray/blue/orange badges), Version History Panel usage, and Trash folder recovery
+- **Documentation screenshots**: Added `docScreenshot` calls to capture five key UI states:
+  - `versioning--badge--single-version` — gray badge for documents without history (`frontend/tests/VersionBadge.ct.tsx`)
+  - `versioning--badge--latest-version` — blue badge showing version count (`frontend/tests/VersionBadge.ct.tsx`)
+  - `versioning--badge--older-version` — orange badge for outdated versions (`frontend/tests/VersionBadge.ct.tsx`)
+  - `versioning--history-panel--with-versions` — already captured in `frontend/tests/VersionHistoryPanel.ct.tsx`
+  - `versioning--trash-folder--restore-ui` — deleted document recovery interface (`frontend/tests/TrashFolderView.ct.tsx`)
 
 ### Fixed
 

--- a/docs/features/document_versioning.md
+++ b/docs/features/document_versioning.md
@@ -1,0 +1,162 @@
+# Document Version Selector
+
+## Overview
+
+OpenContracts tracks every change to your documents using an immutable version
+history. When you re-upload a file at the same path inside a corpus, the platform
+creates a **new version** rather than overwriting the original. A small
+**version badge** on each document card tells you at a glance whether the
+document has history, and the **Version History Panel** lets you browse, compare,
+and restore any past version.
+
+## Version Creation
+
+Versions are created automatically when a document is uploaded to a path that
+already contains a file:
+
+1. **First upload** &mdash; creates Version 1 (the initial version).
+2. **Subsequent uploads at the same path** &mdash; each one creates a new
+   version (v2, v3, &hellip;). The previous version is preserved and can be
+   accessed at any time.
+
+Moves and renames do **not** bump the version number &mdash; only content
+changes do.
+
+## Visual Status Indicators
+
+Every document card displays a small badge in its top-right corner. The badge
+color communicates the document's version state at a glance:
+
+| Badge Color | Meaning                            | Example                   |
+| ----------- | ---------------------------------- | ------------------------- |
+| **Gray**    | Single version, no history         | `v1`                      |
+| **Blue**    | Latest version, history available  | `v3 • 5` (version 3 of 5) |
+| **Orange**  | Older version (a newer one exists) | `v2 • 3` (version 2 of 3) |
+
+### Single-Version Badge (Gray)
+
+Documents that have never been updated show a simple gray `v1` badge. The badge
+is not clickable because there is no history to browse.
+
+![Single-version badge](../assets/images/screenshots/auto/versioning--badge--single-version.png)
+
+### Latest-Version Badge (Blue)
+
+When a document has multiple versions and you are viewing the latest one, the
+badge turns blue and shows the version count (e.g. `v3 • 5`). Click the badge
+to open the Version History Panel.
+
+![Latest-version badge](../assets/images/screenshots/auto/versioning--badge--latest-version.png)
+
+### Older-Version Badge (Orange)
+
+If you are viewing a version that is **not** the latest, the badge turns orange
+as a warning. This helps you notice when you are looking at outdated content.
+Hovering over it shows additional context.
+
+![Older-version badge](../assets/images/screenshots/auto/versioning--badge--older-version.png)
+
+## Version History Panel
+
+Clicking a blue or orange version badge opens the **Version History Panel**, a
+modal dialog with a vertical timeline of every version.
+
+![Version History Panel](../assets/images/screenshots/auto/versioning--history-panel--with-versions.png)
+
+Each version card shows:
+
+- **Version number** and whether it is the current version
+- **Change type** badge (Initial, Content Update, Minor Edit, Major Revision)
+- **Author** who created that version
+- **Timestamps** (relative and absolute)
+- **File size**
+
+### Selecting a Version
+
+Click any version card to select it. For non-current versions, two action
+buttons appear:
+
+- **Restore This Version** &mdash; creates a new version with the selected
+  version's content (the old version is preserved, not overwritten).
+- **Download** &mdash; downloads the file for that specific version.
+
+Selecting the current version shows an informational message instead.
+
+### Restore Feedback
+
+After restoring:
+
+- A **green success message** confirms the new version number (auto-dismisses
+  after 5 seconds).
+- If the restore fails, a **red error message** explains why (auto-dismisses
+  after 10 seconds).
+
+Both messages can be dismissed manually by clicking the close icon.
+
+## Trash Folder and Document Recovery
+
+When a document is deleted, it is **soft-deleted** &mdash; it moves to the
+corpus Trash folder rather than being permanently removed.
+
+![Trash folder restore UI](../assets/images/screenshots/auto/versioning--trash-folder--restore-ui.png)
+
+The Trash folder view shows:
+
+- Each deleted document with its original title, file type, page count, and
+  the user who last modified it.
+- The **original folder** the document belonged to (if any).
+- A **Restore** button on every document card.
+- **Select all** / **Clear Selection** controls for bulk operations.
+- A **Restore Selected** button for restoring multiple documents at once.
+- An **Empty Trash** button for permanently removing all items.
+
+### Restoring a Deleted Document
+
+1. Open the Trash folder from the corpus folder sidebar.
+2. Click **Restore** on the document you want to recover, or select multiple
+   documents and click **Restore Selected**.
+3. The document reappears at its original path and folder.
+
+Partial failures during bulk restore are handled gracefully &mdash; successfully
+restored documents are removed from the trash while failed ones remain with an
+error message.
+
+## Technical Details
+
+### Architecture
+
+Document versioning uses a **dual-tree architecture**:
+
+- **Content Tree** (Document model) &mdash; tracks "what is this file's
+  content?" Each upload creates a new Document node linked to its predecessor.
+- **Path Tree** (DocumentPath model) &mdash; tracks "where has this file
+  lived?" Every lifecycle event (import, move, delete, restore) creates a new
+  path node.
+
+For the full architecture specification, see
+[Dual-Tree Document Versioning Architecture](../architecture/document_versioning.md).
+
+### Components
+
+| Component             | Location                                                       | Purpose                                           |
+| --------------------- | -------------------------------------------------------------- | ------------------------------------------------- |
+| `VersionBadge`        | `frontend/src/components/documents/VersionBadge.tsx`           | Color-coded badge on document cards               |
+| `VersionHistoryPanel` | `frontend/src/components/documents/VersionHistoryPanel.tsx`    | Timeline modal with restore/download actions      |
+| `TrashFolderView`     | `frontend/src/components/corpuses/folders/TrashFolderView.tsx` | Trash folder with bulk restore                    |
+| `ModernDocumentItem`  | `frontend/src/components/documents/ModernDocumentItem.tsx`     | Document card that integrates the badge and panel |
+
+### GraphQL Operations
+
+| Operation                     | Type     | Description                                           |
+| ----------------------------- | -------- | ----------------------------------------------------- |
+| `GetDocumentVersionHistory`   | Query    | Fetches version list with metadata for a document     |
+| `RestoreDocumentToVersion`    | Mutation | Creates a new version from a previous one             |
+| `GetDeletedDocumentsInCorpus` | Query    | Lists soft-deleted documents in a corpus              |
+| `RestoreDeletedDocument`      | Mutation | Restores a soft-deleted document to its original path |
+
+### Corpus Isolation
+
+Each corpus maintains completely independent version trees. Uploading the same
+file to two different corpuses creates two separate, unrelated documents. This
+ensures there are no cross-corpus version conflicts and supports per-corpus
+embedding models for vector search.

--- a/frontend/tests/TrashFolderView.ct.tsx
+++ b/frontend/tests/TrashFolderView.ct.tsx
@@ -72,7 +72,7 @@ test.describe("TrashFolderView", () => {
 
     await expect(page.getByText("Trash is Empty")).toBeVisible();
     await expect(
-      page.getByText("Deleted documents will appear here"),
+      page.getByText("Deleted documents will appear here")
     ).toBeVisible();
   });
 
@@ -84,7 +84,7 @@ test.describe("TrashFolderView", () => {
     });
 
     await expect(
-      page.locator(".header").getByText("Failed to load trash"),
+      page.locator(".header").getByText("Failed to load trash")
     ).toBeVisible();
   });
 
@@ -171,7 +171,7 @@ test.describe("TrashFolderView", () => {
       timeout: 10000,
     });
     await expect(
-      page.getByRole("paragraph").getByText("Document restored successfully"),
+      page.getByRole("paragraph").getByText("Document restored successfully")
     ).toBeVisible();
   });
 
@@ -201,7 +201,7 @@ test.describe("TrashFolderView", () => {
         onBack={() => {
           backCalled = true;
         }}
-      />,
+      />
     );
 
     await page.waitForSelector('text="Trash"', { timeout: 10000 });
@@ -323,7 +323,7 @@ test.describe("TrashFolderView", () => {
 
     // Success message should be gone
     await expect(
-      page.locator(".header").getByText("Success"),
+      page.locator(".header").getByText("Success")
     ).not.toBeVisible();
   });
 
@@ -398,7 +398,7 @@ test.describe("TrashFolderView", () => {
 
       // Should show error message about missing document information
       await expect(
-        page.getByText("Cannot restore: document information is missing"),
+        page.getByText("Cannot restore: document information is missing")
       ).toBeVisible({ timeout: 10000 });
     });
 
@@ -413,7 +413,7 @@ test.describe("TrashFolderView", () => {
         <TrashFolderViewTestWrapper
           mockType="mixedNull"
           restoreMockType="mixedNull"
-        />,
+        />
       );
 
       await page.waitForSelector('text="Valid Document"', { timeout: 10000 });
@@ -431,7 +431,7 @@ test.describe("TrashFolderView", () => {
 
       // Should show warning about skipped document with missing data (appears in error message)
       await expect(
-        page.getByText(/1 document skipped: missing or corrupted data/),
+        page.getByText(/1 document skipped: missing or corrupted data/)
       ).toBeVisible({ timeout: 15000 });
     });
 
@@ -455,8 +455,8 @@ test.describe("TrashFolderView", () => {
       // Should show clear error message
       await expect(
         page.getByText(
-          "Selected documents cannot be restored: document data is missing or corrupted",
-        ),
+          "Selected documents cannot be restored: document data is missing or corrupted"
+        )
       ).toBeVisible({ timeout: 10000 });
     });
   });

--- a/frontend/tests/TrashFolderView.ct.tsx
+++ b/frontend/tests/TrashFolderView.ct.tsx
@@ -1,5 +1,6 @@
 import { test, expect } from "@playwright/experimental-ct-react";
 import { TrashFolderViewTestWrapper } from "./TrashFolderViewTestWrapper";
+import { docScreenshot } from "./utils/docScreenshot";
 
 test.describe("TrashFolderView", () => {
   test("renders trash folder header", async ({ mount, page }) => {
@@ -71,7 +72,7 @@ test.describe("TrashFolderView", () => {
 
     await expect(page.getByText("Trash is Empty")).toBeVisible();
     await expect(
-      page.getByText("Deleted documents will appear here")
+      page.getByText("Deleted documents will appear here"),
     ).toBeVisible();
   });
 
@@ -83,7 +84,7 @@ test.describe("TrashFolderView", () => {
     });
 
     await expect(
-      page.locator(".header").getByText("Failed to load trash")
+      page.locator(".header").getByText("Failed to load trash"),
     ).toBeVisible();
   });
 
@@ -151,6 +152,7 @@ test.describe("TrashFolderView", () => {
 
     // At least 2 restore buttons (one per document)
     expect(count).toBeGreaterThanOrEqual(2);
+    await docScreenshot(page, "versioning--trash-folder--restore-ui");
   });
 
   test("shows success message after restore", async ({ mount, page }) => {
@@ -169,7 +171,7 @@ test.describe("TrashFolderView", () => {
       timeout: 10000,
     });
     await expect(
-      page.getByRole("paragraph").getByText("Document restored successfully")
+      page.getByRole("paragraph").getByText("Document restored successfully"),
     ).toBeVisible();
   });
 
@@ -199,7 +201,7 @@ test.describe("TrashFolderView", () => {
         onBack={() => {
           backCalled = true;
         }}
-      />
+      />,
     );
 
     await page.waitForSelector('text="Trash"', { timeout: 10000 });
@@ -321,7 +323,7 @@ test.describe("TrashFolderView", () => {
 
     // Success message should be gone
     await expect(
-      page.locator(".header").getByText("Success")
+      page.locator(".header").getByText("Success"),
     ).not.toBeVisible();
   });
 
@@ -396,7 +398,7 @@ test.describe("TrashFolderView", () => {
 
       // Should show error message about missing document information
       await expect(
-        page.getByText("Cannot restore: document information is missing")
+        page.getByText("Cannot restore: document information is missing"),
       ).toBeVisible({ timeout: 10000 });
     });
 
@@ -411,7 +413,7 @@ test.describe("TrashFolderView", () => {
         <TrashFolderViewTestWrapper
           mockType="mixedNull"
           restoreMockType="mixedNull"
-        />
+        />,
       );
 
       await page.waitForSelector('text="Valid Document"', { timeout: 10000 });
@@ -429,7 +431,7 @@ test.describe("TrashFolderView", () => {
 
       // Should show warning about skipped document with missing data (appears in error message)
       await expect(
-        page.getByText(/1 document skipped: missing or corrupted data/)
+        page.getByText(/1 document skipped: missing or corrupted data/),
       ).toBeVisible({ timeout: 15000 });
     });
 
@@ -453,8 +455,8 @@ test.describe("TrashFolderView", () => {
       // Should show clear error message
       await expect(
         page.getByText(
-          "Selected documents cannot be restored: document data is missing or corrupted"
-        )
+          "Selected documents cannot be restored: document data is missing or corrupted",
+        ),
       ).toBeVisible({ timeout: 10000 });
     });
   });

--- a/frontend/tests/VersionBadge.ct.tsx
+++ b/frontend/tests/VersionBadge.ct.tsx
@@ -1,19 +1,21 @@
 import React from "react";
 import { test, expect } from "@playwright/experimental-ct-react";
 import { VersionBadge } from "../src/components/documents/VersionBadge";
+import { docScreenshot } from "./utils/docScreenshot";
 
 test.describe("VersionBadge", () => {
   test("renders version number correctly", async ({ mount, page }) => {
     const component = await mount(
       <VersionBadge
-        versionNumber={3}
+        versionNumber={1}
         hasHistory={false}
         isLatest={true}
         versionCount={1}
-      />
+      />,
     );
 
-    await expect(component.getByText("v3")).toBeVisible({ timeout: 10000 });
+    await expect(component.getByText("v1")).toBeVisible({ timeout: 10000 });
+    await docScreenshot(page, "versioning--badge--single-version");
   });
 
   test("displays correct cursor for no version history", async ({
@@ -26,7 +28,7 @@ test.describe("VersionBadge", () => {
         hasHistory={false}
         isLatest={true}
         versionCount={1}
-      />
+      />,
     );
 
     // Badge with no history should not have pointer cursor
@@ -48,7 +50,7 @@ test.describe("VersionBadge", () => {
         hasHistory={true}
         isLatest={true}
         versionCount={2}
-      />
+      />,
     );
 
     // Badge with history should have pointer cursor
@@ -70,12 +72,13 @@ test.describe("VersionBadge", () => {
         hasHistory={true}
         isLatest={true}
         versionCount={5}
-      />
+      />,
     );
 
     await expect(component.getByText("v3")).toBeVisible({ timeout: 10000 });
     // Version count should be displayed (• 5)
     await expect(component.getByText("5")).toBeVisible();
+    await docScreenshot(page, "versioning--badge--latest-version");
   });
 
   test("calls onClick when clicked with history", async ({ mount, page }) => {
@@ -90,7 +93,7 @@ test.describe("VersionBadge", () => {
         onClick={() => {
           clicked = true;
         }}
-      />
+      />,
     );
 
     // Use role=button selector which is more reliable
@@ -110,7 +113,7 @@ test.describe("VersionBadge", () => {
         onClick={() => {
           clicked = true;
         }}
-      />
+      />,
     );
 
     await expect(component.getByText("v1")).toBeVisible({ timeout: 10000 });
@@ -127,7 +130,7 @@ test.describe("VersionBadge", () => {
         isLatest={true}
         versionCount={3}
         onClick={() => {}}
-      />
+      />,
     );
 
     const badge = page.getByRole("button");
@@ -146,7 +149,7 @@ test.describe("VersionBadge", () => {
         hasHistory={false}
         isLatest={true}
         versionCount={1}
-      />
+      />,
     );
 
     await expect(component.getByText("v1")).toBeVisible({ timeout: 10000 });
@@ -167,7 +170,7 @@ test.describe("VersionBadge", () => {
         hasHistory={true}
         isLatest={true}
         versionCount={3}
-      />
+      />,
     );
 
     const badge = page.getByRole("button");
@@ -196,11 +199,12 @@ test.describe("VersionBadge", () => {
         hasHistory={true}
         isLatest={false}
         versionCount={3}
-      />
+      />,
     );
 
     const badge = page.getByRole("button");
     await expect(badge).toBeVisible({ timeout: 10000 });
+    await docScreenshot(page, "versioning--badge--older-version");
 
     // Hover to show tooltip
     await badge.hover();
@@ -211,7 +215,7 @@ test.describe("VersionBadge", () => {
       timeout: 5000,
     });
     await expect(
-      page.getByText("A newer version is available (you are viewing v2 of 3)")
+      page.getByText("A newer version is available (you are viewing v2 of 3)"),
     ).toBeVisible();
   });
 
@@ -223,7 +227,7 @@ test.describe("VersionBadge", () => {
         isLatest={true}
         versionCount={3}
         onClick={() => {}}
-      />
+      />,
     );
 
     const badge = page.getByRole("button");
@@ -242,7 +246,7 @@ test.describe("VersionBadge", () => {
         isLatest={true}
         versionCount={2}
         className="custom-test-class"
-      />
+      />,
     );
 
     const badge = page.getByRole("button");
@@ -260,7 +264,7 @@ test.describe("VersionBadge", () => {
         hasHistory={false}
         isLatest={true}
         versionCount={1}
-      />
+      />,
     );
 
     await expect(component.getByText("v1")).toBeVisible({ timeout: 10000 });

--- a/frontend/tests/VersionBadge.ct.tsx
+++ b/frontend/tests/VersionBadge.ct.tsx
@@ -11,7 +11,7 @@ test.describe("VersionBadge", () => {
         hasHistory={false}
         isLatest={true}
         versionCount={1}
-      />,
+      />
     );
 
     await expect(component.getByText("v1")).toBeVisible({ timeout: 10000 });
@@ -28,7 +28,7 @@ test.describe("VersionBadge", () => {
         hasHistory={false}
         isLatest={true}
         versionCount={1}
-      />,
+      />
     );
 
     // Badge with no history should not have pointer cursor
@@ -50,7 +50,7 @@ test.describe("VersionBadge", () => {
         hasHistory={true}
         isLatest={true}
         versionCount={2}
-      />,
+      />
     );
 
     // Badge with history should have pointer cursor
@@ -72,7 +72,7 @@ test.describe("VersionBadge", () => {
         hasHistory={true}
         isLatest={true}
         versionCount={5}
-      />,
+      />
     );
 
     await expect(component.getByText("v3")).toBeVisible({ timeout: 10000 });
@@ -93,7 +93,7 @@ test.describe("VersionBadge", () => {
         onClick={() => {
           clicked = true;
         }}
-      />,
+      />
     );
 
     // Use role=button selector which is more reliable
@@ -113,7 +113,7 @@ test.describe("VersionBadge", () => {
         onClick={() => {
           clicked = true;
         }}
-      />,
+      />
     );
 
     await expect(component.getByText("v1")).toBeVisible({ timeout: 10000 });
@@ -130,7 +130,7 @@ test.describe("VersionBadge", () => {
         isLatest={true}
         versionCount={3}
         onClick={() => {}}
-      />,
+      />
     );
 
     const badge = page.getByRole("button");
@@ -149,7 +149,7 @@ test.describe("VersionBadge", () => {
         hasHistory={false}
         isLatest={true}
         versionCount={1}
-      />,
+      />
     );
 
     await expect(component.getByText("v1")).toBeVisible({ timeout: 10000 });
@@ -170,7 +170,7 @@ test.describe("VersionBadge", () => {
         hasHistory={true}
         isLatest={true}
         versionCount={3}
-      />,
+      />
     );
 
     const badge = page.getByRole("button");
@@ -199,7 +199,7 @@ test.describe("VersionBadge", () => {
         hasHistory={true}
         isLatest={false}
         versionCount={3}
-      />,
+      />
     );
 
     const badge = page.getByRole("button");
@@ -215,7 +215,7 @@ test.describe("VersionBadge", () => {
       timeout: 5000,
     });
     await expect(
-      page.getByText("A newer version is available (you are viewing v2 of 3)"),
+      page.getByText("A newer version is available (you are viewing v2 of 3)")
     ).toBeVisible();
   });
 
@@ -227,7 +227,7 @@ test.describe("VersionBadge", () => {
         isLatest={true}
         versionCount={3}
         onClick={() => {}}
-      />,
+      />
     );
 
     const badge = page.getByRole("button");
@@ -246,7 +246,7 @@ test.describe("VersionBadge", () => {
         isLatest={true}
         versionCount={2}
         className="custom-test-class"
-      />,
+      />
     );
 
     const badge = page.getByRole("button");
@@ -264,7 +264,7 @@ test.describe("VersionBadge", () => {
         hasHistory={false}
         isLatest={true}
         versionCount={1}
-      />,
+      />
     );
 
     await expect(component.getByText("v1")).toBeVisible({ timeout: 10000 });


### PR DESCRIPTION
## Summary

This PR adds comprehensive end-to-end documentation for the document versioning feature, including a detailed user guide and automated screenshot captures for key UI states.

## Key Changes

- **New documentation file** (`docs/features/document_versioning.md`):
  - User-facing guide covering version creation workflow
  - Visual status indicator reference (gray/blue/orange badge meanings)
  - Version History Panel usage and restore workflow
  - Trash folder and document recovery procedures
  - Technical architecture overview and component reference
  - GraphQL operations and corpus isolation details

- **Documentation screenshot integration**:
  - Added `docScreenshot` utility calls to capture five key UI states:
    - Single-version badge (gray, no history)
    - Latest-version badge (blue, with history)
    - Older-version badge (orange, outdated warning)
    - Trash folder restore interface
  - Updated test files to generate screenshots during component testing

- **Test file updates** (`frontend/tests/VersionBadge.ct.tsx`, `frontend/tests/TrashFolderView.ct.tsx`):
  - Integrated `docScreenshot` calls at appropriate test points
  - Minor formatting adjustments (trailing commas for consistency)

## Implementation Details

The documentation is structured to serve both end users (workflow and UI guide) and developers (architecture and technical reference). Screenshots are automatically captured during component tests, ensuring documentation stays synchronized with actual UI implementation. The guide references the dual-tree architecture (Content Tree and Path Tree) that powers the versioning system.

Closes #954

https://claude.ai/code/session_01TQ4gEtHnkXPYPvqd2Rk8NB