### PR TITLE
Add worker document upload system with access tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to OpenContracts will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2026-02-24
+## [Unreleased] - 2026-02-25
 
 ### Fixed
 
@@ -30,6 +30,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Pre-computed embedding storage**: workers can include embeddings in upload metadata; stored directly via bulk_create without re-running embedder models. Supports all vector dimensions (384–4096)
 - **Corpus creator ownership**: all documents, annotations, and labels created via worker uploads are owned by the corpus creator (not the service account), ensuring correct permission inheritance
 - **GraphQL management mutations**: `createWorkerAccount`, `deactivateWorkerAccount`, `createCorpusAccessToken`, `revokeCorpusAccessToken` (all superuser-only) in `config/graphql/worker_mutations.py`
+- **GraphQL management queries**: `workerAccounts` (superuser-only list), `corpusAccessTokens(corpusId)` (superuser or corpus owner), `workerDocumentUploads(corpusId, status)` with optional status filtering in `config/graphql/queries.py`
+- **Frontend admin panel**: Worker Accounts management page at `/admin/workers` with table view of all accounts, create/deactivate functionality, and token count display (`frontend/src/components/admin/WorkerAccountManagement.tsx`)
+- **Frontend corpus settings**: Worker Access Tokens section in corpus settings showing scoped tokens with key prefix, worker name, expiry, rate limit, upload count, and status. Includes create token modal with secure one-time key display and revoke functionality (`frontend/src/components/corpuses/settings/WorkerAccessTokensSection.tsx`)
+- **Admin panel navigation**: Worker Accounts card added to Global Settings Panel for superuser access
+- **Documentation**: Comprehensive walkthrough for external worker integration covering setup, API usage, metadata format, rate limiting, error handling, and security model (`docs/walkthrough/advanced/worker-document-uploads.md`)
 - **Celery task routing**: `CELERY_TASK_ROUTES` canonicalized in one place with guard comment (`config/settings/base.py`)
 - **Settings-based Beat schedule**: `CELERY_BEAT_SCHEDULE` for worker upload drain (60s interval), replacing fragile data migration approach
 - **File size limit**: `MAX_WORKER_UPLOAD_SIZE_BYTES` setting (default 256 MB) enforced at upload endpoint

--- a/config/graphql/queries.py
+++ b/config/graphql/queries.py
@@ -105,6 +105,11 @@ from config.graphql.ratelimits import (
     graphql_ratelimit,
     graphql_ratelimit_dynamic,
 )
+from config.graphql.worker_mutations import (
+    CorpusAccessTokenType,
+    WorkerAccountType,
+    WorkerDocumentUploadType,
+)
 from opencontractserver.analyzer.models import Analyzer, GremlinEngine
 from opencontractserver.annotations.models import (
     Annotation,
@@ -134,6 +139,11 @@ from opencontractserver.feedback.models import UserFeedback
 from opencontractserver.notifications.models import Notification
 from opencontractserver.types.enums import LabelType
 from opencontractserver.users.models import Assignment, UserExport, UserImport
+from opencontractserver.worker_uploads.models import (
+    CorpusAccessToken,
+    WorkerAccount,
+    WorkerDocumentUpload,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -4369,6 +4379,129 @@ class Query(graphene.ObjectType):
             modified=settings_instance.modified,
             modified_by=settings_instance.modified_by,
         )
+
+    # WORKER UPLOAD QUERIES (Superuser only) #################
+    worker_accounts = graphene.List(
+        WorkerAccountType,
+        description="List all worker accounts. Superuser only.",
+    )
+    corpus_access_tokens = graphene.List(
+        CorpusAccessTokenType,
+        corpus_id=graphene.Int(required=True),
+        description="List access tokens scoped to a corpus. Superuser or corpus owner.",
+    )
+    worker_document_uploads = graphene.List(
+        WorkerDocumentUploadType,
+        corpus_id=graphene.Int(required=True),
+        status=graphene.String(required=False),
+        description="List worker document uploads for a corpus, with optional status filter.",
+    )
+
+    @login_required
+    def resolve_worker_accounts(self, info):
+        user = info.context.user
+        if not user.is_superuser:
+            raise GraphQLError("Permission denied. Superuser access required.")
+
+        accounts = WorkerAccount.objects.select_related("creator", "user").all()
+        result = []
+        for account in accounts:
+            token_count = CorpusAccessToken.objects.filter(
+                worker_account=account
+            ).count()
+            result.append(
+                WorkerAccountType(
+                    id=account.id,
+                    name=account.name,
+                    description=account.description,
+                    is_active=account.is_active,
+                    created=account.created,
+                    token_count=token_count,
+                    creator_username=(
+                        account.creator.username if account.creator else None
+                    ),
+                )
+            )
+        return result
+
+    @login_required
+    def resolve_corpus_access_tokens(self, info, corpus_id):
+        user = info.context.user
+
+        try:
+            corpus = Corpus.objects.get(id=corpus_id)
+        except Corpus.DoesNotExist:
+            raise GraphQLError("Corpus not found.")
+
+        # Allow superusers and corpus owners
+        if not user.is_superuser and corpus.creator_id != user.id:
+            raise GraphQLError("Permission denied.")
+
+        tokens = (
+            CorpusAccessToken.objects.filter(corpus=corpus)
+            .select_related("worker_account", "corpus")
+            .order_by("-created")
+        )
+        result = []
+        for token in tokens:
+            upload_count = WorkerDocumentUpload.objects.filter(
+                corpus_access_token=token
+            ).count()
+            result.append(
+                CorpusAccessTokenType(
+                    id=token.id,
+                    key_prefix=token.key_prefix,
+                    worker_account_name=token.worker_account.name,
+                    corpus_id=token.corpus_id,
+                    corpus_title=token.corpus.title,
+                    expires_at=token.expires_at,
+                    is_active=token.is_active,
+                    rate_limit_per_minute=token.rate_limit_per_minute,
+                    created=token.created,
+                    upload_count=upload_count,
+                )
+            )
+        return result
+
+    @login_required
+    def resolve_worker_document_uploads(self, info, corpus_id, status=None):
+        user = info.context.user
+
+        try:
+            corpus = Corpus.objects.get(id=corpus_id)
+        except Corpus.DoesNotExist:
+            raise GraphQLError("Corpus not found.")
+
+        # Allow superusers and corpus owners
+        if not user.is_superuser and corpus.creator_id != user.id:
+            raise GraphQLError("Permission denied.")
+
+        qs = WorkerDocumentUpload.objects.filter(corpus=corpus).select_related(
+            "corpus_access_token__worker_account", "corpus"
+        )
+        if status:
+            qs = qs.filter(status=status)
+        qs = qs.order_by("-created")[:100]
+
+        result = []
+        for upload in qs:
+            worker_name = None
+            if upload.corpus_access_token and upload.corpus_access_token.worker_account:
+                worker_name = upload.corpus_access_token.worker_account.name
+            result.append(
+                WorkerDocumentUploadType(
+                    id=str(upload.id),
+                    status=upload.status,
+                    corpus_id=upload.corpus_id,
+                    corpus_title=upload.corpus.title,
+                    worker_account_name=worker_name,
+                    error_message=upload.error_message,
+                    created=upload.created,
+                    processing_started=upload.processing_started,
+                    processing_finished=upload.processing_finished,
+                )
+            )
+        return result
 
     # DEBUG FIELD ########################################
     if settings.ALLOW_GRAPHQL_DEBUG:

--- a/config/graphql/worker_mutations.py
+++ b/config/graphql/worker_mutations.py
@@ -1,5 +1,5 @@
 """
-GraphQL mutations for managing worker accounts and corpus access tokens.
+GraphQL mutations and types for managing worker accounts and corpus access tokens.
 
 Only superusers can create/manage worker accounts and tokens.
 """
@@ -30,18 +30,22 @@ class WorkerAccountType(graphene.ObjectType):
     description = graphene.String()
     is_active = graphene.Boolean()
     created = graphene.DateTime()
+    token_count = graphene.Int()
+    creator_username = graphene.String()
 
 
 class CorpusAccessTokenType(graphene.ObjectType):
     id = graphene.Int()
-    # Only show the full key on creation; afterwards show a masked version
-    key = graphene.String()
+    # Only show the key prefix after creation; full key shown only on creation
+    key_prefix = graphene.String()
     worker_account_name = graphene.String()
     corpus_id = graphene.Int()
+    corpus_title = graphene.String()
     expires_at = graphene.DateTime()
     is_active = graphene.Boolean()
     rate_limit_per_minute = graphene.Int()
     created = graphene.DateTime()
+    upload_count = graphene.Int()
 
 
 class CorpusAccessTokenCreatedType(graphene.ObjectType):
@@ -56,6 +60,18 @@ class CorpusAccessTokenCreatedType(graphene.ObjectType):
     expires_at = graphene.DateTime()
     rate_limit_per_minute = graphene.Int()
     created = graphene.DateTime()
+
+
+class WorkerDocumentUploadType(graphene.ObjectType):
+    id = graphene.String()
+    status = graphene.String()
+    corpus_id = graphene.Int()
+    corpus_title = graphene.String()
+    worker_account_name = graphene.String()
+    error_message = graphene.String()
+    created = graphene.DateTime()
+    processing_started = graphene.DateTime()
+    processing_finished = graphene.DateTime()
 
 
 # ============================================================================

--- a/docs/walkthrough/advanced/worker-document-uploads.md
+++ b/docs/walkthrough/advanced/worker-document-uploads.md
@@ -1,0 +1,244 @@
+# Worker Document Upload System
+
+## Overview
+
+The Worker Document Upload System allows external document processing workers
+(such as custom Docling pipelines, LlamaParse wrappers, or bespoke NLP services)
+to submit **pre-processed** documents directly into an OpenContracts corpus via a
+REST API. This enables headless, automated ingestion at scale without
+requiring the documents to pass through the built-in parsing pipeline.
+
+## Architecture
+
+```
+External Worker                OpenContracts
+┌──────────────┐   REST API    ┌─────────────────────┐
+│  Docling /   │──────────────>│  /api/worker-uploads │
+│  LlamaParse  │  WorkerKey    │  /documents/         │
+│  Custom NLP  │  Auth Header  │                      │
+└──────────────┘               │  ┌───────────────┐   │
+                               │  │ Staging Table  │   │
+                               │  │ (DB queue)     │   │
+                               │  └───────┬───────┘   │
+                               │          │            │
+                               │  ┌───────▼───────┐   │
+                               │  │ Celery Worker  │   │
+                               │  │ (batch proc.)  │   │
+                               │  └───────┬───────┘   │
+                               │          │            │
+                               │  ┌───────▼───────┐   │
+                               │  │ Document +     │   │
+                               │  │ Annotations +  │   │
+                               │  │ Embeddings     │   │
+                               │  └───────────────┘   │
+                               └─────────────────────┘
+```
+
+## Setup (Four Steps)
+
+### Step 1: Create a Worker Account
+
+Worker accounts are service accounts that represent an external processing
+worker. They are managed by superusers through the Admin Settings panel.
+
+1. Navigate to **Admin Settings** > **Worker Accounts**.
+2. Click **Create Worker Account**.
+3. Enter a descriptive **Name** (e.g., `docling-worker-prod`) and an optional
+   description.
+4. Click **Create Account**.
+
+The worker account will be created with an associated system user. This user
+has an unusable password and cannot log in directly.
+
+### Step 2: Create a Corpus Access Token
+
+Access tokens are scoped to a specific corpus and grant upload permissions
+to a worker account.
+
+1. Navigate to the **Corpus Settings** page for the target corpus.
+2. Scroll to the **Worker Access Tokens** section.
+3. Click **Create Access Token**.
+4. Select the **Worker Account** to grant access.
+5. Optionally set an **expiration** (in days) and a **rate limit** (requests
+   per minute; 0 = unlimited).
+6. Click **Create Token**.
+7. **Copy the displayed token immediately** — it will only be shown once.
+
+The token is stored as a SHA-256 hash. The plaintext cannot be recovered.
+
+### Step 3: Upload Documents via REST API
+
+Workers authenticate using the `WorkerKey` authorization scheme:
+
+```bash
+curl -X POST https://your-instance.example.com/api/worker-uploads/documents/ \
+  -H "Authorization: WorkerKey <your-plaintext-token>" \
+  -F "file=@/path/to/document.pdf" \
+  -F "metadata=$(cat <<'EOF'
+{
+  "title": "Contract Agreement 2024",
+  "content": "Full text content of the document...",
+  "page_count": 12,
+  "pawls_file_content": [
+    {
+      "page": {"width": 612, "height": 792, "index": 0},
+      "tokens": [
+        {"x": 72, "y": 72, "width": 50, "height": 12, "text": "Contract"}
+      ]
+    }
+  ],
+  "description": "Annual service agreement",
+  "file_type": "application/pdf"
+}
+EOF
+)"
+```
+
+A successful upload returns `202 Accepted`:
+
+```json
+{
+  "upload_id": "a1b2c3d4-...",
+  "status": "PENDING",
+  "message": "Upload accepted for processing."
+}
+```
+
+### Step 4: Monitor Upload Status
+
+Check the status of individual uploads or list all uploads for the token:
+
+```bash
+# Single upload status
+curl https://your-instance.example.com/api/worker-uploads/documents/<upload-id>/ \
+  -H "Authorization: WorkerKey <your-token>"
+
+# List all uploads (with optional status filter)
+curl "https://your-instance.example.com/api/worker-uploads/documents/list/?status=COMPLETED" \
+  -H "Authorization: WorkerKey <your-token>"
+```
+
+Upload statuses:
+- **PENDING** — Queued for processing
+- **PROCESSING** — Currently being processed by a Celery worker
+- **COMPLETED** — Successfully imported into the corpus
+- **FAILED** — Processing failed (check `error_message`)
+
+## Metadata Format Reference
+
+### Required Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `title` | string | Document title |
+| `content` | string | Full text content |
+| `page_count` | integer | Number of pages |
+| `pawls_file_content` | array | PAWLs-format token data with bounding boxes |
+
+### Optional Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `description` | string | Document description |
+| `file_type` | string | MIME type (default: `application/pdf`) |
+| `target_path` | string | Corpus path for organization |
+| `target_folder_path` | string | Folder hierarchy (auto-creates folders) |
+| `text_labels` | object | Label definitions `{name: {text, label_type, color, ...}}` |
+| `doc_labels_definitions` | object | Document label definitions |
+| `doc_labels` | array | Document label names to apply |
+| `labelled_text` | array | Pre-annotated text spans |
+| `relationships` | array | Relationships between annotations |
+| `embeddings` | object | Pre-computed vector embeddings |
+
+### Embeddings Format
+
+```json
+{
+  "embeddings": {
+    "embedder_path": "opencontractserver.pipeline.embedders.sent_transformer_encoder.SentenceTransformerEncoder",
+    "document_embedding": [0.1, 0.2, ...],
+    "annotation_embeddings": {
+      "annotation-id-1": [0.1, 0.2, ...],
+      "annotation-id-2": [0.3, 0.4, ...]
+    }
+  }
+}
+```
+
+Supported embedding dimensions: 384, 768, 1024, 1536, 3072.
+
+### Labelled Text Format
+
+```json
+{
+  "labelled_text": [
+    {
+      "id": "unique-annotation-id",
+      "annotationLabel": "CLAUSE",
+      "rawText": "The parties agree to...",
+      "page": 0,
+      "annotation_json": {
+        "0": {"tokensJsons": [{"pageIndex": 0, "tokenIndex": 5}], "rawText": "..."}
+      },
+      "annotation_type": "TOKEN_LABEL",
+      "structural": false
+    }
+  ]
+}
+```
+
+## Rate Limiting
+
+Rate limiting is configured per access token:
+
+- **0** (default): Unlimited uploads
+- **N > 0**: Maximum N requests per minute (best-effort enforcement)
+
+Rate limit state is tracked per-token using the database. When the limit is
+exceeded, the API returns `429 Too Many Requests`.
+
+## Error Handling
+
+### Common HTTP Status Codes
+
+| Code | Meaning |
+|------|---------|
+| `202` | Upload accepted for processing |
+| `400` | Invalid request (bad metadata, missing fields) |
+| `401` | Authentication failed (invalid/expired token) |
+| `413` | File too large (default limit: 256 MB) |
+| `429` | Rate limit exceeded |
+| `500` | Internal server error |
+
+### Failed Upload Recovery
+
+Uploads that become stuck in `PROCESSING` status are automatically recovered
+by a periodic Celery task (`recover_stalled_uploads`). Uploads stalled for
+longer than `WORKER_UPLOAD_STALE_MINUTES` (default: 15 minutes) are reset
+to `PENDING` for reprocessing.
+
+## Security Model
+
+1. **Token Hashing**: Tokens are stored as SHA-256 hashes. Plaintext is
+   shown exactly once at creation time.
+2. **Corpus Scoping**: Each token grants access to exactly one corpus.
+   Tokens cannot be used to upload to other corpora.
+3. **Worker Account Isolation**: Worker accounts have associated system
+   users with unusable passwords (cannot log in to the UI).
+4. **Document Ownership**: Documents uploaded by workers are owned by the
+   **corpus creator**, not the worker service account.
+5. **Permission Inheritance**: Uploaded documents inherit the corpus's
+   permission model automatically.
+6. **Token Revocation**: Revoking a token immediately blocks future uploads.
+   Deactivating a worker account implicitly revokes all its tokens.
+
+## Configuration
+
+The following environment variables control worker upload behavior:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `WORKER_UPLOAD_BATCH_SIZE` | `50` | Uploads processed per batch |
+| `MAX_WORKER_UPLOAD_SIZE_BYTES` | `268435456` (256 MB) | Maximum file size |
+| `WORKER_UPLOAD_STALE_MINUTES` | `15` | Minutes before stalled upload recovery |
+| `MAX_WORKER_METADATA_SIZE_BYTES` | `524288000` (500 MB) | Maximum metadata size |

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -73,6 +73,7 @@ import {
   GlobalSettingsPanel,
   GlobalAgentManagement,
   SystemSettings,
+  WorkerAccountManagement,
 } from "./components/admin";
 import { useEnv } from "./components/hooks/UseEnv";
 import { ExtractDetailRoute } from "./components/routes/ExtractDetailRoute";
@@ -517,6 +518,10 @@ export const App = () => {
                   <Route
                     path="/admin/agents"
                     element={<GlobalAgentManagement />}
+                  />
+                  <Route
+                    path="/admin/workers"
+                    element={<WorkerAccountManagement />}
                   />
                   <Route path="/system_settings" element={<SystemSettings />} />
 

--- a/frontend/src/components/admin/GlobalSettingsPanel.tsx
+++ b/frontend/src/components/admin/GlobalSettingsPanel.tsx
@@ -207,6 +207,15 @@ const settingsItems: SettingItem[] = [
     route: "/system_settings",
   },
   {
+    id: "worker-accounts",
+    title: "Worker Accounts",
+    description:
+      "Manage external worker accounts and access tokens for automated document uploads.",
+    icon: "server",
+    color: "linear-gradient(135deg, #0ea5e9 0%, #0284c7 100%)",
+    route: "/admin/workers",
+  },
+  {
     id: "user-management",
     title: "User Management",
     description:

--- a/frontend/src/components/admin/WorkerAccountManagement.tsx
+++ b/frontend/src/components/admin/WorkerAccountManagement.tsx
@@ -1,0 +1,333 @@
+import React, { useState } from "react";
+import { useQuery, useMutation } from "@apollo/client";
+import {
+  Button,
+  Table,
+  Header,
+  Message,
+  Dimmer,
+  Loader,
+  Icon,
+  Modal,
+  Form,
+  Input,
+  TextArea,
+  Label,
+} from "semantic-ui-react";
+import styled from "styled-components";
+import { toast } from "react-toastify";
+import { ConfirmModal } from "../widgets/modals/ConfirmModal";
+import {
+  GET_WORKER_ACCOUNTS,
+  GetWorkerAccountsOutput,
+  WorkerAccountData,
+  CREATE_WORKER_ACCOUNT,
+  CreateWorkerAccountInput,
+  CreateWorkerAccountOutput,
+  DEACTIVATE_WORKER_ACCOUNT,
+  DeactivateWorkerAccountInput,
+  DeactivateWorkerAccountOutput,
+} from "../../graphql/queries/workerQueries";
+
+// ============================================================================
+// Styled Components
+// ============================================================================
+
+const Container = styled.div`
+  padding: 2rem;
+  max-width: 1400px;
+  margin: 0 auto;
+
+  @media (max-width: 768px) {
+    padding: 1rem;
+  }
+`;
+
+const PageHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 2rem;
+
+  @media (max-width: 768px) {
+    flex-direction: column;
+    gap: 1rem;
+    text-align: center;
+  }
+`;
+
+const PageTitle = styled(Header)`
+  &.ui.header {
+    margin: 0;
+    color: #1e293b;
+
+    @media (max-width: 768px) {
+      font-size: 1.5rem !important;
+    }
+  }
+`;
+
+const StyledSegment = styled.div`
+  border-radius: 12px;
+  background: white;
+  border: 1px solid rgba(226, 232, 240, 0.8);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+  overflow-x: auto;
+  padding: 1rem;
+`;
+
+const StatusBadge = styled(Label)<{ $active: boolean }>`
+  &.ui.label {
+    background: ${(props) => (props.$active ? "#dcfce7" : "#fef3c7")};
+    color: ${(props) => (props.$active ? "#166534" : "#92400e")};
+    font-weight: 500;
+  }
+`;
+
+const TokenCountBadge = styled(Label)`
+  &.ui.label {
+    background: #f1f5f9;
+    color: #475569;
+    font-weight: 500;
+  }
+`;
+
+// ============================================================================
+// Component
+// ============================================================================
+
+export const WorkerAccountManagement: React.FC = () => {
+  const [showCreateModal, setShowCreateModal] = useState(false);
+  const [deactivateModalOpen, setDeactivateModalOpen] = useState(false);
+  const [accountToDeactivate, setAccountToDeactivate] =
+    useState<WorkerAccountData | null>(null);
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+
+  const { loading, error, data, refetch } =
+    useQuery<GetWorkerAccountsOutput>(GET_WORKER_ACCOUNTS);
+
+  const [createAccount, { loading: creating }] = useMutation<
+    CreateWorkerAccountOutput,
+    CreateWorkerAccountInput
+  >(CREATE_WORKER_ACCOUNT, {
+    onCompleted: (data) => {
+      if (data.createWorkerAccount.ok) {
+        toast.success("Worker account created successfully");
+        setShowCreateModal(false);
+        setName("");
+        setDescription("");
+        refetch();
+      }
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const [deactivateAccount, { loading: deactivating }] = useMutation<
+    DeactivateWorkerAccountOutput,
+    DeactivateWorkerAccountInput
+  >(DEACTIVATE_WORKER_ACCOUNT, {
+    onCompleted: (data) => {
+      if (data.deactivateWorkerAccount.ok) {
+        toast.success("Worker account deactivated");
+        setDeactivateModalOpen(false);
+        setAccountToDeactivate(null);
+        refetch();
+      }
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const handleCreate = () => {
+    if (!name.trim()) {
+      toast.error("Name is required");
+      return;
+    }
+    createAccount({
+      variables: {
+        name: name.trim(),
+        description: description.trim() || undefined,
+      },
+    });
+  };
+
+  const accounts: WorkerAccountData[] = data?.workerAccounts || [];
+
+  if (loading) {
+    return (
+      <Container>
+        <Dimmer active inverted>
+          <Loader>Loading worker accounts...</Loader>
+        </Dimmer>
+      </Container>
+    );
+  }
+
+  if (error) {
+    return (
+      <Container>
+        <Message negative>
+          <Message.Header>Error loading worker accounts</Message.Header>
+          <p>{error.message}</p>
+        </Message>
+      </Container>
+    );
+  }
+
+  return (
+    <Container>
+      <PageHeader>
+        <PageTitle as="h1">
+          <Icon name="server" /> Worker Account Management
+        </PageTitle>
+        <Button
+          primary
+          icon
+          labelPosition="left"
+          onClick={() => {
+            setName("");
+            setDescription("");
+            setShowCreateModal(true);
+          }}
+        >
+          <Icon name="plus" />
+          Create Worker Account
+        </Button>
+      </PageHeader>
+
+      <StyledSegment>
+        {accounts.length === 0 ? (
+          <Message info>
+            <Message.Header>No Worker Accounts</Message.Header>
+            <p>
+              Create a worker account to allow external document processing
+              workers to upload pre-processed documents.
+            </p>
+          </Message>
+        ) : (
+          <Table basic="very" striped>
+            <Table.Header>
+              <Table.Row>
+                <Table.HeaderCell>Name</Table.HeaderCell>
+                <Table.HeaderCell>Status</Table.HeaderCell>
+                <Table.HeaderCell>Creator</Table.HeaderCell>
+                <Table.HeaderCell>Tokens</Table.HeaderCell>
+                <Table.HeaderCell>Created</Table.HeaderCell>
+                <Table.HeaderCell textAlign="right">Actions</Table.HeaderCell>
+              </Table.Row>
+            </Table.Header>
+            <Table.Body>
+              {accounts.map((account) => (
+                <Table.Row key={account.id}>
+                  <Table.Cell>
+                    <strong>{account.name}</strong>
+                    {account.description && (
+                      <div style={{ color: "#64748b", fontSize: "0.875rem" }}>
+                        {account.description}
+                      </div>
+                    )}
+                  </Table.Cell>
+                  <Table.Cell>
+                    <StatusBadge $active={account.isActive}>
+                      {account.isActive ? "Active" : "Inactive"}
+                    </StatusBadge>
+                  </Table.Cell>
+                  <Table.Cell>{account.creatorUsername || "—"}</Table.Cell>
+                  <Table.Cell>
+                    <TokenCountBadge>
+                      <Icon name="key" />
+                      {account.tokenCount}
+                    </TokenCountBadge>
+                  </Table.Cell>
+                  <Table.Cell>
+                    {new Date(account.created).toLocaleDateString()}
+                  </Table.Cell>
+                  <Table.Cell textAlign="right">
+                    {account.isActive && (
+                      <Button
+                        size="small"
+                        color="orange"
+                        icon
+                        labelPosition="left"
+                        onClick={() => {
+                          setAccountToDeactivate(account);
+                          setDeactivateModalOpen(true);
+                        }}
+                      >
+                        <Icon name="ban" />
+                        Deactivate
+                      </Button>
+                    )}
+                  </Table.Cell>
+                </Table.Row>
+              ))}
+            </Table.Body>
+          </Table>
+        )}
+      </StyledSegment>
+
+      {/* Create Worker Account Modal */}
+      <Modal
+        open={showCreateModal}
+        onClose={() => setShowCreateModal(false)}
+        size="small"
+      >
+        <Modal.Header>
+          <Icon name="server" /> Create Worker Account
+        </Modal.Header>
+        <Modal.Content>
+          <Form>
+            <Form.Field required>
+              <label>Name</label>
+              <Input
+                placeholder="e.g., docling-worker-1"
+                value={name}
+                onChange={(_, d) => setName(d.value)}
+              />
+            </Form.Field>
+            <Form.Field>
+              <label>Description</label>
+              <TextArea
+                placeholder="Optional description of this worker account"
+                value={description}
+                onChange={(_, d) => setDescription(d.value as string)}
+              />
+            </Form.Field>
+          </Form>
+        </Modal.Content>
+        <Modal.Actions>
+          <Button onClick={() => setShowCreateModal(false)}>Cancel</Button>
+          <Button
+            primary
+            loading={creating}
+            disabled={!name.trim() || creating}
+            onClick={handleCreate}
+          >
+            Create Account
+          </Button>
+        </Modal.Actions>
+      </Modal>
+
+      {/* Deactivate Confirmation */}
+      <ConfirmModal
+        visible={deactivateModalOpen}
+        message={`Are you sure you want to deactivate worker account "${accountToDeactivate?.name}"? This will implicitly revoke all its access tokens.`}
+        yesAction={() => {
+          if (accountToDeactivate) {
+            deactivateAccount({
+              variables: { workerAccountId: accountToDeactivate.id },
+            });
+          }
+        }}
+        noAction={() => {
+          setAccountToDeactivate(null);
+        }}
+        toggleModal={() => {
+          setDeactivateModalOpen(false);
+        }}
+      />
+    </Container>
+  );
+};
+
+export default WorkerAccountManagement;

--- a/frontend/src/components/admin/index.ts
+++ b/frontend/src/components/admin/index.ts
@@ -1,3 +1,4 @@
 export { GlobalSettingsPanel } from "./GlobalSettingsPanel";
 export { GlobalAgentManagement } from "./GlobalAgentManagement";
 export { SystemSettings } from "./SystemSettings";
+export { WorkerAccountManagement } from "./WorkerAccountManagement";

--- a/frontend/src/components/corpuses/CorpusSettings.tsx
+++ b/frontend/src/components/corpuses/CorpusSettings.tsx
@@ -44,6 +44,7 @@ import {
   VisibilitySlugSection,
   CategoriesSection,
   CorpusActionsSection,
+  WorkerAccessTokensSection,
 } from "./settings";
 
 // Shared styles
@@ -436,6 +437,21 @@ export const CorpusSettings: React.FC<CorpusSettingsProps> = ({ corpus }) => {
             <CorpusAgentManagement corpusId={corpus.id} canUpdate={canUpdate} />
           </SettingsCardContent>
         </SettingsCard>
+
+        {(isSuperuser || isOwner) && (
+          <SettingsCard id="worker-access-tokens-section">
+            <SettingsCardHeader>
+              <SettingsCardTitle>Worker Access Tokens</SettingsCardTitle>
+            </SettingsCardHeader>
+            <SettingsCardContent>
+              <WorkerAccessTokensSection
+                corpusId={corpus.id}
+                isSuperuser={isSuperuser}
+                isOwner={isOwner}
+              />
+            </SettingsCardContent>
+          </SettingsCard>
+        )}
 
         <CreateCorpusActionModal
           corpusId={corpus.id}

--- a/frontend/src/components/corpuses/settings/WorkerAccessTokensSection.tsx
+++ b/frontend/src/components/corpuses/settings/WorkerAccessTokensSection.tsx
@@ -1,0 +1,456 @@
+import React, { useState } from "react";
+import { useQuery, useMutation } from "@apollo/client";
+import {
+  Button,
+  Table,
+  Message,
+  Icon,
+  Modal,
+  Form,
+  Input,
+  Dropdown,
+  Loader,
+  Label,
+} from "semantic-ui-react";
+import { toast } from "react-toastify";
+import styled from "styled-components";
+import {
+  OS_LEGAL_COLORS,
+  OS_LEGAL_TYPOGRAPHY,
+  OS_LEGAL_SPACING,
+} from "../../../assets/configurations/osLegalStyles";
+import {
+  GET_CORPUS_ACCESS_TOKENS,
+  GetCorpusAccessTokensInput,
+  GetCorpusAccessTokensOutput,
+  CorpusAccessTokenData,
+  GET_WORKER_ACCOUNTS,
+  GetWorkerAccountsOutput,
+  CREATE_CORPUS_ACCESS_TOKEN,
+  CreateCorpusAccessTokenInput,
+  CreateCorpusAccessTokenOutput,
+  REVOKE_CORPUS_ACCESS_TOKEN,
+  RevokeCorpusAccessTokenInput,
+  RevokeCorpusAccessTokenOutput,
+} from "../../../graphql/queries/workerQueries";
+
+// ============================================================================
+// Styled Components
+// ============================================================================
+
+const TokenKeyDisplay = styled.div`
+  background: ${OS_LEGAL_COLORS.surfaceHover};
+  border: 1px solid ${OS_LEGAL_COLORS.border};
+  border-radius: ${OS_LEGAL_SPACING.borderRadiusButton};
+  padding: 1rem;
+  margin-top: 1rem;
+  font-family: monospace;
+  word-break: break-all;
+  position: relative;
+`;
+
+const TokenKeyLabel = styled.div`
+  font-family: ${OS_LEGAL_TYPOGRAPHY.fontFamilySans};
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: ${OS_LEGAL_COLORS.danger};
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+`;
+
+const TokenKeyValue = styled.code`
+  font-size: 0.875rem;
+  color: ${OS_LEGAL_COLORS.textPrimary};
+  display: block;
+  padding: 0.5rem;
+  background: white;
+  border: 1px solid ${OS_LEGAL_COLORS.border};
+  border-radius: 4px;
+`;
+
+const StatusBadge = styled(Label)<{ $active: boolean }>`
+  &.ui.label {
+    background: ${(props) => (props.$active ? "#dcfce7" : "#fef3c7")};
+    color: ${(props) => (props.$active ? "#166534" : "#92400e")};
+    font-weight: 500;
+    font-size: 0.75rem;
+  }
+`;
+
+const UploadCountBadge = styled(Label)`
+  &.ui.label {
+    background: #f1f5f9;
+    color: #475569;
+    font-weight: 500;
+    font-size: 0.75rem;
+  }
+`;
+
+const InfoBanner = styled.div`
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 1rem 1.25rem;
+  background: rgba(14, 165, 233, 0.08);
+  border: 1px solid rgba(14, 165, 233, 0.2);
+  border-radius: ${OS_LEGAL_SPACING.borderRadiusButton};
+  margin-bottom: 1rem;
+  font-family: ${OS_LEGAL_TYPOGRAPHY.fontFamilySans};
+  font-size: 0.875rem;
+  color: #0c4a6e;
+  line-height: 1.5;
+`;
+
+// ============================================================================
+// Component
+// ============================================================================
+
+interface WorkerAccessTokensSectionProps {
+  corpusId: string;
+  isSuperuser: boolean;
+  isOwner: boolean;
+}
+
+export const WorkerAccessTokensSection: React.FC<
+  WorkerAccessTokensSectionProps
+> = ({ corpusId, isSuperuser, isOwner }) => {
+  const [showCreateModal, setShowCreateModal] = useState(false);
+  const [showTokenModal, setShowTokenModal] = useState(false);
+  const [createdTokenKey, setCreatedTokenKey] = useState("");
+  const [selectedWorkerId, setSelectedWorkerId] = useState<number | null>(null);
+  const [expiresInDays, setExpiresInDays] = useState<string>("");
+  const [rateLimit, setRateLimit] = useState<string>("0");
+
+  // Parse numeric corpus ID from the relay-style global ID
+  const numericCorpusId = parseInt(
+    corpusId.includes(":")
+      ? atob(corpusId).split(":")[1]
+      : corpusId.replace(/\D/g, ""),
+    10
+  );
+
+  const {
+    data: tokensData,
+    loading: tokensLoading,
+    refetch: refetchTokens,
+  } = useQuery<GetCorpusAccessTokensOutput, GetCorpusAccessTokensInput>(
+    GET_CORPUS_ACCESS_TOKENS,
+    {
+      variables: { corpusId: numericCorpusId },
+      skip: !numericCorpusId,
+      fetchPolicy: "network-only",
+    }
+  );
+
+  const { data: accountsData } = useQuery<GetWorkerAccountsOutput>(
+    GET_WORKER_ACCOUNTS,
+    { skip: !isSuperuser }
+  );
+
+  const [createToken, { loading: creatingToken }] = useMutation<
+    CreateCorpusAccessTokenOutput,
+    CreateCorpusAccessTokenInput
+  >(CREATE_CORPUS_ACCESS_TOKEN, {
+    onCompleted: (data) => {
+      if (data.createCorpusAccessToken.ok) {
+        setCreatedTokenKey(data.createCorpusAccessToken.token.key);
+        setShowCreateModal(false);
+        setShowTokenModal(true);
+        resetForm();
+        refetchTokens();
+      }
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const [revokeToken] = useMutation<
+    RevokeCorpusAccessTokenOutput,
+    RevokeCorpusAccessTokenInput
+  >(REVOKE_CORPUS_ACCESS_TOKEN, {
+    onCompleted: (data) => {
+      if (data.revokeCorpusAccessToken.ok) {
+        toast.success("Token revoked");
+        refetchTokens();
+      }
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const resetForm = () => {
+    setSelectedWorkerId(null);
+    setExpiresInDays("");
+    setRateLimit("0");
+  };
+
+  const handleCreate = () => {
+    if (!selectedWorkerId) {
+      toast.error("Select a worker account");
+      return;
+    }
+
+    let expiresAt: string | undefined;
+    if (expiresInDays && parseInt(expiresInDays, 10) > 0) {
+      const date = new Date();
+      date.setDate(date.getDate() + parseInt(expiresInDays, 10));
+      expiresAt = date.toISOString();
+    }
+
+    createToken({
+      variables: {
+        workerAccountId: selectedWorkerId,
+        corpusId: numericCorpusId,
+        expiresAt,
+        rateLimitPerMinute: parseInt(rateLimit, 10) || 0,
+      },
+    });
+  };
+
+  const handleCopyToken = () => {
+    navigator.clipboard.writeText(createdTokenKey).then(
+      () => toast.success("Token copied to clipboard"),
+      () => toast.error("Failed to copy token")
+    );
+  };
+
+  const tokens: CorpusAccessTokenData[] = tokensData?.corpusAccessTokens || [];
+  const workerAccounts = accountsData?.workerAccounts || [];
+  const activeWorkerAccounts = workerAccounts.filter((a) => a.isActive);
+
+  const workerOptions = activeWorkerAccounts.map((a) => ({
+    key: a.id,
+    value: a.id,
+    text: a.name,
+  }));
+
+  if (!isSuperuser && !isOwner) {
+    return null;
+  }
+
+  return (
+    <>
+      <InfoBanner>
+        <Icon name="info circle" style={{ color: "#0284c7", flexShrink: 0 }} />
+        <span>
+          Worker access tokens allow external document processing workers to
+          upload pre-processed documents directly to this corpus. Tokens are
+          scoped to this corpus only.
+        </span>
+      </InfoBanner>
+
+      {tokensLoading ? (
+        <Loader active inline="centered" />
+      ) : tokens.length === 0 ? (
+        <Message info>
+          <Message.Header>No Access Tokens</Message.Header>
+          <p>
+            No worker access tokens have been created for this corpus yet.
+            {isSuperuser && " Click the button below to create one."}
+          </p>
+        </Message>
+      ) : (
+        <Table basic="very" striped compact size="small">
+          <Table.Header>
+            <Table.Row>
+              <Table.HeaderCell>Key Prefix</Table.HeaderCell>
+              <Table.HeaderCell>Worker</Table.HeaderCell>
+              <Table.HeaderCell>Status</Table.HeaderCell>
+              <Table.HeaderCell>Expires</Table.HeaderCell>
+              <Table.HeaderCell>Rate Limit</Table.HeaderCell>
+              <Table.HeaderCell>Uploads</Table.HeaderCell>
+              <Table.HeaderCell>Created</Table.HeaderCell>
+              {isSuperuser && (
+                <Table.HeaderCell textAlign="right">Actions</Table.HeaderCell>
+              )}
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            {tokens.map((token) => (
+              <Table.Row key={token.id}>
+                <Table.Cell>
+                  <code>{token.keyPrefix}...</code>
+                </Table.Cell>
+                <Table.Cell>{token.workerAccountName}</Table.Cell>
+                <Table.Cell>
+                  <StatusBadge $active={token.isActive}>
+                    {token.isActive ? "Active" : "Revoked"}
+                  </StatusBadge>
+                </Table.Cell>
+                <Table.Cell>
+                  {token.expiresAt
+                    ? new Date(token.expiresAt).toLocaleDateString()
+                    : "Never"}
+                </Table.Cell>
+                <Table.Cell>
+                  {token.rateLimitPerMinute > 0
+                    ? `${token.rateLimitPerMinute}/min`
+                    : "Unlimited"}
+                </Table.Cell>
+                <Table.Cell>
+                  <UploadCountBadge>
+                    <Icon name="upload" />
+                    {token.uploadCount}
+                  </UploadCountBadge>
+                </Table.Cell>
+                <Table.Cell>
+                  {new Date(token.created).toLocaleDateString()}
+                </Table.Cell>
+                {isSuperuser && (
+                  <Table.Cell textAlign="right">
+                    {token.isActive && (
+                      <Button
+                        size="mini"
+                        color="orange"
+                        icon
+                        labelPosition="left"
+                        onClick={() =>
+                          revokeToken({
+                            variables: { tokenId: token.id },
+                          })
+                        }
+                      >
+                        <Icon name="ban" />
+                        Revoke
+                      </Button>
+                    )}
+                  </Table.Cell>
+                )}
+              </Table.Row>
+            ))}
+          </Table.Body>
+        </Table>
+      )}
+
+      {isSuperuser && (
+        <div style={{ marginTop: "1rem" }}>
+          <Button
+            primary
+            icon
+            labelPosition="left"
+            size="small"
+            onClick={() => {
+              resetForm();
+              setShowCreateModal(true);
+            }}
+          >
+            <Icon name="plus" />
+            Create Access Token
+          </Button>
+        </div>
+      )}
+
+      {/* Create Token Modal */}
+      <Modal
+        open={showCreateModal}
+        onClose={() => setShowCreateModal(false)}
+        size="small"
+      >
+        <Modal.Header>
+          <Icon name="key" /> Create Corpus Access Token
+        </Modal.Header>
+        <Modal.Content>
+          <Form>
+            <Form.Field required>
+              <label>Worker Account</label>
+              <Dropdown
+                placeholder="Select a worker account"
+                fluid
+                selection
+                options={workerOptions}
+                value={selectedWorkerId || ""}
+                onChange={(_, d) => setSelectedWorkerId(d.value as number)}
+              />
+            </Form.Field>
+            <Form.Field>
+              <label>Expires In (days)</label>
+              <Input
+                type="number"
+                min="0"
+                placeholder="Leave empty for no expiration"
+                value={expiresInDays}
+                onChange={(_, d) => setExpiresInDays(d.value)}
+              />
+            </Form.Field>
+            <Form.Field>
+              <label>Rate Limit (requests per minute)</label>
+              <Input
+                type="number"
+                min="0"
+                placeholder="0 = unlimited"
+                value={rateLimit}
+                onChange={(_, d) => setRateLimit(d.value)}
+              />
+            </Form.Field>
+          </Form>
+        </Modal.Content>
+        <Modal.Actions>
+          <Button onClick={() => setShowCreateModal(false)}>Cancel</Button>
+          <Button
+            primary
+            loading={creatingToken}
+            disabled={!selectedWorkerId || creatingToken}
+            onClick={handleCreate}
+          >
+            Create Token
+          </Button>
+        </Modal.Actions>
+      </Modal>
+
+      {/* Token Display Modal (one-time display) */}
+      <Modal
+        open={showTokenModal}
+        onClose={() => {
+          setShowTokenModal(false);
+          setCreatedTokenKey("");
+        }}
+        size="small"
+        closeOnDimmerClick={false}
+      >
+        <Modal.Header>
+          <Icon name="warning sign" color="orange" /> Save Your Access Token
+        </Modal.Header>
+        <Modal.Content>
+          <Message warning>
+            <Message.Header>This token will only be shown once</Message.Header>
+            <p>
+              Copy and securely store this token now. After closing this dialog,
+              you will not be able to see the full token again.
+            </p>
+          </Message>
+          <TokenKeyDisplay>
+            <TokenKeyLabel>Access Token</TokenKeyLabel>
+            <TokenKeyValue>{createdTokenKey}</TokenKeyValue>
+          </TokenKeyDisplay>
+          <div style={{ marginTop: "1rem" }}>
+            <strong>Usage:</strong>
+            <pre
+              style={{
+                background: "#f8fafc",
+                padding: "0.75rem",
+                borderRadius: "4px",
+                fontSize: "0.8rem",
+                overflow: "auto",
+              }}
+            >
+              {`Authorization: WorkerKey ${createdTokenKey.substring(0, 8)}...`}
+            </pre>
+          </div>
+        </Modal.Content>
+        <Modal.Actions>
+          <Button primary icon labelPosition="left" onClick={handleCopyToken}>
+            <Icon name="copy" />
+            Copy Token
+          </Button>
+          <Button
+            onClick={() => {
+              setShowTokenModal(false);
+              setCreatedTokenKey("");
+            }}
+          >
+            Done
+          </Button>
+        </Modal.Actions>
+      </Modal>
+    </>
+  );
+};

--- a/frontend/src/components/corpuses/settings/index.ts
+++ b/frontend/src/components/corpuses/settings/index.ts
@@ -6,3 +6,4 @@ export { CorpusInfoSection } from "./CorpusInfoSection";
 export { VisibilitySlugSection } from "./VisibilitySlugSection";
 export { CategoriesSection } from "./CategoriesSection";
 export { CorpusActionsSection } from "./CorpusActionsSection";
+export { WorkerAccessTokensSection } from "./WorkerAccessTokensSection";

--- a/frontend/src/graphql/queries/workerQueries.ts
+++ b/frontend/src/graphql/queries/workerQueries.ts
@@ -1,0 +1,234 @@
+import { gql } from "@apollo/client";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface WorkerAccountData {
+  id: number;
+  name: string;
+  description: string;
+  isActive: boolean;
+  created: string;
+  tokenCount: number;
+  creatorUsername: string | null;
+}
+
+export interface CorpusAccessTokenData {
+  id: number;
+  keyPrefix: string;
+  workerAccountName: string;
+  corpusId: number;
+  corpusTitle: string;
+  expiresAt: string | null;
+  isActive: boolean;
+  rateLimitPerMinute: number;
+  created: string;
+  uploadCount: number;
+}
+
+export interface WorkerDocumentUploadData {
+  id: string;
+  status: string;
+  corpusId: number;
+  corpusTitle: string;
+  workerAccountName: string | null;
+  errorMessage: string;
+  created: string;
+  processingStarted: string | null;
+  processingFinished: string | null;
+}
+
+// ============================================================================
+// Queries
+// ============================================================================
+
+export interface GetWorkerAccountsOutput {
+  workerAccounts: WorkerAccountData[];
+}
+
+export const GET_WORKER_ACCOUNTS = gql`
+  query GetWorkerAccounts {
+    workerAccounts {
+      id
+      name
+      description
+      isActive
+      created
+      tokenCount
+      creatorUsername
+    }
+  }
+`;
+
+export interface GetCorpusAccessTokensInput {
+  corpusId: number;
+}
+
+export interface GetCorpusAccessTokensOutput {
+  corpusAccessTokens: CorpusAccessTokenData[];
+}
+
+export const GET_CORPUS_ACCESS_TOKENS = gql`
+  query GetCorpusAccessTokens($corpusId: Int!) {
+    corpusAccessTokens(corpusId: $corpusId) {
+      id
+      keyPrefix
+      workerAccountName
+      corpusId
+      corpusTitle
+      expiresAt
+      isActive
+      rateLimitPerMinute
+      created
+      uploadCount
+    }
+  }
+`;
+
+export interface GetWorkerDocumentUploadsInput {
+  corpusId: number;
+  status?: string;
+}
+
+export interface GetWorkerDocumentUploadsOutput {
+  workerDocumentUploads: WorkerDocumentUploadData[];
+}
+
+export const GET_WORKER_DOCUMENT_UPLOADS = gql`
+  query GetWorkerDocumentUploads($corpusId: Int!, $status: String) {
+    workerDocumentUploads(corpusId: $corpusId, status: $status) {
+      id
+      status
+      corpusId
+      corpusTitle
+      workerAccountName
+      errorMessage
+      created
+      processingStarted
+      processingFinished
+    }
+  }
+`;
+
+// ============================================================================
+// Mutations
+// ============================================================================
+
+export interface CreateWorkerAccountInput {
+  name: string;
+  description?: string;
+}
+
+export interface CreateWorkerAccountOutput {
+  createWorkerAccount: {
+    ok: boolean;
+    workerAccount: {
+      id: number;
+      name: string;
+      description: string;
+      isActive: boolean;
+      created: string;
+    };
+  };
+}
+
+export const CREATE_WORKER_ACCOUNT = gql`
+  mutation CreateWorkerAccount($name: String!, $description: String) {
+    createWorkerAccount(name: $name, description: $description) {
+      ok
+      workerAccount {
+        id
+        name
+        description
+        isActive
+        created
+      }
+    }
+  }
+`;
+
+export interface DeactivateWorkerAccountInput {
+  workerAccountId: number;
+}
+
+export interface DeactivateWorkerAccountOutput {
+  deactivateWorkerAccount: {
+    ok: boolean;
+  };
+}
+
+export const DEACTIVATE_WORKER_ACCOUNT = gql`
+  mutation DeactivateWorkerAccount($workerAccountId: Int!) {
+    deactivateWorkerAccount(workerAccountId: $workerAccountId) {
+      ok
+    }
+  }
+`;
+
+export interface CreateCorpusAccessTokenInput {
+  workerAccountId: number;
+  corpusId: number;
+  expiresAt?: string;
+  rateLimitPerMinute?: number;
+}
+
+export interface CreateCorpusAccessTokenOutput {
+  createCorpusAccessToken: {
+    ok: boolean;
+    token: {
+      id: number;
+      key: string;
+      workerAccountName: string;
+      corpusId: number;
+      expiresAt: string | null;
+      rateLimitPerMinute: number;
+      created: string;
+    };
+  };
+}
+
+export const CREATE_CORPUS_ACCESS_TOKEN = gql`
+  mutation CreateCorpusAccessToken(
+    $workerAccountId: Int!
+    $corpusId: Int!
+    $expiresAt: DateTime
+    $rateLimitPerMinute: Int
+  ) {
+    createCorpusAccessToken(
+      workerAccountId: $workerAccountId
+      corpusId: $corpusId
+      expiresAt: $expiresAt
+      rateLimitPerMinute: $rateLimitPerMinute
+    ) {
+      ok
+      token {
+        id
+        key
+        workerAccountName
+        corpusId
+        expiresAt
+        rateLimitPerMinute
+        created
+      }
+    }
+  }
+`;
+
+export interface RevokeCorpusAccessTokenInput {
+  tokenId: number;
+}
+
+export interface RevokeCorpusAccessTokenOutput {
+  revokeCorpusAccessToken: {
+    ok: boolean;
+  };
+}
+
+export const REVOKE_CORPUS_ACCESS_TOKEN = gql`
+  mutation RevokeCorpusAccessToken($tokenId: Int!) {
+    revokeCorpusAccessToken(tokenId: $tokenId) {
+      ok
+    }
+  }
+`;


### PR DESCRIPTION
## Summary

This PR introduces a complete worker document upload system that allows external document processing workers (e.g., Docling, LlamaParse) to submit pre-processed documents directly into OpenContracts corpora via REST API, without requiring them to pass through the built-in parsing pipeline.

## Key Changes

### Backend
- **Worker Account Management**: New `WorkerAccount` model and mutations to create/deactivate service accounts for external workers
- **Corpus Access Tokens**: New `CorpusAccessToken` model with SHA-256 hashing, expiration, and per-token rate limiting
- **GraphQL Queries & Mutations**: 
  - `workerAccounts` - list all worker accounts (superuser only)
  - `corpusAccessTokens` - list tokens for a corpus (superuser/owner)
  - `workerDocumentUploads` - list uploads with optional status filtering
  - `createWorkerAccount`, `deactivateWorkerAccount` mutations
  - `createCorpusAccessToken`, `revokeCorpusAccessToken` mutations
- **Worker Upload Types**: GraphQL types for `WorkerAccountType`, `CorpusAccessTokenType`, and `WorkerDocumentUploadType`

### Frontend
- **Worker Account Management UI** (`WorkerAccountManagement.tsx`):
  - Admin panel for creating and deactivating worker accounts
  - Display account status, token count, and creation metadata
  - Confirmation modal for deactivation with warning about token revocation
  
- **Corpus Access Tokens Section** (`WorkerAccessTokensSection.tsx`):
  - Token creation modal with worker account selection, expiration, and rate limit configuration
  - One-time token display modal with copy-to-clipboard functionality
  - Token management table showing key prefix, status, expiration, rate limits, and upload counts
  - Token revocation capability for superusers
  
- **Integration**: Added sections to Corpus Settings and Global Settings Panel for accessing worker management features

### Documentation
- **Comprehensive walkthrough** (`worker-document-uploads.md`):
  - Architecture overview with diagram
  - Four-step setup guide (create account → create token → upload → monitor)
  - REST API examples with `WorkerKey` authentication scheme
  - Detailed metadata format reference including embeddings and pre-annotated text
  - Rate limiting, error handling, and security model documentation

## Notable Implementation Details

- **Token Security**: Plaintext tokens shown only once at creation; stored as SHA-256 hashes in database
- **Corpus Scoping**: Each token grants access to exactly one corpus; documents inherit corpus permissions
- **Rate Limiting**: Per-token configuration (0 = unlimited) with best-effort enforcement
- **Worker Isolation**: Worker accounts have associated system users with unusable passwords (cannot log in to UI)
- **Styled Components**: Consistent UI with status badges, info banners, and token display formatting
- **GraphQL Type Safety**: Full TypeScript interfaces for all queries and mutations

https://claude.ai/code/session_01YZiXwePp325TGCUKyVsJ2n