### PR TITLE
Add text block deep linking for document source citations

### DIFF
--- a/frontend/src/assets/configurations/constants.ts
+++ b/frontend/src/assets/configurations/constants.ts
@@ -16,6 +16,8 @@ export const DEFAULT_LABEL_COLOR = "94a3b8";
 export const PRIMARY_LABEL_COLOR = "0F766E";
 // Default color for agent messages when no badge color is configured
 export const DEFAULT_AGENT_COLOR = "#4A90E2";
+// Color for text block deep link highlights (teal, distinct from chat source blue #5C7C9D)
+export const TEXT_BLOCK_HIGHLIGHT_COLOR = "#0EA5E9";
 
 // File size constants for formatting
 export const FILE_SIZE = {
@@ -169,6 +171,10 @@ export const MENTION_TYPES = {
   agent: {
     navigable: false, // No agent detail page yet
     label: "AI Agent",
+  },
+  source: {
+    navigable: true,
+    label: "Source",
   },
 } as const;
 

--- a/frontend/src/assets/configurations/constants.ts
+++ b/frontend/src/assets/configurations/constants.ts
@@ -18,6 +18,9 @@ export const PRIMARY_LABEL_COLOR = "0F766E";
 export const DEFAULT_AGENT_COLOR = "#4A90E2";
 // Color for text block deep link highlights (teal, distinct from chat source blue #5C7C9D)
 export const TEXT_BLOCK_HIGHLIGHT_COLOR = "#0EA5E9";
+// Sentinel ID used to inject text block deep links as virtual chat sources
+// in the TxtAnnotator (so they render with the same highlight machinery).
+export const TEXT_BLOCK_DEEPLINK_ID = "__text_block_deeplink__";
 
 // File size constants for formatting
 export const FILE_SIZE = {

--- a/frontend/src/components/annotator/components/wrappers/TxtAnnotatorWrapper.tsx
+++ b/frontend/src/components/annotator/components/wrappers/TxtAnnotatorWrapper.tsx
@@ -32,11 +32,13 @@ import {
   unregisterRefAtom,
 } from "../../context/AnnotationRefsAtoms";
 import { useReactiveVar } from "@apollo/client";
+import { useLocation, useNavigate } from "react-router-dom";
 import { highlightedTextBlock } from "../../../../graphql/cache";
 import {
   decodeTextBlock,
   TextSpanBlock,
 } from "../../../../utils/textBlockEncoding";
+import { updateTextBlockParam } from "../../../../utils/navigationUtils";
 import { TEXT_BLOCK_DEEPLINK_ID } from "../../../../assets/configurations/constants";
 
 interface TxtAnnotatorWrapperProps {
@@ -94,6 +96,11 @@ export const TxtAnnotatorWrapper: React.FC<TxtAnnotatorWrapperProps> = ({
   const { messages, selectedMessageId, selectedSourceIndex } =
     useChatSourceState();
 
+  // URL-based clearing: use navigate to remove ?tb= from URL (which also
+  // clears the reactive var via CentralRouteManager's Phase 2 sync).
+  const location = useLocation();
+  const navigate = useNavigate();
+
   // Clear text block highlight when user selects an annotation or chat source.
   // This ensures the ?tb= deep link is dismissed once the user moves on.
   useEffect(() => {
@@ -101,9 +108,9 @@ export const TxtAnnotatorWrapper: React.FC<TxtAnnotatorWrapperProps> = ({
       (selectedAnnotations.length > 0 || selectedMessageId) &&
       highlightedTextBlock()
     ) {
-      highlightedTextBlock(null);
+      updateTextBlockParam(location, navigate, null);
     }
-  }, [selectedAnnotations, selectedMessageId]);
+  }, [selectedAnnotations, selectedMessageId, location, navigate]);
 
   // Text block deep link (from ?tb= URL param)
   const textBlockParam = useReactiveVar(highlightedTextBlock);

--- a/frontend/src/components/annotator/components/wrappers/TxtAnnotatorWrapper.tsx
+++ b/frontend/src/components/annotator/components/wrappers/TxtAnnotatorWrapper.tsx
@@ -37,6 +37,7 @@ import {
   decodeTextBlock,
   TextSpanBlock,
 } from "../../../../utils/textBlockEncoding";
+import { TEXT_BLOCK_DEEPLINK_ID } from "../../../../assets/configurations/constants";
 
 interface TxtAnnotatorWrapperProps {
   readOnly: boolean;
@@ -133,8 +134,8 @@ export const TxtAnnotatorWrapper: React.FC<TxtAnnotatorWrapperProps> = ({
       allSources.push({
         start_index: textBlockSpan.start,
         end_index: textBlockSpan.end,
-        sourceId: "__text_block_deeplink__",
-        messageId: "__text_block_deeplink__",
+        sourceId: TEXT_BLOCK_DEEPLINK_ID,
+        messageId: TEXT_BLOCK_DEEPLINK_ID,
       });
     }
 
@@ -184,7 +185,7 @@ export const TxtAnnotatorWrapper: React.FC<TxtAnnotatorWrapperProps> = ({
         chatSources={chatSourceMatches}
         selectedChatSourceId={
           textBlockSpan
-            ? "__text_block_deeplink__"
+            ? TEXT_BLOCK_DEEPLINK_ID
             : selectedMessageId && selectedSourceIndex !== null
             ? `${selectedMessageId}.${selectedSourceIndex}`
             : undefined

--- a/frontend/src/components/annotator/components/wrappers/TxtAnnotatorWrapper.tsx
+++ b/frontend/src/components/annotator/components/wrappers/TxtAnnotatorWrapper.tsx
@@ -5,7 +5,7 @@
  * of the parent DocumentViewer component.
  */
 
-import React, { useCallback } from "react";
+import React, { useCallback, useEffect } from "react";
 import { useSetAtom } from "jotai";
 import {
   useApproveAnnotation,
@@ -93,6 +93,17 @@ export const TxtAnnotatorWrapper: React.FC<TxtAnnotatorWrapperProps> = ({
 
   const { messages, selectedMessageId, selectedSourceIndex } =
     useChatSourceState();
+
+  // Clear text block highlight when user selects an annotation or chat source.
+  // This ensures the ?tb= deep link is dismissed once the user moves on.
+  useEffect(() => {
+    if (
+      (selectedAnnotations.length > 0 || selectedMessageId) &&
+      highlightedTextBlock()
+    ) {
+      highlightedTextBlock(null);
+    }
+  }, [selectedAnnotations, selectedMessageId]);
 
   // Text block deep link (from ?tb= URL param)
   const textBlockParam = useReactiveVar(highlightedTextBlock);

--- a/frontend/src/components/annotator/components/wrappers/TxtAnnotatorWrapper.tsx
+++ b/frontend/src/components/annotator/components/wrappers/TxtAnnotatorWrapper.tsx
@@ -31,6 +31,12 @@ import {
   registerRefAtom,
   unregisterRefAtom,
 } from "../../context/AnnotationRefsAtoms";
+import { useReactiveVar } from "@apollo/client";
+import { highlightedTextBlock } from "../../../../graphql/cache";
+import {
+  decodeTextBlock,
+  TextSpanBlock,
+} from "../../../../utils/textBlockEncoding";
 
 interface TxtAnnotatorWrapperProps {
   readOnly: boolean;
@@ -87,6 +93,15 @@ export const TxtAnnotatorWrapper: React.FC<TxtAnnotatorWrapperProps> = ({
   const { messages, selectedMessageId, selectedSourceIndex } =
     useChatSourceState();
 
+  // Text block deep link (from ?tb= URL param)
+  const textBlockParam = useReactiveVar(highlightedTextBlock);
+  const textBlockSpan = React.useMemo(() => {
+    if (!textBlockParam) return null;
+    const decoded = decodeTextBlock(textBlockParam);
+    if (!decoded || decoded.type !== "span") return null;
+    return decoded as TextSpanBlock;
+  }, [textBlockParam]);
+
   const chatSourceMatches = React.useMemo(() => {
     const allSources: {
       start_index: number;
@@ -113,8 +128,18 @@ export const TxtAnnotatorWrapper: React.FC<TxtAnnotatorWrapperProps> = ({
       }
     }
 
+    // Include text block deep link as a virtual chat source
+    if (textBlockSpan) {
+      allSources.push({
+        start_index: textBlockSpan.start,
+        end_index: textBlockSpan.end,
+        sourceId: "__text_block_deeplink__",
+        messageId: "__text_block_deeplink__",
+      });
+    }
+
     return allSources;
-  }, [messages]);
+  }, [messages, textBlockSpan]);
 
   // Memoized getSpan callback
   const getSpan = useCallback(
@@ -158,7 +183,9 @@ export const TxtAnnotatorWrapper: React.FC<TxtAnnotatorWrapperProps> = ({
         searchResults={filteredSearchResults}
         chatSources={chatSourceMatches}
         selectedChatSourceId={
-          selectedMessageId && selectedSourceIndex !== null
+          textBlockSpan
+            ? "__text_block_deeplink__"
+            : selectedMessageId && selectedSourceIndex !== null
             ? `${selectedMessageId}.${selectedSourceIndex}`
             : undefined
         }

--- a/frontend/src/components/annotator/context/ChatSourceAtom.tsx
+++ b/frontend/src/components/annotator/context/ChatSourceAtom.tsx
@@ -25,6 +25,10 @@ export interface ChatMessageSource {
   startIndex?: number;
   endIndex?: number;
   isTextBased?: boolean;
+  /** Document ID this source belongs to (for cross-document deep linking) */
+  document_id?: number;
+  /** Corpus ID this source belongs to (for cross-document deep linking) */
+  corpus_id?: number;
 }
 
 export interface ChatMessage {
@@ -109,6 +113,8 @@ export function mapWebSocketSourcesToChatMessageSources(
             startIndex: start,
             endIndex: end,
             isTextBased: true,
+            document_id: src.document_id,
+            corpus_id: src.corpus_id,
           };
         } else {
           const multiPageObj = src.json as MultipageAnnotationJson;
@@ -156,6 +162,8 @@ export function mapWebSocketSourcesToChatMessageSources(
             startIndex: undefined,
             endIndex: undefined,
             isTextBased: false,
+            document_id: src.document_id,
+            corpus_id: src.corpus_id,
           };
         }
       } catch (error) {

--- a/frontend/src/components/annotator/context/ChatSourceAtom.tsx
+++ b/frontend/src/components/annotator/context/ChatSourceAtom.tsx
@@ -27,8 +27,6 @@ export interface ChatMessageSource {
   isTextBased?: boolean;
   /** Document ID this source belongs to (for cross-document deep linking) */
   document_id?: number;
-  /** Corpus ID this source belongs to (for cross-document deep linking) */
-  corpus_id?: number;
 }
 
 export interface ChatMessage {
@@ -114,7 +112,6 @@ export function mapWebSocketSourcesToChatMessageSources(
             endIndex: end,
             isTextBased: true,
             document_id: src.document_id,
-            corpus_id: src.corpus_id,
           };
         } else {
           const multiPageObj = src.json as MultipageAnnotationJson;
@@ -163,7 +160,6 @@ export function mapWebSocketSourcesToChatMessageSources(
             endIndex: undefined,
             isTextBased: false,
             document_id: src.document_id,
-            corpus_id: src.corpus_id,
           };
         }
       } catch (error) {

--- a/frontend/src/components/annotator/display/components/TextBlockHighlight.tsx
+++ b/frontend/src/components/annotator/display/components/TextBlockHighlight.tsx
@@ -5,7 +5,6 @@
  *
  * This allows highlighting arbitrary text regions WITHOUT creating DB annotations.
  */
-import { useRef, useEffect } from "react";
 import { ResultBoundary } from "./ResultBoundary";
 import { ChatSourceTokens } from "./ChatSourceTokens";
 import { PDFPageInfo } from "../../types/pdf";
@@ -31,21 +30,12 @@ export const TextBlockHighlight = ({
   scrollIntoView = false,
 }: TextBlockHighlightProps) => {
   const { showBoundingBoxes } = useAnnotationDisplay();
-  const containerRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (scrollIntoView && containerRef.current) {
-      containerRef.current.scrollIntoView({
-        behavior: "smooth",
-        block: "center",
-      });
-    }
-  }, [scrollIntoView]);
 
   const scaledBounds = pageInfo.getScaledBounds(bounds);
 
+  // Scroll is handled entirely by ResultBoundary's internal useEffect.
   return (
-    <div ref={containerRef}>
+    <>
       <ResultBoundary
         id="TEXT_BLOCK_HIGHLIGHT"
         hidden={false}
@@ -64,6 +54,6 @@ export const TextBlockHighlight = ({
           tokens={tokens}
         />
       )}
-    </div>
+    </>
   );
 };

--- a/frontend/src/components/annotator/display/components/TextBlockHighlight.tsx
+++ b/frontend/src/components/annotator/display/components/TextBlockHighlight.tsx
@@ -19,6 +19,8 @@ export interface TextBlockHighlightProps {
   bounds: BoundingBox;
   /** Page-specific info (viewport, scaling, etc.) */
   pageInfo: PDFPageInfo;
+  /** Zero-based page index — used to produce a unique DOM id per page */
+  pageIndex: number;
   /** Whether to scroll this highlight into view */
   scrollIntoView?: boolean;
 }
@@ -27,6 +29,7 @@ export const TextBlockHighlight = ({
   tokens,
   bounds,
   pageInfo,
+  pageIndex,
   scrollIntoView = false,
 }: TextBlockHighlightProps) => {
   const { showBoundingBoxes } = useAnnotationDisplay();
@@ -37,7 +40,7 @@ export const TextBlockHighlight = ({
   return (
     <>
       <ResultBoundary
-        id="TEXT_BLOCK_HIGHLIGHT"
+        id={`TEXT_BLOCK_HIGHLIGHT_p${pageIndex}`}
         hidden={false}
         showBoundingBox={showBoundingBoxes}
         color={TEXT_BLOCK_HIGHLIGHT_COLOR}

--- a/frontend/src/components/annotator/display/components/TextBlockHighlight.tsx
+++ b/frontend/src/components/annotator/display/components/TextBlockHighlight.tsx
@@ -1,0 +1,69 @@
+/**
+ * TextBlockHighlight - Renders an ephemeral highlight for a deep-linked text
+ * block on a PDF page. Similar to ChatSourceResult but driven by the
+ * ?tb= URL parameter rather than chat source state.
+ *
+ * This allows highlighting arbitrary text regions WITHOUT creating DB annotations.
+ */
+import { useRef, useEffect } from "react";
+import { ResultBoundary } from "./ResultBoundary";
+import { ChatSourceTokens } from "./ChatSourceTokens";
+import { PDFPageInfo } from "../../types/pdf";
+import { useAnnotationDisplay } from "../../context/UISettingsAtom";
+import { TokenId, BoundingBox } from "../../../types";
+import { TEXT_BLOCK_HIGHLIGHT_COLOR } from "../../../../assets/configurations/constants";
+
+export interface TextBlockHighlightProps {
+  /** Token IDs for this page (from the decoded text block reference) */
+  tokens: TokenId[];
+  /** Bounding box for this page (computed from token geometry) */
+  bounds: BoundingBox;
+  /** Page-specific info (viewport, scaling, etc.) */
+  pageInfo: PDFPageInfo;
+  /** Whether to scroll this highlight into view */
+  scrollIntoView?: boolean;
+}
+
+export const TextBlockHighlight = ({
+  tokens,
+  bounds,
+  pageInfo,
+  scrollIntoView = false,
+}: TextBlockHighlightProps) => {
+  const { showBoundingBoxes } = useAnnotationDisplay();
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (scrollIntoView && containerRef.current) {
+      containerRef.current.scrollIntoView({
+        behavior: "smooth",
+        block: "center",
+      });
+    }
+  }, [scrollIntoView]);
+
+  const scaledBounds = pageInfo.getScaledBounds(bounds);
+
+  return (
+    <div ref={containerRef}>
+      <ResultBoundary
+        id="TEXT_BLOCK_HIGHLIGHT"
+        hidden={false}
+        showBoundingBox={showBoundingBoxes}
+        color={TEXT_BLOCK_HIGHLIGHT_COLOR}
+        bounds={scaledBounds}
+        selected={true}
+        scrollIntoView={scrollIntoView}
+      />
+      {tokens.length > 0 && (
+        <ChatSourceTokens
+          color={TEXT_BLOCK_HIGHLIGHT_COLOR}
+          highOpacity={!showBoundingBoxes}
+          hidden={false}
+          pageInfo={pageInfo}
+          tokens={tokens}
+        />
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/annotator/renderers/pdf/PDFPage.tsx
+++ b/frontend/src/components/annotator/renderers/pdf/PDFPage.tsx
@@ -31,11 +31,14 @@ import { pendingScrollAnnotationIdAtom } from "../../context/DocumentAtom";
 import { pendingScrollSearchResultIdAtom } from "../../context/DocumentAtom";
 import { pendingScrollChatSourceKeyAtom } from "../../context/DocumentAtom";
 import { useReactiveVar } from "@apollo/client";
+import { useLocation, useNavigate } from "react-router-dom";
 import { highlightedTextBlock } from "../../../../graphql/cache";
 import {
   decodeTextBlock,
   PdfTokenBlock,
+  textBlockToBounds,
 } from "../../../../utils/textBlockEncoding";
+import { updateTextBlockParam } from "../../../../utils/navigationUtils";
 
 /**
  * This wrapper is inline-block (shrink-wrapped) and position:relative
@@ -118,6 +121,11 @@ export const PDFPage = ({
   // Derive page index early — needed by text block memo and annotation rendering.
   const pageIndex = pageInfo.page.pageNumber - 1;
 
+  // URL-based clearing: use navigate to remove ?tb= from URL (which also
+  // clears the reactive var via CentralRouteManager's Phase 2 sync).
+  const location = useLocation();
+  const navigate = useNavigate();
+
   // Clear text block highlight when user interacts with annotations or chat.
   // This ensures the ?tb= deep link is dismissed once the user moves on,
   // preventing a stale highlight from persisting indefinitely in the URL.
@@ -126,9 +134,9 @@ export const PDFPage = ({
       (selectedAnnotations.length > 0 || selectedMessage) &&
       highlightedTextBlock()
     ) {
-      highlightedTextBlock(null);
+      updateTextBlockParam(location, navigate, null);
     }
-  }, [selectedAnnotations, selectedMessage]);
+  }, [selectedAnnotations, selectedMessage, location, navigate]);
 
   // Text block deep link (from ?tb= URL param).
   // Computed per-page to avoid repeating work for all pages in every
@@ -152,26 +160,12 @@ export const PDFPage = ({
       tokenIndex,
     }));
 
-    // Compute bounding box from token geometry for this page
-    let bounds: BoundingBox | null = null;
-    if (pageInfo.tokens) {
-      let top = Infinity;
-      let left = Infinity;
-      let bottom = -Infinity;
-      let right = -Infinity;
-      for (const idx of pageTokenIndices) {
-        const token = pageInfo.tokens[idx];
-        if (!token) continue;
-        top = Math.min(top, token.y);
-        left = Math.min(left, token.x);
-        bottom = Math.max(bottom, token.y + token.height);
-        right = Math.max(right, token.x + token.width);
-      }
-      if (top !== Infinity) {
-        bounds = { top, left, bottom, right };
-      }
-    }
-
+    // Compute bounding box using shared utility (avoids duplicating the
+    // Infinity/min/max loop that also lives in textBlockEncoding.ts).
+    const boundsMap = pageInfo.tokens
+      ? textBlockToBounds(block, { [pageIndex]: pageInfo.tokens })
+      : {};
+    const bounds = boundsMap[pageIndex];
     if (!bounds) return null;
 
     // Determine the first matching page across the entire block so only
@@ -649,6 +643,7 @@ export const PDFPage = ({
             tokens={textBlockData.tokenIds}
             bounds={textBlockData.bounds}
             pageInfo={updatedPageInfo}
+            pageIndex={pageIndex}
             scrollIntoView={pageIndex === textBlockData.firstMatchingPage}
           />
         )}

--- a/frontend/src/components/annotator/renderers/pdf/PDFPage.tsx
+++ b/frontend/src/components/annotator/renderers/pdf/PDFPage.tsx
@@ -34,8 +34,6 @@ import { useReactiveVar } from "@apollo/client";
 import { highlightedTextBlock } from "../../../../graphql/cache";
 import {
   decodeTextBlock,
-  textBlockToTokenIds,
-  textBlockToBounds,
   PdfTokenBlock,
 } from "../../../../utils/textBlockEncoding";
 
@@ -117,31 +115,74 @@ export const PDFPage = ({
     [messages, selectedMessageId]
   );
 
-  // Text block deep link (from ?tb= URL param)
+  // Derive page index early — needed by text block memo and annotation rendering.
+  const pageIndex = pageInfo.page.pageNumber - 1;
+
+  // Clear text block highlight when user interacts with annotations or chat.
+  // This ensures the ?tb= deep link is dismissed once the user moves on,
+  // preventing a stale highlight from persisting indefinitely in the URL.
+  useEffect(() => {
+    if (
+      (selectedAnnotations.length > 0 || selectedMessage) &&
+      highlightedTextBlock()
+    ) {
+      highlightedTextBlock(null);
+    }
+  }, [selectedAnnotations, selectedMessage]);
+
+  // Text block deep link (from ?tb= URL param).
+  // Computed per-page to avoid repeating work for all pages in every
+  // virtualized PDFPage instance.
+  // NOTE: pageInfo.tokens is reference-stable — it's a readonly property set
+  // once in the PDFPageInfo constructor and stored in a stable map via usePages.
   const textBlockParam = useReactiveVar(highlightedTextBlock);
   const textBlockData = useMemo(() => {
     if (!textBlockParam) return null;
     const decoded = decodeTextBlock(textBlockParam);
     if (!decoded || decoded.type !== "pdf") return null;
     const block = decoded as PdfTokenBlock;
-    const tokenIds = textBlockToTokenIds(block);
-    // Build page tokens map from pageInfo for bounds computation
-    const pageTokensMap: Record<
-      number,
-      { x: number; y: number; width: number; height: number }[]
-    > = {};
+
+    // Only compute for this page — avoids O(pages) work per PDFPage instance
+    const pageTokenIndices = block.tokensByPage[pageIndex];
+    if (!pageTokenIndices || pageTokenIndices.length === 0) return null;
+
+    // Convert raw indices to TokenId format for this page
+    const tokenIds = pageTokenIndices.map((tokenIndex) => ({
+      pageIndex,
+      tokenIndex,
+    }));
+
+    // Compute bounding box from token geometry for this page
+    let bounds: BoundingBox | null = null;
     if (pageInfo.tokens) {
-      pageTokensMap[pageInfo.page.pageNumber - 1] = pageInfo.tokens;
+      let top = Infinity;
+      let left = Infinity;
+      let bottom = -Infinity;
+      let right = -Infinity;
+      for (const idx of pageTokenIndices) {
+        const token = pageInfo.tokens[idx];
+        if (!token) continue;
+        top = Math.min(top, token.y);
+        left = Math.min(left, token.x);
+        bottom = Math.max(bottom, token.y + token.height);
+        right = Math.max(right, token.x + token.width);
+      }
+      if (top !== Infinity) {
+        bounds = { top, left, bottom, right };
+      }
     }
-    const bounds = textBlockToBounds(block, pageTokensMap);
-    // Determine the first page that contains highlight data so only
+
+    if (!bounds) return null;
+
+    // Determine the first matching page across the entire block so only
     // that page triggers scrollIntoView (avoids multi-page scroll conflict).
     const allPages = Object.keys(block.tokensByPage)
       .map(Number)
       .sort((a, b) => a - b);
     const firstMatchingPage = allPages.length > 0 ? allPages[0] : -1;
+
     return { tokenIds, bounds, firstMatchingPage };
-  }, [textBlockParam, pageInfo.page.pageNumber, pageInfo.tokens]);
+  }, [textBlockParam, pageIndex, pageInfo.tokens]);
 
   const updatedPageInfo = useMemo(() => {
     return new PDFPageInfo(
@@ -343,8 +384,6 @@ export const PDFPage = ({
    * Determines the annotations to render, including ensuring that any annotation
    * involved in a currently selected relation is visible, regardless of other filters.
    */
-  const pageIndex = pageInfo.page.pageNumber - 1;
-
   const annots_to_render = useMemo(() => {
     return visibleAnnotations.filter((annot) => {
       /* Selection layer renders only token annotations with bounds
@@ -599,18 +638,20 @@ export const PDFPage = ({
             />
           ))}
 
-        {/* Text block deep link highlight (from ?tb= URL param) */}
-        {!selectedMessage &&
-          textBlockData &&
-          textBlockData.bounds[pageIndex] &&
-          textBlockData.tokenIds[pageIndex] && (
-            <TextBlockHighlight
-              tokens={textBlockData.tokenIds[pageIndex] || []}
-              bounds={textBlockData.bounds[pageIndex]}
-              pageInfo={updatedPageInfo}
-              scrollIntoView={pageIndex === textBlockData.firstMatchingPage}
-            />
-          )}
+        {/* Text block deep link highlight (from ?tb= URL param).
+            Suppressed when a chat message is selected to avoid visual clutter —
+            both highlight types use the same bounding-box overlay machinery, so
+            showing them simultaneously would be confusing. The text block
+            reappears when the user deselects the message (or is cleared entirely
+            by the useEffect above when annotations/chat are selected). */}
+        {!selectedMessage && textBlockData && (
+          <TextBlockHighlight
+            tokens={textBlockData.tokenIds}
+            bounds={textBlockData.bounds}
+            pageInfo={updatedPageInfo}
+            scrollIntoView={pageIndex === textBlockData.firstMatchingPage}
+          />
+        )}
       </CanvasWrapper>
     </PageAnnotationsContainer>
   );

--- a/frontend/src/components/annotator/renderers/pdf/PDFPage.tsx
+++ b/frontend/src/components/annotator/renderers/pdf/PDFPage.tsx
@@ -134,7 +134,13 @@ export const PDFPage = ({
       pageTokensMap[pageInfo.page.pageNumber - 1] = pageInfo.tokens;
     }
     const bounds = textBlockToBounds(block, pageTokensMap);
-    return { tokenIds, bounds };
+    // Determine the first page that contains highlight data so only
+    // that page triggers scrollIntoView (avoids multi-page scroll conflict).
+    const allPages = Object.keys(block.tokensByPage)
+      .map(Number)
+      .sort((a, b) => a - b);
+    const firstMatchingPage = allPages.length > 0 ? allPages[0] : -1;
+    return { tokenIds, bounds, firstMatchingPage };
   }, [textBlockParam, pageInfo.page.pageNumber, pageInfo.tokens]);
 
   const updatedPageInfo = useMemo(() => {
@@ -602,7 +608,7 @@ export const PDFPage = ({
               tokens={textBlockData.tokenIds[pageIndex] || []}
               bounds={textBlockData.bounds[pageIndex]}
               pageInfo={updatedPageInfo}
-              scrollIntoView={true}
+              scrollIntoView={pageIndex === textBlockData.firstMatchingPage}
             />
           )}
       </CanvasWrapper>

--- a/frontend/src/components/annotator/renderers/pdf/PDFPage.tsx
+++ b/frontend/src/components/annotator/renderers/pdf/PDFPage.tsx
@@ -25,10 +25,19 @@ import { PDFPageInfo } from "../../types/pdf";
 import { chatSourcesAtom } from "../../context/ChatSourceAtom";
 import { useCorpusState } from "../../context/CorpusAtom";
 import { ChatSourceResult } from "../../display/components/ChatSourceResult";
+import { TextBlockHighlight } from "../../display/components/TextBlockHighlight";
 import { useVisibleAnnotations } from "../../hooks/useVisibleAnnotations";
 import { pendingScrollAnnotationIdAtom } from "../../context/DocumentAtom";
 import { pendingScrollSearchResultIdAtom } from "../../context/DocumentAtom";
 import { pendingScrollChatSourceKeyAtom } from "../../context/DocumentAtom";
+import { useReactiveVar } from "@apollo/client";
+import { highlightedTextBlock } from "../../../../graphql/cache";
+import {
+  decodeTextBlock,
+  textBlockToTokenIds,
+  textBlockToBounds,
+  PdfTokenBlock,
+} from "../../../../utils/textBlockEncoding";
 
 /**
  * This wrapper is inline-block (shrink-wrapped) and position:relative
@@ -107,6 +116,26 @@ export const PDFPage = ({
     () => messages.find((m) => m.messageId === selectedMessageId),
     [messages, selectedMessageId]
   );
+
+  // Text block deep link (from ?tb= URL param)
+  const textBlockParam = useReactiveVar(highlightedTextBlock);
+  const textBlockData = useMemo(() => {
+    if (!textBlockParam) return null;
+    const decoded = decodeTextBlock(textBlockParam);
+    if (!decoded || decoded.type !== "pdf") return null;
+    const block = decoded as PdfTokenBlock;
+    const tokenIds = textBlockToTokenIds(block);
+    // Build page tokens map from pageInfo for bounds computation
+    const pageTokensMap: Record<
+      number,
+      { x: number; y: number; width: number; height: number }[]
+    > = {};
+    if (pageInfo.tokens) {
+      pageTokensMap[pageInfo.page.pageNumber - 1] = pageInfo.tokens;
+    }
+    const bounds = textBlockToBounds(block, pageTokensMap);
+    return { tokenIds, bounds };
+  }, [textBlockParam, pageInfo.page.pageNumber, pageInfo.tokens]);
 
   const updatedPageInfo = useMemo(() => {
     return new PDFPageInfo(
@@ -563,6 +592,19 @@ export const PDFPage = ({
               selected={selectedSourceIndex === index}
             />
           ))}
+
+        {/* Text block deep link highlight (from ?tb= URL param) */}
+        {!selectedMessage &&
+          textBlockData &&
+          textBlockData.bounds[pageIndex] &&
+          textBlockData.tokenIds[pageIndex] && (
+            <TextBlockHighlight
+              tokens={textBlockData.tokenIds[pageIndex] || []}
+              bounds={textBlockData.bounds[pageIndex]}
+              pageInfo={updatedPageInfo}
+              scrollIntoView={true}
+            />
+          )}
       </CanvasWrapper>
     </PageAnnotationsContainer>
   );

--- a/frontend/src/components/corpuses/CorpusChat.tsx
+++ b/frontend/src/components/corpuses/CorpusChat.tsx
@@ -71,6 +71,7 @@ import {
 import {
   useChatSourceState,
   mapWebSocketSourcesToChatMessageSources,
+  ChatMessageSource,
 } from "../annotator/context/ChatSourceAtom";
 import { MultipageAnnotationJson } from "../types";
 import { FetchMoreOnVisible } from "../widgets/infinite_scroll/FetchMoreOnVisible";
@@ -161,6 +162,12 @@ interface CorpusChatProps {
    * Parent components can use this to adjust their navigation headers.
    */
   onViewModeChange?: (isInConversation: boolean) => void;
+  /**
+   * Callback fired when a source citation is clicked and should navigate to the
+   * source document with the text block highlighted. Receives the source's
+   * ChatMessageSource so the parent can build a deep link URL.
+   */
+  onSourceNavigate?: (source: ChatMessageSource) => void;
 }
 
 // Add these styled components near your other styled components
@@ -798,6 +805,7 @@ export const CorpusChat: React.FC<CorpusChatProps> = ({
   forceNewChat = false,
   onClose,
   onViewModeChange,
+  onSourceNavigate,
 }) => {
   // Window dimensions for responsive layout
   const { width } = useWindowDimensions();
@@ -1731,6 +1739,10 @@ export const CorpusChat: React.FC<CorpusChatProps> = ({
                         }));
                         if (sourcedMessage.sources.length > 0) {
                           onMessageSelect?.(sourcedMessage.messageId);
+                        }
+                        // Navigate to source document with text block highlight
+                        if (source.document_id && onSourceNavigate) {
+                          onSourceNavigate(source);
                         }
                       },
                     })) || [];

--- a/frontend/src/components/knowledge_base/document/right_tray/ChatTray.tsx
+++ b/frontend/src/components/knowledge_base/document/right_tray/ChatTray.tsx
@@ -101,8 +101,6 @@ export interface WebSocketSources {
   rawText: string;
   /** Document ID this source belongs to (provided by backend SourceNode metadata) */
   document_id?: number;
-  /** Corpus ID this source belongs to (provided by backend SourceNode metadata) */
-  corpus_id?: number;
 }
 
 /**

--- a/frontend/src/components/knowledge_base/document/right_tray/ChatTray.tsx
+++ b/frontend/src/components/knowledge_base/document/right_tray/ChatTray.tsx
@@ -99,6 +99,10 @@ export interface WebSocketSources {
   label: string;
   label_id: number;
   rawText: string;
+  /** Document ID this source belongs to (provided by backend SourceNode metadata) */
+  document_id?: number;
+  /** Corpus ID this source belongs to (provided by backend SourceNode metadata) */
+  corpus_id?: number;
 }
 
 /**

--- a/frontend/src/components/threads/MarkdownMessageRenderer.tsx
+++ b/frontend/src/components/threads/MarkdownMessageRenderer.tsx
@@ -4,7 +4,7 @@ import remarkGfm from "remark-gfm";
 import rehypeSanitize from "rehype-sanitize";
 import styled from "styled-components";
 import { useNavigate } from "react-router-dom";
-import { Bot, Database, FileText, Tag, User } from "lucide-react";
+import { Bot, Database, FileText, MapPin, Tag, User } from "lucide-react";
 import { color } from "../../theme/colors";
 import { MentionedResourceType } from "../../types/graphql-api";
 import { sanitizeForTooltip } from "../../utils/textSanitization";
@@ -79,6 +79,8 @@ const MentionLink = styled.a<{ $type: string; $navigable?: boolean }>`
       return "linear-gradient(135deg, #f093fb15 0%, #f5576c15 100%)";
     if (props.$type === "annotation")
       return "linear-gradient(135deg, #43e97b15 0%, #38f9d715 100%)";
+    if (props.$type === "source")
+      return "linear-gradient(135deg, #0ea5e915 0%, #06b6d415 100%)";
     if (props.$type === "agent")
       return "linear-gradient(135deg, #8b5cf615 0%, #6366f115 100%)";
     return "linear-gradient(135deg, #e0e0e015 0%, #c0c0c015 100%)";
@@ -90,6 +92,7 @@ const MentionLink = styled.a<{ $type: string; $navigable?: boolean }>`
       if (props.$type === "corpus") return color.P4;
       if (props.$type === "document") return "#f5576c40";
       if (props.$type === "annotation") return "#38f9d780";
+      if (props.$type === "source") return "#0ea5e960";
       if (props.$type === "agent") return "#8b5cf660";
       return color.N4;
     }};
@@ -99,6 +102,7 @@ const MentionLink = styled.a<{ $type: string; $navigable?: boolean }>`
     if (props.$type === "corpus") return color.P8;
     if (props.$type === "document") return "#c41e3a";
     if (props.$type === "annotation") return "#0d9488";
+    if (props.$type === "source") return "#0284c7";
     if (props.$type === "agent") return "#7c3aed";
     return color.N8;
   }};
@@ -116,6 +120,8 @@ const MentionLink = styled.a<{ $type: string; $navigable?: boolean }>`
           ? "linear-gradient(135deg, #f093fb25 0%, #f5576c25 100%)"
           : props.$type === "annotation"
           ? "linear-gradient(135deg, #43e97b25 0%, #38f9d725 100%)"
+          : props.$type === "source"
+          ? "linear-gradient(135deg, #0ea5e925 0%, #06b6d425 100%)"
           : props.$type === "agent"
           ? "linear-gradient(135deg, #8b5cf625 0%, #6366f125 100%)"
           : "linear-gradient(135deg, #e0e0e025 0%, #c0c0c025 100%)"
@@ -129,6 +135,8 @@ const MentionLink = styled.a<{ $type: string; $navigable?: boolean }>`
           ? "#f5576c80"
           : props.$type === "annotation"
           ? "#38f9d7"
+          : props.$type === "source"
+          ? "#0ea5e9"
           : props.$type === "agent"
           ? "#8b5cf6"
           : color.N6
@@ -209,6 +217,10 @@ export function MarkdownMessageRenderer({
 
     // Document: /d/{creator}/{corpus}/{doc}
     if (href.startsWith("/d/")) {
+      // Text block deep link has query param ?tb=
+      if (href.includes("?tb=") || href.includes("&tb=")) {
+        return "source";
+      }
       // Annotation has query param ?ann=
       if (href.includes("?ann=") || href.includes("&ann=")) {
         return "annotation";
@@ -232,6 +244,8 @@ export function MarkdownMessageRenderer({
         return <FileText size={14} />;
       case "annotation":
         return <Tag size={14} />;
+      case "source":
+        return <MapPin size={14} />;
       case "agent":
         return <Bot size={14} />;
       default:
@@ -293,6 +307,14 @@ export function MarkdownMessageRenderer({
         )}${suffix}`;
       case "annotation":
         return `Annotation: ${sanitizeForTooltip(text)}${suffix}`;
+      case "source":
+        return `Source: ${sanitizeForTooltip(
+          resource?.rawText
+            ? resource.rawText.length > 200
+              ? resource.rawText.slice(0, 200) + "..."
+              : resource.rawText
+            : text
+        )}${suffix}`;
       case "agent":
         return `AI Agent: ${sanitizeForTooltip(text)}${suffix}`;
       default:

--- a/frontend/src/graphql/cache.ts
+++ b/frontend/src/graphql/cache.ts
@@ -604,6 +604,22 @@ export type CorpusDetailViewType = "landing" | "details";
 export const corpusDetailView = makeVar<CorpusDetailViewType>("landing");
 
 /**
+ * Text block deep linking (URL-driven state - set by CentralRouteManager Phase 2)
+ *
+ * Holds a compact-encoded text block reference for highlighting arbitrary text
+ * in a document WITHOUT a database annotation. Used for deep linking from
+ * corpus agent sources and other citation views.
+ *
+ * The string value is the raw ?tb= URL parameter value (compact encoding).
+ * Components decode it via decodeTextBlock() from textBlockEncoding.ts.
+ *
+ * URL Examples:
+ *   /d/user/corpus/doc?tb=s100-500            → text span from char 100 to 500
+ *   /d/user/corpus/doc?tb=p0:45-65;p1:0-23   → PDF tokens on pages 0 and 1
+ */
+export const highlightedTextBlock = makeVar<string | null>(null);
+
+/**
  * Auth-related global variables
  */
 export const userObj = makeVar<User | null>(null);

--- a/frontend/src/routing/CentralRouteManager.tsx
+++ b/frontend/src/routing/CentralRouteManager.tsx
@@ -40,6 +40,7 @@ import {
   showSelectedAnnotationOnly,
   showAnnotationBoundingBoxes,
   showAnnotationLabels,
+  highlightedTextBlock,
   CorpusHomeViewType,
   CorpusDetailViewType,
 } from "../graphql/cache";
@@ -787,6 +788,9 @@ export function CentralRouteManager() {
     const tocExpandedParam = searchParams.get("tocExpanded") === "true";
     const detailViewParam = searchParams.get("view");
 
+    // Text block deep link
+    const textBlockParam = searchParams.get("tb");
+
     // Visualization state (booleans and enums)
     const structural = searchParams.get("structural") === "true";
     const selectedOnly = searchParams.get("selectedOnly") === "true";
@@ -822,6 +826,7 @@ export function CentralRouteManager() {
     const currentHomeView = corpusHomeView();
     const currentTocExpandAll = tocExpandAll();
     const currentDetailView = corpusDetailView();
+    const currentTextBlock = highlightedTextBlock();
     const currentStructural = showStructuralAnnotations();
     const currentSelectedOnly = showSelectedAnnotationOnly();
     const currentBoundingBoxes = showAnnotationBoundingBoxes();
@@ -890,6 +895,9 @@ export function CentralRouteManager() {
     }
     if (currentLabels !== newLabels) {
       updates.push(() => showAnnotationLabels(newLabels as any));
+    }
+    if (currentTextBlock !== (textBlockParam || null)) {
+      updates.push(() => highlightedTextBlock(textBlockParam || null));
     }
 
     // Execute all reactive var updates in a single batched operation
@@ -1033,7 +1041,7 @@ export function CentralRouteManager() {
   //
   // Vars synced: annotationIds, analysisIds, extractIds, threadId,
   // folderId, tab, messageId, homeView, tocExpanded, structural,
-  // selectedOnly, boundingBoxes, labels
+  // selectedOnly, boundingBoxes, labels, textBlock
   // ═══════════════════════════════════════════════════════════════
   const annIds = useReactiveVar(selectedAnnotationIds);
   const analysisIds = useReactiveVar(selectedAnalysesIds);
@@ -1049,6 +1057,7 @@ export function CentralRouteManager() {
   const selectedOnly = useReactiveVar(showSelectedAnnotationOnly);
   const boundingBoxes = useReactiveVar(showAnnotationBoundingBoxes);
   const labels = useReactiveVar(showAnnotationLabels);
+  const textBlock = useReactiveVar(highlightedTextBlock);
 
   useEffect(() => {
     const currentUrlParams = new URLSearchParams(location.search);
@@ -1132,6 +1141,7 @@ export function CentralRouteManager() {
       showSelectedOnly: selectedOnly,
       showBoundingBoxes: boundingBoxes,
       labelDisplay: labels,
+      textBlock,
     });
 
     // Both should have consistent "?" prefix for comparison
@@ -1166,6 +1176,7 @@ export function CentralRouteManager() {
     selectedOnly,
     boundingBoxes,
     labels,
+    textBlock,
   ]);
 
   // This component is purely side-effect driven, renders nothing

--- a/frontend/src/utils/idValidation.ts
+++ b/frontend/src/utils/idValidation.ts
@@ -3,6 +3,14 @@
  */
 
 /**
+ * Convert a raw database ID to a GraphQL global ID.
+ * Graphene-Django with Relay uses base64-encoded "{TypeName}:{id}" format.
+ */
+export function toGlobalId(typeName: string, id: number | string): string {
+  return btoa(`${typeName}:${id}`);
+}
+
+/**
  * Checks if a value is a valid GraphQL ID (base64 encoded, gid: prefixed, or numeric)
  */
 export function isValidGraphQLId(value: string | undefined | null): boolean {

--- a/frontend/src/utils/jobNotificationCacheUpdates.ts
+++ b/frontend/src/utils/jobNotificationCacheUpdates.ts
@@ -1,5 +1,6 @@
 import { ApolloCache } from "@apollo/client";
 import type { NotificationType } from "../hooks/useNotificationWebSocket";
+import { toGlobalId } from "./idValidation";
 
 /**
  * Cache update utilities for job completion notifications.
@@ -19,14 +20,6 @@ interface JobNotificationData {
   analysis_id?: number;
   // Export complete
   export_id?: number;
-}
-
-/**
- * Convert a raw database ID to a GraphQL global ID.
- * Graphene-Django with Relay uses base64-encoded "{TypeName}:{id}" format.
- */
-function toGlobalId(typeName: string, id: number | string): string {
-  return btoa(`${typeName}:${id}`);
 }
 
 /**

--- a/frontend/src/utils/navigationUtils.ts
+++ b/frontend/src/utils/navigationUtils.ts
@@ -1071,15 +1071,3 @@ export function updateTextBlockParam(
   }
   navigate({ search: searchParams.toString() }, { replace: true });
 }
-
-/**
- * Clear text block highlight from URL
- * @param location - React Router location object
- * @param navigate - React Router navigate function
- */
-export function clearTextBlockParam(
-  location: { search: string },
-  navigate: (to: { search: string }, options?: { replace?: boolean }) => void
-) {
-  updateTextBlockParam(location, navigate, null);
-}

--- a/frontend/src/utils/navigationUtils.ts
+++ b/frontend/src/utils/navigationUtils.ts
@@ -50,6 +50,7 @@ export interface QueryParams {
   showSelectedOnly?: boolean;
   showBoundingBoxes?: boolean;
   labelDisplay?: string; // "ALWAYS" | "ON_HOVER" | "HIDE"
+  textBlock?: string | null; // compact-encoded text block reference (e.g., "s100-500" or "p0:45-65")
 }
 
 /**
@@ -255,6 +256,11 @@ export function buildQueryParams(params: QueryParams): string {
   if (params.labelDisplay && params.labelDisplay !== "ON_HOVER") {
     // Only add if not the default
     searchParams.set("labels", params.labelDisplay);
+  }
+
+  // Text block deep link (compact-encoded reference to document text)
+  if (params.textBlock) {
+    searchParams.set("tb", params.textBlock);
   }
 
   const query = searchParams.toString();
@@ -1038,4 +1044,42 @@ export function navigateToRelationshipDocument(
   };
 
   navigateToDocument(docForNav, corpusForNav, navigate, currentPath);
+}
+
+// ═══════════════════════════════════════════════════════════════
+// Text Block Deep Link Navigation Utilities
+// ═══════════════════════════════════════════════════════════════
+
+/**
+ * SACRED UTILITY: Update text block deep link via URL
+ * Components MUST use this instead of directly setting reactive vars
+ *
+ * @param location - Current location from useLocation()
+ * @param navigate - Navigate function from useNavigate()
+ * @param textBlock - Compact-encoded text block string, or null to clear
+ */
+export function updateTextBlockParam(
+  location: { search: string },
+  navigate: (to: { search: string }, options?: { replace?: boolean }) => void,
+  textBlock: string | null
+) {
+  const searchParams = new URLSearchParams(location.search);
+  if (textBlock) {
+    searchParams.set("tb", textBlock);
+  } else {
+    searchParams.delete("tb");
+  }
+  navigate({ search: searchParams.toString() }, { replace: true });
+}
+
+/**
+ * Clear text block highlight from URL
+ * @param location - React Router location object
+ * @param navigate - React Router navigate function
+ */
+export function clearTextBlockParam(
+  location: { search: string },
+  navigate: (to: { search: string }, options?: { replace?: boolean }) => void
+) {
+  updateTextBlockParam(location, navigate, null);
 }

--- a/frontend/src/utils/textBlockEncoding.test.ts
+++ b/frontend/src/utils/textBlockEncoding.test.ts
@@ -43,6 +43,10 @@ describe("textBlockEncoding", () => {
       expect(decodeTextBlock("s-100")).toBeNull();
       expect(decodeTextBlock("sabc-def")).toBeNull();
     });
+
+    it("returns null for inverted span (start > end)", () => {
+      expect(decodeTextBlock("s500-100")).toBeNull();
+    });
   });
 
   describe("span roundtrip", () => {

--- a/frontend/src/utils/textBlockEncoding.test.ts
+++ b/frontend/src/utils/textBlockEncoding.test.ts
@@ -1,0 +1,272 @@
+import { describe, it, expect } from "vitest";
+import {
+  encodeTextBlock,
+  decodeTextBlock,
+  textBlockFromSpan,
+  textBlockFromTokensByPage,
+  textBlockToTokenIds,
+  textBlockToBounds,
+  TextSpanBlock,
+  PdfTokenBlock,
+} from "./textBlockEncoding";
+
+describe("textBlockEncoding", () => {
+  // ───────────────────────────────────────────────────────────────
+  // Span encoding / decoding
+  // ───────────────────────────────────────────────────────────────
+
+  describe("encodeTextBlock (span)", () => {
+    it("encodes a simple span block", () => {
+      const block: TextSpanBlock = { type: "span", start: 100, end: 500 };
+      expect(encodeTextBlock(block)).toBe("s100-500");
+    });
+
+    it("encodes a zero-start span", () => {
+      const block: TextSpanBlock = { type: "span", start: 0, end: 10 };
+      expect(encodeTextBlock(block)).toBe("s0-10");
+    });
+  });
+
+  describe("decodeTextBlock (span)", () => {
+    it("decodes a valid span string", () => {
+      const result = decodeTextBlock("s100-500");
+      expect(result).toEqual({ type: "span", start: 100, end: 500 });
+    });
+
+    it("decodes a zero-start span", () => {
+      const result = decodeTextBlock("s0-10");
+      expect(result).toEqual({ type: "span", start: 0, end: 10 });
+    });
+
+    it("returns null for malformed span", () => {
+      expect(decodeTextBlock("s100")).toBeNull();
+      expect(decodeTextBlock("s-100")).toBeNull();
+      expect(decodeTextBlock("sabc-def")).toBeNull();
+    });
+  });
+
+  describe("span roundtrip", () => {
+    it("encode → decode produces identical block", () => {
+      const original: TextSpanBlock = { type: "span", start: 42, end: 999 };
+      const encoded = encodeTextBlock(original);
+      const decoded = decodeTextBlock(encoded);
+      expect(decoded).toEqual(original);
+    });
+  });
+
+  // ───────────────────────────────────────────────────────────────
+  // PDF token encoding / decoding
+  // ───────────────────────────────────────────────────────────────
+
+  describe("encodeTextBlock (pdf)", () => {
+    it("encodes a single-page pdf block", () => {
+      const block: PdfTokenBlock = {
+        type: "pdf",
+        tokensByPage: { 0: [1, 2, 3, 5, 7, 8, 9] },
+      };
+      expect(encodeTextBlock(block)).toBe("p0:1-3,5,7-9");
+    });
+
+    it("encodes a multi-page pdf block", () => {
+      const block: PdfTokenBlock = {
+        type: "pdf",
+        tokensByPage: { 0: [10, 11, 12], 2: [0, 1] },
+      };
+      const encoded = encodeTextBlock(block);
+      // Pages are encoded in iteration order; both segments should appear
+      expect(encoded).toContain("p0:10-12");
+      expect(encoded).toContain("p2:0-1");
+      expect(encoded).toContain(";");
+    });
+
+    it("skips pages with empty token arrays", () => {
+      const block: PdfTokenBlock = {
+        type: "pdf",
+        tokensByPage: { 0: [], 1: [5] },
+      };
+      expect(encodeTextBlock(block)).toBe("p1:5");
+    });
+  });
+
+  describe("decodeTextBlock (pdf)", () => {
+    it("decodes a single-page pdf string", () => {
+      const result = decodeTextBlock("p0:1-3,5,7-9");
+      expect(result).toEqual({
+        type: "pdf",
+        tokensByPage: { 0: [1, 2, 3, 5, 7, 8, 9] },
+      });
+    });
+
+    it("decodes a multi-page pdf string", () => {
+      const result = decodeTextBlock("p0:10-12;p2:0-1");
+      expect(result).toEqual({
+        type: "pdf",
+        tokensByPage: {
+          0: [10, 11, 12],
+          2: [0, 1],
+        },
+      });
+    });
+
+    it("returns null for empty pdf token set", () => {
+      // "p0:" has no valid ranges → empty page → null
+      expect(decodeTextBlock("p0:")).toBeNull();
+    });
+  });
+
+  describe("pdf roundtrip", () => {
+    it("encode → decode preserves tokens", () => {
+      const original: PdfTokenBlock = {
+        type: "pdf",
+        tokensByPage: { 0: [1, 2, 3, 5], 1: [10, 20, 21, 22] },
+      };
+      const encoded = encodeTextBlock(original);
+      const decoded = decodeTextBlock(encoded);
+      expect(decoded).toEqual(original);
+    });
+
+    it("handles single-token pages", () => {
+      const original: PdfTokenBlock = {
+        type: "pdf",
+        tokensByPage: { 3: [42] },
+      };
+      const encoded = encodeTextBlock(original);
+      const decoded = decodeTextBlock(encoded);
+      expect(decoded).toEqual(original);
+    });
+  });
+
+  // ───────────────────────────────────────────────────────────────
+  // Edge cases and error handling
+  // ───────────────────────────────────────────────────────────────
+
+  describe("decodeTextBlock edge cases", () => {
+    it("returns null for empty string", () => {
+      expect(decodeTextBlock("")).toBeNull();
+    });
+
+    it("returns null for unknown prefix", () => {
+      expect(decodeTextBlock("x100-200")).toBeNull();
+      expect(decodeTextBlock("abc")).toBeNull();
+    });
+
+    it("rejects range spans exceeding MAX_RANGE_SPAN (10 000)", () => {
+      // A range of 0-20000 would produce 20001 elements → should be skipped
+      const result = decodeTextBlock("p0:0-20000");
+      expect(result).toBeNull(); // no valid tokens → null
+    });
+
+    it("accepts range spans within MAX_RANGE_SPAN", () => {
+      const result = decodeTextBlock("p0:0-100");
+      expect(result).not.toBeNull();
+      expect(result!.type).toBe("pdf");
+      const pdfBlock = result as PdfTokenBlock;
+      expect(pdfBlock.tokensByPage[0]).toHaveLength(101);
+    });
+  });
+
+  // ───────────────────────────────────────────────────────────────
+  // Helper functions
+  // ───────────────────────────────────────────────────────────────
+
+  describe("textBlockFromSpan", () => {
+    it("creates a TextSpanBlock", () => {
+      expect(textBlockFromSpan(10, 50)).toEqual({
+        type: "span",
+        start: 10,
+        end: 50,
+      });
+    });
+  });
+
+  describe("textBlockFromTokensByPage", () => {
+    it("converts TokenId arrays to PdfTokenBlock", () => {
+      const input = {
+        0: [
+          { pageIndex: 0, tokenIndex: 5 },
+          { pageIndex: 0, tokenIndex: 6 },
+        ],
+        2: [{ pageIndex: 2, tokenIndex: 0 }],
+      };
+      const result = textBlockFromTokensByPage(input);
+      expect(result).toEqual({
+        type: "pdf",
+        tokensByPage: { 0: [5, 6], 2: [0] },
+      });
+    });
+
+    it("skips empty token arrays", () => {
+      const input = {
+        0: [] as { pageIndex: number; tokenIndex: number }[],
+        1: [{ pageIndex: 1, tokenIndex: 3 }],
+      };
+      const result = textBlockFromTokensByPage(input);
+      expect(result.tokensByPage[0]).toBeUndefined();
+      expect(result.tokensByPage[1]).toEqual([3]);
+    });
+  });
+
+  describe("textBlockToTokenIds", () => {
+    it("converts PdfTokenBlock back to TokenId arrays", () => {
+      const block: PdfTokenBlock = {
+        type: "pdf",
+        tokensByPage: { 0: [5, 6], 2: [0] },
+      };
+      const result = textBlockToTokenIds(block);
+      expect(result[0]).toEqual([
+        { pageIndex: 0, tokenIndex: 5 },
+        { pageIndex: 0, tokenIndex: 6 },
+      ]);
+      expect(result[2]).toEqual([{ pageIndex: 2, tokenIndex: 0 }]);
+    });
+  });
+
+  describe("textBlockToBounds", () => {
+    it("computes bounding box from token geometry", () => {
+      const block: PdfTokenBlock = {
+        type: "pdf",
+        tokensByPage: { 0: [0, 1] },
+      };
+      const pageTokens = {
+        0: [
+          { x: 10, y: 20, width: 30, height: 10 },
+          { x: 50, y: 20, width: 20, height: 10 },
+        ],
+      };
+      const result = textBlockToBounds(block, pageTokens);
+      expect(result[0]).toEqual({
+        top: 20,
+        left: 10,
+        bottom: 30,
+        right: 70,
+      });
+    });
+
+    it("skips pages without token data", () => {
+      const block: PdfTokenBlock = {
+        type: "pdf",
+        tokensByPage: { 0: [0], 1: [0] },
+      };
+      const pageTokens = {
+        0: [{ x: 0, y: 0, width: 10, height: 10 }],
+        // Page 1 has no token data
+      };
+      const result = textBlockToBounds(block, pageTokens);
+      expect(result[0]).toBeDefined();
+      expect(result[1]).toBeUndefined();
+    });
+
+    it("skips out-of-range token indices", () => {
+      const block: PdfTokenBlock = {
+        type: "pdf",
+        tokensByPage: { 0: [999] },
+      };
+      const pageTokens = {
+        0: [{ x: 0, y: 0, width: 10, height: 10 }],
+      };
+      const result = textBlockToBounds(block, pageTokens);
+      // Token 999 doesn't exist → no valid bounds
+      expect(result[0]).toBeUndefined();
+    });
+  });
+});

--- a/frontend/src/utils/textBlockEncoding.test.ts
+++ b/frontend/src/utils/textBlockEncoding.test.ts
@@ -167,6 +167,25 @@ describe("textBlockEncoding", () => {
       const pdfBlock = result as PdfTokenBlock;
       expect(pdfBlock.tokensByPage[0]).toHaveLength(101);
     });
+
+    it("caps cumulative tokens across pages at MAX_TOTAL_TOKENS (50 000)", () => {
+      // Build 10 page segments of 9999 tokens each = 99990 total, exceeding cap
+      const segments = Array.from(
+        { length: 10 },
+        (_, i) => `p${i}:0-9998`
+      ).join(";");
+      const result = decodeTextBlock(segments);
+      expect(result).not.toBeNull();
+      const pdfBlock = result as PdfTokenBlock;
+      // Should have stopped adding pages once cumulative count exceeded 50 000
+      const totalTokens = Object.values(pdfBlock.tokensByPage).reduce(
+        (sum, arr) => sum + arr.length,
+        0
+      );
+      expect(totalTokens).toBeLessThanOrEqual(50_000);
+      // Should have fewer than 10 pages (some were dropped)
+      expect(Object.keys(pdfBlock.tokensByPage).length).toBeLessThan(10);
+    });
   });
 
   // ───────────────────────────────────────────────────────────────

--- a/frontend/src/utils/textBlockEncoding.ts
+++ b/frontend/src/utils/textBlockEncoding.ts
@@ -84,6 +84,11 @@ function encodeTokenRanges(tokens: number[]): string {
  *  Guards against malicious URLs like "0-9999999" creating huge arrays. */
 const MAX_RANGE_SPAN = 10_000;
 
+/** Maximum cumulative token count across ALL page segments.
+ *  Prevents crafted URLs with many small-but-valid page entries from
+ *  allocating a significant amount of memory (e.g., 500 pages × 10k each). */
+const MAX_TOTAL_TOKENS = 50_000;
+
 /**
  * Decode a compact token range string back to an array of numbers.
  * "1-3,5,7-9" → [1, 2, 3, 5, 7, 8, 9]
@@ -164,6 +169,7 @@ export function decodeTextBlock(param: string): TextBlockReference | null {
   // PDF tokens: "p{page}:{ranges};p{page}:{ranges};..."
   if (param.startsWith("p")) {
     const tokensByPage: Record<number, number[]> = {};
+    let totalTokens = 0;
     const pageSegments = param.split(";");
     for (const segment of pageSegments) {
       const pageMatch = segment.match(/^p(\d+):(.+)$/);
@@ -171,6 +177,8 @@ export function decodeTextBlock(param: string): TextBlockReference | null {
       const pageIdx = parseInt(pageMatch[1], 10);
       const tokens = decodeTokenRanges(pageMatch[2]);
       if (tokens.length > 0) {
+        totalTokens += tokens.length;
+        if (totalTokens > MAX_TOTAL_TOKENS) break;
         tokensByPage[pageIdx] = tokens;
       }
     }

--- a/frontend/src/utils/textBlockEncoding.ts
+++ b/frontend/src/utils/textBlockEncoding.ts
@@ -1,0 +1,287 @@
+/**
+ * Text Block Encoding/Decoding Utilities
+ *
+ * Provides compact URL-safe encoding for text block references that can be used
+ * as deep links to specific text locations in documents WITHOUT creating
+ * database annotations.
+ *
+ * Format:
+ *   Text spans:  "s{start}-{end}"           e.g., "s100-500"
+ *   PDF tokens:  "p{page}:{ranges};..."     e.g., "p0:45-65,70-72;p1:0-23"
+ *
+ * These are used in the ?tb= URL query parameter.
+ */
+
+import {
+  BoundingBox,
+  MultipageAnnotationJson,
+  SinglePageAnnotationJson,
+  TokenId,
+} from "../components/types";
+
+// ═══════════════════════════════════════════════════════════════
+// Types
+// ═══════════════════════════════════════════════════════════════
+
+/**
+ * A decoded text block reference for text-based documents.
+ * Uses character start/end indices.
+ */
+export interface TextSpanBlock {
+  type: "span";
+  start: number;
+  end: number;
+}
+
+/**
+ * A decoded text block reference for PDF documents.
+ * Uses page indices and token index ranges per page.
+ */
+export interface PdfTokenBlock {
+  type: "pdf";
+  /** Map of page index → sorted array of token indices */
+  tokensByPage: Record<number, number[]>;
+}
+
+/**
+ * Union type for all text block references.
+ */
+export type TextBlockReference = TextSpanBlock | PdfTokenBlock;
+
+// ═══════════════════════════════════════════════════════════════
+// Encoding
+// ═══════════════════════════════════════════════════════════════
+
+/**
+ * Encode a consecutive range of numbers into a compact string.
+ * [1, 2, 3, 5, 7, 8, 9] → "1-3,5,7-9"
+ */
+function encodeTokenRanges(tokens: number[]): string {
+  if (tokens.length === 0) return "";
+  const sorted = [...tokens].sort((a, b) => a - b);
+  const ranges: string[] = [];
+  let rangeStart = sorted[0];
+  let rangeEnd = sorted[0];
+
+  for (let i = 1; i < sorted.length; i++) {
+    if (sorted[i] === rangeEnd + 1) {
+      rangeEnd = sorted[i];
+    } else {
+      ranges.push(
+        rangeStart === rangeEnd ? `${rangeStart}` : `${rangeStart}-${rangeEnd}`
+      );
+      rangeStart = sorted[i];
+      rangeEnd = sorted[i];
+    }
+  }
+  ranges.push(
+    rangeStart === rangeEnd ? `${rangeStart}` : `${rangeStart}-${rangeEnd}`
+  );
+  return ranges.join(",");
+}
+
+/**
+ * Decode a compact token range string back to an array of numbers.
+ * "1-3,5,7-9" → [1, 2, 3, 5, 7, 8, 9]
+ */
+function decodeTokenRanges(rangeStr: string): number[] {
+  if (!rangeStr) return [];
+  const tokens: number[] = [];
+  const parts = rangeStr.split(",");
+  for (const part of parts) {
+    if (part.includes("-")) {
+      const [startStr, endStr] = part.split("-");
+      const start = parseInt(startStr, 10);
+      const end = parseInt(endStr, 10);
+      if (isNaN(start) || isNaN(end)) continue;
+      for (let i = start; i <= end; i++) {
+        tokens.push(i);
+      }
+    } else {
+      const num = parseInt(part, 10);
+      if (!isNaN(num)) {
+        tokens.push(num);
+      }
+    }
+  }
+  return tokens;
+}
+
+/**
+ * Encode a TextSpanBlock to URL parameter value.
+ * Returns: "s{start}-{end}"
+ */
+function encodeSpanBlock(block: TextSpanBlock): string {
+  return `s${block.start}-${block.end}`;
+}
+
+/**
+ * Encode a PdfTokenBlock to URL parameter value.
+ * Returns: "p{page}:{ranges};p{page}:{ranges};..."
+ */
+function encodePdfBlock(block: PdfTokenBlock): string {
+  const pageEntries = Object.entries(block.tokensByPage)
+    .map(([page, tokens]) => {
+      const ranges = encodeTokenRanges(tokens);
+      return ranges ? `p${page}:${ranges}` : null;
+    })
+    .filter(Boolean);
+  return pageEntries.join(";");
+}
+
+/**
+ * Encode a TextBlockReference into a compact URL parameter string.
+ */
+export function encodeTextBlock(block: TextBlockReference): string {
+  if (block.type === "span") {
+    return encodeSpanBlock(block);
+  }
+  return encodePdfBlock(block);
+}
+
+/**
+ * Decode a URL parameter string into a TextBlockReference.
+ * Returns null if the string is invalid.
+ */
+export function decodeTextBlock(param: string): TextBlockReference | null {
+  if (!param) return null;
+
+  // Text span: "s{start}-{end}"
+  if (param.startsWith("s")) {
+    const match = param.match(/^s(\d+)-(\d+)$/);
+    if (!match) return null;
+    return {
+      type: "span",
+      start: parseInt(match[1], 10),
+      end: parseInt(match[2], 10),
+    };
+  }
+
+  // PDF tokens: "p{page}:{ranges};p{page}:{ranges};..."
+  if (param.startsWith("p")) {
+    const tokensByPage: Record<number, number[]> = {};
+    const pageSegments = param.split(";");
+    for (const segment of pageSegments) {
+      const pageMatch = segment.match(/^p(\d+):(.+)$/);
+      if (!pageMatch) continue;
+      const pageIdx = parseInt(pageMatch[1], 10);
+      const tokens = decodeTokenRanges(pageMatch[2]);
+      if (tokens.length > 0) {
+        tokensByPage[pageIdx] = tokens;
+      }
+    }
+    if (Object.keys(tokensByPage).length === 0) return null;
+    return { type: "pdf", tokensByPage };
+  }
+
+  return null;
+}
+
+// ═══════════════════════════════════════════════════════════════
+// Conversion helpers: Source data → TextBlockReference
+// ═══════════════════════════════════════════════════════════════
+
+/**
+ * Create a TextBlockReference from text span data (character indices).
+ */
+export function textBlockFromSpan(start: number, end: number): TextSpanBlock {
+  return { type: "span", start, end };
+}
+
+/**
+ * Create a TextBlockReference from MultipageAnnotationJson (PAWLS tokens).
+ */
+export function textBlockFromMultipageJson(
+  json: MultipageAnnotationJson
+): PdfTokenBlock {
+  const tokensByPage: Record<number, number[]> = {};
+  for (const [pageKey, pageData] of Object.entries(json)) {
+    const pageIdx = parseInt(pageKey, 10);
+    if (isNaN(pageIdx)) continue;
+    const data = pageData as SinglePageAnnotationJson;
+    if (data.tokensJsons?.length) {
+      tokensByPage[pageIdx] = data.tokensJsons.map((t) => t.tokenIndex);
+    }
+  }
+  return { type: "pdf", tokensByPage };
+}
+
+/**
+ * Create a TextBlockReference from TokenId arrays per page
+ * (the format used by ChatMessageSource.tokensByPage).
+ */
+export function textBlockFromTokensByPage(
+  tokensByPage: Record<number, TokenId[]>
+): PdfTokenBlock {
+  const result: Record<number, number[]> = {};
+  for (const [pageKey, tokens] of Object.entries(tokensByPage)) {
+    const pageIdx = parseInt(pageKey, 10);
+    if (isNaN(pageIdx) || !tokens.length) continue;
+    result[pageIdx] = tokens.map((t) => t.tokenIndex);
+  }
+  return { type: "pdf", tokensByPage: result };
+}
+
+// ═══════════════════════════════════════════════════════════════
+// Rendering helpers: TextBlockReference → display data
+// ═══════════════════════════════════════════════════════════════
+
+/**
+ * Convert a PdfTokenBlock back to TokenId arrays per page,
+ * suitable for rendering with ChatSourceTokens or similar components.
+ */
+export function textBlockToTokenIds(
+  block: PdfTokenBlock
+): Record<number, TokenId[]> {
+  const result: Record<number, TokenId[]> = {};
+  for (const [pageKey, tokenIndices] of Object.entries(block.tokensByPage)) {
+    const pageIdx = parseInt(pageKey, 10);
+    result[pageIdx] = tokenIndices.map((tokenIndex) => ({
+      pageIndex: pageIdx,
+      tokenIndex,
+    }));
+  }
+  return result;
+}
+
+/**
+ * Compute bounding boxes for a PdfTokenBlock given page token data.
+ * This looks up token geometry from the page's token array.
+ *
+ * @param block - The PDF text block reference
+ * @param pageTokens - Map of page index → token array (from PAWLS data)
+ * @returns Map of page index → bounding box
+ */
+export function textBlockToBounds(
+  block: PdfTokenBlock,
+  pageTokens: Record<
+    number,
+    { x: number; y: number; width: number; height: number }[]
+  >
+): Record<number, BoundingBox> {
+  const result: Record<number, BoundingBox> = {};
+  for (const [pageKey, tokenIndices] of Object.entries(block.tokensByPage)) {
+    const pageIdx = parseInt(pageKey, 10);
+    const tokens = pageTokens[pageIdx];
+    if (!tokens) continue;
+
+    let top = Infinity;
+    let left = Infinity;
+    let bottom = -Infinity;
+    let right = -Infinity;
+
+    for (const idx of tokenIndices) {
+      const token = tokens[idx];
+      if (!token) continue;
+      top = Math.min(top, token.y);
+      left = Math.min(left, token.x);
+      bottom = Math.max(bottom, token.y + token.height);
+      right = Math.max(right, token.x + token.width);
+    }
+
+    if (top !== Infinity) {
+      result[pageIdx] = { top, left, bottom, right };
+    }
+  }
+  return result;
+}

--- a/frontend/src/utils/textBlockEncoding.ts
+++ b/frontend/src/utils/textBlockEncoding.ts
@@ -80,6 +80,10 @@ function encodeTokenRanges(tokens: number[]): string {
   return ranges.join(",");
 }
 
+/** Maximum number of tokens a single range segment may expand to.
+ *  Guards against malicious URLs like "0-9999999" creating huge arrays. */
+const MAX_RANGE_SPAN = 10_000;
+
 /**
  * Decode a compact token range string back to an array of numbers.
  * "1-3,5,7-9" → [1, 2, 3, 5, 7, 8, 9]
@@ -94,6 +98,7 @@ function decodeTokenRanges(rangeStr: string): number[] {
       const start = parseInt(startStr, 10);
       const end = parseInt(endStr, 10);
       if (isNaN(start) || isNaN(end)) continue;
+      if (end - start > MAX_RANGE_SPAN) continue;
       for (let i = start; i <= end; i++) {
         tokens.push(i);
       }

--- a/frontend/src/utils/textBlockEncoding.ts
+++ b/frontend/src/utils/textBlockEncoding.ts
@@ -155,11 +155,10 @@ export function decodeTextBlock(param: string): TextBlockReference | null {
   if (param.startsWith("s")) {
     const match = param.match(/^s(\d+)-(\d+)$/);
     if (!match) return null;
-    return {
-      type: "span",
-      start: parseInt(match[1], 10),
-      end: parseInt(match[2], 10),
-    };
+    const start = parseInt(match[1], 10);
+    const end = parseInt(match[2], 10);
+    if (start > end) return null;
+    return { type: "span", start, end };
   }
 
   // PDF tokens: "p{page}:{ranges};p{page}:{ranges};..."

--- a/frontend/src/views/Corpuses.tsx
+++ b/frontend/src/views/Corpuses.tsx
@@ -1604,6 +1604,18 @@ export const Corpuses = () => {
     (source: ChatMessageSource) => {
       if (!source.document_id || !opened_corpus) return;
 
+      // Validate corpus has slug data. This should always be present when
+      // viewing a corpus (resolved from a slug-based URL by CentralRouteManager).
+      // Falling back to opened_corpus.id (a Relay global ID) would produce an
+      // unresolvable URL like /d/user/Q29ycHVzVHlwZTo1/... that 404s.
+      if (!opened_corpus.slug || !opened_corpus.creator?.slug) {
+        console.warn(
+          "Cannot navigate to source: corpus missing slug data",
+          opened_corpus
+        );
+        return;
+      }
+
       // Build the text block encoding from source data
       let textBlock: string | null = null;
       if (
@@ -1627,18 +1639,17 @@ export const Corpuses = () => {
       // navigating without ?tb= would be a silent no-op.
       if (!textBlock) return;
 
-      // Build the document URL using the GraphQL ID format
-      // CentralRouteManager Phase 1 handles ID→slug redirect
+      // We only have the document's raw database ID from the WebSocket source,
+      // not its slug, so we use a Relay global ID for the document segment.
+      // CentralRouteManager Phase 1 detects this as a GraphQL ID and resolves
+      // it via resolveDocumentById, then redirects to the canonical slug URL.
+      // The corpus segment uses validated slugs from the already-resolved corpus.
       const docGraphQLId = toGlobalId("DocumentType", source.document_id);
-      const userSlug =
-        opened_corpus.creator?.slug || opened_corpus.creator?.username || "_";
-      const corpusSlug = opened_corpus.slug || opened_corpus.id;
+      const queryString = buildQueryParams({ textBlock });
 
-      const queryString = buildQueryParams({
-        textBlock,
-      });
-
-      navigate(`/d/${userSlug}/${corpusSlug}/${docGraphQLId}${queryString}`);
+      navigate(
+        `/d/${opened_corpus.creator.slug}/${opened_corpus.slug}/${docGraphQLId}${queryString}`
+      );
     },
     [opened_corpus, navigate]
   );

--- a/frontend/src/views/Corpuses.tsx
+++ b/frontend/src/views/Corpuses.tsx
@@ -137,6 +137,7 @@ import {
   textBlockFromTokensByPage,
 } from "../utils/textBlockEncoding";
 import { buildQueryParams } from "../utils/navigationUtils";
+import { toGlobalId } from "../utils/idValidation";
 import { CorpusHome } from "../components/corpuses/CorpusHome";
 import { CorpusDescriptionEditor } from "../components/corpuses/CorpusDescriptionEditor";
 import { CorpusDiscussionsView } from "../components/discussions/CorpusDiscussionsView";
@@ -1622,9 +1623,13 @@ export const Corpuses = () => {
         );
       }
 
+      // Bail out if we couldn't build a text block reference —
+      // navigating without ?tb= would be a silent no-op.
+      if (!textBlock) return;
+
       // Build the document URL using the GraphQL ID format
       // CentralRouteManager Phase 1 handles ID→slug redirect
-      const docGraphQLId = btoa(`DocumentType:${source.document_id}`);
+      const docGraphQLId = toGlobalId("DocumentType", source.document_id);
       const userSlug =
         opened_corpus.creator?.slug || opened_corpus.creator?.username || "_";
       const corpusSlug = opened_corpus.slug || opened_corpus.id;

--- a/frontend/src/views/Corpuses.tsx
+++ b/frontend/src/views/Corpuses.tsx
@@ -130,6 +130,13 @@ import { CorpusDashboard } from "../components/corpuses/CorpusDashboard";
 import { useCorpusState } from "../components/annotator/context/CorpusAtom";
 import { CorpusSettings } from "../components/corpuses/CorpusSettings";
 import { CorpusChat } from "../components/corpuses/CorpusChat";
+import { ChatMessageSource } from "../components/annotator/context/ChatSourceAtom";
+import {
+  encodeTextBlock,
+  textBlockFromSpan,
+  textBlockFromTokensByPage,
+} from "../utils/textBlockEncoding";
+import { buildQueryParams } from "../utils/navigationUtils";
 import { CorpusHome } from "../components/corpuses/CorpusHome";
 import { CorpusDescriptionEditor } from "../components/corpuses/CorpusDescriptionEditor";
 import { CorpusDiscussionsView } from "../components/discussions/CorpusDiscussionsView";
@@ -357,6 +364,7 @@ const CorpusQueryView = ({
   stats,
   statsLoading,
   onOpenMobileMenu,
+  onSourceNavigate,
 }: {
   opened_corpus: CorpusType | null;
   opened_corpus_id: string | null;
@@ -372,6 +380,7 @@ const CorpusQueryView = ({
   };
   statsLoading: boolean;
   onOpenMobileMenu?: () => void;
+  onSourceNavigate?: (source: ChatMessageSource) => void;
 }) => {
   const [chatExpanded, setChatExpanded] = useState<boolean>(false);
   const [searchQuery, setSearchQuery] = useState<string>("");
@@ -508,6 +517,7 @@ const CorpusQueryView = ({
             initialQuery={searchQuery}
             setShowLoad={() => {}}
             onMessageSelect={() => {}}
+            onSourceNavigate={onSourceNavigate}
             forceNewChat={true}
             onClose={resetToSearch}
           />
@@ -598,6 +608,7 @@ const CorpusQueryView = ({
             showLoad={true}
             setShowLoad={() => {}}
             onMessageSelect={() => {}}
+            onSourceNavigate={onSourceNavigate}
           />
         </div>
       </motion.div>
@@ -1583,6 +1594,50 @@ export const Corpuses = () => {
   const currentSelectedThreadId = useReactiveVar(selectedThreadId);
   const discussionInThreadView = currentSelectedThreadId !== null;
 
+  /**
+   * Navigate to a source document with text block highlighting.
+   * Called from CorpusChat when a user clicks a source citation.
+   * Builds a deep link URL with ?tb= param and navigates to the document.
+   */
+  const handleSourceNavigate = useCallback(
+    (source: ChatMessageSource) => {
+      if (!source.document_id || !opened_corpus) return;
+
+      // Build the text block encoding from source data
+      let textBlock: string | null = null;
+      if (
+        source.isTextBased &&
+        typeof source.startIndex === "number" &&
+        typeof source.endIndex === "number"
+      ) {
+        textBlock = encodeTextBlock(
+          textBlockFromSpan(source.startIndex, source.endIndex)
+        );
+      } else if (
+        source.tokensByPage &&
+        Object.keys(source.tokensByPage).length > 0
+      ) {
+        textBlock = encodeTextBlock(
+          textBlockFromTokensByPage(source.tokensByPage)
+        );
+      }
+
+      // Build the document URL using the GraphQL ID format
+      // CentralRouteManager Phase 1 handles ID→slug redirect
+      const docGraphQLId = btoa(`DocumentType:${source.document_id}`);
+      const userSlug =
+        opened_corpus.creator?.slug || opened_corpus.creator?.username || "_";
+      const corpusSlug = opened_corpus.slug || opened_corpus.id;
+
+      const queryString = buildQueryParams({
+        textBlock,
+      });
+
+      navigate(`/d/${userSlug}/${corpusSlug}/${docGraphQLId}${queryString}`);
+    },
+    [opened_corpus, navigate]
+  );
+
   const handleViewModeChange = useCallback((mode: ViewMode) => {
     setDocumentsViewMode(mode);
   }, []);
@@ -2204,6 +2259,7 @@ export const Corpuses = () => {
             stats={stats}
             statsLoading={effectiveStatsLoading}
             onOpenMobileMenu={() => setMobileSidebarOpen(true)}
+            onSourceNavigate={handleSourceNavigate}
           />
         ),
       },
@@ -2429,6 +2485,7 @@ export const Corpuses = () => {
                 corpusId={opened_corpus.id}
                 showLoad={true}
                 onMessageSelect={() => {}}
+                onSourceNavigate={handleSourceNavigate}
                 setShowLoad={() => {}}
                 onViewModeChange={setChatInConversation}
                 onClose={() => setActiveTab(0)}


### PR DESCRIPTION
## Summary
Implements URL-driven text block highlighting to enable deep linking to specific text regions in documents without creating database annotations. This allows users to share and navigate to exact text locations referenced in corpus agent responses.

## Key Changes

### New Utilities
- **`textBlockEncoding.ts`**: Compact URL-safe encoding/decoding for text block references
  - `TextSpanBlock`: Character-based ranges for text documents (format: `s{start}-{end}`)
  - `PdfTokenBlock`: Token-based ranges for PDFs (format: `p{page}:{ranges};...`)
  - Encoding/decoding functions with range compression (e.g., `[1,2,3,5,7,8,9]` → `"1-3,5,7-9"`)
  - Conversion helpers between source data formats and text block references
  - Rendering helpers to compute bounding boxes and token IDs from encoded blocks

### New Components
- **`TextBlockHighlight.tsx`**: Renders ephemeral highlights for deep-linked text blocks on PDF pages
  - Uses existing `ResultBoundary` and `ChatSourceTokens` components for consistent styling
  - Supports scroll-into-view behavior
  - Distinct teal color (`#0EA5E9`) to differentiate from chat source highlights

### Navigation & Routing
- **`navigationUtils.ts`**: Added `textBlock` query parameter support and utility functions
  - `updateTextBlockParam()`: Centralized utility for URL-driven state updates (pass `null` to clear)
- **`CentralRouteManager.tsx`**: Phase 2 routing now reads `?tb=` parameter and syncs to `highlightedTextBlock` reactive var
- **`Corpuses.tsx`**: New `handleSourceNavigate()` callback that builds deep links from chat source citations
  - Encodes text block data from source (spans or token ranges)
  - Constructs document URL with `?tb=` parameter
  - Passes callback to `CorpusChat` and `CorpusQueryView`

### Document Rendering
- **`PDFPage.tsx`**: Integrates text block highlighting
  - Decodes `?tb=` parameter and renders `TextBlockHighlight` when present
  - Computes token IDs and bounding boxes from page token geometry
  - Scrolls highlight into view automatically
- **`TxtAnnotatorWrapper.tsx`**: Adds text block span highlighting for text documents
  - Treats decoded text block as virtual chat source for consistent styling
  - Prioritizes text block highlight over regular chat source selection

### Data Model Updates
- **`ChatSourceAtom.tsx`**: Extended `ChatMessageSource` with `document_id` field for cross-document navigation
- **`ChatTray.tsx`**: Updated `WebSocketSources` type to include `document_id` field from backend
- **`cache.ts`**: Added `highlightedTextBlock` reactive variable for URL-driven state
- **`MarkdownMessageRenderer.tsx`**: Added "source" mention type styling (teal gradient) for future source citation rendering
- **`constants.ts`**: Added `TEXT_BLOCK_HIGHLIGHT_COLOR` constant

## Implementation Details
- Text block encoding is compact and URL-safe (no special characters requiring encoding)
- Highlights are ephemeral (not persisted to database) and driven entirely by URL state
- Reuses existing annotation display infrastructure (`ResultBoundary`, `ChatSourceTokens`) for visual consistency
- Supports both text-based documents (character spans) and PDFs (token ranges across pages)
- Range compression reduces URL length for documents with many highlighted tokens