### PR TITLE
Add comprehensive test coverage for corpus export functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to OpenContracts will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2026-02-27
+## [Unreleased] - 2026-02-28
 
 ### Changed
 
@@ -38,6 +38,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **DocumentKnowledgeBase.tsx**: Memoized `getPanelWidthPercentage` with `useCallback` to prevent auto-zoom effect from re-running on every render.
 
 ### Added
+
+#### Corpus Export Test Coverage (Closes #997)
+- Added `test_exported_document_structure` to validate exported document data structure: top-level keys, PAWLS page schema, annotation structure with bounding boxes and token references, and PDF burn-in validity (`opencontractserver/tests/test_corpus_export.py`)
+- Added `test_round_trip_consistency` to compare exported data against original import fixture: document title, content, PAWLS page dimensions and token counts, annotation count, raw text, label names (mapped through label lookups), and bounding box coordinates (`opencontractserver/tests/test_corpus_export.py`)
+- Added `test_exported_label_names_match_fixture` to verify exported label name sets match the labels actually used in the import fixture (`opencontractserver/tests/test_corpus_export.py`)
+- Loaded import fixture data in setUp for round-trip comparison, replacing the previous TODO placeholder (`opencontractserver/tests/test_corpus_export.py:62`)
+- Cleaned up existing tests by removing verbose print statements and TODO comments
 
 #### Test Coverage for Untested Backend Modules (Closes #975)
 - Unit tests for five previously uncovered modules: feedback, shared (defaults, db_utils, slug_utils, utils, mixins), constants, types (enums, TypedDicts), and MCP extended (telemetry, TTLLRUCache, RateLimiter, formatters, config, permissions, URI parser) (`opencontractserver/tests/`)

--- a/opencontractserver/tests/test_corpus_export.py
+++ b/opencontractserver/tests/test_corpus_export.py
@@ -1,6 +1,8 @@
 import base64
+import json
 import pathlib
 import uuid
+import zipfile
 
 import pytest
 from django.contrib.auth import get_user_model
@@ -21,6 +23,9 @@ User = get_user_model()
 
 pytestmark = pytest.mark.django_db
 
+# Expected bounding-box keys on every annotation page entry
+_BOUNDS_KEYS = {"top", "bottom", "left", "right"}
+
 
 class ExportCorpusTestCase(TestCase):
     fixtures_path = pathlib.Path(__file__).parent / "fixtures"
@@ -28,9 +33,9 @@ class ExportCorpusTestCase(TestCase):
     def setUp(self):
         self.user = User.objects.create_user(username="bob", password="12345678")
 
-        export_zip_base64_file_string = package_zip_into_base64(
-            self.fixtures_path / "Test_Corpus_EXPORT.zip"
-        )
+        zip_path = self.fixtures_path / "Test_Corpus_EXPORT.zip"
+
+        export_zip_base64_file_string = package_zip_into_base64(zip_path)
         self.original_corpus_obj = Corpus.objects.create(
             title="New Import", creator=self.user, backend_lock=False
         )
@@ -53,67 +58,36 @@ class ExportCorpusTestCase(TestCase):
 
         import_task.apply().get()
 
-        # TODO - load the import zip into memory so we can compare exports against original import
-        self.import_zip = None
+        # Load the import fixture so we can compare exports against original import
+        with zipfile.ZipFile(zip_path, "r") as zf:
+            self.import_data = json.loads(zf.read("data.json").decode("utf-8"))
 
-    # TODO - we really need to update the export format... to make it more useful for exchanges analyses,
-    #  stopped exporting ALL labelset labels
-    #  and not just export labels used in the corpus. This is a temporary fix to get working outputs,
-    #  but more thorough redesign is needed..
     def test_export_utils(self):
-        print(
-            "# TEST CORPUS EXPORT PIPELINE #########################################################################"
-        )
+        """Test that the export pipeline runs without errors and returns
+        the expected label counts."""
         self.original_corpus_obj.refresh_from_db()
 
-        print("1)\tTest building label lookups")
         label_lookups = build_label_lookups(corpus_id=self.original_corpus_obj.id)
-        print("\t\tSUCCESS")
 
-        print("2)\tTest that we have proper text_labels value in return obj")
         assert "text_labels" in label_lookups
-        print(f"\t\tlabel_lookups['text_labels']: {label_lookups['text_labels']}")
-        print(f"Length of text_labels: {len(label_lookups['text_labels'])}")
         assert len(label_lookups["text_labels"]) == 3
-        print("\t\tSUCCESS")
 
-        print("3)\tTest that we have proper doc_labels value in return obj")
         assert "doc_labels" in label_lookups
-        print(f"\t\tlabel_lookups['doc_labels']: {label_lookups['doc_labels']}")
-        print(f"Length of doc_labels: {len(label_lookups['doc_labels'])}")
         assert len(label_lookups["doc_labels"]) == 1
-        print("\t\tSUCCESS")
 
-        print(
-            "4)\tTest that we can burn in each document and produce labelled document"
-        )
         for doc in self.original_corpus_obj.get_documents():
-
-            build_document_export(
+            result = build_document_export(
                 label_lookups=label_lookups,
                 doc_id=doc.id,
                 corpus_id=self.original_corpus_obj.id,
             )
-
-            # TODO - need to check that each doc returns data of this format and it's valid (check against import)
-
-            # return (
-            #     doc_name,
-            #     base64_encoded_message,
-            #     doc_annotation_json,
-            #     text_labels,
-            #     doc_labels,
-            # )
-
-            # TODO - how do we check for the highlights and make sure they're right? PyMuPdf maybe?
+            # Should return a 5-tuple with non-None annotation JSON
+            self.assertEqual(len(result), 5)
+            self.assertIsNotNone(result[2])
 
     def test_exported_values_match_types(self):
-        """
-        Test that the exported values from build_document_export match the expected data shapes.
-        """
-        print("5)\tTest that exported values match the expected data shapes")
-
-        # Build label lookups
+        """Test that exported values from build_document_export match the
+        expected Pydantic / TypedDict data shapes."""
         label_lookups = build_label_lookups(corpus_id=self.original_corpus_obj.id)
 
         for doc in self.original_corpus_obj.get_documents():
@@ -129,9 +103,8 @@ class ExportCorpusTestCase(TestCase):
                 corpus_id=self.original_corpus_obj.id,
             )
 
-            # Validate types using Pydantic TypeAdapter
+            # Validate doc_annotation_json matches OpenContractDocExport
             try:
-                # Validate doc_annotation_json matches OpenContractDocExport
                 adapter = TypeAdapter(OpenContractDocExport)
                 adapter.validate_python(doc_annotation_json)
             except ValidationError as e:
@@ -139,25 +112,341 @@ class ExportCorpusTestCase(TestCase):
                     f"doc_annotation_json does not match OpenContractDocExport: {e}"
                 )
 
-            # Assert other types
             self.assertIsInstance(doc_name, str)
             self.assertIsInstance(base64_encoded_message, str)
             self.assertIsInstance(text_labels, dict)
             self.assertIsInstance(doc_labels, dict)
 
-            # Additional checks on text_labels and doc_labels
             for label in text_labels.values():
-                self.assertTrue(isinstance(label, dict))
+                self.assertIsInstance(label, dict)
                 self.assertIn("id", label)
                 self.assertIn("text", label)
                 self.assertIn("color", label)
 
             for label in doc_labels.values():
-                self.assertTrue(isinstance(label, dict))
+                self.assertIsInstance(label, dict)
                 self.assertIn("id", label)
                 self.assertIn("text", label)
                 self.assertIn("color", label)
 
-            print(f"\t\tDocument '{doc_name}' exported successfully and matches types")
+    # ------------------------------------------------------------------
+    # New: Structure validation
+    # ------------------------------------------------------------------
 
-        print("\t\tSUCCESS")
+    def test_exported_document_structure(self):
+        """Validate that each exported document contains all required
+        top-level keys and that nested structures (annotations, PAWLS
+        pages, bounding boxes) conform to the expected schema."""
+        label_lookups = build_label_lookups(corpus_id=self.original_corpus_obj.id)
+
+        for doc in self.original_corpus_obj.get_documents():
+            (
+                doc_name,
+                base64_encoded_message,
+                doc_annotation_json,
+                text_labels,
+                doc_labels,
+            ) = build_document_export(
+                label_lookups=label_lookups,
+                doc_id=doc.id,
+                corpus_id=self.original_corpus_obj.id,
+            )
+
+            # ----- Top-level keys -----
+            required_keys = {
+                "title",
+                "content",
+                "doc_labels",
+                "labelled_text",
+                "pawls_file_content",
+                "page_count",
+            }
+            self.assertTrue(
+                required_keys.issubset(doc_annotation_json.keys()),
+                f"Missing keys: {required_keys - doc_annotation_json.keys()}",
+            )
+
+            # ----- Title / content / page_count -----
+            self.assertIsInstance(doc_annotation_json["title"], str)
+            self.assertTrue(len(doc_annotation_json["title"]) > 0)
+            self.assertIsInstance(doc_annotation_json["content"], str)
+            self.assertIsInstance(doc_annotation_json["page_count"], int)
+            self.assertGreater(doc_annotation_json["page_count"], 0)
+
+            # ----- doc_labels list -----
+            self.assertIsInstance(doc_annotation_json["doc_labels"], list)
+            for dl in doc_annotation_json["doc_labels"]:
+                self.assertIsInstance(dl, str)
+
+            # ----- PAWLS pages -----
+            pawls = doc_annotation_json["pawls_file_content"]
+            self.assertIsInstance(pawls, list)
+            self.assertGreater(len(pawls), 0)
+            for page_obj in pawls:
+                self.assertIn("page", page_obj)
+                self.assertIn("tokens", page_obj)
+                page_meta = page_obj["page"]
+                for dim_key in ("width", "height", "index"):
+                    self.assertIn(dim_key, page_meta)
+                self.assertIsInstance(page_obj["tokens"], list)
+
+            # ----- Annotations -----
+            labelled_text = doc_annotation_json["labelled_text"]
+            self.assertIsInstance(labelled_text, list)
+
+            for annot in labelled_text:
+                # Required fields on every annotation
+                for field in (
+                    "id",
+                    "annotationLabel",
+                    "rawText",
+                    "page",
+                    "annotation_json",
+                ):
+                    self.assertIn(field, annot, f"Annotation missing '{field}'")
+
+                self.assertIsInstance(annot["rawText"], str)
+                self.assertTrue(len(annot["rawText"]) > 0)
+                self.assertIsInstance(annot["page"], int)
+
+                # annotation_json maps page numbers (as strings) to page data
+                self.assertIsInstance(annot["annotation_json"], dict)
+                for page_key, page_data in annot["annotation_json"].items():
+                    self.assertIn("bounds", page_data)
+                    self.assertTrue(
+                        _BOUNDS_KEYS.issubset(page_data["bounds"].keys()),
+                        f"Bounds missing keys: "
+                        f"{_BOUNDS_KEYS - set(page_data['bounds'].keys())}",
+                    )
+                    self.assertIn("tokensJsons", page_data)
+                    self.assertIsInstance(page_data["tokensJsons"], list)
+                    for token_ref in page_data["tokensJsons"]:
+                        self.assertIn("pageIndex", token_ref)
+                        self.assertIn("tokenIndex", token_ref)
+
+            # ----- PDF burn-in produces valid base64 for PDFs -----
+            if doc.file_type == "application/pdf" and base64_encoded_message:
+                decoded = base64.b64decode(base64_encoded_message)
+                self.assertTrue(
+                    decoded[:5] == b"%PDF-",
+                    "Burned-in PDF does not start with %PDF- header",
+                )
+
+    # ------------------------------------------------------------------
+    # New: Round-trip consistency (export vs. original import fixture)
+    # ------------------------------------------------------------------
+
+    def test_round_trip_consistency(self):
+        """Compare exported data against the original import fixture to
+        verify round-trip fidelity.
+
+        Checks:
+        - Document title matches
+        - Document text content matches
+        - PAWLS page count and dimensions match
+        - Number of annotations matches
+        - Annotation raw text values match
+        - Annotation label names match (mapped through label lookups)
+        - Annotation bounding boxes match (within tolerance)
+        - Document-level labels match
+        """
+        label_lookups = build_label_lookups(corpus_id=self.original_corpus_obj.id)
+
+        # The fixture has exactly one document
+        fixture_doc_key = list(self.import_data["annotated_docs"].keys())[0]
+        fixture_doc = self.import_data["annotated_docs"][fixture_doc_key]
+        fixture_text_labels = self.import_data["text_labels"]
+
+        # Export the single document in the corpus
+        docs = list(self.original_corpus_obj.get_documents())
+        self.assertEqual(len(docs), 1, "Expected exactly 1 document in corpus")
+
+        (
+            doc_name,
+            _base64_msg,
+            exported,
+            text_labels,
+            doc_labels,
+        ) = build_document_export(
+            label_lookups=label_lookups,
+            doc_id=docs[0].id,
+            corpus_id=self.original_corpus_obj.id,
+        )
+
+        # ----- Document title -----
+        self.assertEqual(
+            exported["title"],
+            fixture_doc["title"],
+            "Document title does not match fixture",
+        )
+
+        # ----- Document content -----
+        self.assertEqual(
+            exported["content"],
+            fixture_doc["content"],
+            "Document content does not match fixture",
+        )
+
+        # ----- PAWLS pages -----
+        fixture_pawls = fixture_doc["pawls_file_content"]
+        exported_pawls = exported["pawls_file_content"]
+        self.assertEqual(
+            len(exported_pawls),
+            len(fixture_pawls),
+            "PAWLS page count mismatch",
+        )
+        for i, (exp_page, fix_page) in enumerate(zip(exported_pawls, fixture_pawls)):
+            self.assertEqual(
+                exp_page["page"]["width"],
+                fix_page["page"]["width"],
+                f"Page {i} width mismatch",
+            )
+            self.assertEqual(
+                exp_page["page"]["height"],
+                fix_page["page"]["height"],
+                f"Page {i} height mismatch",
+            )
+            self.assertEqual(
+                exp_page["page"]["index"],
+                fix_page["page"]["index"],
+                f"Page {i} index mismatch",
+            )
+            self.assertEqual(
+                len(exp_page["tokens"]),
+                len(fix_page["tokens"]),
+                f"Page {i} token count mismatch",
+            )
+
+        # ----- Document-level labels -----
+        self.assertEqual(
+            sorted(exported["doc_labels"]),
+            sorted(fixture_doc["doc_labels"]),
+            "Document-level labels do not match fixture",
+        )
+
+        # ----- Annotation count -----
+        fixture_annots = fixture_doc["labelled_text"]
+        exported_annots = exported["labelled_text"]
+        self.assertEqual(
+            len(exported_annots),
+            len(fixture_annots),
+            "Annotation count mismatch",
+        )
+
+        # Build a map from fixture label ID -> label text for comparison.
+        # The export uses new DB IDs for labels, so we compare by label text.
+        fixture_label_id_to_text = {
+            lid: ldata["text"] for lid, ldata in fixture_text_labels.items()
+        }
+        exported_label_id_to_text = {
+            lid: ldata["text"] for lid, ldata in text_labels.items()
+        }
+
+        # Sort both annotation lists by rawText for stable comparison
+        fixture_sorted = sorted(fixture_annots, key=lambda a: a["rawText"])
+        exported_sorted = sorted(exported_annots, key=lambda a: a["rawText"])
+
+        for fix_annot, exp_annot in zip(fixture_sorted, exported_sorted):
+            # Raw text
+            self.assertEqual(
+                exp_annot["rawText"],
+                fix_annot["rawText"],
+                "Annotation rawText mismatch",
+            )
+
+            # Page number
+            self.assertEqual(
+                exp_annot["page"],
+                fix_annot["page"],
+                f"Annotation page mismatch for '{exp_annot['rawText'][:40]}'",
+            )
+
+            # Label name (compare by resolved text, not by ID)
+            fix_label_text = fixture_label_id_to_text[fix_annot["annotationLabel"]]
+            exp_label_text = exported_label_id_to_text[exp_annot["annotationLabel"]]
+            self.assertEqual(
+                exp_label_text,
+                fix_label_text,
+                f"Label mismatch for annotation '{exp_annot['rawText'][:40]}'",
+            )
+
+            # Bounding boxes (compare per-page)
+            fix_json = fix_annot["annotation_json"]
+            exp_json = exp_annot["annotation_json"]
+            self.assertEqual(
+                set(exp_json.keys()),
+                set(fix_json.keys()),
+                f"Annotation page keys mismatch for '{exp_annot['rawText'][:40]}'",
+            )
+
+            for page_key in fix_json:
+                fix_bounds = fix_json[page_key]["bounds"]
+                exp_bounds = exp_json[page_key]["bounds"]
+                for coord in ("top", "bottom", "left", "right"):
+                    self.assertAlmostEqual(
+                        exp_bounds[coord],
+                        fix_bounds[coord],
+                        places=2,
+                        msg=(
+                            f"Bounds '{coord}' mismatch on page {page_key} "
+                            f"for '{exp_annot['rawText'][:40]}'"
+                        ),
+                    )
+
+                # Token references count
+                self.assertEqual(
+                    len(exp_json[page_key]["tokensJsons"]),
+                    len(fix_json[page_key]["tokensJsons"]),
+                    f"Token ref count mismatch on page {page_key} "
+                    f"for '{exp_annot['rawText'][:40]}'",
+                )
+
+    def test_exported_label_names_match_fixture(self):
+        """Verify that the set of label *names* in the export matches the
+        set of label names actually used in the import fixture's
+        annotations."""
+        label_lookups = build_label_lookups(corpus_id=self.original_corpus_obj.id)
+
+        # Gather label names referenced by fixture annotations
+        fixture_doc_key = list(self.import_data["annotated_docs"].keys())[0]
+        fixture_doc = self.import_data["annotated_docs"][fixture_doc_key]
+        fixture_text_labels = self.import_data["text_labels"]
+        fixture_doc_labels_defs = self.import_data["doc_labels"]
+
+        used_text_label_ids = {
+            a["annotationLabel"] for a in fixture_doc["labelled_text"]
+        }
+        expected_text_label_names = {
+            fixture_text_labels[lid]["text"]
+            for lid in used_text_label_ids
+            if lid in fixture_text_labels
+        }
+
+        expected_doc_label_names = set(fixture_doc["doc_labels"])
+
+        # Exported label names
+        exported_text_label_names = {
+            v["text"] for v in label_lookups["text_labels"].values()
+        }
+        exported_doc_label_names = {
+            v["text"] for v in label_lookups["doc_labels"].values()
+        }
+
+        self.assertEqual(
+            exported_text_label_names,
+            expected_text_label_names,
+            "Exported text label names do not match fixture",
+        )
+
+        # Doc-level: the label lookup should contain at least the doc labels
+        # used by the document
+        expected_doc_label_names_from_defs = {
+            v["text"]
+            for v in fixture_doc_labels_defs.values()
+            if v["text"] in expected_doc_label_names
+        }
+        self.assertTrue(
+            expected_doc_label_names_from_defs.issubset(exported_doc_label_names),
+            f"Missing doc labels: "
+            f"{expected_doc_label_names_from_defs - exported_doc_label_names}",
+        )

--- a/opencontractserver/tests/test_corpus_export.py
+++ b/opencontractserver/tests/test_corpus_export.py
@@ -169,7 +169,7 @@ class ExportCorpusTestCase(TestCase):
 
             # ----- Title / content / page_count -----
             self.assertIsInstance(doc_annotation_json["title"], str)
-            self.assertTrue(len(doc_annotation_json["title"]) > 0)
+            self.assertGreater(len(doc_annotation_json["title"]), 0)
             self.assertIsInstance(doc_annotation_json["content"], str)
             self.assertIsInstance(doc_annotation_json["page_count"], int)
             self.assertGreater(doc_annotation_json["page_count"], 0)
@@ -207,7 +207,7 @@ class ExportCorpusTestCase(TestCase):
                     self.assertIn(field, annot, f"Annotation missing '{field}'")
 
                 self.assertIsInstance(annot["rawText"], str)
-                self.assertTrue(len(annot["rawText"]) > 0)
+                self.assertGreater(len(annot["rawText"]), 0)
                 self.assertIsInstance(annot["page"], int)
 
                 # annotation_json maps page numbers (as strings) to page data
@@ -343,9 +343,11 @@ class ExportCorpusTestCase(TestCase):
             lid: ldata["text"] for lid, ldata in text_labels.items()
         }
 
-        # Sort both annotation lists by rawText for stable comparison
-        fixture_sorted = sorted(fixture_annots, key=lambda a: a["rawText"])
-        exported_sorted = sorted(exported_annots, key=lambda a: a["rawText"])
+        # Sort both annotation lists by (rawText, page) to break ties stably
+        fixture_sorted = sorted(fixture_annots, key=lambda a: (a["rawText"], a["page"]))
+        exported_sorted = sorted(
+            exported_annots, key=lambda a: (a["rawText"], a["page"])
+        )
 
         for fix_annot, exp_annot in zip(fixture_sorted, exported_sorted):
             # Raw text
@@ -412,7 +414,6 @@ class ExportCorpusTestCase(TestCase):
         fixture_doc_key = list(self.import_data["annotated_docs"].keys())[0]
         fixture_doc = self.import_data["annotated_docs"][fixture_doc_key]
         fixture_text_labels = self.import_data["text_labels"]
-        fixture_doc_labels_defs = self.import_data["doc_labels"]
 
         used_text_label_ids = {
             a["annotationLabel"] for a in fixture_doc["labelled_text"]
@@ -441,13 +442,8 @@ class ExportCorpusTestCase(TestCase):
 
         # Doc-level: the label lookup should contain at least the doc labels
         # used by the document
-        expected_doc_label_names_from_defs = {
-            v["text"]
-            for v in fixture_doc_labels_defs.values()
-            if v["text"] in expected_doc_label_names
-        }
         self.assertTrue(
-            expected_doc_label_names_from_defs.issubset(exported_doc_label_names),
+            expected_doc_label_names.issubset(exported_doc_label_names),
             f"Missing doc labels: "
-            f"{expected_doc_label_names_from_defs - exported_doc_label_names}",
+            f"{expected_doc_label_names - exported_doc_label_names}",
         )


### PR DESCRIPTION
## Summary
This PR significantly expands test coverage for the corpus export pipeline by adding three new test methods that validate the structure, type correctness, and round-trip consistency of exported documents.

## Key Changes

### Test Infrastructure
- Added imports for `json` and `zipfile` to enable fixture data loading
- Added `_BOUNDS_KEYS` constant to define expected bounding box coordinate keys
- Modified `setUp()` to load and parse the import fixture (`data.json`) from the test ZIP file for comparison purposes

### New Test Methods

1. **`test_exported_document_structure()`**
   - Validates that exported documents contain all required top-level keys: `title`, `content`, `doc_labels`, `labelled_text`, `pawls_file_content`, `page_count`
   - Verifies PAWLS page structure (page metadata with width/height/index, token lists)
   - Validates annotation structure with required fields (`id`, `annotationLabel`, `rawText`, `page`, `annotation_json`)
   - Checks bounding box completeness (top, bottom, left, right coordinates)
   - Verifies token reference structure (pageIndex, tokenIndex)
   - Validates PDF burn-in produces valid base64-encoded PDF files (checks for `%PDF-` header)

2. **`test_round_trip_consistency()`**
   - Compares exported data against the original import fixture to ensure fidelity
   - Validates document title and content match
   - Verifies PAWLS page count, dimensions, and token counts match
   - Confirms annotation count matches fixture
   - Compares annotation raw text, page numbers, and label names (mapped through label lookups to account for new DB IDs)
   - Validates bounding box coordinates match within 2 decimal places
   - Checks token reference counts per page

3. **`test_exported_label_names_match_fixture()`**
   - Verifies that exported label names match the set of labels actually used in the import fixture
   - Compares both text-level and document-level label names

### Code Quality Improvements
- Removed verbose print statements and TODO comments from `test_export_utils()` and `test_exported_values_match_types()`
- Improved docstrings with clearer descriptions of test intent
- Replaced `isinstance()` calls with `assertIsInstance()` for consistency
- Simplified assertion logic and removed commented-out code blocks

## Implementation Details
- Tests load the fixture ZIP file directly to access `data.json` for comparison
- Label ID mapping accounts for the fact that exported documents use new database IDs while fixture uses original IDs—comparison is done by label text instead
- Annotations are sorted by `rawText` for stable comparison across export/import cycles
- Bounding box coordinate comparison uses `assertAlmostEqual()` with 2 decimal places to handle floating-point precision

https://claude.ai/code/session_01EJyCSMxYEVViNejPjxfJro