### PR TITLE
Fix JSON field validation to reject malformed input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,15 @@ All notable changes to OpenContracts will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2026-02-27
+## [Unreleased] - 2026-02-28
+
+### Fixed
+
+#### Tighten JSON Field Validation for Malformed Input (Closes #1001)
+- **Root cause**: `CustomJSONFieldFormTests.TestForm` used `NullableJSONField()` (a model field) instead of `UTF8JSONFormField` (a form field). Django's `Form` metaclass silently ignores model fields, so the form had zero fields and `is_valid()` always returned `True` — masking the fact that malformed JSON was never validated.
+- **Fix**: Changed `TestForm.json_field` to `UTF8JSONFormField(required=False)` so form validation actually runs through Django's `forms.JSONField.to_python()`, which raises `ValidationError` on `json.JSONDecodeError` (`opencontractserver/tests/test_custom_fields.py:76`).
+- **Re-enabled**: `test_form_with_invalid_json` now asserts that `'not json'` is correctly rejected (`opencontractserver/tests/test_custom_fields.py:90-92`).
+- **Added**: `test_formfield_rejects_invalid_json` and `test_formfield_accepts_valid_json` integration tests on `NullableJSONFieldTests` to verify the model field's `formfield()` method produces a form field that properly validates JSON (`opencontractserver/tests/test_custom_fields.py:63-71`).
 
 ### Changed
 

--- a/opencontractserver/tests/test_custom_fields.py
+++ b/opencontractserver/tests/test_custom_fields.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import ValidationError
 from django.forms import Form
 from django.test import TestCase
 
@@ -59,10 +60,20 @@ class NullableJSONFieldTests(TestCase):
         self.assertIn([], self.field.empty_values)
         self.assertIn({}, self.field.empty_values)
 
+    def test_formfield_rejects_invalid_json(self):
+        form_field = self.field.formfield()
+        with self.assertRaises(ValidationError):
+            form_field.clean("not json")
+
+    def test_formfield_accepts_valid_json(self):
+        form_field = self.field.formfield()
+        result = form_field.clean('{"key": "value"}')
+        self.assertEqual(result, {"key": "value"})
+
 
 class CustomJSONFieldFormTests(TestCase):
     class TestForm(Form):
-        json_field = NullableJSONField()
+        json_field = UTF8JSONFormField(required=False)
 
     def test_form_with_valid_json(self):
         form = self.TestForm({"json_field": '{"key": "value"}'})
@@ -76,7 +87,6 @@ class CustomJSONFieldFormTests(TestCase):
         form = self.TestForm({"json_field": ""})
         self.assertTrue(form.is_valid())
 
-    # TODO - this test is not quite working as expected. Minimal risk ATM.
-    # def test_form_with_invalid_json(self):
-    #     form = self.TestForm({'json_field': 'not json'})
-    #     self.assertFalse(form.is_valid())
+    def test_form_with_invalid_json(self):
+        form = self.TestForm({"json_field": "not json"})
+        self.assertFalse(form.is_valid())


### PR DESCRIPTION
## Summary
Fixed a bug where malformed JSON input was not being validated in forms due to incorrect field type usage. The test form was using a model field instead of a form field, causing Django to silently ignore it and always return `True` for validation.

## Changes
- **Fixed test form field type**: Changed `CustomJSONFieldFormTests.TestForm.json_field` from `NullableJSONField()` (model field) to `UTF8JSONFormField(required=False)` (form field) so that Django's form validation actually runs
- **Re-enabled validation test**: Uncommented and activated `test_form_with_invalid_json` which now correctly asserts that malformed JSON (`'not json'`) is rejected
- **Added integration tests**: Created `test_formfield_rejects_invalid_json` and `test_formfield_accepts_valid_json` to verify that the model field's `formfield()` method produces a properly validating form field

## Implementation Details
The root cause was that Django's `Form` metaclass silently ignores model fields—it only processes form fields. By using `NullableJSONField()` (a model field) in the test form, the field was never actually added to the form, so `is_valid()` always returned `True` regardless of input. The fix ensures form validation runs through Django's `forms.JSONField.to_python()`, which properly raises `ValidationError` on invalid JSON.

https://claude.ai/code/session_01NibxcihYq9bZvhikwYPpqA