### PR TITLE
Expand burn_doc_annotations test to cover text labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to OpenContracts will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2026-02-27
+## [Unreleased] - 2026-02-28
 
 ### Changed
 
@@ -38,6 +38,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **DocumentKnowledgeBase.tsx**: Memoized `getPanelWidthPercentage` with `useCallback` to prevent auto-zoom effect from re-running on every render.
 
 ### Added
+
+#### Expand burn_doc_annotations Test (Closes #1000)
+- Added `test_burn_doc_annotations_with_text_labels` to exercise the text-label PDF burning code path with TOKEN_LABEL fixtures and bounding-box annotation data (`opencontractserver/tests/test_doc_tasks.py`)
+- Validates output PDF contains highlight annotations with correct subtype, label text, and non-empty base64-encoded content
+- Validates `doc_export` JSON contains expected `doc_labels` and `labelled_text` entries
+- Renamed existing test to `test_burn_doc_annotations_doc_labels_only` for clarity
 
 #### Test Coverage for Untested Backend Modules (Closes #975)
 - Unit tests for five previously uncovered modules: feedback, shared (defaults, db_utils, slug_utils, utils, mixins), constants, types (enums, TypedDicts), and MCP extended (telemetry, TTLLRUCache, RateLimiter, formatters, config, permissions, URI parser) (`opencontractserver/tests/`)

--- a/opencontractserver/tests/test_doc_tasks.py
+++ b/opencontractserver/tests/test_doc_tasks.py
@@ -1,4 +1,5 @@
 #  Copyright (C) 2022  John Scrudato
+import io
 import logging
 from unittest.mock import MagicMock, patch
 
@@ -75,11 +76,11 @@ class DocParserTestCase(TestCase):
         self.doc.refresh_from_db()
         self.assertTrue(self.doc.backend_lock)
 
-    def test_burn_doc_annotations(self) -> None:
+    def test_burn_doc_annotations_doc_labels_only(self) -> None:
         """
-        Test burning annotations into the document.
+        Test burning annotations with only doc-level labels (no text labels).
+        Verifies the 5-tuple structure is returned correctly.
         """
-        # TODO - handle text labels and perform a substantive test
         label_lookups = {
             "text_labels": {},
             "doc_labels": {
@@ -97,6 +98,143 @@ class DocParserTestCase(TestCase):
             args=(label_lookups, self.doc.id, self.corpus.id)
         ).get()
         self.assertEqual(len(result), 5)
+
+    def test_burn_doc_annotations_with_text_labels(self) -> None:
+        """
+        Test burning annotations with text labels exercises the PDF highlight
+        code path and produces valid annotated output.
+        """
+        import base64
+
+        from pypdf import PdfReader
+
+        # Create a text-level annotation label in the database
+        text_label = AnnotationLabel.objects.create(
+            text="Important Clause",
+            creator=self.user,
+            label_type="TOKEN_LABEL",
+            color="#FF5733",
+            description="Highlights important clauses",
+            icon="tag",
+        )
+
+        # Create a doc-level annotation label in the database
+        doc_label = AnnotationLabel.objects.create(
+            text="Contract",
+            creator=self.user,
+            label_type="DOC_TYPE_LABEL",
+            color="#33FF57",
+            description="Marks document as a contract",
+            icon="file",
+        )
+
+        # Create a text annotation on page 1 with bounding-box data.
+        # The JSON keys are 1-based page number strings; bounds use
+        # left/right/top/bottom matching BoundingBoxPythonType.
+        Annotation.objects.create(
+            raw_text="Development Agreement",
+            annotation_label=text_label,
+            annotation_type="TOKEN_LABEL",
+            document=self.doc,
+            corpus=self.corpus,
+            creator=self.user,
+            page=1,
+            json={
+                "1": {
+                    "bounds": {
+                        "left": 100,
+                        "top": 100,
+                        "right": 300,
+                        "bottom": 120,
+                    },
+                    "tokensJsons": [{"pageIndex": 0, "tokenIndex": 0}],
+                    "rawText": "Development Agreement",
+                }
+            },
+        )
+
+        # Create a doc-level annotation
+        Annotation.objects.create(
+            raw_text="Contract",
+            annotation_label=doc_label,
+            annotation_type="DOC_TYPE_LABEL",
+            document=self.doc,
+            corpus=self.corpus,
+            creator=self.user,
+        )
+
+        # Build label lookups referencing actual DB primary keys
+        label_lookups = {
+            "text_labels": {
+                str(text_label.pk): {
+                    "id": str(text_label.pk),
+                    "color": "#FF5733",
+                    "description": "Highlights important clauses",
+                    "icon": "tag",
+                    "text": "Important Clause",
+                    "label_type": LabelType.TOKEN_LABEL,
+                }
+            },
+            "doc_labels": {
+                str(doc_label.pk): {
+                    "id": str(doc_label.pk),
+                    "color": "#33FF57",
+                    "description": "Marks document as a contract",
+                    "icon": "file",
+                    "text": "Contract",
+                    "label_type": LabelType.DOC_TYPE_LABEL,
+                }
+            },
+        }
+
+        result = burn_doc_annotations.apply(
+            args=(label_lookups, self.doc.id, self.corpus.id)
+        ).get()
+
+        # Verify 5-tuple structure
+        self.assertEqual(len(result), 5)
+        filename, base64_pdf, doc_export, returned_text_labels, returned_doc_labels = (
+            result
+        )
+
+        # Filename should be the PDF basename
+        self.assertIsNotNone(filename)
+        self.assertTrue(filename.endswith(".pdf"))
+
+        # base64-encoded PDF should be non-empty (annotations were burned in)
+        self.assertIsInstance(base64_pdf, str)
+        self.assertGreater(len(base64_pdf), 0)
+
+        # Decode and verify it's a valid PDF
+        pdf_bytes = base64.b64decode(base64_pdf)
+        reader = PdfReader(io.BytesIO(pdf_bytes))
+        self.assertGreater(len(reader.pages), 0)
+
+        # The first page should contain a highlight annotation
+        first_page = reader.pages[0]
+        annots = first_page.get("/Annots")
+        self.assertIsNotNone(annots, "First page should have PDF annotations")
+        self.assertGreater(len(annots), 0)
+
+        # Verify the highlight annotation metadata
+        highlight_annot = annots[0].get_object()
+        self.assertEqual(highlight_annot["/Subtype"], "/Highlight")
+        self.assertEqual(highlight_annot["/Contents"], "Important Clause")
+
+        # doc_export should contain the expected annotation data
+        self.assertIsNotNone(doc_export)
+        self.assertIn("Contract", doc_export["doc_labels"])
+        self.assertEqual(len(doc_export["labelled_text"]), 1)
+        self.assertEqual(
+            doc_export["labelled_text"][0]["rawText"], "Development Agreement"
+        )
+        self.assertEqual(
+            doc_export["labelled_text"][0]["annotationLabel"], str(text_label.pk)
+        )
+
+        # Returned label dicts should match what was passed in
+        self.assertIn(str(text_label.pk), returned_text_labels)
+        self.assertIn(str(doc_label.pk), returned_doc_labels)
 
     def test_convert_doc_to_funsd(self) -> None:
         """


### PR DESCRIPTION
## Summary
This PR expands test coverage for the `burn_doc_annotations` task by adding a comprehensive test that exercises the text-label PDF annotation code path, which was previously untested.

## Key Changes
- **Renamed existing test** from `test_burn_doc_annotations` to `test_burn_doc_annotations_doc_labels_only` for clarity, as it only tests doc-level labels
- **Added new test** `test_burn_doc_annotations_with_text_labels` that:
  - Creates TOKEN_LABEL and DOC_TYPE_LABEL fixtures with realistic metadata
  - Creates text annotations with bounding-box data on specific PDF pages
  - Verifies the returned 5-tuple structure (filename, base64_pdf, doc_export, text_labels, doc_labels)
  - Decodes and validates the base64-encoded PDF output using PyPDF
  - Confirms PDF highlight annotations are correctly embedded with proper subtype and label text
  - Validates the `doc_export` JSON structure contains expected annotation data
  - Verifies returned label dictionaries match the input lookups

## Implementation Details
- The new test uses realistic bounding-box coordinates and page-indexed annotation data matching the expected JSON schema
- PDF validation includes checking for the presence of `/Annots` on the first page and verifying highlight annotation properties (`/Subtype` and `/Contents`)
- Added `io` import to support BytesIO operations for PDF validation
- Updated CHANGELOG.md to document the test expansion and reference issue #1000

https://claude.ai/code/session_0189DRkAfrrPSmmyJ9315iUn