### PR TITLE
Fix: Raise PermissionError in analysis deletion mutation

### DIFF
--- a/config/graphql/analysis_mutations.py
+++ b/config/graphql/analysis_mutations.py
@@ -195,7 +195,7 @@ class DeleteAnalysisMutation(graphene.Mutation):
             permission=PermissionTypes.DELETE,
             include_group_permissions=True,
         ):
-            PermissionError("You don't have permission to delete this analysis.")
+            raise PermissionError("You don't have permission to delete this analysis.")
 
         # Kick off an async task to delete the analysis (as it can be very large)
         delete_analysis_and_annotations_task.si(analysis_pk=analysis_pk).apply_async()


### PR DESCRIPTION
## Summary
Fixed a bug in the analysis deletion mutation where a `PermissionError` was being instantiated but not raised, causing permission checks to be silently ignored.

## Key Changes
- Added `raise` keyword before `PermissionError` in the `delete_analysis` mutation's permission validation logic
- This ensures that users without proper deletion permissions will receive an appropriate error response instead of the operation proceeding silently

## Implementation Details
The permission check was already in place to verify that users have the `DELETE` permission (including group permissions), but the error was never being raised to the caller. This fix ensures the permission validation is actually enforced by raising the exception when the permission check fails.
