### PR TITLE
Fix tool popover positioning with portal rendering

### DIFF
--- a/frontend/src/assets/configurations/constants.ts
+++ b/frontend/src/assets/configurations/constants.ts
@@ -130,6 +130,18 @@ export const EXTRACT_STATUS_COLORS = {
 // Tool usage UI constants (used by chat ToolUsageIndicator)
 export const TOOL_UNKNOWN_LABEL = "Unknown Tool";
 
+// Tool popover positioning constants (used by ToolUsageIndicator portal)
+/** Z-index for the fixed-position tool popover rendered via portal */
+export const POPOVER_Z_INDEX = 100002;
+/** Gap in pixels between the badge and the popover */
+export const POPOVER_GAP = 8;
+/**
+ * Maximum height of the tool popover in pixels.
+ * Must match ToolPopoverBody max-height (400px) + header height (~100px).
+ * If ToolPopoverBody max-height changes, update this value accordingly.
+ */
+export const POPOVER_MAX_HEIGHT = 500;
+
 // Conversation type constants (matches backend ConversationTypeChoices)
 export const CONVERSATION_TYPE = {
   CHAT: "CHAT",

--- a/frontend/src/components/widgets/chat/ChatMessage.tsx
+++ b/frontend/src/components/widgets/chat/ChatMessage.tsx
@@ -1,4 +1,11 @@
-import React, { useState, useEffect, useRef, useCallback } from "react";
+import React, {
+  useState,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useCallback,
+  useId,
+} from "react";
 import { createPortal } from "react-dom";
 import { isTextFileType } from "../../../utils/files";
 import styled from "styled-components";
@@ -39,7 +46,12 @@ import {
   SpanAnnotationJson,
 } from "../../types";
 import { AnnotationLabelType } from "../../../types/graphql-api";
-import { TOOL_UNKNOWN_LABEL } from "../../../assets/configurations/constants";
+import {
+  TOOL_UNKNOWN_LABEL,
+  POPOVER_Z_INDEX,
+  POPOVER_GAP,
+  POPOVER_MAX_HEIGHT,
+} from "../../../assets/configurations/constants";
 
 // Timeline entry type based on the schema
 export interface TimelineEntry {
@@ -695,7 +707,6 @@ const TimelineItemArgs = styled.div`
 
 // Tool Usage Badge & Popover styled components
 const ToolBadgeWrapper = styled.div`
-  position: relative;
   display: inline-flex;
 `;
 
@@ -739,7 +750,7 @@ const ToolBadge = styled.div<{ $isSelected?: boolean }>`
 
 const ToolPopover = styled(motion.div)`
   position: fixed;
-  z-index: 100002;
+  z-index: ${POPOVER_Z_INDEX};
   min-width: 320px;
   max-width: 440px;
   background: rgba(255, 255, 255, 0.98);
@@ -1193,6 +1204,7 @@ const ToolUsageIndicator: React.FC<{
   const [isOpen, setIsOpen] = useState(false);
   const closeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const badgeRef = useRef<HTMLDivElement>(null);
+  const baseId = useId();
   const [popoverStyle, setPopoverStyle] = useState<React.CSSProperties>({});
 
   // Cleanup timeout on unmount to prevent memory leaks
@@ -1207,8 +1219,6 @@ const ToolUsageIndicator: React.FC<{
   const updatePopoverPosition = useCallback(() => {
     if (!badgeRef.current) return;
     const rect = badgeRef.current.getBoundingClientRect();
-    const POPOVER_GAP = 8;
-    const POPOVER_MAX_HEIGHT = 500; // header + body max-height
     const spaceBelow = window.innerHeight - rect.bottom - POPOVER_GAP;
     const openUpward = spaceBelow < POPOVER_MAX_HEIGHT && rect.top > spaceBelow;
 
@@ -1227,8 +1237,8 @@ const ToolUsageIndicator: React.FC<{
     }
   }, []);
 
-  // Track position while popover is open
-  useEffect(() => {
+  // Track position while popover is open (useLayoutEffect prevents flash at 0,0)
+  useLayoutEffect(() => {
     if (!isOpen) return;
     updatePopoverPosition();
     window.addEventListener("scroll", updatePopoverPosition, true);
@@ -1262,7 +1272,7 @@ const ToolUsageIndicator: React.FC<{
     }
   };
 
-  const popoverId = `tool-popover-${toolCalls.length}`;
+  const popoverId = `tool-popover-${baseId}`;
 
   return (
     <>

--- a/frontend/src/components/widgets/chat/ChatMessage.tsx
+++ b/frontend/src/components/widgets/chat/ChatMessage.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useRef, useCallback } from "react";
+import { createPortal } from "react-dom";
 import { isTextFileType } from "../../../utils/files";
 import styled from "styled-components";
 import { motion, AnimatePresence } from "framer-motion";
@@ -737,10 +738,8 @@ const ToolBadge = styled.div<{ $isSelected?: boolean }>`
 `;
 
 const ToolPopover = styled(motion.div)`
-  position: absolute;
-  top: calc(100% + 0.5rem);
-  right: 0;
-  z-index: 100;
+  position: fixed;
+  z-index: 100002;
   min-width: 320px;
   max-width: 440px;
   background: rgba(255, 255, 255, 0.98);
@@ -753,7 +752,6 @@ const ToolPopover = styled(motion.div)`
   @media (max-width: 768px) {
     min-width: 260px;
     max-width: 320px;
-    right: -1rem;
   }
 `;
 
@@ -1184,6 +1182,9 @@ export const formatToolName = (name: string): string => {
 /**
  * Displays a tool usage badge next to assistant messages. On hover, opens a
  * popover listing each tool call with its input arguments and output result.
+ *
+ * The popover is rendered via a portal to document.body to avoid clipping by
+ * ancestor containers with overflow:hidden (ChatContainer, FlexColumnPanel).
  */
 const ToolUsageIndicator: React.FC<{
   timeline: TimelineEntry[];
@@ -1191,6 +1192,8 @@ const ToolUsageIndicator: React.FC<{
   const toolCalls = useMemo(() => extractToolCalls(timeline), [timeline]);
   const [isOpen, setIsOpen] = useState(false);
   const closeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const badgeRef = useRef<HTMLDivElement>(null);
+  const [popoverStyle, setPopoverStyle] = useState<React.CSSProperties>({});
 
   // Cleanup timeout on unmount to prevent memory leaks
   useEffect(() => {
@@ -1200,6 +1203,41 @@ const ToolUsageIndicator: React.FC<{
       }
     };
   }, []);
+
+  const updatePopoverPosition = useCallback(() => {
+    if (!badgeRef.current) return;
+    const rect = badgeRef.current.getBoundingClientRect();
+    const POPOVER_GAP = 8;
+    const POPOVER_MAX_HEIGHT = 500; // header + body max-height
+    const spaceBelow = window.innerHeight - rect.bottom - POPOVER_GAP;
+    const openUpward = spaceBelow < POPOVER_MAX_HEIGHT && rect.top > spaceBelow;
+
+    if (openUpward) {
+      setPopoverStyle({
+        bottom: window.innerHeight - rect.top + POPOVER_GAP,
+        right: window.innerWidth - rect.right,
+        top: undefined,
+      });
+    } else {
+      setPopoverStyle({
+        top: rect.bottom + POPOVER_GAP,
+        right: window.innerWidth - rect.right,
+        bottom: undefined,
+      });
+    }
+  }, []);
+
+  // Track position while popover is open
+  useEffect(() => {
+    if (!isOpen) return;
+    updatePopoverPosition();
+    window.addEventListener("scroll", updatePopoverPosition, true);
+    window.addEventListener("resize", updatePopoverPosition);
+    return () => {
+      window.removeEventListener("scroll", updatePopoverPosition, true);
+      window.removeEventListener("resize", updatePopoverPosition);
+    };
+  }, [isOpen, updatePopoverPosition]);
 
   if (toolCalls.length === 0) return null;
 
@@ -1227,71 +1265,81 @@ const ToolUsageIndicator: React.FC<{
   const popoverId = `tool-popover-${toolCalls.length}`;
 
   return (
-    <ToolBadgeWrapper
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
-      onClick={(e: React.MouseEvent) => e.stopPropagation()}
-    >
-      <ToolBadge
-        $isSelected={isOpen}
-        role="button"
-        tabIndex={0}
-        aria-expanded={isOpen}
-        aria-haspopup="dialog"
-        aria-describedby={isOpen ? popoverId : undefined}
-        onKeyDown={handleKeyDown}
+    <>
+      <ToolBadgeWrapper
+        ref={badgeRef}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        onClick={(e: React.MouseEvent) => e.stopPropagation()}
       >
-        <Wrench size={14} />
-        {toolCalls.length} {toolCalls.length === 1 ? "tool" : "tools"} used
-      </ToolBadge>
-      <AnimatePresence>
-        {isOpen && (
-          <ToolPopover
-            id={popoverId}
-            role="dialog"
-            aria-label={`Tool usage details: ${toolCalls.length} ${
-              toolCalls.length === 1 ? "call" : "calls"
-            }`}
-            initial={{ opacity: 0, y: -4, scale: 0.98 }}
-            animate={{ opacity: 1, y: 0, scale: 1 }}
-            exit={{ opacity: 0, y: -4, scale: 0.98 }}
-            transition={{ duration: 0.15, ease: "easeOut" }}
-          >
-            <ToolPopoverHeader>
-              <Wrench />
-              Tool Usage ({toolCalls.length}{" "}
-              {toolCalls.length === 1 ? "call" : "calls"})
-            </ToolPopoverHeader>
-            <ToolPopoverBody>
-              {toolCalls.map((call) => (
-                <ToolCallCard key={call.id}>
-                  <ToolCallName>
-                    <Wrench />
-                    {formatToolName(call.tool)}
-                  </ToolCallName>
-                  {call.args !== undefined && (
-                    <ToolCallSection>
-                      <ToolCallSectionLabel>Input</ToolCallSectionLabel>
-                      <ToolCallCodeBlock>
-                        {typeof call.args === "string"
-                          ? call.args
-                          : JSON.stringify(call.args, null, 2)}
-                      </ToolCallCodeBlock>
-                    </ToolCallSection>
-                  )}
-                  {call.result && (
-                    <ToolCallSection>
-                      <ToolCallSectionLabel>Output</ToolCallSectionLabel>
-                      <ToolCallResultBlock>{call.result}</ToolCallResultBlock>
-                    </ToolCallSection>
-                  )}
-                </ToolCallCard>
-              ))}
-            </ToolPopoverBody>
-          </ToolPopover>
-        )}
-      </AnimatePresence>
-    </ToolBadgeWrapper>
+        <ToolBadge
+          $isSelected={isOpen}
+          role="button"
+          tabIndex={0}
+          aria-expanded={isOpen}
+          aria-haspopup="dialog"
+          aria-describedby={isOpen ? popoverId : undefined}
+          onKeyDown={handleKeyDown}
+        >
+          <Wrench size={14} />
+          {toolCalls.length} {toolCalls.length === 1 ? "tool" : "tools"} used
+        </ToolBadge>
+      </ToolBadgeWrapper>
+      {createPortal(
+        <AnimatePresence>
+          {isOpen && (
+            <ToolPopover
+              key="tool-popover"
+              id={popoverId}
+              role="dialog"
+              aria-label={`Tool usage details: ${toolCalls.length} ${
+                toolCalls.length === 1 ? "call" : "calls"
+              }`}
+              style={popoverStyle}
+              initial={{ opacity: 0, y: -4, scale: 0.98 }}
+              animate={{ opacity: 1, y: 0, scale: 1 }}
+              exit={{ opacity: 0, y: -4, scale: 0.98 }}
+              transition={{ duration: 0.15, ease: "easeOut" }}
+              onMouseEnter={handleMouseEnter}
+              onMouseLeave={handleMouseLeave}
+            >
+              <ToolPopoverHeader>
+                <Wrench />
+                Tool Usage ({toolCalls.length}{" "}
+                {toolCalls.length === 1 ? "call" : "calls"})
+              </ToolPopoverHeader>
+              <ToolPopoverBody>
+                {toolCalls.map((call) => (
+                  <ToolCallCard key={call.id}>
+                    <ToolCallName>
+                      <Wrench />
+                      {formatToolName(call.tool)}
+                    </ToolCallName>
+                    {call.args !== undefined && (
+                      <ToolCallSection>
+                        <ToolCallSectionLabel>Input</ToolCallSectionLabel>
+                        <ToolCallCodeBlock>
+                          {typeof call.args === "string"
+                            ? call.args
+                            : JSON.stringify(call.args, null, 2)}
+                        </ToolCallCodeBlock>
+                      </ToolCallSection>
+                    )}
+                    {call.result && (
+                      <ToolCallSection>
+                        <ToolCallSectionLabel>Output</ToolCallSectionLabel>
+                        <ToolCallResultBlock>{call.result}</ToolCallResultBlock>
+                      </ToolCallSection>
+                    )}
+                  </ToolCallCard>
+                ))}
+              </ToolPopoverBody>
+            </ToolPopover>
+          )}
+        </AnimatePresence>,
+        document.body
+      )}
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary
Refactored the ToolUsageIndicator popover to render via React portal to document.body and implemented dynamic positioning logic to prevent clipping by ancestor containers with `overflow: hidden`.

## Key Changes
- **Portal rendering**: Moved popover from inline rendering to `createPortal(document.body)` to escape overflow constraints of parent containers (ChatContainer, FlexColumnPanel)
- **Dynamic positioning**: Implemented `updatePopoverPosition()` callback that calculates popover position based on badge location and available viewport space
- **Smart direction**: Popover opens downward by default, but automatically opens upward when insufficient space below and more space available above
- **Position tracking**: Added scroll and resize event listeners to keep popover positioned correctly when viewport changes
- **Styling updates**: Changed ToolPopover from `position: absolute` to `position: fixed` with higher z-index (100002) and removed hardcoded `top`/`right` values in favor of dynamic style props
- **Accessibility**: Maintained all ARIA attributes and keyboard navigation support

## Implementation Details
- Badge element now has a ref (`badgeRef`) to measure its position via `getBoundingClientRect()`
- Popover position calculated with 8px gap from badge and 500px max-height consideration
- Event listeners properly cleaned up on unmount and when popover closes to prevent memory leaks
- Popover maintains hover state across both badge and portal-rendered popover to prevent flickering

https://claude.ai/code/session_011YquE5crP6XyKERUx4JCZ3