### PR TITLE
Auto-sync pipeline settings on Docker Compose startup

### DIFF
--- a/compose/local/django/start
+++ b/compose/local/django/start
@@ -6,6 +6,6 @@ set -o nounset
 
 
 python manage.py migrate
-python manage.py migrate_pipeline_settings --sync-preferences
+python manage.py migrate_pipeline_settings --sync-preferences --init-only
 python manage.py migrate_pipeline_settings
 python manage.py runserver 0.0.0.0:8000

--- a/compose/local/django/start
+++ b/compose/local/django/start
@@ -6,4 +6,6 @@ set -o nounset
 
 
 python manage.py migrate
+python manage.py migrate_pipeline_settings --sync-preferences
+python manage.py migrate_pipeline_settings
 python manage.py runserver 0.0.0.0:8000

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -990,6 +990,11 @@ PARSER_KWARGS = {
     },
 }
 
+# Enabled pipeline components. An empty list means all registered components are enabled.
+# To restrict to specific components, list their full class paths, e.g.:
+#   ENABLED_COMPONENTS = ["opencontractserver.pipeline.parsers.docling_parser.DoclingParser"]
+ENABLED_COMPONENTS: list[str] = []
+
 # Analyzers
 # ------------------------------------------------------------------------------
 ANALYZER_KWARGS = {

--- a/opencontractserver/documents/management/commands/migrate_pipeline_settings.py
+++ b/opencontractserver/documents/management/commands/migrate_pipeline_settings.py
@@ -77,6 +77,12 @@ class Command(BaseCommand):
             "have new defaults you want to adopt.",
         )
         parser.add_argument(
+            "--init-only",
+            action="store_true",
+            help="Only populate fields that are currently empty/unset in the database. "
+            "Existing non-empty values are preserved. Safe for use on every startup.",
+        )
+        parser.add_argument(
             "--list-components",
             action="store_true",
             help="List all available pipeline components and their settings schemas. "
@@ -92,6 +98,7 @@ class Command(BaseCommand):
         force_overwrite = options.get("force", False)
         strict_mode = options.get("strict", False)
         sync_preferences = options.get("sync_preferences", False)
+        init_only = options.get("init_only", False)
         list_components = options.get("list_components", False)
 
         # Handle --list-components first (doesn't need the header)
@@ -116,7 +123,7 @@ class Command(BaseCommand):
             return
 
         if sync_preferences:
-            self._sync_preferences(dry_run, verbose)
+            self._sync_preferences(dry_run, verbose, init_only=init_only)
             return
 
         # Import here to avoid circular imports
@@ -448,7 +455,7 @@ class Command(BaseCommand):
 
         self.stdout.write("=" * 70 + "\n")
 
-    def _sync_preferences(self, dry_run: bool, verbose: bool):
+    def _sync_preferences(self, dry_run: bool, verbose: bool, init_only: bool = False):
         """
         Sync main pipeline preferences from Django settings to database.
 
@@ -459,12 +466,19 @@ class Command(BaseCommand):
         - parser_kwargs from PARSER_KWARGS
         - default_embedder from DEFAULT_EMBEDDER
         - enabled_components from ENABLED_COMPONENTS (defaults to [] = all enabled)
+
+        When init_only=True, fields that already have non-empty values in the
+        database are preserved. This makes the command safe to run on every
+        startup without overwriting admin-configured values.
         """
         from opencontractserver.documents.models import PipelineSettings
 
         pipeline_settings = PipelineSettings.get_instance(use_cache=False)
 
-        self.stdout.write("Syncing main pipeline preferences from Django settings...\n")
+        mode_label = " (init-only)" if init_only else ""
+        self.stdout.write(
+            f"Syncing main pipeline preferences from Django settings{mode_label}...\n"
+        )
 
         # Map of DB field -> Django setting name
         preference_mappings = [
@@ -477,10 +491,18 @@ class Command(BaseCommand):
         ]
 
         changes = []
+        skipped = []
 
         for db_field, setting_name, default in preference_mappings:
             current_value = getattr(pipeline_settings, db_field)
             new_value = getattr(django_settings, setting_name, default)
+
+            # In init-only mode, skip fields that already have non-empty values
+            if init_only and current_value not in (None, "", {}, []):
+                skipped.append(db_field)
+                if verbose:
+                    self.stdout.write(f"  {db_field}: [PRESERVED] (already configured)")
+                continue
 
             # Normalize for comparison (handle None vs empty dict/string)
             current_normalized = current_value if current_value else default
@@ -522,6 +544,13 @@ class Command(BaseCommand):
             self.stdout.write(
                 "  No changes needed - database already matches Django settings"
             )
+
+        if skipped:
+            self.stdout.write(
+                f"  Fields preserved (already configured): {len(skipped)}"
+            )
+            for field in skipped:
+                self.stdout.write(f"    - {field}")
 
         if dry_run:
             self.stdout.write(

--- a/opencontractserver/documents/management/commands/migrate_pipeline_settings.py
+++ b/opencontractserver/documents/management/commands/migrate_pipeline_settings.py
@@ -15,7 +15,7 @@ import logging
 from typing import Any
 
 from django.conf import settings as django_settings
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 
 logger = logging.getLogger(__name__)
 
@@ -100,6 +100,10 @@ class Command(BaseCommand):
         sync_preferences = options.get("sync_preferences", False)
         init_only = options.get("init_only", False)
         list_components = options.get("list_components", False)
+
+        # Validate flag combinations
+        if init_only and not sync_preferences:
+            raise CommandError("--init-only requires --sync-preferences")
 
         # Handle --list-components first (doesn't need the header)
         if list_components:

--- a/opencontractserver/documents/management/commands/migrate_pipeline_settings.py
+++ b/opencontractserver/documents/management/commands/migrate_pipeline_settings.py
@@ -458,6 +458,7 @@ class Command(BaseCommand):
         - preferred_thumbnailers from PREFERRED_THUMBNAILERS (if defined)
         - parser_kwargs from PARSER_KWARGS
         - default_embedder from DEFAULT_EMBEDDER
+        - enabled_components from ENABLED_COMPONENTS (defaults to [] = all enabled)
         """
         from opencontractserver.documents.models import PipelineSettings
 
@@ -472,6 +473,7 @@ class Command(BaseCommand):
             ("preferred_thumbnailers", "PREFERRED_THUMBNAILERS", {}),
             ("parser_kwargs", "PARSER_KWARGS", {}),
             ("default_embedder", "DEFAULT_EMBEDDER", ""),
+            ("enabled_components", "ENABLED_COMPONENTS", []),
         ]
 
         changes = []

--- a/opencontractserver/tests/test_migrate_pipeline_settings_command.py
+++ b/opencontractserver/tests/test_migrate_pipeline_settings_command.py
@@ -5,6 +5,7 @@ Tests for the migrate_pipeline_settings management command.
 from io import StringIO
 
 from django.core.management import call_command
+from django.core.management.base import CommandError
 from django.test import TestCase, override_settings
 
 from opencontractserver.documents.models import PipelineSettings
@@ -332,6 +333,17 @@ class InitOnlyTestCase(TestCase):
         self.assertTrue(args.init_only)
         self.assertTrue(args.sync_preferences)
 
+    def test_init_only_without_sync_preferences_raises_error(self):
+        """Test --init-only without --sync-preferences raises CommandError."""
+        out = StringIO()
+        with self.assertRaises(CommandError) as ctx:
+            call_command(
+                "migrate_pipeline_settings",
+                "--init-only",
+                stdout=out,
+            )
+        self.assertIn("--sync-preferences", str(ctx.exception))
+
     @override_settings(
         PREFERRED_PARSERS={"application/pdf": "settings.parser.Path"},
         PREFERRED_EMBEDDERS={"application/pdf": "settings.embedder.Path"},
@@ -361,7 +373,7 @@ class InitOnlyTestCase(TestCase):
         DEFAULT_EMBEDDER="settings.embedder.Default",
     )
     def test_init_only_summary_shows_preserved_count(self):
-        """Test --init-only summary shows count of preserved fields."""
+        """Test --init-only summary shows correct count of preserved fields."""
         out = StringIO()
 
         call_command(
@@ -372,7 +384,9 @@ class InitOnlyTestCase(TestCase):
         )
 
         output = out.getvalue()
-        self.assertIn("Fields preserved (already configured):", output)
+        # setUp has 5 non-empty fields: preferred_parsers, preferred_embedders,
+        # parser_kwargs, default_embedder, enabled_components
+        self.assertIn("Fields preserved (already configured): 5", output)
 
 
 class ListComponentsTestCase(TestCase):

--- a/opencontractserver/tests/test_migrate_pipeline_settings_command.py
+++ b/opencontractserver/tests/test_migrate_pipeline_settings_command.py
@@ -206,6 +206,175 @@ class MigratePipelineSettingsCommandTestCase(TestCase):
         self.assertTrue(args.dry_run)
 
 
+class InitOnlyTestCase(TestCase):
+    """Tests for the --init-only flag with --sync-preferences."""
+
+    def setUp(self):
+        """Set up test fixtures with admin-configured values."""
+        PipelineSettings.objects.all().delete()
+        self.pipeline_settings = PipelineSettings.objects.create(
+            id=1,
+            preferred_parsers={"application/pdf": "admin.configured.Parser"},
+            preferred_embedders={"application/pdf": "admin.configured.Embedder"},
+            preferred_thumbnailers={},
+            parser_kwargs={"admin.configured.Parser": {"custom": True}},
+            default_embedder="admin.configured.DefaultEmbedder",
+            enabled_components=["admin.configured.Component"],
+        )
+
+    @override_settings(
+        PREFERRED_PARSERS={"application/pdf": "settings.parser.Path"},
+        PREFERRED_EMBEDDERS={"application/pdf": "settings.embedder.Path"},
+        PARSER_KWARGS={"settings.parser.Path": {"force_ocr": False}},
+        DEFAULT_EMBEDDER="settings.embedder.Default",
+    )
+    def test_init_only_preserves_existing_values(self):
+        """Test --init-only skips fields that already have non-empty values."""
+        out = StringIO()
+
+        call_command(
+            "migrate_pipeline_settings",
+            "--sync-preferences",
+            "--init-only",
+            stdout=out,
+        )
+
+        # DB values should be unchanged
+        refreshed = PipelineSettings.get_instance(use_cache=False)
+        self.assertEqual(
+            refreshed.preferred_parsers,
+            {"application/pdf": "admin.configured.Parser"},
+        )
+        self.assertEqual(
+            refreshed.preferred_embedders,
+            {"application/pdf": "admin.configured.Embedder"},
+        )
+        self.assertEqual(
+            refreshed.parser_kwargs,
+            {"admin.configured.Parser": {"custom": True}},
+        )
+        self.assertEqual(
+            refreshed.default_embedder,
+            "admin.configured.DefaultEmbedder",
+        )
+        self.assertEqual(
+            refreshed.enabled_components,
+            ["admin.configured.Component"],
+        )
+
+        output = out.getvalue()
+        self.assertIn("Fields preserved (already configured):", output)
+
+    @override_settings(
+        PREFERRED_PARSERS={"application/pdf": "settings.parser.Path"},
+        PREFERRED_EMBEDDERS={"application/pdf": "settings.embedder.Path"},
+        PREFERRED_THUMBNAILERS={"application/pdf": "settings.thumb.Path"},
+        PARSER_KWARGS={"settings.parser.Path": {"force_ocr": False}},
+        DEFAULT_EMBEDDER="settings.embedder.Default",
+    )
+    def test_init_only_populates_empty_fields(self):
+        """Test --init-only still populates fields that are empty."""
+        # preferred_thumbnailers is {} (empty) so it should be populated
+        out = StringIO()
+
+        call_command(
+            "migrate_pipeline_settings",
+            "--sync-preferences",
+            "--init-only",
+            stdout=out,
+        )
+
+        refreshed = PipelineSettings.get_instance(use_cache=False)
+        # Empty field should be populated from settings
+        self.assertEqual(
+            refreshed.preferred_thumbnailers,
+            {"application/pdf": "settings.thumb.Path"},
+        )
+        # Non-empty fields should be preserved
+        self.assertEqual(
+            refreshed.preferred_parsers,
+            {"application/pdf": "admin.configured.Parser"},
+        )
+
+    @override_settings(
+        PREFERRED_PARSERS={"application/pdf": "settings.parser.Path"},
+        PREFERRED_EMBEDDERS={"application/pdf": "settings.embedder.Path"},
+        PARSER_KWARGS={"settings.parser.Path": {"force_ocr": False}},
+        DEFAULT_EMBEDDER="settings.embedder.Default",
+    )
+    def test_without_init_only_overwrites(self):
+        """Test that without --init-only, existing values ARE overwritten."""
+        out = StringIO()
+
+        call_command(
+            "migrate_pipeline_settings",
+            "--sync-preferences",
+            stdout=out,
+        )
+
+        refreshed = PipelineSettings.get_instance(use_cache=False)
+        # Values should be overwritten with Django settings
+        self.assertEqual(
+            refreshed.preferred_parsers,
+            {"application/pdf": "settings.parser.Path"},
+        )
+        self.assertEqual(refreshed.default_embedder, "settings.embedder.Default")
+
+    def test_init_only_argument_exists(self):
+        """Test that --init-only argument is recognized."""
+        from django.core.management import get_commands, load_command_class
+
+        app_name = get_commands()["migrate_pipeline_settings"]
+        command = load_command_class(app_name, "migrate_pipeline_settings")
+        parser = command.create_parser("manage.py", "migrate_pipeline_settings")
+
+        args = parser.parse_args(["--sync-preferences", "--init-only"])
+        self.assertTrue(args.init_only)
+        self.assertTrue(args.sync_preferences)
+
+    @override_settings(
+        PREFERRED_PARSERS={"application/pdf": "settings.parser.Path"},
+        PREFERRED_EMBEDDERS={"application/pdf": "settings.embedder.Path"},
+        PARSER_KWARGS={"settings.parser.Path": {"force_ocr": False}},
+        DEFAULT_EMBEDDER="settings.embedder.Default",
+    )
+    def test_init_only_verbose_shows_preserved(self):
+        """Test --init-only --verbose shows which fields were preserved."""
+        out = StringIO()
+
+        call_command(
+            "migrate_pipeline_settings",
+            "--sync-preferences",
+            "--init-only",
+            "--verbose",
+            stdout=out,
+        )
+
+        output = out.getvalue()
+        self.assertIn("PRESERVED", output)
+        self.assertIn("already configured", output)
+
+    @override_settings(
+        PREFERRED_PARSERS={"application/pdf": "settings.parser.Path"},
+        PREFERRED_EMBEDDERS={"application/pdf": "settings.embedder.Path"},
+        PARSER_KWARGS={"settings.parser.Path": {"force_ocr": False}},
+        DEFAULT_EMBEDDER="settings.embedder.Default",
+    )
+    def test_init_only_summary_shows_preserved_count(self):
+        """Test --init-only summary shows count of preserved fields."""
+        out = StringIO()
+
+        call_command(
+            "migrate_pipeline_settings",
+            "--sync-preferences",
+            "--init-only",
+            stdout=out,
+        )
+
+        output = out.getvalue()
+        self.assertIn("Fields preserved (already configured):", output)
+
+
 class ListComponentsTestCase(TestCase):
     """Tests for the --list-components option."""
 

--- a/production.yml
+++ b/production.yml
@@ -14,7 +14,7 @@ services:
     env_file:
       - ./.envs/.production/.django
       - ./.envs/.production/.postgres
-    command: python manage.py migrate --noinput
+    command: /bin/bash -c "python manage.py migrate --noinput && python manage.py migrate_pipeline_settings --sync-preferences && python manage.py migrate_pipeline_settings"
     profiles:
       - migrate
 

--- a/production.yml
+++ b/production.yml
@@ -14,7 +14,7 @@ services:
     env_file:
       - ./.envs/.production/.django
       - ./.envs/.production/.postgres
-    command: /bin/bash -c "python manage.py migrate --noinput && python manage.py migrate_pipeline_settings --sync-preferences && python manage.py migrate_pipeline_settings"
+    command: /bin/bash -c "python manage.py migrate --noinput && python manage.py migrate_pipeline_settings --sync-preferences --init-only && python manage.py migrate_pipeline_settings"
     profiles:
       - migrate
 


### PR DESCRIPTION
## Summary
- Wires existing `migrate_pipeline_settings` management command into local and production Docker startup scripts so PipelineSettings singleton is auto-populated from Django settings on every startup
- Adds `enabled_components` to `--sync-preferences` mapping so it resets to `[]` (all enabled) by default
- Eliminates need for manual pipeline configuration after `docker compose up`

## Changes
- **`compose/local/django/start`**: Runs `migrate_pipeline_settings --sync-preferences` then `migrate_pipeline_settings` after `migrate`
- **`production.yml`**: Chains the same commands in the `migrate` service
- **`migrate_pipeline_settings.py`**: Adds `enabled_components → ENABLED_COMPONENTS` to `_sync_preferences` preference mappings

## How it works
1. `--sync-preferences` syncs top-level preferences (preferred parsers/embedders/thumbnailers, parser kwargs, default embedder, enabled components) from Django settings to DB
2. Base `migrate_pipeline_settings` scans all registered components, extracts Settings schemas, reads env vars, and populates `component_settings` and encrypted secrets

## Test plan
- [ ] Fresh local startup: `docker compose -f local.yml up --build django` — verify pipeline settings are populated without manual steps
- [ ] Production migrate: `docker compose -f production.yml --profile migrate up migrate` — verify no errors from chained commands
- [ ] Idempotent: Running startup multiple times doesn't overwrite DB values that were manually configured (existing values preserved without `--force`)