### PR TITLE
Improve corpus forking tests with caching and duplicate detection

### DIFF
--- a/opencontractserver/tests/test_corpus_forking.py
+++ b/opencontractserver/tests/test_corpus_forking.py
@@ -39,7 +39,7 @@ class CorpusForkTestCase(TransactionTestCase):
         original_corpus, forked_corpus = self._import_and_fork_corpus()
         self.original_corpus_id = original_corpus.id
         self.forked_corpus_id = forked_corpus.id
-        self._label_map_cache = None
+        self._label_map_cache = {}
 
     def _import_and_fork_corpus(self):
         """Import a test corpus and fork it. Returns (original_corpus, forked_corpus)."""
@@ -117,16 +117,17 @@ class CorpusForkTestCase(TransactionTestCase):
         """Build a mapping from original label IDs to forked label IDs by
         matching on label text.
 
-        The result is cached per test run (each setUp creates fresh data)
-        so multiple test helpers can share the same label map without
-        redundant queries.
+        The result is cached by (original_corpus.id, forked_corpus.id) so
+        multiple test helpers can share the same label map without redundant
+        queries.  Each setUp creates fresh data and a fresh cache dict.
 
         Note: if multiple labels share the same ``text``, only the last one
         wins in the dict comprehension (silently dropped).  The assertions
         below guard against this in the test fixture.
         """
-        if self._label_map_cache is not None:
-            return self._label_map_cache
+        cache_key = (original_corpus.id, forked_corpus.id)
+        if cache_key in self._label_map_cache:
+            return self._label_map_cache[cache_key]
 
         original_labels = list(original_corpus.label_set.annotation_labels.all())
         forked_labels = list(forked_corpus.label_set.annotation_labels.all())
@@ -155,7 +156,7 @@ class CorpusForkTestCase(TransactionTestCase):
         missing = original_label_ids - set(label_map.keys())
         self.assertEqual(missing, set(), f"Labels dropped during fork: {missing}")
 
-        self._label_map_cache = label_map
+        self._label_map_cache[cache_key] = label_map
         return label_map
 
     def test_forked_label_properties(self):
@@ -321,8 +322,7 @@ class CorpusForkTestCase(TransactionTestCase):
 
         label_map = self._build_label_map(original_corpus, forked_corpus)
 
-        for orig in original_annots:
-            key = (orig.raw_text, orig.page)
+        for key, orig in original_by_key.items():
             forked = forked_by_key.get(key)
             self.assertIsNotNone(
                 forked,

--- a/opencontractserver/tests/test_corpus_forking.py
+++ b/opencontractserver/tests/test_corpus_forking.py
@@ -39,6 +39,7 @@ class CorpusForkTestCase(TransactionTestCase):
         original_corpus, forked_corpus = self._import_and_fork_corpus()
         self.original_corpus_id = original_corpus.id
         self.forked_corpus_id = forked_corpus.id
+        self._label_map_cache = None
 
     def _import_and_fork_corpus(self):
         """Import a test corpus and fork it. Returns (original_corpus, forked_corpus)."""
@@ -77,7 +78,7 @@ class CorpusForkTestCase(TransactionTestCase):
         return original_corpus, forked_corpus
 
     def _load_corpuses(self):
-        """Load fresh QuerySets from stored IDs."""
+        """Retrieve fresh Corpus instances from stored IDs."""
         original = Corpus.objects.get(id=self.original_corpus_id)
         forked = Corpus.objects.get(id=self.forked_corpus_id)
         return original, forked
@@ -116,10 +117,17 @@ class CorpusForkTestCase(TransactionTestCase):
         """Build a mapping from original label IDs to forked label IDs by
         matching on label text.
 
+        The result is cached per test run (each setUp creates fresh data)
+        so multiple test helpers can share the same label map without
+        redundant queries.
+
         Note: if multiple labels share the same ``text``, only the last one
         wins in the dict comprehension (silently dropped).  The assertions
         below guard against this in the test fixture.
         """
+        if self._label_map_cache is not None:
+            return self._label_map_cache
+
         original_labels = list(original_corpus.label_set.annotation_labels.all())
         forked_labels = list(forked_corpus.label_set.annotation_labels.all())
 
@@ -147,6 +155,7 @@ class CorpusForkTestCase(TransactionTestCase):
         missing = original_label_ids - set(label_map.keys())
         self.assertEqual(missing, set(), f"Labels dropped during fork: {missing}")
 
+        self._label_map_cache = label_map
         return label_map
 
     def test_forked_label_properties(self):
@@ -215,7 +224,14 @@ class CorpusForkTestCase(TransactionTestCase):
         self.assertEqual(len(forked_docs), len(original_docs))
 
         # Join forked documents by source_document_id for robust matching
-        forked_by_source = {d.source_document_id: d for d in forked_docs}
+        forked_by_source = {}
+        for d in forked_docs:
+            self.assertNotIn(
+                d.source_document_id,
+                forked_by_source,
+                f"Forked corpus has duplicate source_document_id: {d.source_document_id}",
+            )
+            forked_by_source[d.source_document_id] = d
 
         for orig_doc in original_docs:
             forked_doc = forked_by_source.get(orig_doc.id)
@@ -280,6 +296,17 @@ class CorpusForkTestCase(TransactionTestCase):
             len(original_annots), 0, "Fixture should contain annotations"
         )
         self.assertEqual(len(forked_annots), len(original_annots))
+
+        # Guard: ensure original annotations have unambiguous (raw_text, page) keys
+        original_by_key = {}
+        for annot in original_annots:
+            key = (annot.raw_text, annot.page)
+            self.assertNotIn(
+                key,
+                original_by_key,
+                f"Original corpus has duplicate (raw_text, page) pair: {key}",
+            )
+            original_by_key[key] = annot
 
         # Build dict-based lookup for forked annotations by (raw_text, page)
         forked_by_key = {}
@@ -419,7 +446,13 @@ class CorpusForkTestCase(TransactionTestCase):
             rel_label_text = (
                 rel.relationship_label.text if rel.relationship_label else None
             )
-            forked_rel_by_key[(rel_label_text, src_keys, tgt_keys)] = rel
+            composite_key = (rel_label_text, src_keys, tgt_keys)
+            self.assertNotIn(
+                composite_key,
+                forked_rel_by_key,
+                f"Forked corpus has duplicate relationship key: {composite_key}",
+            )
+            forked_rel_by_key[composite_key] = rel
 
         label_map = self._build_label_map(original_corpus, forked_corpus)
 


### PR DESCRIPTION
## Summary
Enhanced the corpus forking test suite with performance optimizations and stricter validation to catch data integrity issues during fork operations.

## Key Changes
- **Added label map caching**: The `_build_label_map()` method now caches results keyed by corpus ID pair to avoid redundant database queries when multiple test helpers need the same mapping
- **Improved duplicate detection**: Added explicit assertions to detect duplicate keys when building lookup dictionaries:
  - Detects duplicate `source_document_id` values in forked documents
  - Detects duplicate `(raw_text, page)` pairs in original and forked annotations
  - Detects duplicate relationship keys in forked relationships
- **Refactored dict building**: Converted dict comprehensions to explicit loops with `assertNotIn` assertions for richer failure messages when data integrity issues are found

## Implementation Details
- The `_label_map_cache` is a dict keyed by `(original_corpus.id, forked_corpus.id)`, initialized in `setUp()` and reset with each test run
- `original_by_key` dict is used both for duplicate detection AND for the matching loop, eliminating the dead-variable issue
- Duplicate detection uses `assertNotIn()` where dicts are built via explicit loops (richer failure messages naming the offending key), and `len(dict)==len(list)` where dicts are built via comprehension and only need a uniqueness guard