### PR TITLE
Improve corpus landing page styling and interactions

### DIFF
--- a/frontend/src/components/corpuses/CorpusHome.tsx
+++ b/frontend/src/components/corpuses/CorpusHome.tsx
@@ -33,6 +33,9 @@ export interface CorpusHomeProps {
   onNavigateToCorpuses?: () => void;
   // Mobile navigation
   onOpenMobileMenu?: () => void;
+  // Mode toggle
+  onModeToggle?: () => void;
+  isPowerUserMode?: boolean;
 }
 
 /**
@@ -57,6 +60,8 @@ export const CorpusHome: React.FC<CorpusHomeProps> = ({
   onViewChatHistory,
   onNavigateToCorpuses,
   onOpenMobileMenu,
+  onModeToggle,
+  isPowerUserMode,
 }) => {
   const location = useLocation();
   const navigate = useNavigate();
@@ -123,6 +128,8 @@ export const CorpusHome: React.FC<CorpusHomeProps> = ({
       onChatSubmit={onChatSubmit}
       onViewChatHistory={onViewChatHistory}
       onOpenMobileMenu={onOpenMobileMenu}
+      onModeToggle={onModeToggle}
+      isPowerUserMode={isPowerUserMode}
       onViewDiscussions={handleViewDiscussions}
       onThreadClick={handleThreadClick}
       testId="corpus-home-landing"

--- a/frontend/src/components/corpuses/CorpusHome/CorpusLandingView.tsx
+++ b/frontend/src/components/corpuses/CorpusHome/CorpusLandingView.tsx
@@ -10,6 +10,7 @@ import {
   ArrowRight,
   Plus,
   MoreVertical,
+  Zap,
 } from "lucide-react";
 import { formatDistanceToNow } from "date-fns";
 
@@ -40,6 +41,7 @@ import {
   MetadataItem,
   MetadataSeparator,
   AccessBadge,
+  PowerUserMetaButton,
   ChatSection,
   ViewDetailsButton,
   HeaderRow,
@@ -66,6 +68,10 @@ export interface CorpusLandingViewProps {
   onViewDiscussions?: () => void;
   /** Callback when a specific thread is clicked from the feed */
   onThreadClick?: (threadId: string) => void;
+  /** Callback when mode toggle is clicked (only shown when present) */
+  onModeToggle?: () => void;
+  /** Whether the power user mode is active (changes toggle label) */
+  isPowerUserMode?: boolean;
   /** Test ID for the component */
   testId?: string;
 }
@@ -94,6 +100,8 @@ export const CorpusLandingView: React.FC<CorpusLandingViewProps> = ({
   onOpenMobileMenu,
   onViewDiscussions,
   onThreadClick,
+  onModeToggle,
+  isPowerUserMode = false,
   testId = "corpus-landing",
 }) => {
   const [mdContent, setMdContent] = React.useState<string | null>(null);
@@ -264,6 +272,24 @@ export const CorpusLandingView: React.FC<CorpusLandingViewProps> = ({
                     {docCount} {docCount === 1 ? "document" : "documents"}
                   </span>
                 </MetadataItem>
+              </>
+            )}
+
+            {onModeToggle && (
+              <>
+                <MetadataSeparator />
+                <PowerUserMetaButton
+                  onClick={onModeToggle}
+                  title={
+                    isPowerUserMode
+                      ? "Switch to focused view"
+                      : "Switch to full corpus management view"
+                  }
+                  data-testid={`${testId}-mode-toggle`}
+                >
+                  <Zap aria-hidden="true" />
+                  {isPowerUserMode ? "Focus Mode" : "Power User"}
+                </PowerUserMetaButton>
               </>
             )}
           </CenteredMetadataRow>

--- a/frontend/src/components/corpuses/CorpusHome/CorpusLandingView.tsx
+++ b/frontend/src/components/corpuses/CorpusHome/CorpusLandingView.tsx
@@ -70,7 +70,11 @@ export interface CorpusLandingViewProps {
   onThreadClick?: (threadId: string) => void;
   /** Callback when mode toggle is clicked (only shown when present) */
   onModeToggle?: () => void;
-  /** Whether the power user mode is active (changes toggle label) */
+  /**
+   * Whether the view is rendered from the power-user sidebar's home tab
+   * (true) vs the clean/focus landing mode (false). Controls the toggle
+   * button label ("Focus Mode" vs "Power User").
+   */
   isPowerUserMode?: boolean;
   /** Test ID for the component */
   testId?: string;
@@ -285,7 +289,7 @@ export const CorpusLandingView: React.FC<CorpusLandingViewProps> = ({
                       ? "Switch to focused view"
                       : "Switch to full corpus management view"
                   }
-                  data-testid={`${testId}-mode-toggle`}
+                  data-testid="power-user-toggle"
                 >
                   <Zap aria-hidden="true" />
                   {isPowerUserMode ? "Focus Mode" : "Power User"}

--- a/frontend/src/components/corpuses/CorpusHome/RecentDiscussions.tsx
+++ b/frontend/src/components/corpuses/CorpusHome/RecentDiscussions.tsx
@@ -250,7 +250,9 @@ export const RecentDiscussions: React.FC<RecentDiscussionsProps> = ({
               onClick={() => onThreadClick?.(thread.id)}
               data-testid={`${testId}-thread-${thread.id}`}
             >
-              <ThreadTitle className="thread-title">{thread.title || "Untitled Discussion"}</ThreadTitle>
+              <ThreadTitle className="thread-title">
+                {thread.title || "Untitled Discussion"}
+              </ThreadTitle>
               <ThreadMeta>
                 <MetaItem>
                   <User />

--- a/frontend/src/components/corpuses/CorpusHome/RecentDiscussions.tsx
+++ b/frontend/src/components/corpuses/CorpusHome/RecentDiscussions.tsx
@@ -103,31 +103,34 @@ const ViewAll = styled.span`
 const ThreadList = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 1px;
-  border: 1px solid ${CORPUS_COLORS.slate[200]};
-  border-radius: ${CORPUS_RADII.md};
-  overflow: hidden;
-  background: ${CORPUS_COLORS.slate[200]};
 `;
 
 const ThreadItem = styled.button`
   display: flex;
   flex-direction: column;
   gap: 0.375rem;
-  padding: 0.875rem 1rem;
-  background: ${CORPUS_COLORS.white};
+  padding: 0.75rem 0;
+  background: transparent;
   border: none;
+  border-bottom: 1px solid ${CORPUS_COLORS.slate[200]};
   cursor: pointer;
   text-align: left;
-  transition: background ${CORPUS_TRANSITIONS.fast};
+  transition: color ${CORPUS_TRANSITIONS.fast};
+
+  &:last-child {
+    border-bottom: none;
+  }
 
   &:hover {
-    background: ${CORPUS_COLORS.slate[50]};
+    .thread-title {
+      color: ${CORPUS_COLORS.teal[700]};
+    }
   }
 
   &:focus-visible {
     outline: 2px solid ${CORPUS_COLORS.teal[500]};
-    outline-offset: -2px;
+    outline-offset: 2px;
+    border-radius: ${CORPUS_RADII.sm};
   }
 `;
 
@@ -164,12 +167,7 @@ const MetaItem = styled.span`
 `;
 
 const EmptyState = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 1.5rem 1rem;
-  border: 1px dashed ${CORPUS_COLORS.slate[200]};
-  border-radius: ${CORPUS_RADII.md};
+  padding: 0.75rem 0;
   font-family: ${CORPUS_FONTS.sans};
   font-size: 0.875rem;
   color: ${CORPUS_COLORS.slate[400]};
@@ -252,7 +250,7 @@ export const RecentDiscussions: React.FC<RecentDiscussionsProps> = ({
               onClick={() => onThreadClick?.(thread.id)}
               data-testid={`${testId}-thread-${thread.id}`}
             >
-              <ThreadTitle>{thread.title || "Untitled Discussion"}</ThreadTitle>
+              <ThreadTitle className="thread-title">{thread.title || "Untitled Discussion"}</ThreadTitle>
               <ThreadMeta>
                 <MetaItem>
                   <User />

--- a/frontend/src/components/corpuses/CorpusHome/RecentDiscussions.tsx
+++ b/frontend/src/components/corpuses/CorpusHome/RecentDiscussions.tsx
@@ -37,35 +37,6 @@ const FeedContainer = styled.div`
   }
 `;
 
-const FeedHeader = styled.button`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  width: 100%;
-  padding: 0;
-  margin-bottom: 0.75rem;
-  background: none;
-  border: none;
-  cursor: pointer;
-  transition: color ${CORPUS_TRANSITIONS.fast};
-
-  &:hover {
-    .view-all {
-      color: ${CORPUS_COLORS.teal[600]};
-    }
-
-    .view-all svg {
-      transform: translateX(3px);
-    }
-  }
-
-  &:focus-visible {
-    outline: 2px solid ${CORPUS_COLORS.teal[500]};
-    outline-offset: 4px;
-    border-radius: ${CORPUS_RADII.sm};
-  }
-`;
-
 const FeedLabel = styled.span`
   display: flex;
   align-items: center;
@@ -100,9 +71,50 @@ const ViewAll = styled.span`
   }
 `;
 
+const FeedHeader = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 0;
+  margin-bottom: 0.75rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  transition: color ${CORPUS_TRANSITIONS.fast};
+
+  &:hover {
+    ${ViewAll} {
+      color: ${CORPUS_COLORS.teal[600]};
+    }
+
+    ${ViewAll} svg {
+      transform: translateX(3px);
+    }
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${CORPUS_COLORS.teal[500]};
+    outline-offset: 4px;
+    border-radius: ${CORPUS_RADII.sm};
+  }
+`;
+
 const ThreadList = styled.div`
   display: flex;
   flex-direction: column;
+`;
+
+const ThreadTitle = styled.span`
+  font-family: ${CORPUS_FONTS.sans};
+  font-size: 0.9375rem;
+  font-weight: 500;
+  color: ${CORPUS_COLORS.slate[800]};
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 `;
 
 const ThreadItem = styled.button`
@@ -122,7 +134,7 @@ const ThreadItem = styled.button`
   }
 
   &:hover {
-    .thread-title {
+    ${ThreadTitle} {
       color: ${CORPUS_COLORS.teal[700]};
     }
   }
@@ -132,18 +144,6 @@ const ThreadItem = styled.button`
     outline-offset: 2px;
     border-radius: ${CORPUS_RADII.sm};
   }
-`;
-
-const ThreadTitle = styled.span`
-  font-family: ${CORPUS_FONTS.sans};
-  font-size: 0.9375rem;
-  font-weight: 500;
-  color: ${CORPUS_COLORS.slate[800]};
-  line-height: 1.4;
-  display: -webkit-box;
-  -webkit-line-clamp: 1;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
 `;
 
 const ThreadMeta = styled.div`
@@ -236,7 +236,7 @@ export const RecentDiscussions: React.FC<RecentDiscussionsProps> = ({
           <MessageSquare />
           Discussions
         </FeedLabel>
-        <ViewAll className="view-all">
+        <ViewAll>
           View all
           <ArrowRight />
         </ViewAll>
@@ -250,9 +250,7 @@ export const RecentDiscussions: React.FC<RecentDiscussionsProps> = ({
               onClick={() => onThreadClick?.(thread.id)}
               data-testid={`${testId}-thread-${thread.id}`}
             >
-              <ThreadTitle className="thread-title">
-                {thread.title || "Untitled Discussion"}
-              </ThreadTitle>
+              <ThreadTitle>{thread.title || "Untitled Discussion"}</ThreadTitle>
               <ThreadMeta>
                 <MetaItem>
                   <User />

--- a/frontend/src/components/corpuses/CorpusHome/styles.ts
+++ b/frontend/src/components/corpuses/CorpusHome/styles.ts
@@ -35,9 +35,28 @@ export const BaseContainer = styled.div`
 // LANDING VIEW STYLES
 // ============================================================================
 
-/** Landing page container - centered content */
+/** Landing page container - centered, scrollable content */
 export const LandingContainer = styled(BaseContainer)`
   align-items: center;
+  overflow-y: auto;
+  overflow-x: hidden;
+
+  &::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: ${CORPUS_COLORS.slate[200]};
+    border-radius: 3px;
+
+    &:hover {
+      background: ${CORPUS_COLORS.slate[300]};
+    }
+  }
 `;
 
 /** Centered content wrapper for landing view */
@@ -48,9 +67,6 @@ export const LandingContent = styled.div`
   width: 100%;
   max-width: 800px;
   padding: 2rem 1.5rem;
-  flex: 1;
-  overflow-y: auto;
-  overflow-x: hidden;
 
   ${mediaQuery.tablet} {
     padding: 1.25rem 1rem;
@@ -262,6 +278,51 @@ export const AccessBadge = styled.div<{ $isPublic?: boolean }>`
   svg {
     width: 12px;
     height: 12px;
+  }
+`;
+
+/** Power User toggle - styled as a metadata item with interactive hover */
+export const PowerUserMetaButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0;
+  background: none;
+  border: none;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: ${CORPUS_COLORS.slate[500]};
+  cursor: pointer;
+  transition: color ${CORPUS_TRANSITIONS.fast};
+
+  svg {
+    width: 14px;
+    height: 14px;
+    color: ${CORPUS_COLORS.slate[400]};
+    transition: color ${CORPUS_TRANSITIONS.fast};
+  }
+
+  &:hover {
+    color: ${CORPUS_COLORS.teal[700]};
+
+    svg {
+      color: ${CORPUS_COLORS.teal[700]};
+    }
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${CORPUS_COLORS.teal[500]};
+    outline-offset: 4px;
+    border-radius: ${CORPUS_RADII.sm};
+  }
+
+  ${mediaQuery.tablet} {
+    font-size: 0.75rem;
+
+    svg {
+      width: 12px;
+      height: 12px;
+    }
   }
 `;
 

--- a/frontend/src/views/Corpuses.tsx
+++ b/frontend/src/views/Corpuses.tsx
@@ -912,17 +912,22 @@ const NavItemBadge = styled.span<{ isActive: boolean; $isZero?: boolean }>`
     props.$isZero
       ? "transparent"
       : props.isActive
-      ? "linear-gradient(135deg, #4a90e2 0%, #357abd 100%)"
-      : "#e2e8f0"};
+      ? CORPUS_COLORS.teal[700]
+      : CORPUS_COLORS.slate[200]};
   color: ${(props) =>
-    props.$isZero ? "#94a3b8" : props.isActive ? "white" : "#64748b"};
-  border: ${(props) => (props.$isZero ? "1px dashed #cbd5e1" : "none")};
+    props.$isZero
+      ? CORPUS_COLORS.slate[400]
+      : props.isActive
+      ? CORPUS_COLORS.white
+      : CORPUS_COLORS.slate[600]};
+  border: ${(props) =>
+    props.$isZero ? `1px dashed ${CORPUS_COLORS.slate[300]}` : "none"};
   transition: all 0.2s ease;
   box-shadow: ${(props) =>
     props.$isZero
       ? "none"
       : props.isActive
-      ? "0 2px 4px rgba(74, 144, 226, 0.3)"
+      ? `0 2px 4px rgba(15, 118, 110, 0.25)`
       : "0 1px 2px rgba(0, 0, 0, 0.05)"};
 `;
 
@@ -1346,9 +1351,9 @@ const CollapsedBadge = styled.div<{ $isZero: boolean }>`
   padding: 0 4px;
   background: ${(props) =>
     props.$isZero
-      ? "linear-gradient(135deg, #94a3b8 0%, #64748b 100%)"
-      : "linear-gradient(135deg, #ef4444 0%, #dc2626 100%)"};
-  color: white;
+      ? CORPUS_COLORS.slate[400]
+      : CORPUS_COLORS.teal[700]};
+  color: ${CORPUS_COLORS.white};
   border-radius: 8px;
   display: flex;
   align-items: center;
@@ -1356,7 +1361,7 @@ const CollapsedBadge = styled.div<{ $isZero: boolean }>`
   font-size: 0.6rem;
   font-weight: 700;
   z-index: 2;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.15);
 `;
 
 // Split view container for extracts tab

--- a/frontend/src/views/Corpuses.tsx
+++ b/frontend/src/views/Corpuses.tsx
@@ -1350,9 +1350,7 @@ const CollapsedBadge = styled.div<{ $isZero: boolean }>`
   height: 16px;
   padding: 0 4px;
   background: ${(props) =>
-    props.$isZero
-      ? CORPUS_COLORS.slate[400]
-      : CORPUS_COLORS.teal[700]};
+    props.$isZero ? CORPUS_COLORS.slate[400] : CORPUS_COLORS.teal[700]};
   color: ${CORPUS_COLORS.white};
   border-radius: 8px;
   display: flex;
@@ -2708,9 +2706,7 @@ export const Corpuses = () => {
       : navigationItems.find((item) => item.id === "home")?.component;
 
     content = isPowerUserMode ? (
-          <CorpusViewContainer
-            id="corpus-view-container"
-          >
+      <CorpusViewContainer id="corpus-view-container">
         {/* Mobile backdrop */}
         <AnimatePresence>
           {mobileSidebarOpen && (
@@ -2869,9 +2865,7 @@ export const Corpuses = () => {
             >
               <ArrowLeft />
               {(use_mobile_layout ? mobileSidebarOpen : sidebarExpanded) && (
-                <span style={{ flex: "1", textAlign: "left" }}>
-                  Focus Mode
-                </span>
+                <span style={{ flex: "1", textAlign: "left" }}>Focus Mode</span>
               )}
             </NavigationItem>
           </ExitPowerUserWrapper>
@@ -2884,13 +2878,11 @@ export const Corpuses = () => {
         >
           {mainContent}
         </MainContentArea>
-          </CorpusViewContainer>
+      </CorpusViewContainer>
     ) : (
-          <CleanViewContainer
-            id="corpus-clean-view"
-          >
-            {mainContent}
-          </CleanViewContainer>
+      <CleanViewContainer id="corpus-clean-view">
+        {mainContent}
+      </CleanViewContainer>
     );
   } else if (
     opened_corpus !== null &&

--- a/frontend/src/views/Corpuses.tsx
+++ b/frontend/src/views/Corpuses.tsx
@@ -29,7 +29,6 @@ import {
   BarChart3,
   MoreVertical,
   Link2,
-  Zap,
 } from "lucide-react";
 import styled from "styled-components";
 import { motion, AnimatePresence } from "framer-motion";
@@ -150,8 +149,6 @@ import { CorpusDocumentRelationships } from "../components/corpuses/CorpusDocume
 import {
   CORPUS_COLORS,
   CORPUS_RADII,
-  CORPUS_SHADOWS,
-  CORPUS_TRANSITIONS,
   mediaQuery as corpusMediaQuery,
 } from "../components/corpuses/styles/corpusDesignTokens";
 
@@ -376,6 +373,8 @@ const CorpusQueryView = ({
   statsLoading,
   onOpenMobileMenu,
   onSourceNavigate,
+  onModeToggle,
+  isPowerUserMode,
 }: {
   opened_corpus: CorpusType | null;
   opened_corpus_id: string | null;
@@ -392,6 +391,8 @@ const CorpusQueryView = ({
   statsLoading: boolean;
   onOpenMobileMenu?: () => void;
   onSourceNavigate?: (source: ChatMessageSource) => void;
+  onModeToggle?: () => void;
+  isPowerUserMode?: boolean;
 }) => {
   const [chatExpanded, setChatExpanded] = useState<boolean>(false);
   const [searchQuery, setSearchQuery] = useState<string>("");
@@ -580,6 +581,8 @@ const CorpusQueryView = ({
               onViewChatHistory={openHistoryView}
               onNavigateToCorpuses={onBack}
               onOpenMobileMenu={onOpenMobileMenu}
+              onModeToggle={onModeToggle}
+              isPowerUserMode={isPowerUserMode}
             />
           </ContentWrapper>
         </DashboardContainer>
@@ -1090,7 +1093,6 @@ const MainContentArea = styled.div<{ $sidebarExpanded: boolean }>`
 
   @media (max-width: ${MOBILE_VIEW_BREAKPOINT}px) {
     margin-left: 0;
-    /* No extra padding needed - FAB is compact and positioned absolutely */
   }
 `;
 
@@ -1527,62 +1529,13 @@ const ExtractsTabContent: React.FC<{
   );
 };
 
-// Power user mode toggle - subtle, positioned at top-right of clean view
-const PowerUserToggle = styled(motion.button)`
-  position: absolute;
-  top: 1rem;
-  right: 1rem;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.375rem;
-  padding: 0.5rem 0.875rem;
-  background: rgba(255, 255, 255, 0.9);
-  backdrop-filter: blur(8px);
-  border: 1px solid ${CORPUS_COLORS.slate[200]};
-  border-radius: ${CORPUS_RADII.md};
-  color: ${CORPUS_COLORS.slate[500]};
-  font-size: 0.8125rem;
-  font-weight: 500;
-  cursor: pointer;
-  transition: all ${CORPUS_TRANSITIONS.normal};
-  z-index: 10;
-  box-shadow: ${CORPUS_SHADOWS.sm};
-
-  svg {
-    width: 14px;
-    height: 14px;
-  }
-
-  &:hover {
-    background: ${CORPUS_COLORS.teal[50]};
-    border-color: ${CORPUS_COLORS.teal[200]};
-    color: ${CORPUS_COLORS.teal[700]};
-    box-shadow: 0 2px 8px rgba(15, 118, 110, 0.12);
-  }
-
-  &:focus-visible {
-    outline: 2px solid ${CORPUS_COLORS.teal[500]};
-    outline-offset: 2px;
-  }
-
-  ${corpusMediaQuery.tablet} {
-    padding: 0.375rem 0.625rem;
-    font-size: 0.75rem;
-    top: 0.75rem;
-    right: 0.75rem;
-  }
-`;
-
 // Container for the clean landing view (no sidebar)
+// Does NOT scroll — the parent ScrollableSegment (from CardLayout) handles scrolling.
 const CleanViewContainer = styled.div`
   position: relative;
   display: flex;
   flex-direction: column;
   width: 100%;
-  height: 100%;
-  min-height: 0;
-  max-height: 100dvh;
-  overflow: hidden;
 `;
 
 // Wrapper for the "Simple View" exit button at the bottom of the sidebar
@@ -2353,6 +2306,17 @@ export const Corpuses = () => {
             statsLoading={effectiveStatsLoading}
             onOpenMobileMenu={() => setMobileSidebarOpen(true)}
             onSourceNavigate={handleSourceNavigate}
+            isPowerUserMode={isPowerUserMode}
+            onModeToggle={
+              canUpdateCorpus
+                ? () =>
+                    updateModeParam(
+                      location,
+                      navigate,
+                      isPowerUserMode ? null : "power"
+                    )
+                : undefined
+            }
           />
         ),
       },
@@ -2699,6 +2663,7 @@ export const Corpuses = () => {
     documentsViewMode, // Required for view mode toggle to work
     chatInConversation, // Required for chat tab header visibility
     currentSelectedThreadId, // Required for discussions tab header visibility (URL-driven)
+    isPowerUserMode, // Required for mode toggle button label and callback
     // Note: corpusAtomPermissions is an array that changes, but canUpdateCorpus is derived from it
     // and is a stable boolean, so we don't need corpusAtomPermissions in deps
   ]);
@@ -2738,7 +2703,9 @@ export const Corpuses = () => {
       : navigationItems.find((item) => item.id === "home")?.component;
 
     content = isPowerUserMode ? (
-      <CorpusViewContainer id="corpus-view-container">
+          <CorpusViewContainer
+            id="corpus-view-container"
+          >
         {/* Mobile backdrop */}
         <AnimatePresence>
           {mobileSidebarOpen && (
@@ -2898,7 +2865,7 @@ export const Corpuses = () => {
               <ArrowLeft />
               {(use_mobile_layout ? mobileSidebarOpen : sidebarExpanded) && (
                 <span style={{ flex: "1", textAlign: "left" }}>
-                  Simple View
+                  Focus Mode
                 </span>
               )}
             </NavigationItem>
@@ -2912,24 +2879,13 @@ export const Corpuses = () => {
         >
           {mainContent}
         </MainContentArea>
-      </CorpusViewContainer>
+          </CorpusViewContainer>
     ) : (
-      <CleanViewContainer id="corpus-clean-view">
-        {/* Power User toggle - only shown for users with edit rights */}
-        {canUpdateCorpus && (
-          <PowerUserToggle
-            onClick={() => updateModeParam(location, navigate, "power")}
-            whileHover={{ scale: 1.02 }}
-            whileTap={{ scale: 0.98 }}
-            data-testid="power-user-toggle"
-            title="Switch to full corpus management view"
+          <CleanViewContainer
+            id="corpus-clean-view"
           >
-            <Zap />
-            Power User
-          </PowerUserToggle>
-        )}
-        {mainContent}
-      </CleanViewContainer>
+            {mainContent}
+          </CleanViewContainer>
     );
   } else if (
     opened_corpus !== null &&

--- a/frontend/src/views/Corpuses.tsx
+++ b/frontend/src/views/Corpuses.tsx
@@ -149,6 +149,8 @@ import { CorpusDocumentRelationships } from "../components/corpuses/CorpusDocume
 import {
   CORPUS_COLORS,
   CORPUS_RADII,
+  CORPUS_SHADOWS,
+  CORPUS_TRANSITIONS,
   mediaQuery as corpusMediaQuery,
 } from "../components/corpuses/styles/corpusDesignTokens";
 
@@ -922,13 +924,13 @@ const NavItemBadge = styled.span<{ isActive: boolean; $isZero?: boolean }>`
       : CORPUS_COLORS.slate[600]};
   border: ${(props) =>
     props.$isZero ? `1px dashed ${CORPUS_COLORS.slate[300]}` : "none"};
-  transition: all 0.2s ease;
+  transition: all ${CORPUS_TRANSITIONS.normal};
   box-shadow: ${(props) =>
     props.$isZero
       ? "none"
       : props.isActive
       ? `0 2px 4px rgba(15, 118, 110, 0.25)`
-      : "0 1px 2px rgba(0, 0, 0, 0.05)"};
+      : CORPUS_SHADOWS.sm};
 `;
 
 const NavigationItem = styled(motion.button)<{
@@ -1359,7 +1361,7 @@ const CollapsedBadge = styled.div<{ $isZero: boolean }>`
   font-size: 0.6rem;
   font-weight: 700;
   z-index: 2;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.15);
+  box-shadow: ${CORPUS_SHADOWS.sm};
 `;
 
 // Split view container for extracts tab


### PR DESCRIPTION
## Summary

- **Scrollbar refinement**: Move scroll ownership to `LandingContainer` with a slim 6px custom scrollbar (track-transparent, slate-200 thumb) that works correctly in both Focus and Power User modes
- **Discussions restyle**: Replace card-style discussion feed with a minimal divider list — transparent background, 1px bottom borders, hover-highlights on thread title only — matching the text-forward aesthetic
- **Mode toggle in metadata row**: Remove the floating Power User button and add an inline toggle in the metadata row (shows "Power User" in focus mode, "Focus Mode" in power user mode) with bidirectional switching
- **Badge color alignment**: Replace hardcoded red/blue sidebar badges with `CORPUS_COLORS` design tokens (teal-700 active, slate-200/400 inactive) for visual consistency

## Files Changed

| File | Change |
|------|--------|
| `CorpusHome/styles.ts` | Added `PowerUserMetaButton`, updated `LandingContainer` scroll, simplified `LandingContent` |
| `CorpusHome/RecentDiscussions.tsx` | Restyled `ThreadList`, `ThreadItem`, `EmptyState` to minimal divider pattern |
| `CorpusHome/CorpusLandingView.tsx` | Added mode toggle rendering in metadata row with Zap icon |
| `CorpusHome.tsx` | Threaded `onModeToggle` + `isPowerUserMode` props to landing view |
| `Corpuses.tsx` | Removed floating toggle, renamed sidebar "Simple View" → "Focus Mode", fixed `useMemo` deps, aligned badge colors to design tokens |

## Test plan

- [X] Focus mode: page scrolls with slim custom scrollbar on the right edge
- [X] Power User mode: page scrolls correctly (no clipped content)
- [X] Discussion feed renders as flat divider list, thread titles highlight teal on hover
- [X] Metadata row shows "Power User" toggle in focus mode — clicking switches to power user mode
- [X] Power User mode metadata row shows "Focus Mode" — clicking switches back
- [X] Toggle works repeatedly (not just once)
- [X] Sidebar in power user mode shows "Focus Mode" exit button (was "Simple View")
- [X] Collapsed sidebar badges use teal (non-zero) and slate (zero) colors
- [X] Expanded sidebar badges use teal active / slate inactive colors
- [ ] Mobile responsive: metadata row wraps gracefully, toggle still accessible