### PR TITLE
Address PR #1043 review: scroll comments, layout docs, empty state

### DIFF
--- a/frontend/src/components/corpuses/CorpusHome/RecentDiscussions.tsx
+++ b/frontend/src/components/corpuses/CorpusHome/RecentDiscussions.tsx
@@ -167,10 +167,12 @@ const MetaItem = styled.span`
 `;
 
 const EmptyState = styled.div`
-  padding: 0.75rem 0;
+  padding: 1rem 0;
   font-family: ${CORPUS_FONTS.sans};
   font-size: 0.875rem;
+  font-style: italic;
   color: ${CORPUS_COLORS.slate[400]};
+  border-top: 1px dashed ${CORPUS_COLORS.slate[200]};
 `;
 
 // ============================================================================

--- a/frontend/src/views/Corpuses.tsx
+++ b/frontend/src/views/Corpuses.tsx
@@ -1343,7 +1343,10 @@ const NotificationBadge = styled.div`
   }
 `;
 
-// Compact badge for collapsed sidebar - slight overlap at corner
+// Compact badge for collapsed sidebar - slight overlap at corner.
+// Teal (non-zero) / slate (zero) is intentional: these badges display entity
+// counts (documents, annotations, analyses, etc.), not action-required items,
+// so the teal design-token color is appropriate rather than a warning palette.
 const CollapsedBadge = styled.div<{ $isZero: boolean }>`
   position: absolute;
   top: -4px;
@@ -1534,8 +1537,15 @@ const ExtractsTabContent: React.FC<{
   );
 };
 
-// Container for the clean landing view (no sidebar)
-// Does NOT scroll — the parent ScrollableSegment (from CardLayout) handles scrolling.
+// Container for the clean landing view (no sidebar).
+// Does NOT scroll — LandingContainer (inside CorpusLandingView) handles scrolling
+// via overflow-y: auto.  This wrapper only provides flex layout so that the
+// LandingContainer child can fill the available height from CardLayout's flex
+// ancestor chain.  Height constraints (height: 100%, min-height: 0,
+// max-height: 100dvh, overflow: hidden) were intentionally removed because
+// LandingContainer inherits bounded height through the flex column
+// (CardLayout → CleanViewContainer → LandingContainer), and those properties
+// conflicted with the scroll container living inside LandingContainer.
 const CleanViewContainer = styled.div`
   position: relative;
   display: flex;


### PR DESCRIPTION
## Summary
- Fixes 2 blocking and 2 recommended items from the PR #1043 review
- **CleanViewContainer comment** (blocking): Corrected misleading comment that said ScrollableSegment handles scrolling; it is actually LandingContainer via overflow-y: auto
- **Height constraint removal** (blocking): Added explanation for why height 100%, min-height 0, max-height 100dvh, and overflow hidden were safely removed from CleanViewContainer
- **CollapsedBadge teal color** (recommendation): Added design-intent comment confirming badges show entity counts (not action-required items), so teal is the correct semantic choice
- **EmptyState visual distinction** (recommendation): Restored visual separator with dashed border and italic text so the empty state is clearly distinguishable from content/loading states

## Test plan
- [x] yarn lint passes (prettier formatting verified)
- [x] npx tsc --noEmit passes (TypeScript compilation verified)
- [x] Pre-commit hooks pass
- [ ] Visual check: empty discussions state shows dashed border separator
- [ ] Visual check: scrolling still works correctly in LandingContainer