### PR TITLE
Remove unused django-crispy-forms and crispy-bootstrap5 dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to OpenContracts will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2026-03-02
+## [Unreleased] - 2026-03-04
+
+### Removed
+
+- **Unused `django-crispy-forms` and `crispy-bootstrap5` dependencies**: These were cookiecutter-django boilerplate never used by the project (React frontend uses its own form components). Removed packages from `requirements/base.txt`, `INSTALLED_APPS`, and `CRISPY_*` settings from `config/settings/base.py`.
 
 ### Fixed
 

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -135,8 +135,6 @@ THIRD_PARTY_APPS = [
     "django_filters",
     "graphene_django",
     "guardian",
-    "crispy_forms",
-    "crispy_bootstrap5",
     "django_celery_beat",
     "rest_framework",
     "rest_framework.authtoken",
@@ -491,10 +489,6 @@ TEMPLATES = [
 
 # https://docs.djangoproject.com/en/dev/ref/settings/#form-renderer
 FORM_RENDERER = "django.forms.renderers.TemplatesSetting"
-
-# http://django-crispy-forms.readthedocs.io/en/latest/install.html#template-packs
-CRISPY_TEMPLATE_PACK = "bootstrap5"
-CRISPY_ALLOWED_TEMPLATE_PACKS = "bootstrap5"
 
 # FIXTURES
 # ------------------------------------------------------------------------------

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -19,8 +19,6 @@ tokenizers>=0.21,<0.23  # Pin to prevent conflicts with transformers
 django==5.2.11  # https://www.djangoproject.com/
 django-environ==0.13.0  # https://github.com/joke2k/django-environ
 django-model-utils==5.0.0  # https://github.com/jazzband/django-model-utils
-django-crispy-forms==2.5  # https://github.com/django-crispy-forms/django-crispy-forms
-crispy-bootstrap5==2025.6  # https://github.com/django-crispy-forms/crispy-bootstrap5
 django-redis==6.0.0  # https://github.com/jazzband/django-redis
 django-filter==25.1  # https://github.com/carltongibson/django-filter
 django-storages[boto3,google]==1.14.6  # https://github.com/jschneier/django-storages


### PR DESCRIPTION
## Summary
Removes the unused `django-crispy-forms` and `crispy-bootstrap5` packages that were included as cookiecutter-django boilerplate but never utilized by the project. The React frontend implements its own form components, making these Django form libraries unnecessary.

## Changes
- Removed `django-crispy-forms` and `crispy-bootstrap5` from `requirements/base.txt`
- Removed `crispy_forms` and `crispy_bootstrap5` from `INSTALLED_APPS` in `config/settings/base.py`
- Removed `CRISPY_TEMPLATE_PACK` and `CRISPY_ALLOWED_TEMPLATE_PACKS` settings from `config/settings/base.py`
- Updated CHANGELOG.md to document the removal

## Notes
This is a cleanup change that reduces unnecessary dependencies without affecting functionality, as these packages were never integrated into the application.

https://claude.ai/code/session_01PpJTdoaBKSnTMBk8aGC37F