### PR TITLE
Address review nits from PR #1058

### DIFF
--- a/opencontractserver/tests/test_corpus_collector.py
+++ b/opencontractserver/tests/test_corpus_collector.py
@@ -94,13 +94,17 @@ class TestCollectCorpusObjects(TestCase):
         self.assertCountEqual(result.document_ids, [doc1.id, doc2.id])
 
     def test_document_ids_are_distinct(self):
-        """Multiple active DocumentPaths for the same document produce one ID."""
+        """Defensive coverage for data integrity bugs upstream.
+
+        Multiple active DocumentPaths for the same document should still
+        produce a single ID in the collected results.
+        """
         corpus = self._make_corpus()
         doc = Document.objects.create(title="Shared Doc", creator=self.user)
 
         # Two is_current=True DocumentPath records for the same document is not
-        # a normal application state, but we test it as defensive coverage against
-        # the edge case to ensure collect_corpus_objects de-duplicates correctly.
+        # a normal application state; this is defensive coverage for data
+        # integrity bugs upstream to ensure collect_corpus_objects de-duplicates.
         DocumentPath.objects.create(
             document=doc,
             corpus=corpus,

--- a/opencontractserver/utils/corpus_forking.py
+++ b/opencontractserver/utils/corpus_forking.py
@@ -23,32 +23,34 @@ def build_fork_corpus_task(corpus_pk_to_fork: str, user: User):
     Returns:
         Celery task signature for fork_corpus
     """
-    corpus_copy = Corpus.objects.get(pk=corpus_pk_to_fork)
+    source_corpus = Corpus.objects.get(pk=corpus_pk_to_fork)
 
     # Collect all object IDs using the shared collector
-    collected = collect_corpus_objects(corpus_copy, include_metadata=True)
+    collected = collect_corpus_objects(source_corpus, include_metadata=True)
 
     # Clone the corpus: https://docs.djangoproject.com/en/3.1/topics/db/queries/copying-model-instances
-    corpus_copy.pk = None
-    corpus_copy.slug = ""  # Clear slug so save() generates a new unique one
+    source_corpus.pk = None
+    source_corpus.slug = ""  # Clear slug so save() generates a new unique one
 
-    # Adjust the title to indicate it's a fork
-    corpus_copy.title = f"[FORK] {corpus_copy.title}"
+    # At this point the in-memory instance is detached from the original row;
+    # saving it will INSERT a new Corpus.  Rename for clarity.
+    corpus_clone = source_corpus
+    corpus_clone.title = f"[FORK] {corpus_clone.title}"
     # Lock corpus to tell frontend to show this as loading and disable selection
-    corpus_copy.backend_lock = True
-    corpus_copy.creator = user
-    corpus_copy.parent_id = corpus_pk_to_fork
-    corpus_copy.save()
+    corpus_clone.backend_lock = True
+    corpus_clone.creator = user
+    corpus_clone.parent_id = corpus_pk_to_fork
+    corpus_clone.save()
 
-    set_permissions_for_obj_to_user(user, corpus_copy, [PermissionTypes.CRUD])
+    set_permissions_for_obj_to_user(user, corpus_clone, [PermissionTypes.CRUD])
 
     # Remove references to related objects on the new object, as these point to original docs and labels
     # Note: New forked corpus has no DocumentPath records yet, so no document cleanup needed
-    corpus_copy.label_set = None
+    corpus_clone.label_set = None
 
     # Copy docs, annotations, folders, relationships, and metadata using async task
     return fork_corpus.si(
-        corpus_copy.id,
+        corpus_clone.id,
         collected.document_ids,
         collected.label_set_id,
         collected.annotation_ids,


### PR DESCRIPTION
## Summary
- Rename `corpus_copy` to `source_corpus` / `corpus_clone` in `corpus_forking.py` to clarify that the variable initially holds the source corpus (not a copy), and after `pk = None` detaches it from the DB row, it becomes the clone
- Update `test_document_ids_are_distinct` docstring to say "defensive coverage for data integrity bugs upstream" per reviewer suggestion

Follow-up from review comments on #1058.