### PR TITLE
Fix Auth0 SDK blocked by CSP on admin login page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@ All notable changes to OpenContracts will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2026-03-08
+## [Unreleased] - 2026-03-09
 
 ### Fixed
 
+- **Auth0 SDK blocked by CSP on admin login page** (Closes #1077): The admin login template loads the Auth0 SPA SDK from `cdn.jsdelivr.net`, but the Content-Security-Policy `script-src` directive did not include this origin, causing browsers to block the script. Added `https://cdn.jsdelivr.net` to `script-src` when Auth0 is enabled. (`config/settings/base.py`)
 - **PostgreSQL HNSW config warning on startup** (Closes #1074): Fixed `invalid configuration parameter name 'hnsw.iterative_scan', removing it` warning caused by database-level GUC settings being applied before the pgvector extension loaded. Added `shared_preload_libraries=vector` to all Docker Compose postgres commands so pgvector registers its GUC variables at server startup, before database-level settings are applied. Also upgraded pgvector from v0.8.0 to v0.8.2. (`local.yml`, `production.yml`, `test.yml`, `compose/production/postgres/Dockerfile`)
 
 ### Changed

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -538,8 +538,15 @@ SECURE_CSP_DIRECTIVES = {
 
 # When Auth0 is enabled, the browser must be able to load scripts from and
 # connect to the Auth0 tenant domain for authentication flows.
-# The admin login page loads the Auth0 SPA SDK from cdn.jsdelivr.net,
-# so that origin must also be allowed in script-src.
+#
+# The admin login page loads the Auth0 SPA SDK from cdn.jsdelivr.net, so that
+# origin must also be allowed in script-src.  NOTE: this allowlists the entire
+# cdn.jsdelivr.net origin app-wide (CSP is not page-scoped).  The actual Auth0
+# script tag in auth0_login.html is pinned with an SRI integrity hash, but SRI
+# only protects that specific <script> element — other pages could still load
+# arbitrary jsDelivr-hosted scripts if an XSS vector existed.  This is an
+# accepted trade-off for CDN-hosted dependencies; keep it in mind when auditing
+# script injection surface area.
 if USE_AUTH0:
     from config.middleware import validate_csp_domain
 

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -538,12 +538,15 @@ SECURE_CSP_DIRECTIVES = {
 
 # When Auth0 is enabled, the browser must be able to load scripts from and
 # connect to the Auth0 tenant domain for authentication flows.
+# The admin login page loads the Auth0 SPA SDK from cdn.jsdelivr.net,
+# so that origin must also be allowed in script-src.
 if USE_AUTH0:
     from config.middleware import validate_csp_domain
 
     validate_csp_domain(AUTH0_DOMAIN)
     SECURE_CSP_DIRECTIVES["connect-src"].append(f"https://{AUTH0_DOMAIN}")
     SECURE_CSP_DIRECTIVES["script-src"].append(f"https://{AUTH0_DOMAIN}")
+    SECURE_CSP_DIRECTIVES["script-src"].append("https://cdn.jsdelivr.net")
 
 # Permissions-Policy — opt out of browser features not needed by the app.
 SECURE_PERMISSIONS_POLICY = {

--- a/opencontractserver/templates/admin/auth0_login.html
+++ b/opencontractserver/templates/admin/auth0_login.html
@@ -336,10 +336,10 @@
             }
             try {
                 auth0Client = await auth0.createAuth0Client({
-                    domain: '{{ auth0_domain }}',
-                    clientId: '{{ auth0_client_id }}',
+                    domain: '{{ auth0_domain|escapejs }}',
+                    clientId: '{{ auth0_client_id|escapejs }}',
                     authorizationParams: {
-                        audience: '{{ auth0_audience }}',
+                        audience: '{{ auth0_audience|escapejs }}',
                         redirect_uri: window.location.origin + window.location.pathname
                     },
                     cacheLocation: 'memory'


### PR DESCRIPTION
## Summary
Fixed a Content-Security-Policy (CSP) issue that was blocking the Auth0 SPA SDK from loading on the admin login page.

## Changes
- Added `https://cdn.jsdelivr.net` to the `script-src` CSP directive when Auth0 is enabled
- Updated comments in `config/settings/base.py` to document that the admin login page loads the Auth0 SPA SDK from the jsDelivr CDN

## Details
The admin login template loads the Auth0 SPA SDK from `cdn.jsdelivr.net`, but this origin was not included in the Content-Security-Policy `script-src` directive. This caused browsers to block the script from loading, preventing authentication flows from working properly.

The fix ensures that when Auth0 is enabled, the CSP policy explicitly allows scripts from `https://cdn.jsdelivr.net` alongside the existing Auth0 domain allowlist.

Closes #1077

https://claude.ai/code/session_015Zm7gdsjkuW61mpH8cTit5