### PR TITLE
Fix token bounding box drift in PDF viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@ All notable changes to OpenContracts will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2026-03-08
+## [Unreleased] - 2026-03-09
 
 ### Fixed
+
+- **Token bounding box drift in PDF viewer**: Fixed progressive misalignment between token bounding boxes (blue outlines) and rendered PDF text. PAWLs token coordinates are extracted by the parser in its own coordinate system, which can differ from PDF.js's viewport coordinate system. The frontend now normalizes token coordinates by comparing PAWLs page dimensions (`page.width`/`page.height`) against the PDF.js viewport dimensions at scale 1, rescaling tokens when they differ. Added `normalizeTokensToPdfViewport()` utility in `frontend/src/utils/transform.tsx` and applied it in both PDF loading paths in `frontend/src/components/knowledge_base/document/DocumentKnowledgeBase.tsx`.
 
 - **PostgreSQL HNSW config warning on startup** (Closes #1074): Fixed `invalid configuration parameter name 'hnsw.iterative_scan', removing it` warning caused by database-level GUC settings being applied before the pgvector extension loaded. Added `shared_preload_libraries=vector` to all Docker Compose postgres commands so pgvector registers its GUC variables at server startup, before database-level settings are applied. Also upgraded pgvector from v0.8.0 to v0.8.2. (`local.yml`, `production.yml`, `test.yml`, `compose/production/postgres/Dockerfile`)
 

--- a/config/graphql/document_queries.py
+++ b/config/graphql/document_queries.py
@@ -45,7 +45,7 @@ class DocumentQueryMixin:
         # queries requesting only basic document fields.
         return Document.objects.visible_to_user(info.context.user, lightweight=True)
 
-    document = graphene.Field(DocumentType, id=graphene.String())
+    document = graphene.Field(DocumentType, id=graphene.ID())
 
     def resolve_document(self, info, **kwargs):
         document_id = kwargs.get("id")

--- a/frontend/src/assets/configurations/constants.ts
+++ b/frontend/src/assets/configurations/constants.ts
@@ -326,6 +326,10 @@ export const KNOWN_ACRONYMS: Record<string, string> = {
   nlm: "NLM",
 };
 
+// PAWLs coordinate normalization
+/** Half a PDF point tolerance for comparing PAWLs vs PDF.js page dimensions */
+export const PAWLS_COORDINATE_EPSILON = 0.5;
+
 // Corpus action trigger display labels
 // Maps backend trigger enum values (lowercase) to user-facing short labels
 export const TRIGGER_LABELS: Record<string, string> = {

--- a/frontend/src/assets/configurations/constants.ts
+++ b/frontend/src/assets/configurations/constants.ts
@@ -330,6 +330,14 @@ export const KNOWN_ACRONYMS: Record<string, string> = {
 /** Half a PDF point tolerance for comparing PAWLs vs PDF.js page dimensions */
 export const PAWLS_COORDINATE_EPSILON = 0.5;
 
+/**
+ * Fraction of page dimensions above which a single token is considered
+ * a degenerate page-level element (e.g. full-page image capture from Docling).
+ * Such tokens are excluded from annotation overlap detection because they
+ * would cause every annotation's bounding box to span the entire page.
+ */
+export const PAGE_SPANNING_TOKEN_THRESHOLD = 0.9;
+
 // Corpus action trigger display labels
 // Maps backend trigger enum values (lowercase) to user-facing short labels
 export const TRIGGER_LABELS: Record<string, string> = {

--- a/frontend/src/components/annotator/context/UISettingsAtom.tsx
+++ b/frontend/src/components/annotator/context/UISettingsAtom.tsx
@@ -51,6 +51,7 @@ export type QueryErrors = {
  * UI Settings Atoms
  */
 export const zoomLevelAtom = atom<number>(1);
+export const initialZoomSetAtom = atom<boolean>(false);
 export const isSidebarVisibleAtom = atom<boolean>(true);
 export const topbarVisibleAtom = atom<boolean>(false);
 export const sidebarWidthAtom = atom<number>(300);

--- a/frontend/src/components/annotator/renderers/pdf/PDFPage.tsx
+++ b/frontend/src/components/annotator/renderers/pdf/PDFPage.tsx
@@ -18,6 +18,7 @@ import {
   useAnnotationDisplay,
   useZoomLevel,
   useAnnotationSelection,
+  initialZoomSetAtom,
 } from "../../context/UISettingsAtom";
 import { useAnnotationRefs } from "../../hooks/useAnnotationRefs";
 import SelectionLayer from "./SelectionLayer";
@@ -86,7 +87,7 @@ export const PDFPage = ({
     bottom: pageViewport.height,
   });
   const [hasPdfPageRendered, setPdfPageRendered] = useState(false);
-  const [initialZoomSet, setInitialZoomSet] = useState(false);
+  const [initialZoomSet, setInitialZoomSet] = useAtom(initialZoomSetAtom);
 
   const { showSelectedOnly, showBoundingBoxes } = useAnnotationDisplay();
   const { zoomLevel, setZoomLevel } = useZoomLevel();

--- a/frontend/src/components/annotator/types/__tests__/pdf.test.ts
+++ b/frontend/src/components/annotator/types/__tests__/pdf.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect, vi } from "vitest";
+import { PDFPageInfo } from "../pdf";
+import { Token, BoundingBox } from "../../../types";
+import { LabelType } from "../../../../types/graphql-api";
+
+/**
+ * Minimal PDFPageProxy stub for tests that only need pageNumber.
+ */
+function makeFakePageProxy(pageNumber: number) {
+  return {
+    pageNumber,
+    getViewport: vi.fn(({ scale }: { scale: number }) => ({
+      width: 612 * scale,
+      height: 792 * scale,
+    })),
+  } as any;
+}
+
+function makeToken(
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  text: string,
+  extra: Partial<Token> = {}
+): Token {
+  return { x, y, width, height, text, ...extra };
+}
+
+const PAGE_BOUNDS: BoundingBox = {
+  left: 0,
+  top: 0,
+  right: 612,
+  bottom: 792,
+};
+
+const FULL_PAGE_SELECTION: BoundingBox = {
+  left: 0,
+  top: 0,
+  right: 612,
+  bottom: 792,
+};
+
+describe("PDFPageInfo", () => {
+  describe("phantom / degenerate token filtering", () => {
+    it("excludes empty-text page-spanning tokens from getPageAnnotationJson", () => {
+      const realToken = makeToken(100, 200, 50, 10, "Hello");
+      const phantomToken = makeToken(0, 0, 612, 792, "");
+
+      const pageInfo = new PDFPageInfo(
+        makeFakePageProxy(1),
+        [realToken, phantomToken],
+        1,
+        PAGE_BOUNDS
+      );
+
+      const result = pageInfo.getPageAnnotationJson([FULL_PAGE_SELECTION]);
+
+      expect(result.tokensJsons).toHaveLength(1);
+      expect(result.tokensJsons[0].tokenIndex).toBe(0);
+      expect(result.rawText).toContain("Hello");
+      expect(result.bounds.left).toBeGreaterThan(0);
+      expect(result.bounds.right).toBeLessThan(612);
+    });
+
+    it("excludes page-spanning image tokens (Docling page captures)", () => {
+      const realToken = makeToken(100, 200, 50, 10, "Text");
+      // Docling emits full-page image tokens with is_image=true
+      const pageImage = makeToken(0, 0, 612, 792, "", {
+        is_image: true,
+        image_path: "/page_capture.jpg",
+      });
+
+      const pageInfo = new PDFPageInfo(
+        makeFakePageProxy(1),
+        [realToken, pageImage],
+        1,
+        PAGE_BOUNDS
+      );
+
+      const result = pageInfo.getPageAnnotationJson([FULL_PAGE_SELECTION]);
+
+      expect(result.tokensJsons).toHaveLength(1);
+      expect(result.tokensJsons[0].tokenIndex).toBe(0);
+      // Bounds should wrap only the real token
+      expect(result.bounds.right).toBeLessThan(612);
+    });
+
+    it("excludes page-spanning tokens from getAnnotationForBounds", () => {
+      const realToken = makeToken(100, 200, 50, 10, "World");
+      const phantomToken = makeToken(0, 0, 612, 792, "", {
+        is_image: true,
+      });
+
+      const pageInfo = new PDFPageInfo(
+        makeFakePageProxy(1),
+        [realToken, phantomToken],
+        1,
+        PAGE_BOUNDS
+      );
+
+      const result = pageInfo.getAnnotationForBounds(FULL_PAGE_SELECTION, {
+        id: "label-1",
+        text: "Test",
+        color: "#FF0000",
+        icon: "tag",
+        description: "",
+        labelType: LabelType.TokenLabel,
+        readonly: false,
+      });
+
+      expect(result).not.toBeNull();
+      expect(result?.tokens).toHaveLength(1);
+      expect(result?.tokens?.[0].tokenIndex).toBe(0);
+    });
+
+    it("excludes page-spanning tokens from getBoundsForTokens", () => {
+      const realToken = makeToken(100, 200, 50, 10, "Real");
+      const phantomToken = makeToken(0, 0, 612, 792, "", {
+        is_image: true,
+      });
+
+      const pageInfo = new PDFPageInfo(
+        makeFakePageProxy(1),
+        [realToken, phantomToken],
+        1,
+        PAGE_BOUNDS
+      );
+
+      const selectedTokens = [
+        { pageIndex: 0, tokenIndex: 0 },
+        { pageIndex: 0, tokenIndex: 1 }, // phantom
+      ];
+
+      const bounds = pageInfo.getBoundsForTokens(selectedTokens);
+
+      expect(bounds).toBeDefined();
+      expect(bounds!.left).toBeGreaterThan(0);
+      expect(bounds!.right).toBeLessThan(612);
+    });
+
+    it("includes normal-sized image tokens with empty text", () => {
+      const imageToken = makeToken(50, 50, 200, 150, "", {
+        is_image: true,
+        image_path: "/test.png",
+      });
+
+      const pageInfo = new PDFPageInfo(
+        makeFakePageProxy(1),
+        [imageToken],
+        1,
+        PAGE_BOUNDS
+      );
+
+      const result = pageInfo.getPageAnnotationJson([FULL_PAGE_SELECTION]);
+
+      expect(result.tokensJsons).toHaveLength(1);
+      expect(result.tokensJsons[0].tokenIndex).toBe(0);
+    });
+
+    it("excludes whitespace-only text tokens that span the page", () => {
+      const realToken = makeToken(100, 200, 50, 10, "Text");
+      const whitespaceToken = makeToken(0, 0, 612, 792, "   ");
+
+      const pageInfo = new PDFPageInfo(
+        makeFakePageProxy(1),
+        [realToken, whitespaceToken],
+        1,
+        PAGE_BOUNDS
+      );
+
+      const result = pageInfo.getPageAnnotationJson([FULL_PAGE_SELECTION]);
+
+      expect(result.tokensJsons).toHaveLength(1);
+      expect(result.tokensJsons[0].tokenIndex).toBe(0);
+    });
+
+    it("excludes empty-text non-image tokens even if small", () => {
+      const realToken = makeToken(100, 200, 50, 10, "Text");
+      const emptySmall = makeToken(50, 50, 20, 10, "");
+
+      const pageInfo = new PDFPageInfo(
+        makeFakePageProxy(1),
+        [realToken, emptySmall],
+        1,
+        PAGE_BOUNDS
+      );
+
+      const result = pageInfo.getPageAnnotationJson([FULL_PAGE_SELECTION]);
+
+      expect(result.tokensJsons).toHaveLength(1);
+      expect(result.tokensJsons[0].tokenIndex).toBe(0);
+    });
+  });
+
+  describe("getPageAnnotationJson", () => {
+    it("returns empty result when no tokens overlap selection", () => {
+      const token = makeToken(100, 200, 50, 10, "Hello");
+
+      const pageInfo = new PDFPageInfo(
+        makeFakePageProxy(1),
+        [token],
+        1,
+        PAGE_BOUNDS
+      );
+
+      const selection: BoundingBox = {
+        left: 500,
+        top: 500,
+        right: 600,
+        bottom: 600,
+      };
+
+      const result = pageInfo.getPageAnnotationJson([selection]);
+
+      expect(result.tokensJsons).toHaveLength(0);
+      expect(result.rawText).toBe("");
+    });
+
+    it("correctly computes bounds from overlapping tokens", () => {
+      const token1 = makeToken(100, 200, 50, 10, "Hello");
+      const token2 = makeToken(160, 200, 50, 10, "World");
+
+      const pageInfo = new PDFPageInfo(
+        makeFakePageProxy(1),
+        [token1, token2],
+        1,
+        PAGE_BOUNDS
+      );
+
+      const selection: BoundingBox = {
+        left: 90,
+        top: 190,
+        right: 220,
+        bottom: 220,
+      };
+
+      const result = pageInfo.getPageAnnotationJson([selection]);
+
+      expect(result.tokensJsons).toHaveLength(2);
+      // spanningBound adds 3px padding
+      expect(result.bounds.left).toBe(100 - 3);
+      expect(result.bounds.top).toBe(200 - 3);
+      expect(result.bounds.right).toBe(210 + 3);
+      expect(result.bounds.bottom).toBe(210 + 3);
+    });
+  });
+});

--- a/frontend/src/components/annotator/types/pdf.ts
+++ b/frontend/src/components/annotator/types/pdf.ts
@@ -24,12 +24,16 @@ export const undefined_bounding_box = {
 };
 
 export class PDFPageInfo {
+  private readonly viewport: ReturnType<PDFPageProxy["getViewport"]>;
+
   constructor(
     public readonly page: PDFPageProxy,
     public readonly tokens: Token[] = [],
     public scale: number,
     public bounds?: BoundingBox
-  ) {}
+  ) {
+    this.viewport = page.getViewport({ scale: 1 });
+  }
 
   /**
    * Returns true if a token should participate in annotation selection.
@@ -43,7 +47,10 @@ export class PDFPageInfo {
     pageWidth: number,
     pageHeight: number
   ): boolean {
-    // Skip tokens with no meaningful text that aren't images
+    // Exclude all non-image tokens with empty text. While the page-spanning
+    // Docling tokens are the most problematic case, any empty-text token
+    // contributes no selectable content and would only inflate annotation
+    // bounding boxes without adding meaningful text to the selection.
     if (!t.text?.trim() && !t.is_image) return false;
 
     // Skip tokens that span the entire page (degenerate page captures)
@@ -84,7 +91,7 @@ export class PDFPageInfo {
     if (this.bounds === undefined) {
       throw new Error("Unknown Page Bounds");
     }
-    const viewport = this.page.getViewport({ scale: 1 });
+    const viewport = this.viewport;
     const ids: TokenId[] = [];
     const tokenBounds: BoundingBox[] = [];
     for (let i = 0; i < this.tokens.length; i++) {
@@ -140,7 +147,7 @@ export class PDFPageInfo {
       (token) => token.pageIndex === this.page.pageNumber - 1
     );
 
-    const viewport = this.page.getViewport({ scale: 1 });
+    const viewport = this.viewport;
     const tokenBounds: BoundingBox[] = [];
     for (let i = 0; i < this_page_tokens.length; i++) {
       const token = this.tokens[this_page_tokens[i].tokenIndex];
@@ -185,7 +192,7 @@ export class PDFPageInfo {
 
     // console.log("Get annotations for bounds", selection);
 
-    const viewport = this.page.getViewport({ scale: 1 });
+    const viewport = this.viewport;
     const ids: TokenId[] = [];
     const tokenBounds: BoundingBox[] = [];
     for (let i = 0; i < this.tokens.length; i++) {

--- a/frontend/src/components/annotator/types/pdf.ts
+++ b/frontend/src/components/annotator/types/pdf.ts
@@ -9,6 +9,7 @@ import {
 } from "../../../utils/transform";
 import { convertAnnotationTokensToText } from "../utils";
 import { RenderedSpanAnnotation, TokenId } from "./annotations";
+import { PAGE_SPANNING_TOKEN_THRESHOLD } from "../../../assets/configurations/constants";
 
 export type Optional<T> = T | undefined;
 
@@ -29,6 +30,32 @@ export class PDFPageInfo {
     public scale: number,
     public bounds?: BoundingBox
   ) {}
+
+  /**
+   * Returns true if a token should participate in annotation selection.
+   * Filters out degenerate tokens such as page-level bounding boxes emitted
+   * by some parsers (e.g. Docling) which have empty text and cover the
+   * entire page.  Including them would cause every annotation's spanning
+   * bound to expand to the full page dimensions.
+   */
+  private isSelectableToken(
+    t: Token,
+    pageWidth: number,
+    pageHeight: number
+  ): boolean {
+    // Skip tokens with no meaningful text that aren't images
+    if (!t.text?.trim() && !t.is_image) return false;
+
+    // Skip tokens that span the entire page (degenerate page captures)
+    if (
+      t.width >= pageWidth * PAGE_SPANNING_TOKEN_THRESHOLD &&
+      t.height >= pageHeight * PAGE_SPANNING_TOKEN_THRESHOLD
+    ) {
+      return false;
+    }
+
+    return true;
+  }
 
   getFreeFormAnnotationForBounds(
     selection: BoundingBox,
@@ -57,10 +84,15 @@ export class PDFPageInfo {
     if (this.bounds === undefined) {
       throw new Error("Unknown Page Bounds");
     }
+    const viewport = this.page.getViewport({ scale: 1 });
     const ids: TokenId[] = [];
     const tokenBounds: BoundingBox[] = [];
-    // console.log("Handle page", this.page.pageNumber);
     for (let i = 0; i < this.tokens.length; i++) {
+      if (
+        !this.isSelectableToken(this.tokens[i], viewport.width, viewport.height)
+      )
+        continue;
+
       for (let j = 0; j < selections.length; j++) {
         const normalized_selection_bounds = normalizeBounds(selections[j]);
         const tokenBound = this.getTokenBounds(this.tokens[i]);
@@ -108,12 +140,14 @@ export class PDFPageInfo {
       (token) => token.pageIndex === this.page.pageNumber - 1
     );
 
+    const viewport = this.page.getViewport({ scale: 1 });
     const tokenBounds: BoundingBox[] = [];
     for (let i = 0; i < this_page_tokens.length; i++) {
-      const tokenBound = this.getTokenBounds(
-        this.tokens[this_page_tokens[i].tokenIndex]
-      );
-      tokenBounds.push(tokenBound);
+      const token = this.tokens[this_page_tokens[i].tokenIndex];
+      if (!this.isSelectableToken(token, viewport.width, viewport.height))
+        continue;
+
+      tokenBounds.push(this.getTokenBounds(token));
     }
     const bounds = spanningBound(tokenBounds);
 
@@ -151,9 +185,15 @@ export class PDFPageInfo {
 
     // console.log("Get annotations for bounds", selection);
 
+    const viewport = this.page.getViewport({ scale: 1 });
     const ids: TokenId[] = [];
     const tokenBounds: BoundingBox[] = [];
     for (let i = 0; i < this.tokens.length; i++) {
+      if (
+        !this.isSelectableToken(this.tokens[i], viewport.width, viewport.height)
+      )
+        continue;
+
       const tokenBound = this.getTokenBounds(this.tokens[i]);
 
       if (doOverlap(scaled(tokenBound, this.scale), selection)) {

--- a/frontend/src/components/knowledge_base/document/DocumentKnowledgeBase.tsx
+++ b/frontend/src/components/knowledge_base/document/DocumentKnowledgeBase.tsx
@@ -82,7 +82,7 @@ import {
   CorpusState,
   useCorpusState,
 } from "../../annotator/context/CorpusAtom";
-import { useAtom } from "jotai";
+import { useAtom, useSetAtom } from "jotai";
 import { useInitialAnnotations } from "../../annotator/hooks/AnnotationHooks";
 import { EnhancedLabelSelector } from "../../annotator/labels/EnhancedLabelSelector";
 import { PDF } from "../../annotator/renderers/pdf/PDF";
@@ -90,6 +90,7 @@ import TxtAnnotatorWrapper from "../../annotator/components/wrappers/TxtAnnotato
 import {
   useAnnotationControls,
   selectedRelationsAtom,
+  initialZoomSetAtom,
 } from "../../annotator/context/UISettingsAtom";
 import { useNavigate, useLocation } from "react-router-dom";
 import { updateAnnotationSelectionParams } from "../../../utils/navigationUtils";
@@ -212,6 +213,13 @@ const DocumentKnowledgeBase: React.FC<DocumentKnowledgeBaseProps> = ({
   const uiSettingsConfig = React.useMemo(() => ({ width }), [width]);
   const { setProgress, zoomLevel, setShiftDown, setZoomLevel } =
     useUISettings(uiSettingsConfig);
+
+  // Reset initial zoom flag when navigating to a different document so the
+  // fit-to-width calculation in PDFPage fires again for the new document.
+  const setInitialZoomSet = useSetAtom(initialZoomSetAtom);
+  useEffect(() => {
+    setInitialZoomSet(false);
+  }, [documentId, setInitialZoomSet]);
 
   const navigate = useNavigate();
   const location = useLocation();

--- a/frontend/src/components/knowledge_base/document/DocumentKnowledgeBase.tsx
+++ b/frontend/src/components/knowledge_base/document/DocumentKnowledgeBase.tsx
@@ -50,7 +50,7 @@ import { PDFDocumentLoadingTask } from "pdfjs-dist";
 import { useUISettings } from "../../annotator/hooks/useUISettings";
 import useWindowDimensions from "../../hooks/WindowDimensionHook";
 import { PDFPageInfo } from "../../annotator/types/pdf";
-import { Token, ViewState, PermissionTypes } from "../../types";
+import { ViewState, PermissionTypes } from "../../types";
 import { toast } from "react-toastify";
 import {
   useDocText,
@@ -68,7 +68,7 @@ import {
   convertToDocTypeAnnotations,
   convertToServerAnnotation,
   getPermissions,
-  normalizeTokensToPdfViewport,
+  resolvePageTokens,
 } from "../../../utils/transform";
 import {
   PdfAnnotations,
@@ -837,43 +837,14 @@ const DocumentKnowledgeBase: React.FC<DocumentKnowledgeBaseProps> = ({
               const pageNum = i; // Capture page number for logging
               loadPagesPromises.push(
                 pdfDocProxy.getPage(pageNum).then((p) => {
-                  let pageTokens: Token[] = [];
-                  const pageIndex = p.pageNumber - 1;
-
-                  if (
-                    !pawlsData ||
-                    !Array.isArray(pawlsData) ||
-                    pageIndex >= pawlsData.length
-                  ) {
-                    console.warn(
-                      `Page ${pageNum}: PAWLS data index out of bounds. Index: ${pageIndex}, Length: ${pawlsData.length}`
-                    );
-                    pageTokens = [];
-                  } else {
-                    const pageData = pawlsData[pageIndex];
-
-                    if (!pageData) {
-                      pageTokens = [];
-                    } else if (typeof pageData.tokens === "undefined") {
-                      pageTokens = [];
-                    } else if (!Array.isArray(pageData.tokens)) {
-                      console.error(
-                        `Page ${pageNum}: CRITICAL - pageData.tokens is not an array at index ${pageIndex}! Type: ${typeof pageData.tokens}`
-                      );
-                      pageTokens = [];
-                    } else {
-                      // Normalize token coordinates from PAWLs coordinate
-                      // space to the PDF.js viewport coordinate space. The
-                      // parser may report different page dimensions than
-                      // PDF.js, causing progressive bbox drift if uncorrected.
-                      const viewport = p.getViewport({ scale: 1 });
-                      pageTokens = normalizeTokensToPdfViewport(
-                        pageData,
-                        viewport.width,
-                        viewport.height
-                      );
-                    }
-                  }
+                  const viewport = p.getViewport({ scale: 1 });
+                  const pageTokens = resolvePageTokens(
+                    pawlsData,
+                    p.pageNumber - 1,
+                    viewport.width,
+                    viewport.height,
+                    pageNum
+                  );
                   return new PDFPageInfo(p, pageTokens, zoomLevel);
                 }) as unknown as Promise<PDFPageInfo>
               );
@@ -1065,41 +1036,14 @@ const DocumentKnowledgeBase: React.FC<DocumentKnowledgeBaseProps> = ({
                 const pageNum = i;
                 loadPagesPromises.push(
                   pdfDocProxy.getPage(pageNum).then((p) => {
-                    let pageTokens: Token[] = [];
-                    const pageIndex = p.pageNumber - 1;
-
-                    if (
-                      !pawlsData ||
-                      !Array.isArray(pawlsData) ||
-                      pageIndex >= pawlsData.length
-                    ) {
-                      console.warn(
-                        `Page ${pageNum}: PAWLS data index out of bounds. Index: ${pageIndex}, Length: ${pawlsData.length}`
-                      );
-                      pageTokens = [];
-                    } else {
-                      const pageData = pawlsData[pageIndex];
-
-                      if (!pageData) {
-                        pageTokens = [];
-                      } else if (typeof pageData.tokens === "undefined") {
-                        pageTokens = [];
-                      } else if (!Array.isArray(pageData.tokens)) {
-                        console.error(
-                          `Page ${pageNum}: CRITICAL - pageData.tokens is not an array at index ${pageIndex}! Type: ${typeof pageData.tokens}`
-                        );
-                        pageTokens = [];
-                      } else {
-                        // Normalize token coordinates from PAWLs coordinate
-                        // space to the PDF.js viewport coordinate space.
-                        const viewport = p.getViewport({ scale: 1 });
-                        pageTokens = normalizeTokensToPdfViewport(
-                          pageData,
-                          viewport.width,
-                          viewport.height
-                        );
-                      }
-                    }
+                    const viewport = p.getViewport({ scale: 1 });
+                    const pageTokens = resolvePageTokens(
+                      pawlsData,
+                      p.pageNumber - 1,
+                      viewport.width,
+                      viewport.height,
+                      pageNum
+                    );
                     return new PDFPageInfo(p, pageTokens, zoomLevel);
                   }) as unknown as Promise<PDFPageInfo>
                 );

--- a/frontend/src/components/knowledge_base/document/DocumentKnowledgeBase.tsx
+++ b/frontend/src/components/knowledge_base/document/DocumentKnowledgeBase.tsx
@@ -68,6 +68,7 @@ import {
   convertToDocTypeAnnotations,
   convertToServerAnnotation,
   getPermissions,
+  normalizeTokensToPdfViewport,
 } from "../../../utils/transform";
 import {
   PdfAnnotations,
@@ -861,7 +862,16 @@ const DocumentKnowledgeBase: React.FC<DocumentKnowledgeBaseProps> = ({
                       );
                       pageTokens = [];
                     } else {
-                      pageTokens = pageData.tokens;
+                      // Normalize token coordinates from PAWLs coordinate
+                      // space to the PDF.js viewport coordinate space. The
+                      // parser may report different page dimensions than
+                      // PDF.js, causing progressive bbox drift if uncorrected.
+                      const viewport = p.getViewport({ scale: 1 });
+                      pageTokens = normalizeTokensToPdfViewport(
+                        pageData,
+                        viewport.width,
+                        viewport.height
+                      );
                     }
                   }
                   return new PDFPageInfo(p, pageTokens, zoomLevel);
@@ -1080,7 +1090,14 @@ const DocumentKnowledgeBase: React.FC<DocumentKnowledgeBaseProps> = ({
                         );
                         pageTokens = [];
                       } else {
-                        pageTokens = pageData.tokens;
+                        // Normalize token coordinates from PAWLs coordinate
+                        // space to the PDF.js viewport coordinate space.
+                        const viewport = p.getViewport({ scale: 1 });
+                        pageTokens = normalizeTokensToPdfViewport(
+                          pageData,
+                          viewport.width,
+                          viewport.height
+                        );
                       }
                     }
                     return new PDFPageInfo(p, pageTokens, zoomLevel);

--- a/frontend/src/components/knowledge_base/document/floating_summary_preview/graphql/documentSummaryQueries.ts
+++ b/frontend/src/components/knowledge_base/document/floating_summary_preview/graphql/documentSummaryQueries.ts
@@ -1,7 +1,7 @@
 import { gql } from "@apollo/client";
 
 export const GET_DOCUMENT_SUMMARY_VERSIONS = gql`
-  query GetDocumentSummaryVersions($documentId: String!, $corpusId: ID!) {
+  query GetDocumentSummaryVersions($documentId: ID!, $corpusId: ID!) {
     document(id: $documentId) {
       id
       summaryContent(corpusId: $corpusId)

--- a/frontend/src/graphql/queries.ts
+++ b/frontend/src/graphql/queries.ts
@@ -2225,7 +2225,7 @@ export interface GetDocumentAnnotationsAndRelationshipsOutput {
  */
 export const GET_DOCUMENT_ANNOTATIONS_AND_RELATIONSHIPS = gql`
   query GetDocumentAnnotationsAndRelationships(
-    $documentId: String!
+    $documentId: ID!
     $corpusId: ID!
     $analysisId: ID
   ) {
@@ -2920,7 +2920,7 @@ export interface GetDocumentDetailsOutput {
 }
 
 export const GET_DOCUMENT_DETAILS = gql`
-  query GetDocumentDetails($documentId: String!) {
+  query GetDocumentDetails($documentId: ID!) {
     document(id: $documentId) {
       id
       title
@@ -2951,7 +2951,7 @@ export interface GetDocumentKnowledgeAndAnnotationsOutput {
 
 export const GET_DOCUMENT_KNOWLEDGE_AND_ANNOTATIONS = gql`
   query GetDocumentKnowledgeAndAnnotations(
-    $documentId: String!
+    $documentId: ID!
     $corpusId: ID!
     $analysisId: ID
   ) {
@@ -3118,7 +3118,7 @@ export interface GetDocumentAnnotationsOnlyOutput {
 
 export const GET_DOCUMENT_ANNOTATIONS_ONLY = gql`
   query GetDocumentAnnotationsOnly(
-    $documentId: String!
+    $documentId: ID!
     $corpusId: ID!
     $analysisId: ID
   ) {
@@ -3240,7 +3240,7 @@ export interface GetDocumentWithStructureOutput {
 }
 
 export const GET_DOCUMENT_WITH_STRUCTURE = gql`
-  query GetDocumentWithStructure($documentId: String!) {
+  query GetDocumentWithStructure($documentId: ID!) {
     document(id: $documentId) {
       id
       title
@@ -3771,7 +3771,7 @@ export interface GetCorpusByIdForRedirectOutput {
 }
 
 export const GET_DOCUMENT_BY_ID_FOR_REDIRECT = gql`
-  query GetDocumentByIdForRedirect($id: String!) {
+  query GetDocumentByIdForRedirect($id: ID!) {
     document(id: $id) {
       id
       slug

--- a/frontend/src/utils/__tests__/transform.normalizeTokens.test.ts
+++ b/frontend/src/utils/__tests__/transform.normalizeTokens.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { normalizeTokensToPdfViewport } from "../transform";
+import { PageTokens, Token } from "../../components/types";
+
+describe("normalizeTokensToPdfViewport", () => {
+  const makePageTokens = (
+    pageWidth: number,
+    pageHeight: number,
+    tokens: Token[]
+  ): PageTokens => ({
+    page: { index: 0, width: pageWidth, height: pageHeight },
+    tokens,
+  });
+
+  const sampleTokens: Token[] = [
+    { x: 100, y: 200, width: 50, height: 10, text: "hello" },
+    { x: 300, y: 400, width: 80, height: 12, text: "world" },
+  ];
+
+  it("returns original tokens when dimensions match within epsilon", () => {
+    const pageData = makePageTokens(612, 792, sampleTokens);
+    const result = normalizeTokensToPdfViewport(pageData, 612, 792);
+    // Should return the exact same array reference (no copy)
+    expect(result).toBe(sampleTokens);
+  });
+
+  it("returns original tokens when dimensions differ by less than 0.5", () => {
+    const pageData = makePageTokens(612, 792, sampleTokens);
+    const result = normalizeTokensToPdfViewport(pageData, 612.3, 792.4);
+    expect(result).toBe(sampleTokens);
+  });
+
+  it("rescales tokens when PAWLs width differs from viewport", () => {
+    // PAWLs reports 612x792 but PDF.js viewport is 595x842
+    const pageData = makePageTokens(612, 792, sampleTokens);
+    const result = normalizeTokensToPdfViewport(pageData, 595, 842);
+
+    const scaleX = 595 / 612;
+    const scaleY = 842 / 792;
+
+    expect(result).toHaveLength(2);
+    expect(result[0].x).toBeCloseTo(100 * scaleX);
+    expect(result[0].y).toBeCloseTo(200 * scaleY);
+    expect(result[0].width).toBeCloseTo(50 * scaleX);
+    expect(result[0].height).toBeCloseTo(10 * scaleY);
+    expect(result[0].text).toBe("hello");
+
+    expect(result[1].x).toBeCloseTo(300 * scaleX);
+    expect(result[1].y).toBeCloseTo(400 * scaleY);
+    expect(result[1].width).toBeCloseTo(80 * scaleX);
+    expect(result[1].height).toBeCloseTo(12 * scaleY);
+    expect(result[1].text).toBe("world");
+  });
+
+  it("preserves image token fields during rescaling", () => {
+    const imageTokens: Token[] = [
+      {
+        x: 50,
+        y: 100,
+        width: 200,
+        height: 150,
+        text: "",
+        is_image: true,
+        image_path: "/images/fig1.jpg",
+        format: "jpeg",
+      },
+    ];
+    const pageData = makePageTokens(612, 792, imageTokens);
+    const result = normalizeTokensToPdfViewport(pageData, 600, 800);
+
+    const scaleX = 600 / 612;
+    const scaleY = 800 / 792;
+
+    expect(result[0].x).toBeCloseTo(50 * scaleX);
+    expect(result[0].y).toBeCloseTo(100 * scaleY);
+    expect(result[0].width).toBeCloseTo(200 * scaleX);
+    expect(result[0].height).toBeCloseTo(150 * scaleY);
+    expect(result[0].is_image).toBe(true);
+    expect(result[0].image_path).toBe("/images/fig1.jpg");
+    expect(result[0].format).toBe("jpeg");
+  });
+
+  it("handles empty token arrays", () => {
+    const pageData = makePageTokens(612, 792, []);
+    const result = normalizeTokensToPdfViewport(pageData, 595, 842);
+    expect(result).toHaveLength(0);
+  });
+});

--- a/frontend/src/utils/__tests__/transform.normalizeTokens.test.ts
+++ b/frontend/src/utils/__tests__/transform.normalizeTokens.test.ts
@@ -63,6 +63,8 @@ describe("normalizeTokensToPdfViewport", () => {
         is_image: true,
         image_path: "/images/fig1.jpg",
         format: "jpeg",
+        original_width: 1024,
+        original_height: 768,
       },
     ];
     const pageData = makePageTokens(612, 792, imageTokens);
@@ -78,6 +80,23 @@ describe("normalizeTokensToPdfViewport", () => {
     expect(result[0].is_image).toBe(true);
     expect(result[0].image_path).toBe("/images/fig1.jpg");
     expect(result[0].format).toBe("jpeg");
+    // original_width/original_height are image pixel dimensions, not PDF
+    // coordinates — they must NOT be rescaled.
+    expect(result[0].original_width).toBe(1024);
+    expect(result[0].original_height).toBe(768);
+  });
+
+  it("returns tokens as-is when PAWLs page dimensions are zero", () => {
+    const pageData = makePageTokens(0, 0, sampleTokens);
+    const result = normalizeTokensToPdfViewport(pageData, 612, 792);
+    // Cannot rescale with zero dimensions — return original tokens untouched
+    expect(result).toBe(sampleTokens);
+  });
+
+  it("returns tokens as-is when only one PAWLs dimension is zero", () => {
+    const pageData = makePageTokens(612, 0, sampleTokens);
+    const result = normalizeTokensToPdfViewport(pageData, 612, 792);
+    expect(result).toBe(sampleTokens);
   });
 
   it("handles empty token arrays", () => {

--- a/frontend/src/utils/__tests__/transform.normalizeTokens.test.ts
+++ b/frontend/src/utils/__tests__/transform.normalizeTokens.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { normalizeTokensToPdfViewport } from "../transform";
+import { describe, it, expect, vi } from "vitest";
+import { normalizeTokensToPdfViewport, resolvePageTokens } from "../transform";
 import { PageTokens, Token } from "../../components/types";
 
 describe("normalizeTokensToPdfViewport", () => {
@@ -99,9 +99,113 @@ describe("normalizeTokensToPdfViewport", () => {
     expect(result).toBe(sampleTokens);
   });
 
+  it("returns tokens as-is when viewport width is zero", () => {
+    const pageData = makePageTokens(612, 792, sampleTokens);
+    const result = normalizeTokensToPdfViewport(pageData, 0, 792);
+    expect(result).toBe(sampleTokens);
+  });
+
+  it("returns tokens as-is when viewport height is zero", () => {
+    const pageData = makePageTokens(612, 792, sampleTokens);
+    const result = normalizeTokensToPdfViewport(pageData, 612, 0);
+    expect(result).toBe(sampleTokens);
+  });
+
   it("handles empty token arrays", () => {
     const pageData = makePageTokens(612, 792, []);
     const result = normalizeTokensToPdfViewport(pageData, 595, 842);
     expect(result).toHaveLength(0);
+  });
+});
+
+describe("resolvePageTokens", () => {
+  const makePageTokens = (
+    pageWidth: number,
+    pageHeight: number,
+    tokens: Token[]
+  ): PageTokens => ({
+    page: { index: 0, width: pageWidth, height: pageHeight },
+    tokens,
+  });
+
+  const sampleTokens: Token[] = [
+    { x: 100, y: 200, width: 50, height: 10, text: "hello" },
+  ];
+
+  it("returns [] and warns when pawlsData is null", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const result = resolvePageTokens(null, 0, 612, 792, 1);
+    expect(result).toEqual([]);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("PAWLS data index out of bounds")
+    );
+    warnSpy.mockRestore();
+  });
+
+  it("returns [] and warns when pawlsData is undefined", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const result = resolvePageTokens(undefined, 0, 612, 792, 1);
+    expect(result).toEqual([]);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("PAWLS data index out of bounds")
+    );
+    warnSpy.mockRestore();
+  });
+
+  it("returns [] and warns when pageIndex is out of bounds", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const pages = [makePageTokens(612, 792, sampleTokens)];
+    const result = resolvePageTokens(pages, 5, 612, 792, 6);
+    expect(result).toEqual([]);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Index: 5, Length: 1")
+    );
+    warnSpy.mockRestore();
+  });
+
+  it("returns [] and logs error when tokens is not an array", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const badPage = {
+      page: { index: 0, width: 612, height: 792 },
+      tokens: "not-an-array" as unknown as Token[],
+    };
+    const result = resolvePageTokens([badPage], 0, 612, 792, 1);
+    expect(result).toEqual([]);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("CRITICAL - pageData.tokens is not an array")
+    );
+    errorSpy.mockRestore();
+  });
+
+  it("returns [] when pageData is falsy (sparse array)", () => {
+    const sparsePages: PageTokens[] = [];
+    sparsePages[2] = makePageTokens(612, 792, sampleTokens);
+    const result = resolvePageTokens(sparsePages, 0, 612, 792, 1);
+    expect(result).toEqual([]);
+  });
+
+  it("returns [] when pageData.tokens is undefined", () => {
+    const noTokensPage = {
+      page: { index: 0, width: 612, height: 792 },
+    } as unknown as PageTokens;
+    const result = resolvePageTokens([noTokensPage], 0, 612, 792, 1);
+    expect(result).toEqual([]);
+  });
+
+  it("delegates to normalizeTokensToPdfViewport on valid data", () => {
+    const pages = [makePageTokens(612, 792, sampleTokens)];
+    // Same dimensions → should return original tokens reference
+    const result = resolvePageTokens(pages, 0, 612, 792, 1);
+    expect(result).toBe(sampleTokens);
+  });
+
+  it("returns rescaled tokens when viewport differs", () => {
+    const pages = [makePageTokens(612, 792, sampleTokens)];
+    const result = resolvePageTokens(pages, 0, 595, 842, 1);
+    const scaleX = 595 / 612;
+    const scaleY = 842 / 792;
+    expect(result).toHaveLength(1);
+    expect(result[0].x).toBeCloseTo(100 * scaleX);
+    expect(result[0].y).toBeCloseTo(200 * scaleY);
   });
 });

--- a/frontend/src/utils/transform.tsx
+++ b/frontend/src/utils/transform.tsx
@@ -361,8 +361,13 @@ export function normalizeTokensToPdfViewport(
   const pawlsWidth = pawlsPage.page.width;
   const pawlsHeight = pawlsPage.page.height;
 
-  // Cannot rescale if PAWLs reports zero dimensions (malformed data).
-  if (pawlsWidth === 0 || pawlsHeight === 0) {
+  // Cannot rescale if PAWLs or viewport reports zero dimensions (malformed data).
+  if (
+    pawlsWidth === 0 ||
+    pawlsHeight === 0 ||
+    viewportWidth === 0 ||
+    viewportHeight === 0
+  ) {
     return pawlsPage.tokens;
   }
 

--- a/frontend/src/utils/transform.tsx
+++ b/frontend/src/utils/transform.tsx
@@ -3,8 +3,10 @@ import { ServerTokenAnnotation } from "../components/annotator/types/annotations
 import { ServerSpanAnnotation } from "../components/annotator/types/annotations";
 import {
   BoundingBox,
+  PageTokens,
   PermissionTypes,
   SpanAnnotationJson,
+  Token,
 } from "../components/types";
 import {
   AnalyzerManifestType,
@@ -330,4 +332,51 @@ export function doOverlap(a: BoundingBox, b: BoundingBox): boolean {
     return false;
   }
   return true;
+}
+
+/**
+ * Normalizes PAWLs token coordinates to match PDF.js viewport coordinates.
+ *
+ * PAWLs tokens are extracted by the parser (e.g. Docling, pdfplumber) using its
+ * own page dimension measurements. PDF.js computes its own page dimensions from
+ * the PDF's MediaBox/CropBox/rotation. If these differ, token bounding boxes
+ * drift progressively from the rendered PDF content.
+ *
+ * This function rescales token x/y/width/height so they align with the PDF.js
+ * coordinate system at scale&nbsp;1.
+ *
+ * @param pawlsPage  - The PAWLs page data containing `page` dimensions and `tokens`.
+ * @param viewportWidth  - PDF.js viewport width at scale 1.
+ * @param viewportHeight - PDF.js viewport height at scale 1.
+ * @returns A new array of tokens with coordinates rescaled to the PDF.js
+ *          coordinate system. If no rescaling is needed the original array is
+ *          returned as-is (no unnecessary copies).
+ */
+export function normalizeTokensToPdfViewport(
+  pawlsPage: PageTokens,
+  viewportWidth: number,
+  viewportHeight: number
+): Token[] {
+  const pawlsWidth = pawlsPage.page.width;
+  const pawlsHeight = pawlsPage.page.height;
+
+  // If dimensions match (within a tiny epsilon) no rescaling is needed.
+  const EPSILON = 0.5; // half a PDF point tolerance
+  if (
+    Math.abs(pawlsWidth - viewportWidth) < EPSILON &&
+    Math.abs(pawlsHeight - viewportHeight) < EPSILON
+  ) {
+    return pawlsPage.tokens;
+  }
+
+  const scaleX = viewportWidth / pawlsWidth;
+  const scaleY = viewportHeight / pawlsHeight;
+
+  return pawlsPage.tokens.map((t) => ({
+    ...t,
+    x: t.x * scaleX,
+    y: t.y * scaleY,
+    width: t.width * scaleX,
+    height: t.height * scaleY,
+  }));
 }

--- a/frontend/src/utils/transform.tsx
+++ b/frontend/src/utils/transform.tsx
@@ -14,6 +14,7 @@ import {
   RawServerAnnotationType,
   ServerAnnotationType,
 } from "../types/graphql-api";
+import { PAWLS_COORDINATE_EPSILON } from "../assets/configurations/constants";
 import { isSpanAnnotation } from "./annotationGuards";
 
 // https://gist.github.com/JamieMason/0566f8412af9fe6a1d470aa1e089a752
@@ -343,7 +344,7 @@ export function doOverlap(a: BoundingBox, b: BoundingBox): boolean {
  * drift progressively from the rendered PDF content.
  *
  * This function rescales token x/y/width/height so they align with the PDF.js
- * coordinate system at scale&nbsp;1.
+ * coordinate system at scale 1.
  *
  * @param pawlsPage  - The PAWLs page data containing `page` dimensions and `tokens`.
  * @param viewportWidth  - PDF.js viewport width at scale 1.
@@ -360,11 +361,15 @@ export function normalizeTokensToPdfViewport(
   const pawlsWidth = pawlsPage.page.width;
   const pawlsHeight = pawlsPage.page.height;
 
+  // Cannot rescale if PAWLs reports zero dimensions (malformed data).
+  if (pawlsWidth === 0 || pawlsHeight === 0) {
+    return pawlsPage.tokens;
+  }
+
   // If dimensions match (within a tiny epsilon) no rescaling is needed.
-  const EPSILON = 0.5; // half a PDF point tolerance
   if (
-    Math.abs(pawlsWidth - viewportWidth) < EPSILON &&
-    Math.abs(pawlsHeight - viewportHeight) < EPSILON
+    Math.abs(pawlsWidth - viewportWidth) < PAWLS_COORDINATE_EPSILON &&
+    Math.abs(pawlsHeight - viewportHeight) < PAWLS_COORDINATE_EPSILON
   ) {
     return pawlsPage.tokens;
   }
@@ -379,4 +384,56 @@ export function normalizeTokensToPdfViewport(
     width: t.width * scaleX,
     height: t.height * scaleY,
   }));
+}
+
+/**
+ * Resolves the token array for a single PDF page given the full PAWLs dataset.
+ *
+ * Validates the PAWLs data for the requested page index and, when valid,
+ * normalizes token coordinates to the PDF.js viewport coordinate space via
+ * {@link normalizeTokensToPdfViewport}.
+ *
+ * @param pawlsData - The full PAWLs dataset (array of per-page token data).
+ * @param pageIndex - Zero-based page index into `pawlsData`.
+ * @param viewportWidth  - PDF.js viewport width at scale 1.
+ * @param viewportHeight - PDF.js viewport height at scale 1.
+ * @param pageNum - One-based page number (used only for log messages).
+ * @returns The resolved (and possibly rescaled) token array for the page.
+ */
+export function resolvePageTokens(
+  pawlsData: PageTokens[] | null | undefined,
+  pageIndex: number,
+  viewportWidth: number,
+  viewportHeight: number,
+  pageNum: number
+): Token[] {
+  if (
+    !pawlsData ||
+    !Array.isArray(pawlsData) ||
+    pageIndex >= pawlsData.length
+  ) {
+    console.warn(
+      `Page ${pageNum}: PAWLS data index out of bounds. Index: ${pageIndex}, Length: ${
+        pawlsData?.length ?? 0
+      }`
+    );
+    return [];
+  }
+
+  const pageData = pawlsData[pageIndex];
+
+  if (!pageData) {
+    return [];
+  }
+  if (typeof pageData.tokens === "undefined") {
+    return [];
+  }
+  if (!Array.isArray(pageData.tokens)) {
+    console.error(
+      `Page ${pageNum}: CRITICAL - pageData.tokens is not an array at index ${pageIndex}! Type: ${typeof pageData.tokens}`
+    );
+    return [];
+  }
+
+  return normalizeTokensToPdfViewport(pageData, viewportWidth, viewportHeight);
 }

--- a/opencontractserver/tests/performance_optimizations/test_pdf_hash_graphql.py
+++ b/opencontractserver/tests/performance_optimizations/test_pdf_hash_graphql.py
@@ -45,7 +45,7 @@ class PDFHashGraphQLTestCase(GraphQLTestCase):
     def test_pdf_file_hash_field_in_document_query(self):
         """Test that pdf_file_hash field is available in DocumentType GraphQL query."""
         query = """
-            query GetDocument($id: String!) {
+            query GetDocument($id: ID!) {
                 document(id: $id) {
                     id
                     title
@@ -116,7 +116,7 @@ class PDFHashGraphQLTestCase(GraphQLTestCase):
         )
 
         query = """
-            query GetDocument($id: String!) {
+            query GetDocument($id: ID!) {
                 document(id: $id) {
                     id
                     title

--- a/opencontractserver/tests/permissioning/test_permissioned_querysets.py
+++ b/opencontractserver/tests/permissioning/test_permissioned_querysets.py
@@ -151,7 +151,7 @@ class ComprehensivePermissionTestCase(TestCase):
 
     def test_nested_annotation_visibility(self):
         query = """
-        query($id: String!) {
+        query($id: ID!) {
           document(id: $id) {
             docAnnotations {
               edges {

--- a/opencontractserver/tests/test_document_queries.py
+++ b/opencontractserver/tests/test_document_queries.py
@@ -55,7 +55,7 @@ class DocumentQueryTestCase(TestCase):
         """Ensure summaryContent, currentSummaryVersion and summaryRevisions work as expected."""
 
         query = """
-            query GetDocumentSummary($docId: String, $corpusId: ID!) {
+            query GetDocumentSummary($docId: ID, $corpusId: ID!) {
               document(id: $docId) {
                 id
                 summaryContent(corpusId: $corpusId)
@@ -99,7 +99,7 @@ class DocumentQueryTestCase(TestCase):
         unsummarised_doc_gid = to_global_id("DocumentType", unsummarised_doc.id)
 
         query = """
-            query GetDocumentSummary($docId: String, $corpusId: ID!) {
+            query GetDocumentSummary($docId: ID, $corpusId: ID!) {
               document(id: $docId) {
                 id
                 summaryContent(corpusId: $corpusId)

--- a/opencontractserver/tests/test_security_hardening.py
+++ b/opencontractserver/tests/test_security_hardening.py
@@ -686,7 +686,7 @@ class TestDocumentSummaryResolverPermissions(TestCase):
     def test_outsider_cannot_read_summary_version_for_inaccessible_corpus(self):
         """Outsider gets version=0 for a corpus they cannot see."""
         query = """
-            query DocSummaryVersion($id: String!, $corpusId: ID!) {
+            query DocSummaryVersion($id: ID!, $corpusId: ID!) {
                 document(id: $id) {
                     currentSummaryVersion(corpusId: $corpusId)
                 }
@@ -708,7 +708,7 @@ class TestDocumentSummaryResolverPermissions(TestCase):
     def test_outsider_cannot_read_summary_content_for_inaccessible_corpus(self):
         """Outsider gets empty string for summary content in inaccessible corpus."""
         query = """
-            query DocSummaryContent($id: String!, $corpusId: ID!) {
+            query DocSummaryContent($id: ID!, $corpusId: ID!) {
                 document(id: $id) {
                     summaryContent(corpusId: $corpusId)
                 }
@@ -728,7 +728,7 @@ class TestDocumentSummaryResolverPermissions(TestCase):
     def test_owner_can_read_summary_version(self):
         """Owner can read summary version for their own corpus."""
         query = """
-            query DocSummaryVersion($id: String!, $corpusId: ID!) {
+            query DocSummaryVersion($id: ID!, $corpusId: ID!) {
                 document(id: $id) {
                     currentSummaryVersion(corpusId: $corpusId)
                 }

--- a/opencontractserver/tests/test_structural_annotations_graphql_backwards_compat.py
+++ b/opencontractserver/tests/test_structural_annotations_graphql_backwards_compat.py
@@ -215,7 +215,7 @@ class StructuralAnnotationGraphQLBackwardsCompatibilityTests(TransactionTestCase
         doc_global_id = to_global_id("DocumentType", self.doc.id)
 
         query = """
-            query GetDocStructuralAnnotations($id: String!) {
+            query GetDocStructuralAnnotations($id: ID!) {
                 document(id: $id) {
                     id
                     title
@@ -327,7 +327,7 @@ class StructuralAnnotationGraphQLBackwardsCompatibilityTests(TransactionTestCase
         doc_global_id = to_global_id("DocumentType", self.doc.id)
 
         pre_migration_query = """
-            query GetDocStructuralAnnotations($id: String!) {
+            query GetDocStructuralAnnotations($id: ID!) {
                 document(id: $id) {
                     allStructuralAnnotations {
                         id
@@ -603,7 +603,7 @@ class StructuralAnnotationGraphQLBackwardsCompatibilityTests(TransactionTestCase
         doc2_global_id = to_global_id("DocumentType", doc2.id)
 
         query = """
-            query GetDocStructuralAnnotations($id: String!) {
+            query GetDocStructuralAnnotations($id: ID!) {
                 document(id: $id) {
                     id
                     title
@@ -654,7 +654,7 @@ class StructuralAnnotationGraphQLBackwardsCompatibilityTests(TransactionTestCase
         corpus_global_id = to_global_id("CorpusType", self.corpus.id)
 
         query = """
-            query GetDocAnnotations($id: String!, $corpusId: ID!) {
+            query GetDocAnnotations($id: ID!, $corpusId: ID!) {
                 document(id: $id) {
                     allAnnotations(corpusId: $corpusId, isStructural: true) {
                         id
@@ -720,7 +720,7 @@ class StructuralAnnotationGraphQLBackwardsCompatibilityTests(TransactionTestCase
         doc_global_id = to_global_id("DocumentType", empty_doc.id)
 
         query = """
-            query GetDocStructuralAnnotations($id: String!) {
+            query GetDocStructuralAnnotations($id: ID!) {
                 document(id: $id) {
                     allStructuralAnnotations {
                         rawText


### PR DESCRIPTION
## Summary
Fixed progressive misalignment between token bounding boxes and rendered PDF text in the document viewer. The issue occurred because PAWLs token coordinates are extracted by the parser in its own coordinate system, which can differ from PDF.js's viewport coordinate system.

## Changes
- **Added `normalizeTokensToPdfViewport()` utility function** in `frontend/src/utils/transform.tsx`:
  - Compares PAWLs page dimensions against PDF.js viewport dimensions at scale 1
  - Rescales token coordinates (x, y, width, height) when dimensions differ by more than 0.5 points
  - Returns original token array unchanged when no rescaling is needed (optimization)
  - Preserves all token properties including image-specific fields during rescaling

- **Applied normalization in both PDF loading paths** in `DocumentKnowledgeBase.tsx`:
  - Integrated `normalizeTokensToPdfViewport()` when processing page data
  - Retrieves viewport dimensions from PDF.js at scale 1 for accurate comparison
  - Added explanatory comments for maintainability

- **Added comprehensive test suite** (`frontend/src/utils/__tests__/transform.normalizeTokens.test.ts`):
  - Tests dimension matching within epsilon tolerance
  - Tests rescaling with different viewport dimensions
  - Tests preservation of image token fields
  - Tests edge cases (empty token arrays)

## Implementation Details
- Uses an epsilon tolerance of 0.5 PDF points to avoid unnecessary rescaling for minor dimension differences
- Applies independent scale factors for X and Y axes to handle non-uniform scaling
- Maintains backward compatibility by returning the original array reference when no rescaling is needed

https://claude.ai/code/session_015A6AjzcvLpNAZ1KNuVyhtq