### PR TITLE
Enhance social media previews with structured data and better descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,17 @@ All notable changes to OpenContracts will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2026-03-09
+## [Unreleased] - 2026-03-11
 
 ### Added
 
+- **Richer social media link previews for corpus and document links**: Improved the Cloudflare OG worker to generate better social tags. Changes include:
+  - Corpus descriptions are now included in OG/Twitter description tags, combined with document count (e.g. "Corpus description — 15 documents")
+  - Document-in-corpus links now surface the parent corpus description when the document lacks its own description
+  - Added Twitter structured data tags (`twitter:label1`/`twitter:data1`, `twitter:label2`/`twitter:data2`) showing author, document count, corpus name, etc.
+  - New `corpus_description` field on `OGDocumentMetadataType` GraphQL type (`config/graphql/og_metadata_types.py`)
+  - Backend resolver returns corpus description for document-in-corpus queries (`config/graphql/og_metadata_queries.py`)
+  - Fixed pre-existing TypeScript type errors in worker test suite and metadata extraction
 - **Creative Commons license support for corpuses**: Corpuses can now have a license applied, choosing from standard Creative Commons licenses (CC BY, CC BY-SA, CC BY-NC, CC BY-NC-SA, CC BY-ND, CC BY-NC-ND, CC0) or a custom license with a URL. Changes include:
   - New `license` (CharField with SPDX identifiers) and `license_link` (URLField) fields on the Corpus model (`opencontractserver/corpuses/models.py`)
   - License constants in `opencontractserver/constants/licenses.py` and `frontend/src/assets/configurations/constants.ts`

--- a/cloudflare-og-worker/src/html.test.ts
+++ b/cloudflare-og-worker/src/html.test.ts
@@ -20,6 +20,8 @@ describe("generateOGHtml", () => {
     type: "corpus",
     title: "Test Corpus",
     description: "A test description",
+    image: null,
+    entityName: "Test Corpus",
     creatorName: "TestUser",
   };
 
@@ -175,12 +177,88 @@ describe("generateGenericOGHtml", () => {
   });
 });
 
+describe("Twitter labeled data", () => {
+  it("renders twitter:label1 and twitter:data1 tags", () => {
+    const metadata: OGMetadata = {
+      type: "corpus",
+      title: "Test",
+      description: "Test",
+      image: null,
+      entityName: "Test",
+      creatorName: "User",
+      labeledData: [
+        { label: "Documents", value: "15 documents" },
+        { label: "Author", value: "TestUser" },
+      ],
+    };
+    const html = generateOGHtml(metadata, "https://example.com", mockEnv);
+
+    expect(html).toContain('twitter:label1" content="Documents"');
+    expect(html).toContain('twitter:data1" content="15 documents"');
+    expect(html).toContain('twitter:label2" content="Author"');
+    expect(html).toContain('twitter:data2" content="TestUser"');
+  });
+
+  it("limits labeled data to 2 pairs", () => {
+    const metadata: OGMetadata = {
+      type: "corpus",
+      title: "Test",
+      description: "Test",
+      image: null,
+      entityName: "Test",
+      creatorName: "User",
+      labeledData: [
+        { label: "One", value: "1" },
+        { label: "Two", value: "2" },
+        { label: "Three", value: "3" },
+      ],
+    };
+    const html = generateOGHtml(metadata, "https://example.com", mockEnv);
+
+    expect(html).toContain("twitter:label1");
+    expect(html).toContain("twitter:label2");
+    expect(html).not.toContain("twitter:label3");
+  });
+
+  it("omits labeled data tags when not provided", () => {
+    const metadata: OGMetadata = {
+      type: "corpus",
+      title: "Test",
+      description: "Test",
+      image: null,
+      entityName: "Test",
+      creatorName: "User",
+    };
+    const html = generateOGHtml(metadata, "https://example.com", mockEnv);
+
+    expect(html).not.toContain("twitter:label1");
+  });
+
+  it("escapes HTML in labeled data values", () => {
+    const metadata: OGMetadata = {
+      type: "corpus",
+      title: "Test",
+      description: "Test",
+      image: null,
+      entityName: "Test",
+      creatorName: "User",
+      labeledData: [{ label: "Test<br>", value: "Val&ue" }],
+    };
+    const html = generateOGHtml(metadata, "https://example.com", mockEnv);
+
+    expect(html).toContain("&lt;br&gt;");
+    expect(html).toContain("&amp;");
+  });
+});
+
 describe("XSS prevention", () => {
   it("prevents script injection via title", () => {
     const metadata: OGMetadata = {
       type: "corpus",
       title: '"><script>alert(1)</script><meta name="',
       description: "Test",
+      image: null,
+      entityName: "Test",
       creatorName: "User",
     };
     const html = generateOGHtml(metadata, "https://example.com", mockEnv);
@@ -193,6 +271,8 @@ describe("XSS prevention", () => {
       type: "corpus",
       title: '" onload="alert(1)',
       description: "Test",
+      image: null,
+      entityName: "Test",
       creatorName: "User",
     };
     const html = generateOGHtml(metadata, "https://example.com", mockEnv);
@@ -206,6 +286,8 @@ describe("XSS prevention", () => {
         type: "corpus",
         title: "Test",
         description: "Test",
+        image: null,
+        entityName: "Test",
         creatorName: "User",
       },
       'javascript:alert("XSS")',
@@ -222,6 +304,8 @@ describe("XSS prevention", () => {
       type: "corpus",
       title: "Test's Title",
       description: "Test",
+      image: null,
+      entityName: "Test",
       creatorName: "User",
     };
     const html = generateOGHtml(metadata, "https://example.com", mockEnv);
@@ -234,6 +318,8 @@ describe("XSS prevention", () => {
       type: "corpus",
       title: "Test & Title",
       description: "Test",
+      image: null,
+      entityName: "Test",
       creatorName: "User",
     };
     const html = generateOGHtml(metadata, "https://example.com", mockEnv);

--- a/cloudflare-og-worker/src/html.ts
+++ b/cloudflare-og-worker/src/html.ts
@@ -5,7 +5,7 @@
  * for social media link previews.
  */
 
-import type { Env, OGMetadata } from "./types";
+import type { Env, OGMetadata, LabeledData } from "./types";
 import { getEntityTypeLabel } from "./parser";
 
 /**
@@ -26,6 +26,23 @@ function escapeHtml(str: string): string {
 function truncate(str: string, maxLength: number): string {
   if (str.length <= maxLength) return str;
   return str.slice(0, maxLength - 3) + "...";
+}
+
+/**
+ * Generate Twitter labeled data meta tags (up to 2 pairs supported by Twitter)
+ */
+function buildTwitterLabelTags(labeledData?: LabeledData[]): string {
+  if (!labeledData || labeledData.length === 0) return "";
+
+  // Twitter supports at most label1/data1 and label2/data2
+  return labeledData
+    .slice(0, 2)
+    .map(
+      (item, i) =>
+        `  <meta name="twitter:label${i + 1}" content="${escapeHtml(item.label)}">\n` +
+        `  <meta name="twitter:data${i + 1}" content="${escapeHtml(item.value)}">`
+    )
+    .join("\n");
 }
 
 /**
@@ -76,6 +93,7 @@ export function generateOGHtml(
   <meta name="twitter:description" content="${description}">
   <meta name="twitter:image" content="${escapeHtml(image)}">
   <meta name="twitter:image:alt" content="${fullTitle}">
+${buildTwitterLabelTags(metadata.labeledData)}
 
   <!-- Additional SEO -->
   <meta name="description" content="${description}">

--- a/cloudflare-og-worker/src/metadata.ts
+++ b/cloudflare-og-worker/src/metadata.ts
@@ -10,6 +10,7 @@ import type {
   EntityType,
   ParsedRoute,
   OGMetadata,
+  LabeledData,
   GraphQLResponse,
   OGCorpusData,
   OGDocumentData,
@@ -58,6 +59,7 @@ const QUERIES: Record<EntityType, string> = {
         description
         iconUrl
         corpusTitle
+        corpusDescription
         creatorName
         isPublic
       }
@@ -154,11 +156,64 @@ export async function fetchOGMetadata(
 }
 
 /**
+ * Build a pluralized document count string (e.g. "1 document", "5 documents")
+ */
+function formatDocCount(count: number): string {
+  return `${count} document${count !== 1 ? "s" : ""}`;
+}
+
+/**
+ * Compose a corpus description that leads with the user-provided description
+ * and appends the document count for additional context.
+ */
+function composeCorpusDescription(
+  userDescription: string | undefined | null,
+  documentCount: number
+): string {
+  const docCountStr = formatDocCount(documentCount);
+  const desc = userDescription?.trim();
+  if (desc) {
+    return `${desc} \u2014 ${docCountStr}`;
+  }
+  return `A corpus with ${docCountStr}`;
+}
+
+/**
+ * Compose a document-in-corpus description that provides corpus context
+ * when the document itself lacks a description.
+ */
+function composeDocInCorpusDescription(
+  docDescription: string | undefined | null,
+  corpusTitle: string | undefined | null,
+  corpusDescription: string | undefined | null
+): string {
+  const docDesc = docDescription?.trim();
+  const corpusDesc = corpusDescription?.trim();
+
+  if (docDesc) {
+    // Document has its own description; append corpus context
+    if (corpusTitle) {
+      return `${docDesc} \u2014 from ${corpusTitle}`;
+    }
+    return docDesc;
+  }
+
+  // No document description — use corpus context
+  if (corpusTitle && corpusDesc) {
+    return `From ${corpusTitle}: ${corpusDesc}`;
+  }
+  if (corpusTitle) {
+    return `Document in ${corpusTitle}`;
+  }
+  return "Document on OpenContracts";
+}
+
+/**
  * Extract and normalize metadata from GraphQL response
  */
 function extractMetadata(
   type: EntityType,
-  data: Record<string, unknown>,
+  data: unknown,
   env: Env
 ): OGMetadata | null {
   switch (type) {
@@ -166,22 +221,36 @@ function extractMetadata(
       const corpus = (data as OGCorpusData).ogCorpusMetadata;
       if (!corpus || !corpus.isPublic) return null;
 
+      const labeledData: LabeledData[] = [
+        { label: "Documents", value: formatDocCount(corpus.documentCount) },
+        { label: "Author", value: corpus.creatorName },
+      ];
+
       return {
         title: corpus.title,
-        description:
-          corpus.description ||
-          `A corpus with ${corpus.documentCount} documents`,
+        description: composeCorpusDescription(
+          corpus.description,
+          corpus.documentCount
+        ),
         image: corpus.iconUrl || `${env.OG_IMAGE_BASE}/corpus-og.png`,
         type,
         entityName: corpus.title,
         creatorName: corpus.creatorName,
         documentCount: corpus.documentCount,
+        labeledData,
       };
     }
 
     case "document": {
       const doc = (data as OGDocumentData).ogDocumentMetadata;
       if (!doc || !doc.isPublic) return null;
+
+      const labeledData: LabeledData[] = [
+        { label: "Author", value: doc.creatorName },
+      ];
+      if (doc.corpusTitle) {
+        labeledData.unshift({ label: "Corpus", value: doc.corpusTitle });
+      }
 
       return {
         title: doc.title,
@@ -191,6 +260,7 @@ function extractMetadata(
         entityName: doc.title,
         creatorName: doc.creatorName,
         corpusTitle: doc.corpusTitle || undefined,
+        labeledData,
       };
     }
 
@@ -201,18 +271,26 @@ function extractMetadata(
       ).ogDocumentInCorpusMetadata;
       if (!doc || !doc.isPublic) return null;
 
+      const labeledData: LabeledData[] = [
+        { label: "Author", value: doc.creatorName },
+      ];
+      if (doc.corpusTitle) {
+        labeledData.unshift({ label: "Corpus", value: doc.corpusTitle });
+      }
+
       return {
         title: doc.title,
-        description:
-          doc.description ||
-          (doc.corpusTitle
-            ? `Document in ${doc.corpusTitle}`
-            : "Document on OpenContracts"),
+        description: composeDocInCorpusDescription(
+          doc.description,
+          doc.corpusTitle,
+          doc.corpusDescription
+        ),
         image: doc.iconUrl || `${env.OG_IMAGE_BASE}/document-og.png`,
         type,
         entityName: doc.title,
         creatorName: doc.creatorName,
         corpusTitle: doc.corpusTitle || undefined,
+        labeledData,
       };
     }
 
@@ -220,20 +298,32 @@ function extractMetadata(
       const thread = (data as OGThreadData).ogThreadMetadata;
       if (!thread || !thread.isPublic) return null;
 
+      const messageStr = `${thread.messageCount} message${thread.messageCount !== 1 ? "s" : ""}`;
+      const labeledData: LabeledData[] = [
+        { label: "Corpus", value: thread.corpusTitle },
+        { label: "Messages", value: messageStr },
+      ];
+
       return {
         title: thread.title || "Discussion",
-        description: `Discussion in ${thread.corpusTitle} with ${thread.messageCount} messages`,
+        description: `Discussion in ${thread.corpusTitle} \u2014 ${messageStr}`,
         image: `${env.OG_IMAGE_BASE}/discussion-og.png`,
         type,
         entityName: thread.title || "Discussion",
         creatorName: thread.creatorName,
         corpusTitle: thread.corpusTitle,
+        labeledData,
       };
     }
 
     case "extract": {
       const extract = (data as OGExtractData).ogExtractMetadata;
       if (!extract || !extract.isPublic) return null;
+
+      const labeledData: LabeledData[] = [
+        { label: "Fieldset", value: extract.fieldsetName },
+        { label: "Corpus", value: extract.corpusTitle },
+      ];
 
       return {
         title: extract.name,
@@ -243,6 +333,7 @@ function extractMetadata(
         entityName: extract.name,
         creatorName: extract.creatorName,
         corpusTitle: extract.corpusTitle,
+        labeledData,
       };
     }
 

--- a/cloudflare-og-worker/src/types.ts
+++ b/cloudflare-og-worker/src/types.ts
@@ -37,6 +37,14 @@ export interface ParsedRoute {
 }
 
 /**
+ * Labeled data pair for Twitter structured card previews
+ */
+export interface LabeledData {
+  label: string;
+  value: string;
+}
+
+/**
  * Open Graph metadata for social media previews
  */
 export interface OGMetadata {
@@ -48,6 +56,8 @@ export interface OGMetadata {
   creatorName: string;
   documentCount?: number;
   corpusTitle?: string;
+  /** Structured key-value pairs for Twitter summary cards */
+  labeledData?: LabeledData[];
 }
 
 /**
@@ -85,6 +95,7 @@ export interface OGDocumentData {
     description: string;
     iconUrl: string | null;
     corpusTitle: string | null;
+    corpusDescription: string | null;
     creatorName: string;
     isPublic: boolean;
   } | null;

--- a/config/graphql/og_metadata_queries.py
+++ b/config/graphql/og_metadata_queries.py
@@ -129,6 +129,7 @@ class OGMetadataQueryMixin:
                 description=document.description or "",
                 icon_url=icon_url,
                 corpus_title=None,
+                corpus_description=None,
                 creator_name=document.creator.username,
                 is_public=True,
             )
@@ -168,6 +169,7 @@ class OGMetadataQueryMixin:
                 description=document.description or "",
                 icon_url=icon_url,
                 corpus_title=corpus.title,
+                corpus_description=corpus.description or "",
                 creator_name=document.creator.username,
                 is_public=True,
             )

--- a/config/graphql/og_metadata_types.py
+++ b/config/graphql/og_metadata_types.py
@@ -33,6 +33,9 @@ class OGDocumentMetadataType(graphene.ObjectType):
     corpus_title = graphene.String(
         description="Title of parent corpus (if document is in a corpus)"
     )
+    corpus_description = graphene.String(
+        description="Description of parent corpus (if document is in a corpus)"
+    )
     creator_name = graphene.String(description="Username of document creator")
     is_public = graphene.Boolean(description="Always True for returned entities")
 

--- a/opencontractserver/tests/test_og_metadata_queries.py
+++ b/opencontractserver/tests/test_og_metadata_queries.py
@@ -269,6 +269,7 @@ class OGDocumentInCorpusMetadataTestCase(TestCase):
         # Public corpus with public document
         cls.public_corpus = Corpus.objects.create(
             title="Public Corpus",
+            description="Corpus for analyzing legal contracts",
             creator=cls.user,
             is_public=True,
         )
@@ -309,7 +310,8 @@ class OGDocumentInCorpusMetadataTestCase(TestCase):
         self.client = Client(schema, context_value=self.request)
 
     def test_public_doc_in_public_corpus_returns_metadata(self):
-        """Test that public doc in public corpus returns metadata."""
+        """Test that public doc in public corpus returns metadata
+        including corpus description for social tag context."""
         query = """
             query GetOGDocInCorpus(
                 $userSlug: String!,
@@ -324,6 +326,7 @@ class OGDocumentInCorpusMetadataTestCase(TestCase):
                     title
                     description
                     corpusTitle
+                    corpusDescription
                     creatorName
                     isPublic
                 }
@@ -343,6 +346,9 @@ class OGDocumentInCorpusMetadataTestCase(TestCase):
         self.assertIsNotNone(data)
         self.assertEqual(data["title"], "Public Doc in Corpus")
         self.assertEqual(data["corpusTitle"], "Public Corpus")
+        self.assertEqual(
+            data["corpusDescription"], "Corpus for analyzing legal contracts"
+        )
         self.assertEqual(data["creatorName"], "og_doc_corpus_user")
 
     def test_private_doc_in_public_corpus_returns_none(self):


### PR DESCRIPTION
## Summary
Improved Open Graph and Twitter card previews for corpus and document links by adding structured labeled data tags and composing richer descriptions that include contextual information like document counts and parent corpus details.

## Key Changes

**Metadata Extraction & Description Composition**
- Added helper functions to compose contextual descriptions:
  - `formatDocCount()`: Pluralizes document counts (e.g., "1 document", "5 documents")
  - `composeCorpusDescription()`: Combines user-provided corpus description with document count
  - `composeDocInCorpusDescription()`: Surfaces corpus context when documents lack their own descriptions
- Updated `extractMetadata()` to build `labeledData` arrays for each entity type with relevant key-value pairs (Author, Documents, Corpus, Messages, Fieldset)

**Twitter Structured Data Support**
- Added `LabeledData` interface for key-value pairs
- Implemented `buildTwitterLabelTags()` to generate Twitter meta tags (`twitter:label1`/`twitter:data1`, `twitter:label2`/`twitter:data2`)
- Twitter supports maximum 2 label/data pairs; implementation respects this limit
- Properly escapes HTML in labeled data values to prevent XSS

**GraphQL & Backend Updates**
- Added `corpus_description` field to `OGDocumentMetadataType` GraphQL type
- Updated `og_document_in_corpus` resolver to fetch and return parent corpus description
- Updated test data and assertions to verify corpus description is properly returned

**Type Safety & Testing**
- Fixed pre-existing TypeScript type inconsistencies in test suite (added missing `image` and `entityName` fields to test metadata objects)
- Added comprehensive test coverage for Twitter labeled data rendering, including:
  - Correct tag generation for multiple label/data pairs
  - Enforcement of 2-pair limit
  - HTML escaping in values
  - Graceful handling when labeled data is not provided

## Notable Implementation Details
- Uses em-dash (`\u2014`) as separator in descriptions for better visual presentation
- Corpus descriptions intelligently fall back to generic text ("A corpus with X documents") when user-provided description is absent
- Document-in-corpus descriptions prioritize document's own description, appending corpus context only when needed
- All description composition is centralized in dedicated functions for maintainability

https://claude.ai/code/session_011HHzrxYtALTCPStKfJPFdU