### PR TITLE
Add corpusVersions field to Apollo cache configuration

### DIFF
--- a/frontend/src/graphql/cache.ts
+++ b/frontend/src/graphql/cache.ts
@@ -102,6 +102,11 @@ export const cache = new InMemoryCache({
           keyArgs: ["corpusId"],
           merge: false,
         },
+        // Corpus-specific version list for version selector UI
+        corpusVersions: {
+          keyArgs: ["corpusId"],
+          merge: false,
+        },
         // Version metadata fields with corpus context
         versionNumber: {
           keyArgs: ["corpusId"],


### PR DESCRIPTION
## Summary
Added a new `corpusVersions` field to the Apollo InMemoryCache field policy configuration to support corpus-specific version list caching for the version selector UI.

## Key Changes
- Added `corpusVersions` field policy with `corpusId` as the key argument
- Set `merge: false` to prevent automatic merging of cached data, ensuring fresh version lists per corpus
- Positioned alongside related corpus and version metadata field policies for logical organization

## Implementation Details
The new field policy follows the same pattern as the existing `pathHistory` field policy above it, using `corpusId` as the cache key to maintain separate version lists for different corpora. The `merge: false` setting ensures that version list updates are treated as replacements rather than merges, which is appropriate for maintaining accurate version selector state.