### PR TITLE
Fix tool naming and async note ordering issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to OpenContracts will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2026-03-18
+## [Unreleased]
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to OpenContracts will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2026-03-15
+## [Unreleased] - 2026-03-18
+
+### Fixed
+
+- **Undefined ordering in async note retrieval** (Closes #1107): Added missing `.order_by("created")` to `aget_notes_for_document_corpus` in `opencontractserver/llms/tools/core_tools.py`, matching the sync counterpart `get_notes_for_document_corpus` which already had deterministic ordering.
+- **Tool name breaking change from async migration** (Closes #1107): `create_document_tools()` in `opencontractserver/llms/tools/tool_factory.py` derived tool names from `func.__name__`, causing names to silently change from e.g. `load_document_md_summary` to `aload_document_md_summary` when the registry switched to async functions. Added explicit `name=` parameters to all `CoreTool.from_function()` calls to preserve the original tool names.
+- **Test username typo**: Fixed "toklenuser" → "tokenuser" in `opencontractserver/tests/test_agent_search_tools.py`.
 
 ### Breaking Changes
 

--- a/opencontractserver/llms/tools/core_tools.py
+++ b/opencontractserver/llms/tools/core_tools.py
@@ -377,7 +377,7 @@ async def aget_notes_for_document_corpus(
         queryset = queryset.filter(corpus_id=corpus_id)
 
     notes = []
-    async for note in queryset:
+    async for note in queryset.order_by("created"):
         notes.append(
             {
                 "id": note.id,

--- a/opencontractserver/llms/tools/tool_factory.py
+++ b/opencontractserver/llms/tools/tool_factory.py
@@ -349,6 +349,7 @@ def create_document_tools() -> list[CoreTool]:
     return [
         CoreTool.from_function(
             asearch_exact_text_as_sources,
+            name="search_exact_text_as_sources",
             description=(
                 "Search for exact text matches in a "
                 "document and return them as source nodes with page numbers and bounding boxes."
@@ -356,26 +357,32 @@ def create_document_tools() -> list[CoreTool]:
         ),
         CoreTool.from_function(
             aload_document_md_summary,
+            name="load_document_md_summary",
             description="Load markdown summary of a document, optionally truncated.",
         ),
         CoreTool.from_function(
             aget_md_summary_token_length,
+            name="get_md_summary_token_length",
             description="Get the token length of a document's markdown summary.",
         ),
         CoreTool.from_function(
             aget_notes_for_document_corpus,
+            name="get_notes_for_document_corpus",
             description="Get notes associated with a document and optional corpus.",
         ),
         CoreTool.from_function(
             aget_note_content_token_length,
+            name="get_note_content_token_length",
             description="Get the token length of a note's content.",
         ),
         CoreTool.from_function(
             aget_partial_note_content,
+            name="get_partial_note_content",
             description="Get a substring of a note's content by start/end indices.",
         ),
         CoreTool.from_function(
             aget_page_image,
+            name="get_page_image",
             description=(
                 "Get a visual image of a specific page from a PDF document. "
                 "Useful for inspecting diagrams, tables, images, and other "
@@ -385,6 +392,7 @@ def create_document_tools() -> list[CoreTool]:
         # Image tools for accessing embedded/extracted images
         CoreTool.from_function(
             alist_document_images,
+            name="list_document_images",
             description=(
                 "List all images in a document. Returns metadata (position, size, format) "
                 "without the actual image data. Use get_document_image to retrieve specific images."
@@ -392,6 +400,7 @@ def create_document_tools() -> list[CoreTool]:
         ),
         CoreTool.from_function(
             aget_document_image,
+            name="get_document_image",
             description=(
                 "Get image data (base64) for a specific image in a document. "
                 "Returns data URL suitable for LLM vision input. Use list_document_images first "
@@ -400,6 +409,7 @@ def create_document_tools() -> list[CoreTool]:
         ),
         CoreTool.from_function(
             aget_annotation_images,
+            name="get_annotation_images",
             description=(
                 "Get all images referenced by an annotation. Use for figure, chart, or image "
                 "annotations that have embedded or referenced images in their bounds."

--- a/opencontractserver/tests/test_agent_search_tools.py
+++ b/opencontractserver/tests/test_agent_search_tools.py
@@ -472,7 +472,7 @@ class TestCoreTools(TestCase):
 
     async def test_aget_note_content_token_length(self):
         """Test async note content token length calculation."""
-        user = await User.objects.acreate(username="toklenuser", password="pass")
+        user = await User.objects.acreate(username="tokenuser", password="pass")
         doc = await Document.objects.acreate(
             title="Doc for token len",
             creator=user,

--- a/opencontractserver/tests/test_core_tool_factory.py
+++ b/opencontractserver/tests/test_core_tool_factory.py
@@ -157,17 +157,17 @@ class TestCreateDocumentTools(SimpleTestCase):
     def test_create_document_tools_names(self):
         tools = create_document_tools()
         expected_names = {
-            "asearch_exact_text_as_sources",
-            "aload_document_md_summary",
-            "aget_md_summary_token_length",
-            "aget_notes_for_document_corpus",
-            "aget_note_content_token_length",
-            "aget_partial_note_content",
-            "aget_page_image",
+            "search_exact_text_as_sources",
+            "load_document_md_summary",
+            "get_md_summary_token_length",
+            "get_notes_for_document_corpus",
+            "get_note_content_token_length",
+            "get_partial_note_content",
+            "get_page_image",
             # Image tools for multimodal support
-            "alist_document_images",
-            "aget_document_image",
-            "aget_annotation_images",
+            "list_document_images",
+            "get_document_image",
+            "get_annotation_images",
         }
         self.assertEqual({tool.name for tool in tools}, expected_names)
         # Ensure all returned objects are CoreTool instances


### PR DESCRIPTION
## Summary

This PR fixes three issues related to the async migration of LLM tools and test data:

1. **Tool name preservation**: Explicit `name=` parameters added to all `CoreTool.from_function()` calls to prevent tool names from silently changing when the registry switched from sync to async functions (e.g., `load_document_md_summary` was becoming `aload_document_md_summary`).

2. **Deterministic note ordering**: Added missing `.order_by("created")` to the async `aget_notes_for_document_corpus` function to match the deterministic ordering of its sync counterpart.

3. **Test data fix**: Corrected username typo in test fixture from "toklenuser" to "tokenuser".

## Key Changes

- **opencontractserver/llms/tools/tool_factory.py**: Added explicit `name=` parameters to 11 `CoreTool.from_function()` calls in `create_document_tools()`:
  - `search_exact_text_as_sources`
  - `load_document_md_summary`
  - `get_md_summary_token_length`
  - `get_notes_for_document_corpus`
  - `get_note_content_token_length`
  - `get_partial_note_content`
  - `get_page_image`
  - `list_document_images`
  - `get_document_image`
  - `get_annotation_images`

- **opencontractserver/llms/tools/core_tools.py**: Added `.order_by("created")` to the async queryset in `aget_notes_for_document_corpus` to ensure deterministic ordering.

- **opencontractserver/tests/test_agent_search_tools.py**: Fixed username typo in `test_aget_note_content_token_length` test.

## Implementation Details

The tool naming issue arose because `CoreTool.from_function()` derives tool names from the function's `__name__` attribute when no explicit name is provided. When the registry migrated from sync functions (e.g., `load_document_md_summary`) to async equivalents (e.g., `aload_document_md_summary`), the tool names changed silently, breaking any external integrations or configurations that referenced the original names. By explicitly specifying the `name=` parameter, we preserve backward compatibility while using the async implementations internally.

Closes #1107

https://claude.ai/code/session_01XF6phmMNu6K7w1qWBPmkcK