### PR TITLE
Tighten MCP telemetry input validation and test coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,16 @@ All notable changes to OpenContracts will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2026-03-15
+## [Unreleased] - 2026-03-18
+
+### Fixed
+
+- **Tighten MCP telemetry input validation and test coverage** (Closes #1106):
+  - Bound User-Agent storage to 512 characters (`MAX_USER_AGENT_LENGTH`) in both `set_request_context()` and `get_user_agent_from_scope()` to prevent attacker-controlled multi-megabyte values from reaching telemetry backends (`opencontractserver/mcp/telemetry.py`)
+  - Empty-string slugs no longer reach telemetry — changed `if slug is not None` to falsy checks (`if slug`) consistently across all sync and async recording functions
+  - Documented the duplicate-header-dropping assumption when converting ASGI header lists to dicts in `get_user_agent_from_scope()` and `get_claimed_client_ip_from_scope()`
+  - Added async telemetry tests for `arecord_mcp_tool_call`, `arecord_mcp_resource_read`, and `arecord_mcp_request` (`opencontractserver/tests/test_mcp_extended.py`)
+  - Added tests for User-Agent truncation and empty-string slug filtering
 
 ### Breaking Changes
 

--- a/opencontractserver/mcp/telemetry.py
+++ b/opencontractserver/mcp/telemetry.py
@@ -27,6 +27,12 @@ logger = logging.getLogger(__name__)
 # Sufficient for unique client identification without storing full hash
 IP_HASH_LENGTH = 16
 
+# Maximum length for stored User-Agent strings.  The User-Agent header is
+# attacker-controlled input; without a cap a malicious client could send
+# multi-megabyte values that get stored in context dicts and forwarded to
+# telemetry backends.  512 characters is generous for any real-world UA.
+MAX_USER_AGENT_LENGTH = 512
+
 # Context variable to store request metadata (client IP, transport type)
 # This allows the telemetry functions to access request context without
 # needing to pass it through all function calls
@@ -51,11 +57,15 @@ def set_request_context(
         transport: The transport type (e.g., 'streamable_http', 'sse', 'stdio')
         user_agent: The User-Agent header value identifying the MCP client/agent
     """
+    # Truncate user_agent to prevent oversized attacker-controlled input from
+    # being stored in context dicts and forwarded to telemetry backends.
+    truncated_ua = user_agent[:MAX_USER_AGENT_LENGTH] if user_agent else None
+
     _mcp_request_context.set(
         {
             "client_ip_hash": _hash_ip(client_ip) if client_ip else None,
             "transport": transport,
-            "user_agent": user_agent,
+            "user_agent": truncated_ua,
         }
     )
 
@@ -155,9 +165,9 @@ def record_mcp_tool_call(
 
     if not success and error_type:
         properties["error_type"] = error_type
-    if corpus_slug is not None:
+    if corpus_slug:
         properties["corpus_slug"] = corpus_slug
-    if document_slug is not None:
+    if document_slug:
         properties["document_slug"] = document_slug
 
     return record_event("mcp_tool_call", properties)
@@ -189,9 +199,9 @@ def record_mcp_resource_read(
 
     if not success and error_type:
         properties["error_type"] = error_type
-    if corpus_slug is not None:
+    if corpus_slug:
         properties["corpus_slug"] = corpus_slug
-    if document_slug is not None:
+    if document_slug:
         properties["document_slug"] = document_slug
 
     return record_event("mcp_resource_read", properties)
@@ -249,9 +259,9 @@ async def arecord_mcp_tool_call(
 
     if not success and error_type:
         properties["error_type"] = error_type
-    if corpus_slug is not None:
+    if corpus_slug:
         properties["corpus_slug"] = corpus_slug
-    if document_slug is not None:
+    if document_slug:
         properties["document_slug"] = document_slug
 
     return await arecord_event("mcp_tool_call", properties)
@@ -276,9 +286,9 @@ async def arecord_mcp_resource_read(
 
     if not success and error_type:
         properties["error_type"] = error_type
-    if corpus_slug is not None:
+    if corpus_slug:
         properties["corpus_slug"] = corpus_slug
-    if document_slug is not None:
+    if document_slug:
         properties["document_slug"] = document_slug
 
     return await arecord_event("mcp_resource_read", properties)
@@ -313,12 +323,21 @@ def get_user_agent_from_scope(scope: dict[str, Any]) -> str | None:
     MCP clients and AI agents typically identify themselves via User-Agent
     (e.g., ``Claude-Code/1.0``, ``cursor/0.45``).
 
-    Returns ``None`` when no User-Agent is present.
+    Returns ``None`` when no User-Agent is present.  The result is truncated
+    to :data:`MAX_USER_AGENT_LENGTH` characters to bound attacker-controlled
+    input.
+
+    .. note::
+       Converting the ASGI header list to a ``dict`` means that if a client
+       sends duplicate ``user-agent`` headers only the last value is kept.
+       This is acceptable because RFC 9110 §5.5 specifies a single
+       User-Agent value, so duplicates indicate a misbehaving client.
     """
     headers = dict(scope.get("headers", []))
     ua = headers.get(b"user-agent")
     if ua:
-        return ua.decode("utf-8", errors="replace").strip()
+        value = ua.decode("utf-8", errors="replace").strip()
+        return value[:MAX_USER_AGENT_LENGTH] if value else None
     return None
 
 
@@ -332,6 +351,13 @@ def get_claimed_client_ip_from_scope(scope: dict[str, Any]) -> str | None:
     to identify the true origin, even if it could be spoofed.
 
     Returns ``None`` when no IP can be determined.
+
+    .. note::
+       Converting the ASGI header list to a ``dict`` drops duplicate header
+       values (only the last value for a given name is kept).  For the
+       headers inspected here (``x-forwarded-for``, ``x-real-ip``) this is
+       safe: proxies append to a single ``X-Forwarded-For`` value rather
+       than adding extra headers, and ``X-Real-IP`` is always singular.
     """
     headers = dict(scope.get("headers", []))
 

--- a/opencontractserver/tests/test_mcp_extended.py
+++ b/opencontractserver/tests/test_mcp_extended.py
@@ -38,8 +38,12 @@ from opencontractserver.mcp.permissions import validate_slug as perm_validate_sl
 from opencontractserver.mcp.server import TTLLRUCache, URIParser
 from opencontractserver.mcp.telemetry import (
     IP_HASH_LENGTH,
+    MAX_USER_AGENT_LENGTH,
     _get_request_context,
     _hash_ip,
+    arecord_mcp_request,
+    arecord_mcp_resource_read,
+    arecord_mcp_tool_call,
     clear_request_context,
     get_claimed_client_ip_from_scope,
     get_user_agent_from_scope,
@@ -311,6 +315,243 @@ class TestTelemetryRecording(TestCase):
             record_mcp_tool_call("test", success=True)
         props = mock_record.call_args[0][1]
         self.assertNotIn("user_agent", props)
+
+
+class TestAsyncTelemetryRecording(TestCase):
+    """Tests for async telemetry event recording functions."""
+
+    def tearDown(self):
+        clear_request_context()
+
+    def _run(self, coro):
+        return asyncio.run(coro)
+
+    @patch("opencontractserver.mcp.telemetry.arecord_event")
+    def test_arecord_mcp_tool_call_success(self, mock_arecord):
+        async def _test():
+            mock_arecord.return_value = True
+            with isolated_telemetry_context():
+                set_request_context(client_ip="1.2.3.4", transport="http")
+                return await arecord_mcp_tool_call("list_public_corpuses", success=True)
+
+        result = self._run(_test())
+        self.assertTrue(result)
+        mock_arecord.assert_called_once()
+        args = mock_arecord.call_args
+        self.assertEqual(args[0][0], "mcp_tool_call")
+        props = args[0][1]
+        self.assertEqual(props["tool_name"], "list_public_corpuses")
+        self.assertTrue(props["success"])
+        self.assertEqual(props["transport"], "http")
+        self.assertIn("client_ip_hash", props)
+
+    @patch("opencontractserver.mcp.telemetry.arecord_event")
+    def test_arecord_mcp_tool_call_with_slugs(self, mock_arecord):
+        async def _test():
+            mock_arecord.return_value = True
+            with isolated_telemetry_context():
+                return await arecord_mcp_tool_call(
+                    "list_documents",
+                    success=True,
+                    corpus_slug="my-corpus",
+                    document_slug="my-doc",
+                )
+
+        result = self._run(_test())
+        self.assertTrue(result)
+        props = mock_arecord.call_args[0][1]
+        self.assertEqual(props["corpus_slug"], "my-corpus")
+        self.assertEqual(props["document_slug"], "my-doc")
+
+    @patch("opencontractserver.mcp.telemetry.arecord_event")
+    def test_arecord_mcp_tool_call_failure(self, mock_arecord):
+        async def _test():
+            mock_arecord.return_value = True
+            with isolated_telemetry_context():
+                return await arecord_mcp_tool_call(
+                    "search_corpus", success=False, error_type="ValueError"
+                )
+
+        result = self._run(_test())
+        self.assertTrue(result)
+        props = mock_arecord.call_args[0][1]
+        self.assertFalse(props["success"])
+        self.assertEqual(props["error_type"], "ValueError")
+
+    @patch("opencontractserver.mcp.telemetry.arecord_event")
+    def test_arecord_mcp_resource_read_success(self, mock_arecord):
+        async def _test():
+            mock_arecord.return_value = True
+            with isolated_telemetry_context():
+                set_request_context(client_ip="1.2.3.4", transport="http")
+                return await arecord_mcp_resource_read("corpus", success=True)
+
+        result = self._run(_test())
+        self.assertTrue(result)
+        props = mock_arecord.call_args[0][1]
+        self.assertEqual(props["resource_type"], "corpus")
+        self.assertTrue(props["success"])
+
+    @patch("opencontractserver.mcp.telemetry.arecord_event")
+    def test_arecord_mcp_resource_read_with_slugs(self, mock_arecord):
+        async def _test():
+            mock_arecord.return_value = True
+            with isolated_telemetry_context():
+                return await arecord_mcp_resource_read(
+                    "document",
+                    success=True,
+                    corpus_slug="my-corpus",
+                    document_slug="my-doc",
+                )
+
+        result = self._run(_test())
+        self.assertTrue(result)
+        props = mock_arecord.call_args[0][1]
+        self.assertEqual(props["corpus_slug"], "my-corpus")
+        self.assertEqual(props["document_slug"], "my-doc")
+
+    @patch("opencontractserver.mcp.telemetry.arecord_event")
+    def test_arecord_mcp_resource_read_failure(self, mock_arecord):
+        async def _test():
+            mock_arecord.return_value = True
+            with isolated_telemetry_context():
+                return await arecord_mcp_resource_read(
+                    "corpus", success=False, error_type="PermissionError"
+                )
+
+        result = self._run(_test())
+        self.assertTrue(result)
+        props = mock_arecord.call_args[0][1]
+        self.assertFalse(props["success"])
+        self.assertEqual(props["error_type"], "PermissionError")
+
+    @patch("opencontractserver.mcp.telemetry.arecord_event")
+    def test_arecord_mcp_request_success(self, mock_arecord):
+        async def _test():
+            mock_arecord.return_value = True
+            with isolated_telemetry_context():
+                set_request_context(client_ip="1.2.3.4", transport="http")
+                return await arecord_mcp_request("/mcp", method="POST", success=True)
+
+        result = self._run(_test())
+        self.assertTrue(result)
+        props = mock_arecord.call_args[0][1]
+        self.assertEqual(props["endpoint"], "/mcp")
+        self.assertEqual(props["method"], "POST")
+        self.assertTrue(props["success"])
+
+    @patch("opencontractserver.mcp.telemetry.arecord_event")
+    def test_arecord_mcp_request_failure(self, mock_arecord):
+        async def _test():
+            mock_arecord.return_value = True
+            with isolated_telemetry_context():
+                return await arecord_mcp_request(
+                    "/mcp", success=False, error_type="TimeoutError"
+                )
+
+        result = self._run(_test())
+        self.assertTrue(result)
+        props = mock_arecord.call_args[0][1]
+        self.assertFalse(props["success"])
+        self.assertEqual(props["error_type"], "TimeoutError")
+
+    @patch("opencontractserver.mcp.telemetry.arecord_event")
+    def test_arecord_mcp_tool_call_user_agent_in_context(self, mock_arecord):
+        async def _test():
+            mock_arecord.return_value = True
+            with isolated_telemetry_context():
+                set_request_context(
+                    client_ip="1.2.3.4",
+                    transport="http",
+                    user_agent="Claude-Code/1.0",
+                )
+                return await arecord_mcp_tool_call("list_documents", success=True)
+
+        self._run(_test())
+        props = mock_arecord.call_args[0][1]
+        self.assertEqual(props["user_agent"], "Claude-Code/1.0")
+
+
+class TestUserAgentTruncation(TestCase):
+    """Tests for User-Agent length bounding."""
+
+    def tearDown(self):
+        clear_request_context()
+
+    def test_set_request_context_truncates_long_user_agent(self):
+        long_ua = "A" * (MAX_USER_AGENT_LENGTH + 500)
+        set_request_context(client_ip="1.2.3.4", transport="http", user_agent=long_ua)
+        ctx = _get_request_context()
+        self.assertEqual(len(ctx["user_agent"]), MAX_USER_AGENT_LENGTH)
+
+    def test_set_request_context_preserves_short_user_agent(self):
+        short_ua = "Claude-Code/1.0"
+        set_request_context(client_ip="1.2.3.4", transport="http", user_agent=short_ua)
+        ctx = _get_request_context()
+        self.assertEqual(ctx["user_agent"], short_ua)
+
+    def test_set_request_context_empty_string_user_agent(self):
+        set_request_context(client_ip="1.2.3.4", transport="http", user_agent="")
+        ctx = _get_request_context()
+        self.assertIsNone(ctx["user_agent"])
+
+    def test_get_user_agent_from_scope_truncates_long_value(self):
+        long_ua = ("B" * (MAX_USER_AGENT_LENGTH + 1000)).encode()
+        scope = {"headers": [(b"user-agent", long_ua)]}
+        result = get_user_agent_from_scope(scope)
+        self.assertEqual(len(result), MAX_USER_AGENT_LENGTH)
+
+    def test_get_user_agent_from_scope_preserves_short_value(self):
+        scope = {"headers": [(b"user-agent", b"cursor/0.45")]}
+        result = get_user_agent_from_scope(scope)
+        self.assertEqual(result, "cursor/0.45")
+
+
+class TestEmptySlugFiltering(TestCase):
+    """Tests that empty-string slugs are excluded from telemetry properties."""
+
+    def tearDown(self):
+        clear_request_context()
+
+    @patch("opencontractserver.mcp.telemetry.record_event")
+    def test_empty_corpus_slug_omitted(self, mock_record):
+        mock_record.return_value = True
+        with isolated_telemetry_context():
+            record_mcp_tool_call("test", success=True, corpus_slug="")
+        props = mock_record.call_args[0][1]
+        self.assertNotIn("corpus_slug", props)
+
+    @patch("opencontractserver.mcp.telemetry.record_event")
+    def test_empty_document_slug_omitted(self, mock_record):
+        mock_record.return_value = True
+        with isolated_telemetry_context():
+            record_mcp_resource_read("corpus", success=True, document_slug="")
+        props = mock_record.call_args[0][1]
+        self.assertNotIn("document_slug", props)
+
+    @patch("opencontractserver.mcp.telemetry.arecord_event")
+    def test_async_empty_corpus_slug_omitted(self, mock_arecord):
+        async def _test():
+            mock_arecord.return_value = True
+            with isolated_telemetry_context():
+                return await arecord_mcp_tool_call("test", success=True, corpus_slug="")
+
+        asyncio.run(_test())
+        props = mock_arecord.call_args[0][1]
+        self.assertNotIn("corpus_slug", props)
+
+    @patch("opencontractserver.mcp.telemetry.arecord_event")
+    def test_async_empty_document_slug_omitted(self, mock_arecord):
+        async def _test():
+            mock_arecord.return_value = True
+            with isolated_telemetry_context():
+                return await arecord_mcp_resource_read(
+                    "corpus", success=True, document_slug=""
+                )
+
+        asyncio.run(_test())
+        props = mock_arecord.call_args[0][1]
+        self.assertNotIn("document_slug", props)
 
 
 class TestGetUserAgentFromScope(TestCase):


### PR DESCRIPTION
## Summary

This PR hardens the MCP telemetry system against attacker-controlled input by bounding User-Agent storage and filtering empty slugs, while significantly expanding test coverage for async telemetry functions.

## Key Changes

- **User-Agent length bounding**: Introduced `MAX_USER_AGENT_LENGTH` constant (512 characters) and applied truncation in both `set_request_context()` and `get_user_agent_from_scope()` to prevent multi-megabyte attacker-controlled values from reaching telemetry backends
- **Empty-string slug filtering**: Changed slug validation from `if slug is not None` to falsy checks (`if slug`) across all sync and async recording functions (`record_mcp_tool_call`, `record_mcp_resource_read`, `arecord_mcp_tool_call`, `arecord_mcp_resource_read`) to exclude empty strings from telemetry properties
- **Documentation improvements**: Added docstring notes explaining the duplicate-header-dropping assumption when converting ASGI header lists to dicts in `get_user_agent_from_scope()` and `get_claimed_client_ip_from_scope()`
- **Comprehensive test coverage**: Added three new test classes with 16 test cases covering:
  - Async telemetry recording functions (`arecord_mcp_tool_call`, `arecord_mcp_resource_read`, `arecord_mcp_request`)
  - User-Agent truncation behavior (long/short/empty values)
  - Empty-string slug filtering in both sync and async contexts

## Implementation Details

- User-Agent truncation is applied at the point of storage (context setting) and extraction (scope parsing) to provide defense-in-depth
- Empty-string filtering uses Python's falsy semantics, which also handles `None` values correctly
- All async recording functions maintain feature parity with their synchronous counterparts
- Tests use `isolated_telemetry_context()` to ensure proper cleanup and isolation

https://claude.ai/code/session_01HTSJzH5PwTBV8FaQVrUp1Q