### PR TITLE
Fix Auth0 SDK loading with CSP script-src-attr restrictions

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -557,6 +557,9 @@ if USE_AUTH0:
     SECURE_CSP_DIRECTIVES["connect-src"].append(f"https://{AUTH0_DOMAIN}")
     SECURE_CSP_DIRECTIVES["script-src"].append(f"https://{AUTH0_DOMAIN}")
     SECURE_CSP_DIRECTIVES["script-src"].append("https://cdn.jsdelivr.net")
+    # Auth0 SPA SDK uses a hidden iframe for silent authentication
+    # (prompt=none, response_mode=web_message) which requires frame-src.
+    SECURE_CSP_DIRECTIVES["frame-src"] = [f"https://{AUTH0_DOMAIN}"]
 
 # Permissions-Policy — opt out of browser features not needed by the app.
 SECURE_PERMISSIONS_POLICY = {

--- a/opencontractserver/templates/admin/auth0_login.html
+++ b/opencontractserver/templates/admin/auth0_login.html
@@ -307,8 +307,10 @@
     </script>
 
     {% if use_auth0 %}
-    <!-- Error handler must be defined BEFORE the SDK script so the onerror
-         attribute can reference it when the browser starts fetching. -->
+    <!-- Auth0 SPA SDK v2.1.3 via jsDelivr CDN with Subresource Integrity.
+         Error handling uses addEventListener instead of an inline onerror
+         attribute because CSP script-src-attr blocks inline event handlers
+         and nonces do not apply to them. -->
     <script nonce="{{ csp_nonce }}">
         function handleScriptError() {
             var btn = document.getElementById('auth0-login-btn');
@@ -318,16 +320,15 @@
             }
             console.error('Failed to load Auth0 SDK - SRI check may have failed');
         }
+
+        var sdkScript = document.createElement('script');
+        sdkScript.id = 'auth0-sdk';
+        sdkScript.src = 'https://cdn.jsdelivr.net/npm/@auth0/auth0-spa-js@2.1.3/dist/auth0-spa-js.production.min.js';
+        sdkScript.integrity = 'sha384-Rm7o4Fw8223WH3gI6PLQ7HyUa90mzfyOcEcDMUpdhm8lU+drc1rkQDwzhxAjhZMb';
+        sdkScript.crossOrigin = 'anonymous';
+        sdkScript.addEventListener('error', handleScriptError);
+        document.currentScript.parentNode.insertBefore(sdkScript, document.currentScript.nextSibling);
     </script>
-    <!-- Auth0 SPA SDK v2.1.3 via jsDelivr CDN with Subresource Integrity.
-         onerror is governed by script-src-elem (not script-src-attr) so the
-         nonce on this tag permits it. -->
-    <script id="auth0-sdk"
-            src="https://cdn.jsdelivr.net/npm/@auth0/auth0-spa-js@2.1.3/dist/auth0-spa-js.production.min.js"
-            integrity="sha384-Rm7o4Fw8223WH3gI6PLQ7HyUa90mzfyOcEcDMUpdhm8lU+drc1rkQDwzhxAjhZMb"
-            crossorigin="anonymous"
-            nonce="{{ csp_nonce }}"
-            onerror="handleScriptError()"></script>
     <script nonce="{{ csp_nonce }}">
         var auth0Client = null;
 


### PR DESCRIPTION
## Summary
This PR fixes Auth0 SDK loading to comply with Content Security Policy (CSP) restrictions on inline event handlers. The changes dynamically inject the Auth0 SDK script and update CSP directives to support silent authentication.

## Key Changes
- **Dynamic script injection**: Replaced inline `<script>` tag with `onerror` attribute with dynamically created script element that uses `addEventListener` for error handling. This avoids CSP `script-src-attr` violations since `addEventListener` is not restricted by that directive.
- **CSP directive updates**: Added `frame-src` directive to allow Auth0's hidden iframe for silent authentication (used by `prompt=none` flow).
- **Updated comments**: Clarified the rationale for the new approach in code comments.

## Implementation Details
- The error handler function `handleScriptError()` is defined in a nonce-protected inline script and referenced via `addEventListener` instead of an inline `onerror` attribute.
- The Auth0 SDK script is created and inserted into the DOM after the handler is defined, ensuring proper error handling.
- Subresource Integrity (SRI) hash is preserved for security.
- The `frame-src` CSP directive is set to allow Auth0's domain for the silent authentication iframe.

https://claude.ai/code/session_01GbLxCJZSjqmSbVe95mncb1