### PR TITLE
Fix annotations connection limit for document index queries

### DIFF
--- a/config/graphql/annotation_queries.py
+++ b/config/graphql/annotation_queries.py
@@ -31,7 +31,10 @@ from opencontractserver.annotations.models import (
     Note,
     Relationship,
 )
-from opencontractserver.constants.annotations import MANUAL_ANNOTATION_SENTINEL
+from opencontractserver.constants.annotations import (
+    DOCUMENT_ANNOTATION_INDEX_LIMIT,
+    MANUAL_ANNOTATION_SENTINEL,
+)
 from opencontractserver.documents.models import Document
 from opencontractserver.types.enums import LabelType
 
@@ -60,6 +63,8 @@ class AnnotationQueryMixin:
         created_by_analysis_ids=graphene.String(),
         created_with_analyzer_id=graphene.String(),
         order_by=graphene.String(),
+        # Higher limit for Document Annotation Index which needs full hierarchy
+        max_limit=DOCUMENT_ANNOTATION_INDEX_LIMIT,
     )
 
     @graphql_ratelimit_dynamic(get_rate=get_user_tier_rate("READ_MEDIUM"))


### PR DESCRIPTION
## Summary
- The `DocumentAnnotationIndex` component requests up to 500 annotations (`DOCUMENT_ANNOTATION_INDEX_LIMIT`) to load the full document TOC hierarchy in one request
- The `annotations` GraphQL connection field used the global `RELAY_CONNECTION_MAX_LIMIT` of 100, rejecting any request over 100 records with: `Requesting 500 records on the annotations connection exceeds the first limit of 100 records`
- Added `max_limit=DOCUMENT_ANNOTATION_INDEX_LIMIT` (500) to the annotations `DjangoConnectionField`, matching the pattern already used by `document_relationships`

## Test plan
- [ ] Navigate to discover view — confirm no GraphQL errors in console
- [ ] Open a document with a TOC — confirm the annotation index loads fully
- [ ] Verify annotations list view still paginates correctly at smaller page sizes