### PR TITLE
Clean up annotation rendering: constants, debug logs, and test setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,16 @@ All notable changes to OpenContracts will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2026-03-23
+## [Unreleased]
+
+### Fixed
+
+- **Annotation rendering cleanup** (Closes #1144): Replaced hardcoded `"4px 4px 0 0"` border-radius with `ANNOTATION_BOUNDARY_RADIUS` constant in `SearchResult.tsx` and `ChatSourceResult.tsx`. Removed dead `border` prop from `SelectionInfo` interface and call sites. Used `APPROVED_RGB` constant for approved-state box-shadow in `SelectionBoundary.tsx` (matching `REJECTED_RGB` pattern). Added `TOKEN_EXPANSION_PX` constant and replaced magic `-1`/`+2` token expansion values across `SelectionTokenGroup.tsx`, `Tokens.tsx`, and `ChatSourceTokens.tsx`. Consolidated `[Previous Unreleased]` CHANGELOG section into single `[Unreleased]` block. Removed debug `console.log` statements from `DocumentKnowledgeBase.ct.tsx`, `SearchResult.tsx`, and `SelectionTokenGroup.tsx`. Moved annotation display reactive var initialization into `useEffect` in `DocumentKnowledgeBaseTestWrapper.tsx`.
 
 ### Changed
 
 - **Softened PDF annotation bounding boxes to diffuse highlighter-pen aesthetic**: Replaced hard-edged borders on annotation boundaries, tokens, and label pills with multi-layer box-shadow glows. Boundaries use a three-layer shadow (outer, mid, inset) that feathers into the page. Tokens use a single-layer soft blur. Approved/rejected states pulse with matching diffuse glows instead of solid borders. Extracted shared `computeAnnotationBoxShadow` utility (`frontend/src/utils/colorUtils.ts`) to eliminate duplicated shadow logic between `SelectionBoundary` and `ResultBoundary`. Added named constants for all shadow radii, opacity levels, border-radius tiers, and status colors (`frontend/src/assets/configurations/constants.ts`). Removed dead code: `getBorderWidthFromBounds`, unused `$border` prop, unused `$isSelected` prop. Fixed `pulseMaroon` animation color mismatch (was `rgba(180, 40, 40)`, now matches static rejected state).
-
-## [Previous Unreleased] - 2026-03-21
+- **Reorganized upload documentation into dedicated `docs/upload_methods/` section**: Consolidated scattered upload-related docs into 8 user-facing reference pages covering single upload, bulk ZIP import, corpus export/import, annotated document import, worker uploads, supported formats, and annotation side effects. Simplified `docs/walkthrough/step-1-add-documents.md` and `docs/walkthrough/advanced/export-import-corpuses.md` to reference the new guides. Trimmed `docs/architecture/bulk-import.md` to focus on internal implementation. Removed obsolete `docs/features/zip_import_with_folders_design.md` design doc (feature is fully implemented).
 
 ### Fixed
 
@@ -23,10 +26,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Test for `skip_pipeline=True` with no `labels.json`** (Closes #1131): New test `test_skip_pipeline_without_labels_json` verifies that pipeline-skipped documents are created successfully even when no labels file is present, and that annotation import errors are recorded properly (`opencontractserver/tests/test_sidecar_import.py`).
 - **Test for `skip_pipeline=True` with `meta.csv` metadata** (Closes #1131): New test `test_skip_pipeline_applies_metadata_from_csv` verifies that pipeline-skipped documents correctly receive title and description overrides from `meta.csv`.
 - **Per-sidecar JSON size limit** (Closes #1131): Added `ZIP_MAX_SIDECAR_SIZE_BYTES` constant (10 MB default) in `opencontractserver/constants/zip_import.py`. Sidecars exceeding this limit are skipped with an error, preventing oversized JSON from consuming excessive memory during import (`opencontractserver/tasks/import_tasks.py`).
-
-### Changed
-
-- **Reorganized upload documentation into dedicated `docs/upload_methods/` section**: Consolidated scattered upload-related docs into 8 user-facing reference pages covering single upload, bulk ZIP import, corpus export/import, annotated document import, worker uploads, supported formats, and annotation side effects. Simplified `docs/walkthrough/step-1-add-documents.md` and `docs/walkthrough/advanced/export-import-corpuses.md` to reference the new guides. Trimmed `docs/architecture/bulk-import.md` to focus on internal implementation. Removed obsolete `docs/features/zip_import_with_folders_design.md` design doc (feature is fully implemented).
 
 ## [Unreleased] - 2026-03-18
 

--- a/frontend/src/assets/configurations/constants.ts
+++ b/frontend/src/assets/configurations/constants.ts
@@ -443,6 +443,9 @@ export const TOKEN_OPACITY_LOW = 0.22;
 export const TOKEN_SHADOW_BLUR = 4;
 export const TOKEN_SHADOW_SPREAD = 1;
 
+// Token expansion (px added around each token to close inter-token gaps)
+export const TOKEN_EXPANSION_PX = 1;
+
 // PAWLs coordinate normalization
 /** Half a PDF point tolerance for comparing PAWLs vs PDF.js page dimensions */
 export const PAWLS_COORDINATE_EPSILON = 0.5;

--- a/frontend/src/components/annotator/display/components/ChatSourceResult.tsx
+++ b/frontend/src/components/annotator/display/components/ChatSourceResult.tsx
@@ -9,6 +9,7 @@ import { useAnnotationDisplay } from "../../context/UISettingsAtom";
 import { BoundingBox } from "../../../types";
 import { useAnnotationRefs } from "../../hooks/useAnnotationRefs";
 import { LabelDisplayBehavior } from "../../../../types/graphql-api";
+import { ANNOTATION_BOUNDARY_RADIUS } from "../../../../assets/configurations/constants";
 
 /**
  * Props for rendering a chat message source on a PDF page.
@@ -88,7 +89,6 @@ export const ChatSourceResult = ({
       >
         {showInfo && !hideLabels ? (
           <SelectionInfo
-            border={0}
             bounds={bounds}
             color={color}
             showBoundingBox={showBoundingBox}
@@ -129,7 +129,6 @@ export const ChatSourceResult = ({
  * Props for the selection info overlay that displays label details.
  */
 interface SelectionInfoProps {
-  border: number;
   bounds: BoundingBox;
   color: string;
   showBoundingBox: boolean;
@@ -144,7 +143,7 @@ const SelectionInfo = styled.div.attrs<SelectionInfoProps>(
       right: "0px",
       transform: "translateY(-100%)",
       border: "none",
-      borderRadius: "4px 4px 0 0",
+      borderRadius: `${ANNOTATION_BOUNDARY_RADIUS} ${ANNOTATION_BOUNDARY_RADIUS} 0 0`,
       background: showBoundingBox ? color : "rgba(255, 255, 255, 0.0)",
       fontWeight: "bold",
       fontSize: "12px",

--- a/frontend/src/components/annotator/display/components/ChatSourceTokens.tsx
+++ b/frontend/src/components/annotator/display/components/ChatSourceTokens.tsx
@@ -7,6 +7,7 @@ import { PDFPageInfo } from "../../types/pdf";
 import { TokenId } from "../../types/annotations";
 import {
   ANNOTATION_TOKEN_RADIUS,
+  TOKEN_EXPANSION_PX,
   TOKEN_OPACITY_HIGH,
   TOKEN_OPACITY_LOW,
   TOKEN_SHADOW_BLUR,
@@ -77,10 +78,10 @@ export const ChatSourceTokens: FC<ChatSourceTokensProps> = ({
         // Scale the token bounds using pageInfo to maintain consistency with SearchResult and Selection rescaling
         const b = pageInfo.getScaledTokenBounds(pageToken);
         const style = {
-          left: `${b.left - 1}px`,
-          top: `${b.top - 1}px`,
-          width: `${b.right - b.left + 2}px`,
-          height: `${b.bottom - b.top + 2}px`,
+          left: `${b.left - TOKEN_EXPANSION_PX}px`,
+          top: `${b.top - TOKEN_EXPANSION_PX}px`,
+          width: `${b.right - b.left + TOKEN_EXPANSION_PX * 2}px`,
+          height: `${b.bottom - b.top + TOKEN_EXPANSION_PX * 2}px`,
         };
 
         return (

--- a/frontend/src/components/annotator/display/components/SearchResult.tsx
+++ b/frontend/src/components/annotator/display/components/SearchResult.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from "react";
+import { useState, useMemo } from "react";
 import styled from "styled-components";
 import _ from "lodash";
 import { VerticallyJustifiedEndDiv } from "../../sidebar/common";
@@ -10,6 +10,7 @@ import { SearchSelectionTokens } from "./SelectionTokens";
 import { LabelTagContainer } from "./Containers";
 import { PDFPageInfo } from "../../types/pdf";
 import { useAnnotationDisplay } from "../../context/UISettingsAtom";
+import { ANNOTATION_BOUNDARY_RADIUS } from "../../../../assets/configurations/constants";
 
 interface SearchResultProps {
   total_results: number;
@@ -54,15 +55,6 @@ export const SearchResult: React.FC<SearchResultProps> = ({
       : null;
   }, [match, pageIdx, pageInfo]);
 
-  useEffect(() => {
-    console.log("SearchResult: Hidden prop changed", {
-      matchId: match.id,
-      pageNumber: pageInfo.page.pageNumber,
-      hidden,
-      timestamp: new Date().toISOString(),
-    });
-  }, [hidden, match.id, pageInfo.page.pageNumber]);
-
   if (!scaledBounds) return null;
 
   return (
@@ -80,7 +72,6 @@ export const SearchResult: React.FC<SearchResultProps> = ({
         {showInfo && !hideLabels ? (
           <SelectionInfo
             bounds={scaledBounds}
-            border={0}
             color={color}
             showBoundingBox={showBoundingBox}
           >
@@ -127,7 +118,6 @@ export const SearchResult: React.FC<SearchResultProps> = ({
 // to sit on top of the bounds as a function of *its own* height,
 // not the height of its parent.
 interface SelectionInfoProps {
-  border: number;
   bounds: BoundingBox;
   color: string;
   showBoundingBox: boolean;
@@ -141,7 +131,7 @@ const SelectionInfo = styled.div.attrs<SelectionInfoProps>(
       right: "0px",
       transform: "translateY(-100%)",
       border: "none",
-      borderRadius: "4px 4px 0 0",
+      borderRadius: `${ANNOTATION_BOUNDARY_RADIUS} ${ANNOTATION_BOUNDARY_RADIUS} 0 0`,
       background: showBoundingBox ? color : "rgba(255, 255, 255, 0.0)",
       fontWeight: "bold",
       fontSize: "12px",

--- a/frontend/src/components/annotator/display/components/SelectionBoundary.tsx
+++ b/frontend/src/components/annotator/display/components/SelectionBoundary.tsx
@@ -4,6 +4,7 @@ import { BoundingBox } from "../../../types";
 import { hexToRgb } from "../../../../utils/transform";
 import { computeAnnotationBoxShadow } from "../../../../utils/colorUtils";
 import {
+  APPROVED_RGB,
   REJECTED_RGB,
   ANNOTATION_BOUNDARY_RADIUS,
   BOUNDARY_OPACITY_SELECTED,
@@ -65,8 +66,10 @@ const BoundarySpan = styled.span.attrs<{
   ${(props) =>
     props.$approved &&
     css`
-      box-shadow: 0 0 12px 3px rgba(46, 204, 113, 0.18),
-        0 0 4px 1px rgba(46, 204, 113, 0.12) !important;
+      box-shadow: 0 0 12px 3px
+          rgba(${APPROVED_RGB.r}, ${APPROVED_RGB.g}, ${APPROVED_RGB.b}, 0.18),
+        0 0 4px 1px
+          rgba(${APPROVED_RGB.r}, ${APPROVED_RGB.g}, ${APPROVED_RGB.b}, 0.12) !important;
       animation: ${pulseGreen} 2s infinite;
     `}
 

--- a/frontend/src/components/annotator/display/components/SelectionTokenGroup.tsx
+++ b/frontend/src/components/annotator/display/components/SelectionTokenGroup.tsx
@@ -6,6 +6,7 @@ import { PDFPageInfo } from "../../types/pdf";
 import { TokenId } from "../../types/annotations";
 import {
   ANNOTATION_TOKEN_RADIUS,
+  TOKEN_EXPANSION_PX,
   TOKEN_OPACITY_HIGH,
   TOKEN_OPACITY_LOW,
   TOKEN_SHADOW_BLUR,
@@ -27,13 +28,17 @@ interface SelectionBoxProps {
 // same-colour blur that feathers the edges into the page.
 const SelectionBox = styled.span.attrs<SelectionBoxProps>((props) => ({
   style: {
-    left: `${(props.$left ?? 0) - 1}px`,
-    top: `${(props.$top ?? 0) - 1}px`,
+    left: `${(props.$left ?? 0) - TOKEN_EXPANSION_PX}px`,
+    top: `${(props.$top ?? 0) - TOKEN_EXPANSION_PX}px`,
     width: `${
-      props.$right && props.$left ? props.$right - props.$left + 2 : 0
+      props.$right && props.$left
+        ? props.$right - props.$left + TOKEN_EXPANSION_PX * 2
+        : 0
     }px`,
     height: `${
-      props.$bottom && props.$top ? props.$bottom - props.$top + 2 : 0
+      props.$bottom && props.$top
+        ? props.$bottom - props.$top + TOKEN_EXPANSION_PX * 2
+        : 0
     }px`,
     backgroundColor: props.$color || "yellow",
     opacity: props.$highOpacity ? TOKEN_OPACITY_HIGH : TOKEN_OPACITY_LOW,
@@ -77,7 +82,6 @@ export const SelectionTokenGroup = ({
   useEffect(() => {
     if (scrollTo) {
       if (containerRef.current !== undefined && containerRef.current !== null) {
-        console.log("Scroll to", scrollTo);
         containerRef.current.scrollIntoView({
           behavior: "smooth",
           block: "center",

--- a/frontend/src/components/annotator/display/components/Tokens.tsx
+++ b/frontend/src/components/annotator/display/components/Tokens.tsx
@@ -2,6 +2,7 @@ import styled, { DefaultTheme } from "styled-components";
 import _ from "lodash";
 import {
   ANNOTATION_TOKEN_RADIUS,
+  TOKEN_EXPANSION_PX,
   TOKEN_OPACITY_HIGH,
   TOKEN_OPACITY_LOW,
   TOKEN_SHADOW_BLUR,
@@ -93,10 +94,10 @@ export const SelectionTokenSpan = styled.span.attrs<SelectionTokenSpanThemeProps
           : props.highOpacity
           ? TOKEN_OPACITY_HIGH
           : TOKEN_OPACITY_LOW,
-        left: `${props.left - 1}px`,
-        top: `${props.top - 1}px`,
-        width: `${props.right - props.left + 2}px`,
-        height: `${props.bottom - props.top + 2}px`,
+        left: `${props.left - TOKEN_EXPANSION_PX}px`,
+        top: `${props.top - TOKEN_EXPANSION_PX}px`,
+        width: `${props.right - props.left + TOKEN_EXPANSION_PX * 2}px`,
+        height: `${props.bottom - props.top + TOKEN_EXPANSION_PX * 2}px`,
         pointerEvents: props.pointerEvents,
         boxShadow:
           props.isSelected && !props.hidden

--- a/frontend/tests/DocumentKnowledgeBase.ct.tsx
+++ b/frontend/tests/DocumentKnowledgeBase.ct.tsx
@@ -962,13 +962,7 @@ test("TXT document allows creating annotations via text selection", async ({
   const selectedText = await page.evaluate(() =>
     window.getSelection()?.toString()
   );
-  console.log(`[TEST] Selected text: "${selectedText}"`);
-
   if (!selectedText || selectedText.length === 0) {
-    console.log(
-      "[TEST WARNING] No text was selected, trying alternative approach"
-    );
-
     // Alternative: Select text programmatically
     const selectionResult = await page.evaluate(() => {
       const container = document.querySelector('[data-testid="txt-annotator"]');
@@ -1006,8 +1000,6 @@ test("TXT document allows creating annotations via text selection", async ({
         textNodeFound: false,
       };
     });
-
-    console.log(`[TEST] Alternative selection result:`, selectionResult);
   }
 
   console.log("[TEST] Completed text selection");

--- a/frontend/tests/DocumentKnowledgeBaseTestWrapper.tsx
+++ b/frontend/tests/DocumentKnowledgeBaseTestWrapper.tsx
@@ -4420,14 +4420,13 @@ export const DocumentKnowledgeBaseTestWrapper: React.FC<WrapperProps> = ({
     username: "testuser",
   });
 
-  // Set annotation display reactive vars before component mounts
-  showAnnotationBoundingBoxes(showBoundingBoxes);
-  showSelectedAnnotationOnly(showSelectedOnly);
-  showAnnotationLabels(showLabels);
-
   // Set reactive vars that CentralRouteManager would normally set
   // Component tests run in isolation, so we set these directly
   useEffect(() => {
+    // Set annotation display reactive vars
+    showAnnotationBoundingBoxes(showBoundingBoxes);
+    showSelectedAnnotationOnly(showSelectedOnly);
+    showAnnotationLabels(showLabels);
     authStatusVar("AUTHENTICATED");
     openedDocument({
       id: documentId,
@@ -4465,7 +4464,14 @@ export const DocumentKnowledgeBaseTestWrapper: React.FC<WrapperProps> = ({
       selectedAnalysesIds([]);
       selectedExtractIds([]);
     }
-  }, [documentId, corpusId, initialUrl]);
+  }, [
+    documentId,
+    corpusId,
+    initialUrl,
+    showBoundingBoxes,
+    showSelectedOnly,
+    showLabels,
+  ]);
   return (
     <MemoryRouter
       initialEntries={[


### PR DESCRIPTION
## Summary
This PR consolidates annotation rendering improvements by extracting magic numbers into named constants, removing debug logging statements, and fixing test setup timing issues. These changes improve code maintainability and consistency across the annotation display system.

## Key Changes

- **Extracted magic numbers into constants**: Added `TOKEN_EXPANSION_PX` constant (value: 1) to replace hardcoded `-1`/`+2` token expansion values across `SelectionTokenGroup.tsx`, `Tokens.tsx`, and `ChatSourceTokens.tsx`

- **Standardized border-radius values**: Replaced hardcoded `"4px 4px 0 0"` border-radius strings with `ANNOTATION_BOUNDARY_RADIUS` constant in `SearchResult.tsx` and `ChatSourceResult.tsx`

- **Used color constants for approved state**: Updated `SelectionBoundary.tsx` to use `APPROVED_RGB` constant for approved-state box-shadow, matching the existing `REJECTED_RGB` pattern

- **Removed dead code**: Eliminated unused `border` prop from `SelectionInfo` interface and all call sites in `SearchResult.tsx` and `ChatSourceResult.tsx`

- **Cleaned up debug logging**: Removed `console.log` statements from:
  - `DocumentKnowledgeBase.ct.tsx` (test file)
  - `SearchResult.tsx` (hidden prop change logging)
  - `SelectionTokenGroup.tsx` (scroll-to logging)

- **Fixed test setup timing**: Moved annotation display reactive var initialization (`showAnnotationBoundingBoxes`, `showSelectedAnnotationOnly`, `showAnnotationLabels`) into `useEffect` in `DocumentKnowledgeBaseTestWrapper.tsx` and added them to the dependency array to ensure proper initialization timing

- **Updated CHANGELOG**: Consolidated multiple unreleased sections and documented all cleanup changes

## Implementation Details

The `TOKEN_EXPANSION_PX` constant replaces the pattern of subtracting 1px from position values and adding 2px to dimension values, which was used to close inter-token gaps. This makes the expansion logic explicit and easier to adjust globally if needed.

The reactive var initialization fix in the test wrapper ensures that annotation display settings are properly set within the effect lifecycle, preventing potential race conditions during component mounting.

https://claude.ai/code/session_01PxbFtQD1zuCrbDgUAexFvz