### PR TITLE
Remove SemanticICONS type system-wide

### DIFF
--- a/frontend/tests/CorpusDashboard.ct.tsx
+++ b/frontend/tests/CorpusDashboard.ct.tsx
@@ -37,7 +37,7 @@ test.describe("CorpusDashboard", () => {
     await mount(
       <MockedProvider mocks={[statsMock]} addTypename={false}>
         <CorpusDashboard corpus={mockCorpus} />
-      </MockedProvider>,
+      </MockedProvider>
     );
 
     // Wait for the stats to load and animate
@@ -59,7 +59,7 @@ test.describe("CorpusDashboard", () => {
     await mount(
       <MockedProvider mocks={[slowMock]} addTypename={false}>
         <CorpusDashboard corpus={mockCorpus} />
-      </MockedProvider>,
+      </MockedProvider>
     );
 
     // The dashboard header should still be visible while loading

--- a/frontend/tests/CorpusDashboard.ct.tsx
+++ b/frontend/tests/CorpusDashboard.ct.tsx
@@ -3,13 +3,14 @@ import { test, expect } from "@playwright/experimental-ct-react";
 import { MockedProvider } from "@apollo/client/testing";
 import { CorpusDashboard } from "../src/components/corpuses/CorpusDashboard";
 import { GET_CORPUS_STATS } from "../src/graphql/queries";
+import { CorpusType } from "../src/types/graphql-api";
 import { docScreenshot } from "./utils/docScreenshot";
 
-const mockCorpus = {
+const mockCorpus: Pick<CorpusType, "id" | "title" | "__typename"> = {
   id: "Q29ycHVzVHlwZTox",
   title: "Test Corpus",
   __typename: "CorpusType",
-} as any;
+};
 
 const statsMock = {
   request: {
@@ -32,11 +33,13 @@ const statsMock = {
   },
 };
 
+test.use({ viewport: { width: 1280, height: 800 } });
+
 test.describe("CorpusDashboard", () => {
   test("renders dashboard with corpus statistics", async ({ mount, page }) => {
     await mount(
       <MockedProvider mocks={[statsMock]} addTypename={false}>
-        <CorpusDashboard corpus={mockCorpus} />
+        <CorpusDashboard corpus={mockCorpus as CorpusType} />
       </MockedProvider>
     );
 
@@ -53,12 +56,12 @@ test.describe("CorpusDashboard", () => {
   test("renders loading state before data arrives", async ({ mount, page }) => {
     const slowMock = {
       ...statsMock,
-      delay: 5000,
+      delay: 500,
     };
 
     await mount(
       <MockedProvider mocks={[slowMock]} addTypename={false}>
-        <CorpusDashboard corpus={mockCorpus} />
+        <CorpusDashboard corpus={mockCorpus as CorpusType} />
       </MockedProvider>
     );
 

--- a/frontend/tests/CorpusDashboard.ct.tsx
+++ b/frontend/tests/CorpusDashboard.ct.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import { test, expect } from "@playwright/experimental-ct-react";
+import { MockedProvider } from "@apollo/client/testing";
+import { CorpusDashboard } from "../src/components/corpuses/CorpusDashboard";
+import { GET_CORPUS_STATS } from "../src/graphql/queries";
+import { docScreenshot } from "./utils/docScreenshot";
+
+const mockCorpus = {
+  id: "Q29ycHVzVHlwZTox",
+  title: "Test Corpus",
+  __typename: "CorpusType",
+} as any;
+
+const statsMock = {
+  request: {
+    query: GET_CORPUS_STATS,
+    variables: { corpusId: mockCorpus.id },
+  },
+  result: {
+    data: {
+      corpusStats: {
+        totalDocs: 42,
+        totalComments: 18,
+        totalAnalyses: 7,
+        totalExtracts: 15,
+        totalAnnotations: 256,
+        totalThreads: 5,
+        totalChats: 3,
+        totalRelationships: 12,
+      },
+    },
+  },
+};
+
+test.describe("CorpusDashboard", () => {
+  test("renders dashboard with corpus statistics", async ({ mount, page }) => {
+    await mount(
+      <MockedProvider mocks={[statsMock]} addTypename={false}>
+        <CorpusDashboard corpus={mockCorpus} />
+      </MockedProvider>,
+    );
+
+    // Wait for the stats to load and animate
+    await expect(page.getByText("Documents")).toBeVisible();
+    await expect(page.getByText("Annotations")).toBeVisible();
+    await expect(page.getByText("Analyses")).toBeVisible();
+    await expect(page.getByText("Extracts")).toBeVisible();
+    await expect(page.getByText("Comments")).toBeVisible();
+
+    await docScreenshot(page, "corpus--dashboard--with-stats");
+  });
+
+  test("renders loading state before data arrives", async ({ mount, page }) => {
+    const slowMock = {
+      ...statsMock,
+      delay: 5000,
+    };
+
+    await mount(
+      <MockedProvider mocks={[slowMock]} addTypename={false}>
+        <CorpusDashboard corpus={mockCorpus} />
+      </MockedProvider>,
+    );
+
+    // The dashboard header should still be visible while loading
+    await expect(page.getByText("Corpus Dashboard")).toBeVisible();
+
+    await docScreenshot(page, "corpus--dashboard--loading");
+  });
+});

--- a/frontend/tests/CorpusEngagementDashboard.ct.tsx
+++ b/frontend/tests/CorpusEngagementDashboard.ct.tsx
@@ -39,7 +39,7 @@ const loadingMock = {
     query: GET_CORPUS_ENGAGEMENT_METRICS,
     variables: { corpusId },
   },
-  delay: 10000,
+  delay: 500,
   result: engagementMetricsMock.result,
 };
 

--- a/frontend/tests/CorpusEngagementDashboard.ct.tsx
+++ b/frontend/tests/CorpusEngagementDashboard.ct.tsx
@@ -75,7 +75,7 @@ test.describe("CorpusEngagementDashboard", () => {
     await mount(
       <MockedProvider mocks={[engagementMetricsMock]} addTypename={false}>
         <CorpusEngagementDashboard corpusId={corpusId} />
-      </MockedProvider>,
+      </MockedProvider>
     );
 
     // Wait for heading and section titles
@@ -98,7 +98,7 @@ test.describe("CorpusEngagementDashboard", () => {
     await mount(
       <MockedProvider mocks={[loadingMock]} addTypename={false}>
         <CorpusEngagementDashboard corpusId={corpusId} />
-      </MockedProvider>,
+      </MockedProvider>
     );
 
     await expect(page.getByText("Loading engagement metrics...")).toBeVisible();
@@ -110,7 +110,7 @@ test.describe("CorpusEngagementDashboard", () => {
     await mount(
       <MockedProvider mocks={[errorMock]} addTypename={false}>
         <CorpusEngagementDashboard corpusId={corpusId} />
-      </MockedProvider>,
+      </MockedProvider>
     );
 
     await expect(page.getByText("Error Loading Metrics")).toBeVisible();
@@ -122,7 +122,7 @@ test.describe("CorpusEngagementDashboard", () => {
     await mount(
       <MockedProvider mocks={[emptyMock]} addTypename={false}>
         <CorpusEngagementDashboard corpusId={corpusId} />
-      </MockedProvider>,
+      </MockedProvider>
     );
 
     await expect(page.getByText("No Engagement Data Available")).toBeVisible();

--- a/frontend/tests/CorpusEngagementDashboard.ct.tsx
+++ b/frontend/tests/CorpusEngagementDashboard.ct.tsx
@@ -81,7 +81,9 @@ test.describe("CorpusEngagementDashboard", () => {
     // Wait for heading and section titles
     await expect(page.getByText("Engagement Analytics")).toBeVisible();
     await expect(page.getByText("Thread Metrics")).toBeVisible();
-    await expect(page.getByText("Message Activity")).toBeVisible();
+    await expect(
+      page.getByText("Message Activity", { exact: true })
+    ).toBeVisible();
     await expect(page.getByText("Community Engagement")).toBeVisible();
 
     // Verify stat labels are present

--- a/frontend/tests/CorpusEngagementDashboard.ct.tsx
+++ b/frontend/tests/CorpusEngagementDashboard.ct.tsx
@@ -1,0 +1,132 @@
+import React from "react";
+import { test, expect } from "@playwright/experimental-ct-react";
+import { MockedProvider } from "@apollo/client/testing";
+import { CorpusEngagementDashboard } from "../src/components/analytics/CorpusEngagementDashboard";
+import { GET_CORPUS_ENGAGEMENT_METRICS } from "../src/graphql/queries";
+import { docScreenshot } from "./utils/docScreenshot";
+
+const corpusId = "Q29ycHVzVHlwZTox";
+
+const engagementMetricsMock = {
+  request: {
+    query: GET_CORPUS_ENGAGEMENT_METRICS,
+    variables: { corpusId },
+  },
+  result: {
+    data: {
+      corpus: {
+        id: corpusId,
+        title: "Test Corpus",
+        engagementMetrics: {
+          totalThreads: 24,
+          activeThreads: 8,
+          totalMessages: 312,
+          messagesLast7Days: 45,
+          messagesLast30Days: 128,
+          uniqueContributors: 15,
+          activeContributors30Days: 9,
+          totalUpvotes: 87,
+          avgMessagesPerThread: 13.0,
+          lastUpdated: "2026-03-20T10:00:00Z",
+        },
+      },
+    },
+  },
+};
+
+const loadingMock = {
+  request: {
+    query: GET_CORPUS_ENGAGEMENT_METRICS,
+    variables: { corpusId },
+  },
+  delay: 10000,
+  result: engagementMetricsMock.result,
+};
+
+const errorMock = {
+  request: {
+    query: GET_CORPUS_ENGAGEMENT_METRICS,
+    variables: { corpusId },
+  },
+  error: new Error("Network error: Failed to fetch"),
+};
+
+const emptyMock = {
+  request: {
+    query: GET_CORPUS_ENGAGEMENT_METRICS,
+    variables: { corpusId },
+  },
+  result: {
+    data: {
+      corpus: {
+        id: corpusId,
+        title: "Empty Corpus",
+        engagementMetrics: null,
+      },
+    },
+  },
+};
+
+test.describe("CorpusEngagementDashboard", () => {
+  test("renders engagement metrics with stats and chart", async ({
+    mount,
+    page,
+  }) => {
+    await mount(
+      <MockedProvider mocks={[engagementMetricsMock]} addTypename={false}>
+        <CorpusEngagementDashboard corpusId={corpusId} />
+      </MockedProvider>,
+    );
+
+    // Wait for heading and section titles
+    await expect(page.getByText("Engagement Analytics")).toBeVisible();
+    await expect(page.getByText("Thread Metrics")).toBeVisible();
+    await expect(page.getByText("Message Activity")).toBeVisible();
+    await expect(page.getByText("Community Engagement")).toBeVisible();
+
+    // Verify stat labels are present
+    await expect(page.getByText("Total Threads")).toBeVisible();
+    await expect(page.getByText("Active Threads")).toBeVisible();
+    await expect(page.getByText("Total Messages")).toBeVisible();
+    await expect(page.getByText("All Contributors")).toBeVisible();
+    await expect(page.getByText("Total Upvotes")).toBeVisible();
+
+    await docScreenshot(page, "analytics--engagement-dashboard--with-data");
+  });
+
+  test("shows loading state", async ({ mount, page }) => {
+    await mount(
+      <MockedProvider mocks={[loadingMock]} addTypename={false}>
+        <CorpusEngagementDashboard corpusId={corpusId} />
+      </MockedProvider>,
+    );
+
+    await expect(page.getByText("Loading engagement metrics...")).toBeVisible();
+
+    await docScreenshot(page, "analytics--engagement-dashboard--loading");
+  });
+
+  test("shows error state", async ({ mount, page }) => {
+    await mount(
+      <MockedProvider mocks={[errorMock]} addTypename={false}>
+        <CorpusEngagementDashboard corpusId={corpusId} />
+      </MockedProvider>,
+    );
+
+    await expect(page.getByText("Error Loading Metrics")).toBeVisible();
+
+    await docScreenshot(page, "analytics--engagement-dashboard--error");
+  });
+
+  test("shows empty state when no metrics", async ({ mount, page }) => {
+    await mount(
+      <MockedProvider mocks={[emptyMock]} addTypename={false}>
+        <CorpusEngagementDashboard corpusId={corpusId} />
+      </MockedProvider>,
+    );
+
+    await expect(page.getByText("No Engagement Data Available")).toBeVisible();
+
+    await docScreenshot(page, "analytics--engagement-dashboard--empty");
+  });
+});

--- a/frontend/tests/CreateAndSearchBar.ct.tsx
+++ b/frontend/tests/CreateAndSearchBar.ct.tsx
@@ -1,0 +1,95 @@
+import React from "react";
+import { test, expect } from "@playwright/experimental-ct-react";
+import {
+  CreateAndSearchBar,
+  DropdownActionProps,
+} from "../src/components/layout/CreateAndSearchBar";
+import { docScreenshot } from "./utils/docScreenshot";
+
+const sampleActions: DropdownActionProps[] = [
+  {
+    icon: "file-plus",
+    title: "New Document",
+    key: "new-doc",
+    color: "#3498db",
+    action_function: () => {},
+  },
+  {
+    icon: "folder-plus",
+    title: "New Folder",
+    key: "new-folder",
+    color: "#2ecc71",
+    action_function: () => {},
+  },
+];
+
+test.describe("CreateAndSearchBar", () => {
+  test("renders search input and action button", async ({ mount, page }) => {
+    await mount(
+      <CreateAndSearchBar actions={sampleActions} placeholder="Search docs…" />,
+    );
+
+    // Search input should be visible with the correct placeholder
+    const input = page.getByPlaceholder("Search docs…");
+    await expect(input).toBeVisible();
+
+    // Add button should be visible
+    const addButton = page.getByRole("button", { name: "Add" });
+    await expect(addButton).toBeVisible();
+
+    await docScreenshot(page, "layout--create-and-search-bar--default");
+  });
+
+  test("opens dropdown menu on add button click", async ({ mount, page }) => {
+    await mount(
+      <CreateAndSearchBar actions={sampleActions} placeholder="Search docs…" />,
+    );
+
+    // Click the add button
+    const addButton = page.getByRole("button", { name: "Add" });
+    await addButton.click();
+
+    // Dropdown items should appear
+    await expect(page.getByText("New Document")).toBeVisible();
+    await expect(page.getByText("New Folder")).toBeVisible();
+
+    await docScreenshot(page, "layout--create-and-search-bar--dropdown-open");
+  });
+
+  test("shows filter button when filters are provided", async ({
+    mount,
+    page,
+  }) => {
+    const filterContent = <div>Filter options here</div>;
+
+    await mount(
+      <CreateAndSearchBar
+        actions={sampleActions}
+        filters={filterContent}
+        placeholder="Search…"
+      />,
+    );
+
+    // Filter button should be visible
+    const filterButton = page.getByRole("button", { name: "Filter" });
+    await expect(filterButton).toBeVisible();
+
+    // Click to open filter popover
+    await filterButton.click();
+    await expect(page.getByText("Filter options here")).toBeVisible();
+
+    await docScreenshot(page, "layout--create-and-search-bar--filter-popover");
+  });
+
+  test("renders without actions", async ({ mount, page }) => {
+    await mount(<CreateAndSearchBar actions={[]} placeholder="Search…" />);
+
+    // Search input should be visible
+    await expect(page.getByPlaceholder("Search…")).toBeVisible();
+
+    // Add button should NOT be visible when no actions
+    await expect(page.getByRole("button", { name: "Add" })).not.toBeVisible();
+
+    await docScreenshot(page, "layout--create-and-search-bar--no-actions");
+  });
+});

--- a/frontend/tests/CreateAndSearchBar.ct.tsx
+++ b/frontend/tests/CreateAndSearchBar.ct.tsx
@@ -26,7 +26,7 @@ const sampleActions: DropdownActionProps[] = [
 test.describe("CreateAndSearchBar", () => {
   test("renders search input and action button", async ({ mount, page }) => {
     await mount(
-      <CreateAndSearchBar actions={sampleActions} placeholder="Search docs…" />,
+      <CreateAndSearchBar actions={sampleActions} placeholder="Search docs…" />
     );
 
     // Search input should be visible with the correct placeholder
@@ -42,7 +42,7 @@ test.describe("CreateAndSearchBar", () => {
 
   test("opens dropdown menu on add button click", async ({ mount, page }) => {
     await mount(
-      <CreateAndSearchBar actions={sampleActions} placeholder="Search docs…" />,
+      <CreateAndSearchBar actions={sampleActions} placeholder="Search docs…" />
     );
 
     // Click the add button
@@ -67,7 +67,7 @@ test.describe("CreateAndSearchBar", () => {
         actions={sampleActions}
         filters={filterContent}
         placeholder="Search…"
-      />,
+      />
     );
 
     // Filter button should be visible

--- a/frontend/tests/mocks/DocumentKnowledgeBase.mocks.ts
+++ b/frontend/tests/mocks/DocumentKnowledgeBase.mocks.ts
@@ -37,18 +37,18 @@ export const MOCK_PDF_URL_FOR_STRUCTURAL_TEST = `/mock-pdf/${PDF_DOC_ID_FOR_STRU
 
 export const TEST_PDF_PATH = path.resolve(
   __dirname,
-  "../../../frontend/test-assets/test.pdf",
+  "../../../frontend/test-assets/test.pdf"
 );
 export const TEST_PAWLS_PATH = path.resolve(
   __dirname,
-  "../../../frontend/test-assets/test.pawls",
+  "../../../frontend/test-assets/test.pawls"
 );
 
 export const createPageInfo = (
   hasNext = false,
   hasPrev = false,
   start = "",
-  end = "",
+  end = ""
 ) => ({
   __typename: "PageInfo",
   hasNextPage: hasNext,
@@ -437,7 +437,7 @@ export const mockDatacell2 = {
  */
 export const createAnnotationsForAnalysisMock = (
   analysisId: string,
-  documentId: string,
+  documentId: string
 ) => ({
   request: {
     query: GET_ANNOTATIONS_FOR_ANALYSIS,
@@ -485,7 +485,7 @@ export const createAnnotationsForAnalysisMock = (
 export const createDocumentKnowledgeMockWithAnalysisAnnotations = (
   documentId: string,
   corpusId: string,
-  analysisId?: string,
+  analysisId?: string
 ) => ({
   request: {
     query: GET_DOCUMENT_KNOWLEDGE_AND_ANNOTATIONS,
@@ -514,7 +514,7 @@ export const createDocumentKnowledgeMockWithAnalysisAnnotations = (
 export const createDocumentAnnotationsOnlyMock = (
   documentId: string,
   corpusId: string,
-  analysisId: string | null | undefined,
+  analysisId: string | null | undefined
 ) => ({
   request: {
     query: GET_DOCUMENT_ANNOTATIONS_ONLY,

--- a/frontend/tests/mocks/DocumentKnowledgeBase.mocks.ts
+++ b/frontend/tests/mocks/DocumentKnowledgeBase.mocks.ts
@@ -37,18 +37,18 @@ export const MOCK_PDF_URL_FOR_STRUCTURAL_TEST = `/mock-pdf/${PDF_DOC_ID_FOR_STRU
 
 export const TEST_PDF_PATH = path.resolve(
   __dirname,
-  "../../../frontend/test-assets/test.pdf"
+  "../../../frontend/test-assets/test.pdf",
 );
 export const TEST_PAWLS_PATH = path.resolve(
   __dirname,
-  "../../../frontend/test-assets/test.pawls"
+  "../../../frontend/test-assets/test.pawls",
 );
 
 export const createPageInfo = (
   hasNext = false,
   hasPrev = false,
   start = "",
-  end = ""
+  end = "",
 ) => ({
   __typename: "PageInfo",
   hasNextPage: hasNext,
@@ -437,7 +437,7 @@ export const mockDatacell2 = {
  */
 export const createAnnotationsForAnalysisMock = (
   analysisId: string,
-  documentId: string
+  documentId: string,
 ) => ({
   request: {
     query: GET_ANNOTATIONS_FOR_ANALYSIS,
@@ -485,7 +485,7 @@ export const createAnnotationsForAnalysisMock = (
 export const createDocumentKnowledgeMockWithAnalysisAnnotations = (
   documentId: string,
   corpusId: string,
-  analysisId?: string
+  analysisId?: string,
 ) => ({
   request: {
     query: GET_DOCUMENT_KNOWLEDGE_AND_ANNOTATIONS,
@@ -514,7 +514,7 @@ export const createDocumentKnowledgeMockWithAnalysisAnnotations = (
 export const createDocumentAnnotationsOnlyMock = (
   documentId: string,
   corpusId: string,
-  analysisId: string | null | undefined
+  analysisId: string | null | undefined,
 ) => ({
   request: {
     query: GET_DOCUMENT_ANNOTATIONS_ONLY,
@@ -599,7 +599,7 @@ export const mockAnnotationStructural1: RawServerAnnotationType = {
     id: "QW5ub3RhdGlvbkxhYmVsVHlwZTo0MQ==", // Example ID
     text: "page_header",
     color: "grey",
-    icon: "expand" as any, // Cast to any if 'expand' is not a valid SemanticICON
+    icon: "expand",
     description: "Parser Structural Label",
     labelType: LabelType.TokenLabel, // Assuming "TOKEN_LABEL" maps to this // Example
   },
@@ -644,7 +644,7 @@ export const mockAnnotationNonStructural1: RawServerAnnotationType = {
     id: "QW5ub3RhdGlvbkxhYmVsVHlwZTo0MQ==", // Example ID
     text: "page_header",
     color: "grey",
-    icon: "expand" as any, // Cast to any if 'expand' is not a valid SemanticICON
+    icon: "expand",
     description: "Parser Structural Label",
     labelType: LabelType.TokenLabel, // Assuming "TOKEN_LABEL" maps to this // Example
   },


### PR DESCRIPTION
## Summary
- Removed the last remaining `SemanticICON` references (stale comments + `as any` casts) from `DocumentKnowledgeBase.mocks.ts`
- Added Playwright component tests with `docScreenshot` coverage for **CorpusDashboard**, **CreateAndSearchBar**, and **CorpusEngagementDashboard** — the three affected components that previously lacked tests
- Verified zero remaining imports of `SemanticICONS`, `SemanticCOLORS`, or `semantic-ui-react` anywhere in the frontend

Note: The bulk of the type migration (replacing `SemanticICONS` with `string` in all 12 affected files) was already completed by prior PRs (#1013, #1014). This PR cleans up the last artifacts and adds the required test coverage.
