### PR TITLE
Fix quickstart: missing env vars, celerybeat race, login blockers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Quickstart blockers** (PR #1179): Fixed several issues preventing first-time setup from working:
+  - Missing `EMBEDDINGS_MICROSERVICE_URL` and `DOCLING_PARSER_SERVICE_URL` env var defaults crash Django on startup (`config/settings/base.py`)
+  - Celerybeat race condition on first boot — added Django healthcheck and `service_healthy` dependency for celery services (`local.yml`)
+  - Password login broken — JWT middleware was gated behind `USE_AUTH0=True` so `tokenAuth` tokens were never validated (`config/settings/base.py`)
+  - Admin user login 500 — `User.save()` re-validated slug on `last_login` updates, and `"admin"` is a reserved slug (`opencontractserver/users/models.py`)
+  - Django admin panel 500 on static files — overrode `StaticFilesStorage` in local settings (`config/settings/local.py`)
+  - Nginx duplicate `.js` MIME type warning (`frontend/conf/conf.d/default.conf`)
+  - Updated README quickstart with missing steps and corrected `docker compose` v2 syntax
+
 ### Added
 
 - **CAML Interactive Article System** (PR #1156): Frontend support for corpus articles using CAML (Corpus Article Markup Language). Includes a two-pass parser (tokenizer + block parsers), typed intermediate representation, and composable renderer supporting hero sections, cards, pills, tabs, timelines, CTAs, signup blocks, corpus stats, and pullquotes. Frontend adds `CamlArticleEditor` modal with live preview, `CorpusArticleView` for rendered article display, and `CorpusLandingView` integration for article discovery. Playwright component tests with `docScreenshot` captures for all block types.

--- a/README.md
+++ b/README.md
@@ -131,10 +131,23 @@ This is the DRY principle applied to institutional knowledge: annotate once, bui
 ### Development
 
 ```bash
-git clone https://github.com/JSv4/OpenContracts.git
+git clone https://github.com/Open-Source-Legal/OpenContracts.git
 cd OpenContracts
-docker compose -f local.yml up
+
+# Copy sample environment files
+mkdir -p .envs/.local
+cp ./docs/sample_env_files/backend/local/.django ./.envs/.local/.django
+cp ./docs/sample_env_files/backend/local/.postgres ./.envs/.local/.postgres
+cp ./docs/sample_env_files/frontend/local/django.auth.env ./.envs/.local/.frontend
+
+# Build and start all services (including frontend)
+docker compose -f local.yml build
+docker compose -f local.yml --profile fullstack up
 ```
+
+Then open http://localhost:3000 and log in with `admin` / `Openc0ntracts_def@ult`.
+
+See the [full Quick Start guide](docs/quick_start.md) for details and troubleshooting.
 
 ### Production
 

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -785,7 +785,7 @@ DEFAULT_PERMISSIONS_GROUP = "Public Objects Access"
 # NOTE(deferred): These could be consolidated into an EMBEDDER_KWARGS dict
 # (similar to PARSER_KWARGS) once all embedder backends are pluggable.
 # Microservice URLs - read from environment with defaults
-EMBEDDINGS_MICROSERVICE_URL = env("EMBEDDINGS_MICROSERVICE_URL")
+EMBEDDINGS_MICROSERVICE_URL = env("EMBEDDINGS_MICROSERVICE_URL", default="http://vector-embedder:8000")
 VECTOR_EMBEDDER_API_KEY = env("VECTOR_EMBEDDER_API_KEY", default="abc123")
 # CLIP embedder configuration (768-dimensional vectors)
 CLIP_EMBEDDER_URL = env("CLIP_EMBEDDER_URL", default="http://vector-embedder:8000")
@@ -817,7 +817,7 @@ MULTIMODAL_EMBEDDING_WEIGHTS = {
     "text_weight": env.float("MULTIMODAL_TEXT_WEIGHT", default=0.3),
     "image_weight": env.float("MULTIMODAL_IMAGE_WEIGHT", default=0.7),
 }
-DOCLING_PARSER_SERVICE_URL = env("DOCLING_PARSER_SERVICE_URL")
+DOCLING_PARSER_SERVICE_URL = env("DOCLING_PARSER_SERVICE_URL", default="http://docling-parser:8000/parse/")
 DOCLING_PARSER_TIMEOUT = env.int(
     "DOCLING_PARSER_TIMEOUT", default=300  # 5 minutes default
 )

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -732,9 +732,10 @@ GRAPHENE_MIDDLEWARE = [
     "config.graphql.permissioning.permission_annotator.middleware.PermissionAnnotatingMiddleware",
 ]
 
-# Add JWT middleware if using Auth0
-if USE_AUTH0:
-    GRAPHENE_MIDDLEWARE.append("graphql_jwt.middleware.JSONWebTokenMiddleware")
+# JWT middleware is always needed — both Auth0 and password login
+# return JWT tokens via the tokenAuth mutation, and subsequent
+# GraphQL requests use Authorization: Bearer <token>.
+GRAPHENE_MIDDLEWARE.append("graphql_jwt.middleware.JSONWebTokenMiddleware")
 
 # Add API Key middleware if enabled
 if USE_API_KEY_AUTH:

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -786,7 +786,9 @@ DEFAULT_PERMISSIONS_GROUP = "Public Objects Access"
 # NOTE(deferred): These could be consolidated into an EMBEDDER_KWARGS dict
 # (similar to PARSER_KWARGS) once all embedder backends are pluggable.
 # Microservice URLs - read from environment with defaults
-EMBEDDINGS_MICROSERVICE_URL = env("EMBEDDINGS_MICROSERVICE_URL", default="http://vector-embedder:8000")
+EMBEDDINGS_MICROSERVICE_URL = env(
+    "EMBEDDINGS_MICROSERVICE_URL", default="http://vector-embedder:8000"
+)
 VECTOR_EMBEDDER_API_KEY = env("VECTOR_EMBEDDER_API_KEY", default="abc123")
 # CLIP embedder configuration (768-dimensional vectors)
 CLIP_EMBEDDER_URL = env("CLIP_EMBEDDER_URL", default="http://vector-embedder:8000")
@@ -818,7 +820,9 @@ MULTIMODAL_EMBEDDING_WEIGHTS = {
     "text_weight": env.float("MULTIMODAL_TEXT_WEIGHT", default=0.3),
     "image_weight": env.float("MULTIMODAL_IMAGE_WEIGHT", default=0.7),
 }
-DOCLING_PARSER_SERVICE_URL = env("DOCLING_PARSER_SERVICE_URL", default="http://docling-parser:8000/parse/")
+DOCLING_PARSER_SERVICE_URL = env(
+    "DOCLING_PARSER_SERVICE_URL", default="http://docling-parser:8000/parse/"
+)
 DOCLING_PARSER_TIMEOUT = env.int(
     "DOCLING_PARSER_TIMEOUT", default=300  # 5 minutes default
 )

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -89,3 +89,11 @@ if DEBUG and USE_SILK:
 # Set DEBUG based on env variable, defaulting to False for better performance
 # You can override this with DJANGO_DEBUG=True in your .env file when needed
 DEBUG = env.bool("DJANGO_DEBUG", False)
+
+# In local dev, use simple static file serving (no manifest required).
+# The base.py CompressedManifestStaticFilesStorage requires collectstatic
+# which is unnecessary when runserver serves static files directly.
+if "staticfiles" in STORAGES:  # noqa: F405
+    STORAGES["staticfiles"] = {  # noqa: F405
+        "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+    }

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -93,7 +93,6 @@ DEBUG = env.bool("DJANGO_DEBUG", False)
 # In local dev, use simple static file serving (no manifest required).
 # The base.py CompressedManifestStaticFilesStorage requires collectstatic
 # which is unnecessary when runserver serves static files directly.
-if "staticfiles" in STORAGES:  # noqa: F405
-    STORAGES["staticfiles"] = {  # noqa: F405
-        "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
-    }
+STORAGES["staticfiles"] = {  # noqa: F405
+    "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+}

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -30,6 +30,7 @@ called source in your user's home directory:
     $ mkdir source
     $ cd source
     $ git clone https://github.com/Open-Source-Legal/OpenContracts.git
+    $ cd OpenContracts
 ```
 
 ## **Step 2**: Copy sample .env files to appropriate folders
@@ -82,19 +83,13 @@ not using something like auth0 and are going to rely on Django auth to provision
 
 ## **Step 3**: Build the Stack
 
-Change into the directory of the repository you just cloned, e.g.:
-
-```
-    $ cd OpenContracts
-```
-
 Now, you need to build the docker compose stack. If you are okay with the default username and password, and, most
 importantly, you are NOT PLANNING TO HOST THE APPLICATION online, the default local settings are sufficient.
 
 **Note:** The build process requires the .env files to be in place (from Step 2), as Docker will use these during the build.
 
 ```
-    $ docker-compose -f local.yml build
+    $ docker compose -f local.yml build
 ```
 
 This command will:
@@ -113,7 +108,7 @@ If you're **not** planning to do any frontend development, the easiest way to ge
 just type:
 
 ```commandline
-    $ docker-compose -f local.yml --profile fullstack up
+    $ docker compose -f local.yml --profile fullstack up
 ```
 
 This will start docker compose and add a container for the frontend to the stack.
@@ -125,7 +120,7 @@ If you plan to actively develop the frontend, you'll need to run the backend and
 First, start the backend services (without the frontend):
 
 ```commandline
-    $ docker-compose -f local.yml up
+    $ docker compose -f local.yml up
 ```
 
 Then, in a new terminal, navigate to the
@@ -147,13 +142,13 @@ Before logging in, let's verify everything is running correctly:
 
 1. **Check that all containers are running:**
    ```
-   $ docker-compose -f local.yml ps
+   $ docker compose -f local.yml ps
    ```
    You should see containers for: django, postgres, redis, celeryworker, celerybeat, and (if using Option 1) frontend.
 
 2. **Check the logs for any errors:**
    ```
-   $ docker-compose -f local.yml logs django
+   $ docker compose -f local.yml logs django
    ```
 
 3. **Verify the backend is accessible:**
@@ -204,14 +199,14 @@ See our [authentication guide](./configuration/authentication.md) for how to cre
 
 3. **Database connection errors**: Ensure the postgres container is fully started before the django container. The system should handle this automatically, but if issues persist, try:
    ```
-   $ docker-compose -f local.yml down
-   $ docker-compose -f local.yml up
+   $ docker compose -f local.yml down
+   $ docker compose -f local.yml up
    ```
 
    If you're reusing an existing PostgreSQL volume with different credentials, clean the volumes:
    ```
-   $ docker-compose -f local.yml down -v
-   $ docker-compose -f local.yml up
+   $ docker compose -f local.yml down -v
+   $ docker compose -f local.yml up
    ```
 
 4. **Missing .envs directory**: Make sure you created the `.envs/.local/` directory and copied all three required env files (.django, .postgres, and .frontend)
@@ -252,10 +247,10 @@ $ docker compose -f production.yml up
 
 | Operation | Local Development | Production |
 |-----------|-------------------|------------|
-| Build | `docker-compose -f local.yml build` | `docker compose -f production.yml build` |
-| Start | `docker-compose -f local.yml up` | `docker compose -f production.yml up` |
-| Migrations | `docker-compose -f local.yml run django python manage.py migrate` | `docker compose -f production.yml --profile migrate up migrate` |
-| Logs | `docker-compose -f local.yml logs django` | `docker compose -f production.yml logs django` |
+| Build | `docker compose -f local.yml build` | `docker compose -f production.yml build` |
+| Start | `docker compose -f local.yml up` | `docker compose -f production.yml up` |
+| Migrations | `docker compose -f local.yml run django python manage.py migrate` | `docker compose -f production.yml --profile migrate up migrate` |
+| Logs | `docker compose -f local.yml logs django` | `docker compose -f production.yml logs django` |
 
 ## **Useful Docker Commands**
 
@@ -264,31 +259,31 @@ Here are some helpful commands for managing your OpenContracts installation:
 ### Container Management
 ```bash
 # View running containers
-$ docker-compose -f local.yml ps
+$ docker compose -f local.yml ps
 
 # Stop all containers
-$ docker-compose -f local.yml down
+$ docker compose -f local.yml down
 
 # Stop and remove all containers and volumes (WARNING: deletes data)
-$ docker-compose -f local.yml down -v
+$ docker compose -f local.yml down -v
 
 # Restart a specific service
-$ docker-compose -f local.yml restart django
+$ docker compose -f local.yml restart django
 
 # View logs for a specific service
-$ docker-compose -f local.yml logs -f django
+$ docker compose -f local.yml logs -f django
 ```
 
 ### Database Management
 ```bash
 # Create a database backup
-$ docker-compose -f local.yml exec postgres backup
+$ docker compose -f local.yml exec postgres backup
 
 # Run Django shell
-$ docker-compose -f local.yml run django python manage.py shell
+$ docker compose -f local.yml run django python manage.py shell
 
 # Run database migrations manually
-$ docker-compose -f local.yml run django python manage.py migrate
+$ docker compose -f local.yml run django python manage.py migrate
 
 # For production deployments - run migrations using the dedicated service
 $ docker compose -f production.yml --profile migrate up migrate
@@ -297,7 +292,7 @@ $ docker compose -f production.yml --profile migrate up migrate
 ### Troubleshooting
 ```bash
 # Rebuild containers after code changes
-$ docker-compose -f local.yml build
+$ docker compose -f local.yml build
 
 # Remove unused Docker resources
 $ docker system prune -a

--- a/docs/sample_env_files/backend/local/.django
+++ b/docs/sample_env_files/backend/local/.django
@@ -44,6 +44,11 @@ USE_AUTH0=False
 OPENAI_API_KEY=<YourKeyHere>
 OPENAI_MODEL=gpt-4o
 
+# Microservice URLs
+# ------------------------------------------------------------------------------
+EMBEDDINGS_MICROSERVICE_URL=http://vector-embedder:8000
+DOCLING_PARSER_SERVICE_URL=http://docling-parser:8000/parse/
+
 # Docling
 # ------------------------------------------------------------------------------
 DOCLING_MODELS_PATH=/models/docling

--- a/docs/sample_env_files/backend/local/.django
+++ b/docs/sample_env_files/backend/local/.django
@@ -7,6 +7,7 @@ DJANGO_SUPERUSER_USERNAME=admin
 
 # General
 # ------------------------------------------------------------------------------
+DJANGO_DEBUG=True
 USE_DOCKER=yes
 IPYTHONDIR=/app/.ipython
 # IMPORTANT: Generate a unique secret key for production!

--- a/docs/sample_env_files/backend/production/.django
+++ b/docs/sample_env_files/backend/production/.django
@@ -62,6 +62,8 @@ AUTH0_M2M_MANAGEMENT_API_ID=<your-m2m-client-id>
 AUTH0_M2M_MANAGEMENT_GRANT_TYPE=client_credentials
 
 # Microservice URLs
+# These defaults use docker-compose internal hostnames. For Kubernetes,
+# bare metal, or managed service deployments, replace with the actual URLs.
 # ------------------------------------------------------------------------------
 EMBEDDINGS_MICROSERVICE_URL=http://vector-embedder:8000
 DOCLING_PARSER_SERVICE_URL=http://docling-parser:8000/parse/

--- a/docs/sample_env_files/backend/production/.django
+++ b/docs/sample_env_files/backend/production/.django
@@ -61,6 +61,11 @@ AUTH0_M2M_MANAGEMENT_API_SECRET=<your-m2m-client-secret>
 AUTH0_M2M_MANAGEMENT_API_ID=<your-m2m-client-id>
 AUTH0_M2M_MANAGEMENT_GRANT_TYPE=client_credentials
 
+# Microservice URLs
+# ------------------------------------------------------------------------------
+EMBEDDINGS_MICROSERVICE_URL=http://vector-embedder:8000
+DOCLING_PARSER_SERVICE_URL=http://docling-parser:8000/parse/
+
 # Docling
 # ------------------------------------------------------------------------------
 DOCLING_MODELS_PATH=/models/docling

--- a/frontend/conf/conf.d/default.conf
+++ b/frontend/conf/conf.d/default.conf
@@ -1,10 +1,10 @@
 server {
     listen 3000;
 
-    # load standard MIME types and map .js and .mjs correctly
+    # load standard MIME types and add .mjs mapping
     include mime.types;
     types {
-        application/javascript  js mjs;
+        application/javascript  mjs;
     }
 
     location / {

--- a/local.yml
+++ b/local.yml
@@ -36,7 +36,7 @@ services:
       test: ["CMD-SHELL", "python -c 'import urllib.request; urllib.request.urlopen(\"http://localhost:8000/admin/login/\")'"]
       interval: 10s
       timeout: 5s
-      retries: 30
+      retries: 12
       start_period: 60s
 
   postgres:
@@ -163,9 +163,9 @@ services:
       - "5555:5555"
     command: /start-flower
     healthcheck:
-      test: ["CMD-SHELL", "celery -A config.celery_app inspect ping --timeout 10"]
+      test: ["CMD-SHELL", "curl -sf http://localhost:5555/ || exit 1"]
       interval: 30s
-      timeout: 15s
+      timeout: 10s
       retries: 3
       start_period: 30s
 

--- a/local.yml
+++ b/local.yml
@@ -32,6 +32,12 @@ services:
     ports:
       - "8000:8000"
     command: /start
+    healthcheck:
+      test: ["CMD-SHELL", "python -c 'import urllib.request; urllib.request.urlopen(\"http://localhost:8000/admin/login/\")'"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 60s
 
   postgres:
     build:
@@ -101,6 +107,8 @@ services:
     image: opencontractserver_local_django
     container_name: celeryworker
     depends_on:
+      django:
+        condition: service_healthy
       redis:
         condition: service_healthy
       postgres:
@@ -122,6 +130,8 @@ services:
     image: opencontractserver_local_django
     container_name: celerybeat
     depends_on:
+      django:
+        condition: service_healthy
       redis:
         condition: service_healthy
       postgres:
@@ -142,9 +152,22 @@ services:
     <<: *django
     image: opencontractserver_local_flower
     container_name: flower
+    depends_on:
+      django:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
     ports:
       - "5555:5555"
     command: /start-flower
+    healthcheck:
+      test: ["CMD-SHELL", "celery -A config.celery_app inspect ping --timeout 10"]
+      interval: 30s
+      timeout: 15s
+      retries: 3
+      start_period: 30s
 
   frontend:
       build:

--- a/opencontractserver/users/models.py
+++ b/opencontractserver/users/models.py
@@ -165,7 +165,11 @@ class User(AbstractUser):
         # Avoid referencing the slug column before it exists in initial migrations
         slug_column_exists = table_has_column(self._meta.db_table, "slug")
 
-        if slug_column_exists:
+        # Skip slug processing when saving unrelated fields (e.g. last_login)
+        update_fields = kwargs.get("update_fields")
+        slug_being_saved = update_fields is None or "slug" in update_fields
+
+        if slug_column_exists and slug_being_saved:
             # Ensure slug exists and is valid
             if not self.slug or not isinstance(self.slug, str) or not self.slug.strip():
                 # Generate a unique slug from username


### PR DESCRIPTION
## Summary

Followed the quickstart instructions exactly and fixed every issue that prevented getting from `git clone` to a working login on both backend and frontend.

- **Missing env vars crash Django on startup**: `EMBEDDINGS_MICROSERVICE_URL` and `DOCLING_PARSER_SERVICE_URL` had no defaults in `base.py` and were missing from sample env files
- **Celerybeat race condition**: crashes on first boot because it starts before Django finishes migrations. Added healthcheck to django service; celerybeat/celeryworker/flower now wait for `service_healthy`
- **Password login completely broken**: JWT middleware was gated behind `USE_AUTH0=True`, so tokens from `tokenAuth` were never validated on subsequent GraphQL requests. Enabled unconditionally (Auth0 unaffected — same middleware handles both)
- **Admin user login crashes with 500**: `User.save()` re-validated the slug on every save (including `last_login` updates), and `"admin"` is a reserved slug. Fixed by skipping slug validation when `update_fields` doesn't include `slug`
- **Django admin panel 500s on static files**: `CompressedManifestStaticFilesStorage` requires `collectstatic` which the local start script doesn't run. Overridden to `StaticFilesStorage` in `local.py`
- **`DJANGO_DEBUG=True` missing from sample env**: runserver needs this to serve static files
- **README quickstart missing steps**: added env file copy, `--profile fullstack`, correct GitHub org URL, login credentials
- **Docs used deprecated `docker-compose` v1 syntax**: replaced with `docker compose` throughout
- **Nginx duplicate `.js` MIME warning**: removed redundant extension mapping

## Test plan

- [ ] `docker compose -f local.yml down -v && docker compose -f local.yml --profile fullstack up` from clean state — all services start, celerybeat waits for django
- [ ] Navigate to `http://localhost:8000/admin/`, login with `admin` / `Openc0ntracts_def@ult` — Django admin loads with CSS
- [ ] Navigate to `http://localhost:3000/login`, login with same credentials — redirects to `/`, Corpuses page shows authenticated content
- [ ] Verify Auth0 login still works when `USE_AUTH0=True` (JWT middleware is now always active)