### PR TITLE
Fix CAML article never displaying on corpus home

### DIFF
--- a/frontend/src/graphql/queries.ts
+++ b/frontend/src/graphql/queries.ts
@@ -5133,7 +5133,12 @@ export const GET_CORPUS_DOCUMENTS_FOR_TOC = gql`
 
 export const GET_CORPUS_ARTICLE = gql`
   query GetCorpusArticle($corpusId: String!, $title: String!) {
-    documents(inCorpusWithId: $corpusId, title: $title, first: 1) {
+    documents(
+      inCorpusWithId: $corpusId
+      title: $title
+      includeCaml: true
+      first: 1
+    ) {
       edges {
         node {
           id


### PR DESCRIPTION
## Summary

- **Root cause:** `GET_CORPUS_ARTICLE` query used `inCorpusWithId` without `includeCaml: true`, causing the backend `DocumentFilter` to silently exclude all `text/markdown` documents from results
- **Fix:** Added `includeCaml: true` to the query — this is the only CAML-fetching query that was missing the flag
- All three reported symptoms resolved: article not rendering on corpus home, editor always showing placeholder template, and saved content being invisible

## Test plan

- [ ] Create a new corpus, click "Create an introductory article", paste CAML content, save
- [ ] Verify corpus home renders the saved CAML article
- [ ] Re-open editor and verify it loads the saved content (not the template)
- [ ] Verify CAML documents are still excluded from extractors/analyzers (they don't pass `includeCaml`)