### PR TITLE
Fix CorpusHome CAML article flicker and document list clipping

### DIFF
--- a/frontend/src/components/corpuses/CorpusHome.tsx
+++ b/frontend/src/components/corpuses/CorpusHome.tsx
@@ -122,7 +122,7 @@ export const CorpusHome: React.FC<CorpusHomeProps> = ({
     [corpus.id]
   );
 
-  const { data: articleData } = useQuery<
+  const { data: articleData, loading: articleLoading } = useQuery<
     GetCorpusArticleOutput,
     GetCorpusArticleInput
   >(GET_CORPUS_ARTICLE, { variables: articleQueryVars });
@@ -201,6 +201,13 @@ export const CorpusHome: React.FC<CorpusHomeProps> = ({
     );
   }
 
+  // Wait for article detection before choosing between article and landing view.
+  // Without this guard, CorpusLandingView renders momentarily then gets swapped
+  // out when the article query resolves, causing a visible flicker.
+  if (articleLoading) {
+    return null;
+  }
+
   // When a Readme.CAML exists, render the article as the default landing view
   // with floating chat and mode-toggle controls overlaid at the bottom.
   if (hasArticle) {
@@ -267,6 +274,7 @@ export const CorpusHome: React.FC<CorpusHomeProps> = ({
     <>
       <CorpusLandingView
         corpus={corpus}
+        hasArticle={hasArticle}
         onViewDetails={handleViewDetails}
         onEditDescription={onEditDescription}
         onNavigateToCorpuses={onNavigateToCorpuses}

--- a/frontend/src/components/corpuses/CorpusHome/CorpusLandingView.tsx
+++ b/frontend/src/components/corpuses/CorpusHome/CorpusLandingView.tsx
@@ -19,11 +19,7 @@ import {
   GET_CORPUS_WITH_HISTORY,
   GetCorpusWithHistoryQuery,
   GetCorpusWithHistoryQueryVariables,
-  GET_CORPUS_ARTICLE,
-  GetCorpusArticleInput,
-  GetCorpusArticleOutput,
 } from "../../../graphql/queries";
-import { CAML_ARTICLE_FILENAME } from "../../../assets/configurations/constants";
 import { OS_LEGAL_COLORS } from "../../../assets/configurations/osLegalStyles";
 import { CorpusType } from "../../../types/graphql-api";
 import { PermissionTypes } from "../../types";
@@ -107,6 +103,8 @@ const CTASubtitle = styled.span`
 export interface CorpusLandingViewProps {
   /** The corpus object */
   corpus: CorpusType;
+  /** Whether a Readme.CAML article exists — provided by parent to avoid redundant query */
+  hasArticle?: boolean;
   /** Callback when "View Details" is clicked */
   onViewDetails: () => void;
   /** Callback when edit description is clicked */
@@ -154,6 +152,7 @@ export interface CorpusLandingViewProps {
  */
 export const CorpusLandingView: React.FC<CorpusLandingViewProps> = ({
   corpus,
+  hasArticle: hasArticleProp,
   onViewDetails,
   onEditDescription,
   onNavigateToCorpuses,
@@ -182,17 +181,7 @@ export const CorpusLandingView: React.FC<CorpusLandingViewProps> = ({
     variables: historyVariables,
   });
 
-  // Check if a Readme.CAML article exists in this corpus
-  const articleVars = useMemo<GetCorpusArticleInput>(
-    () => ({ corpusId: corpus.id, title: CAML_ARTICLE_FILENAME }),
-    [corpus.id]
-  );
-  const { data: articleData } = useQuery<
-    GetCorpusArticleOutput,
-    GetCorpusArticleInput
-  >(GET_CORPUS_ARTICLE, { variables: articleVars });
-
-  const hasArticle = (articleData?.documents?.edges?.length ?? 0) > 0;
+  const hasArticle = hasArticleProp ?? false;
 
   // Fetch markdown content from URL
   useEffect(() => {

--- a/frontend/src/components/documents/CorpusDocumentCards.tsx
+++ b/frontend/src/components/documents/CorpusDocumentCards.tsx
@@ -391,7 +391,6 @@ export const CorpusDocumentCards = ({
               height: "100%",
               display: "flex",
               flexDirection: "column",
-              paddingTop: "3.5rem", // Add padding to prevent overlap with view toggle buttons
             }}
             style={{
               flex: 1,
@@ -413,7 +412,6 @@ export const CorpusDocumentCards = ({
         ) : (
           <div
             style={{
-              paddingTop: "3.5rem",
               height: "100%",
               display: "flex",
               flexDirection: "column",


### PR DESCRIPTION
## Summary

- **Fix landing view flicker**: When a corpus has a `Readme.CAML` article, `CorpusHome` would briefly render `CorpusLandingView` (showing the markdown description) before swapping to `CorpusArticleView` once the article query resolved. Added a `loading` guard so the component waits for article detection before choosing which view to render. Also passes `hasArticle` as a prop to `CorpusLandingView`, eliminating a redundant duplicate query.
- **Fix document list padding/clipping**: Removed stale `paddingTop: 3.5rem` from `CorpusDocumentCards` that was left over from when view toggle buttons floated over the content area (they now live in `FolderToolbar`). This caused the first item to appear offset from the top and the last items to be clipped off-screen.

## Test plan

- [ ] Navigate to a corpus with a `Readme.CAML` — should load directly into article view without flashing the landing page first
- [ ] Navigate to a corpus without a `Readme.CAML` — should still show the landing view normally
- [ ] In manage mode, open the document list — first item should be flush with the toolbar, last items should be fully scrollable
- [ ] Verify both list and grid view modes show content without top offset