### PR TITLE
Display initial query in chat history instead of sending silently

### DIFF
--- a/frontend/src/components/corpuses/CorpusChat.tsx
+++ b/frontend/src/components/corpuses/CorpusChat.tsx
@@ -522,9 +522,8 @@ export const CorpusChat: React.FC<CorpusChatProps> = ({
     }
   }, [forceNewChat]);
 
-  // Modify the effect that sends the initial query
+  // Send the initial query once the WebSocket is ready
   useEffect(() => {
-    // Do not send if the provided initialQuery is empty or whitespace
     if (
       initialQuery &&
       initialQuery.trim().length > 0 &&
@@ -533,8 +532,21 @@ export const CorpusChat: React.FC<CorpusChatProps> = ({
     ) {
       const timer = setTimeout(() => {
         if (socketRef.current && wsReady) {
-          // Simply send the initial query over websocket (without adding it to chat)
-          socketRef.current.send(JSON.stringify({ query: initialQuery }));
+          const trimmed = initialQuery.trim();
+          setChat((prev) => [
+            ...prev,
+            {
+              messageId: `user_${Date.now()}_${Math.random()
+                .toString(36)
+                .substr(2)}`,
+              user: user_obj?.email || "You",
+              content: trimmed,
+              timestamp: new Date().toLocaleString(),
+              isAssistant: false,
+              isComplete: false,
+            },
+          ]);
+          socketRef.current.send(JSON.stringify({ query: trimmed }));
           setNewMessage("");
           setWsError(null);
         }
@@ -542,7 +554,7 @@ export const CorpusChat: React.FC<CorpusChatProps> = ({
 
       return () => clearTimeout(timer);
     }
-  }, [initialQuery, wsReady, isNewChat]);
+  }, [initialQuery, wsReady, isNewChat, user_obj?.email]);
 
   /**
    * Loads existing conversation by ID, clearing local state, then showing chat UI.


### PR DESCRIPTION
## Summary
Modified the initial query handling in CorpusChat to display the user's initial query message in the chat history, rather than sending it to the WebSocket without showing it to the user.

## Key Changes
- **User message visibility**: The initial query is now added to the chat history as a user message before being sent to the WebSocket, making it visible in the conversation
- **Message structure**: Created a properly formatted message object with:
  - Unique message ID (timestamp + random string)
  - User email or "You" as sender
  - Trimmed query content
  - Current timestamp
  - Marked as non-assistant, incomplete message
- **Dependency update**: Added `user_obj?.email` to the useEffect dependency array to ensure the effect re-runs if the user changes
- **Code clarity**: Updated comments to better reflect the actual behavior (sending initial query once WebSocket is ready)

## Implementation Details
The initial query is now handled consistently with regular user messages - it's added to the chat state before being transmitted, providing immediate visual feedback to the user and maintaining a complete conversation history.

https://claude.ai/code/session_01StWvKizXPDTtfdQawFWeYG