### PR TITLE
Fix lodash code injection and prototype pollution vulnerabilities

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -131,7 +131,8 @@
     "ajv-formats/ajv": "8.18.0",
     "glob": "10.5.0",
     "js-yaml": "4.1.1",
-    "lodash-es": "4.17.23",
+    "lodash": ">=4.18.0",
+    "lodash-es": ">=4.18.0",
     "mdast-util-to-hast": "13.2.1",
     "rollup": "^4.59.0",
     "immutable": ">=3.8.3"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -5208,10 +5208,10 @@ listr2@^4.0.5:
     through "^2.3.8"
     wrap-ansi "^7.0.0"
 
-lodash-es@4.17.23, lodash-es@^4.17.21:
-  version "4.17.23"
-  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.23.tgz#58c4360fd1b5d33afc6c0bbd3d1149349b1138e0"
-  integrity sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==
+lodash-es@>=4.18.0, lodash-es@^4.17.21:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.18.1.tgz#b962eeb80d9d983a900bf342961fb7418ca10b1d"
+  integrity sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==
 
 lodash.curry@^4.0.1:
   version "4.1.1"
@@ -5233,15 +5233,10 @@ lodash.uniqueid@^4.0.1:
   resolved "https://registry.yarnpkg.com/lodash.uniqueid/-/lodash.uniqueid-4.0.1.tgz#3268f26a7c88e4f4b1758d679271814e31fa5b26"
   integrity sha512-GQQWaIeGlL6DIIr06kj1j6sSmBxyNMwI8kaX9aKpHR/XsMTiaXDVPNPAkiboOTK9OJpTJF/dXT3xYoFQnj386Q==
 
-lodash@>=4.17.21, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.18.1:
+lodash@>=4.17.21, lodash@>=4.18.0, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.18.1, lodash@~4.17.0:
   version "4.18.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
   integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
-
-lodash@~4.17.0:
-  version "4.17.23"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.23.tgz#f113b0378386103be4f6893388c73d0bde7f2c5a"
-  integrity sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==
 
 log-symbols@^4.0.0, log-symbols@^4.1.0:
   version "4.1.0"


### PR DESCRIPTION
## Summary
- Upgrades `lodash` and `lodash-es` to `>=4.18.0` via yarn resolutions, fixing all 4 open Dependabot alerts (#71-#74)
- Eliminates nested `lodash@4.17.23` copy from `@graphql-codegen/plugin-helpers` by consolidating resolution
- Addresses CVE-2025-23413 (code injection via `_.template`) and CVE-2025-23414 (prototype pollution via `_.unset`/`_.omit`)

## Test plan
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] All 898 frontend unit tests pass (`yarn test:unit --run`)
- [x] Pre-commit hooks pass
- [x] `yarn why lodash` and `yarn why lodash-es` confirm single 4.18.1 version
- [ ] CI passes
- [ ] Dependabot alerts auto-close after merge