### PR TITLE
Harden IngestionSource: rate limits, API exposure, and race condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **IngestionSource follow-up hardening** (Issue #1228):
+  - Added `@graphql_ratelimit` to `CreateIngestionSourceMutation`, `UpdateIngestionSourceMutation`, and `DeleteIngestionSourceMutation` (`config/graphql/ingestion_source_mutations.py`). Previously these mutations only carried `@login_required`, allowing an authenticated user to create thousands of rows (plus Guardian permission entries) in a tight loop. Creates/updates use `WRITE_MEDIUM`, deletes use `WRITE_LIGHT`, matching other CRUD mutations in the codebase.
+  - Guarded the fallback `.get()` inside the `except IntegrityError` handler in `_import_ingestion_sources` (`opencontractserver/tasks/import_tasks_v2.py` ~line 463). In the rare scenario where a concurrent request created-then-deleted the row between the `IntegrityError` and the fallback, the unguarded `.get()` would raise `IngestionSource.DoesNotExist` and abort the entire corpus import. Now logs a warning and continues.
+  - Added an explicit `fields` allowlist to `IngestionSourceType.Meta` (`config/graphql/document_types.py`) to prevent `user_lock`, `backend_lock`, and `is_public` from leaking through the GraphQL API. `user_lock` in particular would leak the username of whoever currently holds the lock — an information-disclosure issue.
+  - Added a clarifying comment documenting the intentional export/import asymmetry for `ingestion_metadata` in `_reconstruct_document_paths` (`opencontractserver/tasks/import_tasks_v2.py`).
+
 - **Document lineage fields dropped on move/delete/restore** (PR #1197): `move_document`, `delete_document`, and `restore_document` in `opencontractserver/documents/versioning.py` now forward `ingestion_source`, `external_id`, and `ingestion_metadata` from the parent path record to newly-created path nodes. Previously these fields were silently dropped, losing lineage provenance on any path operation.
 
 - **`ingestion_metadata` truthiness check** (PR #1197): Changed `if ingestion_metadata:` to `if ingestion_metadata is not None:` in `config/graphql/document_mutations.py` so that an empty dict `{}` is correctly stored rather than silently discarded.

--- a/config/graphql/document_types.py
+++ b/config/graphql/document_types.py
@@ -69,6 +69,19 @@ class IngestionSourceType(AnnotatePermissionsForReadMixin, DjangoObjectType):
         model = IngestionSource
         interfaces = [relay.Node]
         connection_class = CountableConnection
+        # Explicit allowlist: do NOT expose ``user_lock`` (leaks username of
+        # the user holding the lock), ``backend_lock``, or ``is_public`` from
+        # the BaseOCModel parent.  Keep the API surface limited to the
+        # source's descriptive + lifecycle fields.
+        fields = (
+            "id",
+            "name",
+            "source_type",
+            "config",
+            "active",
+            "created",
+            "modified",
+        )
 
     @classmethod
     def get_queryset(cls, queryset, info):

--- a/config/graphql/ingestion_source_mutations.py
+++ b/config/graphql/ingestion_source_mutations.py
@@ -15,6 +15,7 @@ from config.graphql.document_types import (
     IngestionSourceType,
     IngestionSourceTypeEnum,
 )
+from config.graphql.ratelimits import RateLimits, graphql_ratelimit
 from opencontractserver.documents.models import (
     IngestionSource,
     IngestionSourceCategory,
@@ -73,6 +74,7 @@ class CreateIngestionSourceMutation(graphene.Mutation):
     ingestion_source = graphene.Field(IngestionSourceType)
 
     @login_required
+    @graphql_ratelimit(rate=RateLimits.WRITE_MEDIUM)
     def mutate(_root, info, name, source_type=None, config=None):
         user = info.context.user
 
@@ -119,6 +121,7 @@ class UpdateIngestionSourceMutation(graphene.Mutation):
     ingestion_source = graphene.Field(IngestionSourceType)
 
     @login_required
+    @graphql_ratelimit(rate=RateLimits.WRITE_MEDIUM)
     def mutate(_root, info, id, **kwargs):
         user = info.context.user
 
@@ -186,6 +189,7 @@ class DeleteIngestionSourceMutation(graphene.Mutation):
     message = graphene.String()
 
     @login_required
+    @graphql_ratelimit(rate=RateLimits.WRITE_LIGHT)
     def mutate(_root, info, id):
         user = info.context.user
 

--- a/opencontractserver/tasks/import_tasks_v2.py
+++ b/opencontractserver/tasks/import_tasks_v2.py
@@ -462,7 +462,20 @@ def _import_ingestion_sources(
                 )
         except IntegrityError as exc:
             logger.debug("IntegrityError on create, falling back to get: %s", exc)
-            source = IngestionSource.objects.get(creator=user_obj, name=name)
+            # Guard the fallback: in the rare case where a concurrent request
+            # created-then-deleted the row between the IntegrityError and this
+            # .get(), skip the source rather than aborting the entire corpus
+            # import with an unhandled DoesNotExist.
+            try:
+                source = IngestionSource.objects.get(creator=user_obj, name=name)
+            except IngestionSource.DoesNotExist:
+                logger.warning(
+                    "IngestionSource '%s' for user %s vanished between "
+                    "IntegrityError and fallback get; skipping.",
+                    name,
+                    user_obj.id,
+                )
+                continue
             created = False
         source_map[name] = source
 
@@ -566,6 +579,11 @@ def _reconstruct_document_paths(
         if external_id is not None:
             updates["external_id"] = external_id
 
+        # Asymmetry note: export omits ``ingestion_metadata`` entirely when
+        # the value is falsy (see ``package_document_paths``), so a missing
+        # key here is the expected "empty" signal.  An explicit ``None`` is
+        # treated the same as absent — we only restore a dict payload when
+        # the exporter actually wrote one.
         ingestion_metadata = path_data.get("ingestion_metadata")
         if ingestion_metadata is not None:
             updates["ingestion_metadata"] = ingestion_metadata

--- a/opencontractserver/tests/test_ingestion_source.py
+++ b/opencontractserver/tests/test_ingestion_source.py
@@ -600,6 +600,30 @@ class TestIngestionSourceQuery(TestCase):
         self.assertIsNone(result.get("errors"))
         self.assertIsNone(result["data"]["ingestionSource"])
 
+    def test_internal_fields_not_exposed_on_type(self):
+        """``userLock``, ``backendLock``, and ``isPublic`` from BaseOCModel
+        must not be queryable on IngestionSourceType — they were explicitly
+        excluded from the Meta fields allowlist to avoid leaking internal
+        state (user_lock would leak the username of whoever holds the lock).
+        """
+        leak_query = """
+            query GetIngestionSource($id: ID!) {
+                ingestionSource(id: $id) {
+                    id
+                    userLock { username }
+                    backendLock
+                    isPublic
+                }
+            }
+        """
+        gid = to_global_id("IngestionSourceType", self.source.pk)
+        result = self.client.execute(leak_query, variables={"id": gid})
+        # A GraphQL validation error is expected because these fields should
+        # not exist on the type at all.
+        self.assertIsNotNone(result.get("errors"))
+        error_messages = " ".join(str(e.get("message", "")) for e in result["errors"])
+        self.assertIn("userLock", error_messages)
+
 
 # ------------------------------------------------------------------ #
 # ingestionSources list query
@@ -1046,6 +1070,39 @@ class TestImportIngestionSourcesIntegrityFallback(TestCase):
         self.assertIn("race_source", source_map)
         self.assertEqual(source_map["race_source"].pk, existing.pk)
         self.assertEqual(source_map["race_source"].source_type, "api")
+
+    def test_integrity_error_fallback_skips_vanished_row(self):
+        """When the row vanishes between IntegrityError and the fallback
+        .get() (concurrent created-then-deleted), the import should log a
+        warning and skip the source rather than aborting the entire corpus
+        import with a bubbled DoesNotExist."""
+        from django.db import IntegrityError
+
+        sources_data = [
+            {
+                "name": "vanished_source",
+                "source_type": "api",
+                "config": {},
+                "active": True,
+            }
+        ]
+
+        # Patch get_or_create to always raise IntegrityError, and do NOT
+        # pre-create the row.  The fallback .get() will then raise
+        # DoesNotExist, simulating the "created-then-deleted between the
+        # IntegrityError and the fallback" race.  The import must not
+        # bubble DoesNotExist; it must log a warning and continue.
+        with patch.object(
+            type(IngestionSource.objects),
+            "get_or_create",
+            side_effect=IntegrityError("duplicate key value"),
+        ):
+            source_map = _import_ingestion_sources(sources_data, self.user)
+
+        # Vanished source is silently skipped rather than aborting the
+        # whole corpus import.
+        self.assertNotIn("vanished_source", source_map)
+        self.assertEqual(source_map, {})
 
 
 # ------------------------------------------------------------------ #


### PR DESCRIPTION
## Summary
This PR implements follow-up security and reliability hardening for IngestionSource, addressing information disclosure, rate limiting, and a race condition in concurrent import scenarios.

## Key Changes

- **Rate limiting on mutations**: Added `@graphql_ratelimit` decorators to `CreateIngestionSourceMutation`, `UpdateIngestionSourceMutation`, and `DeleteIngestionSourceMutation` using `WRITE_MEDIUM` and `WRITE_LIGHT` rates respectively. Previously these mutations only required `@login_required`, allowing authenticated users to create thousands of rows in tight loops.

- **GraphQL API exposure hardening**: Added an explicit `fields` allowlist to `IngestionSourceType.Meta` to prevent `user_lock`, `backend_lock`, and `is_public` from being queryable. This prevents information disclosure—specifically, `user_lock` would leak the username of whoever holds the lock.

- **Race condition guard in import fallback**: Wrapped the fallback `.get()` call in the `except IntegrityError` handler within `_import_ingestion_sources` with a try-except block. In rare concurrent scenarios where a row is created-then-deleted between the `IntegrityError` and the fallback `.get()`, the code now logs a warning and skips the source rather than aborting the entire corpus import with an unhandled `DoesNotExist`.

- **Documentation**: Added clarifying comments explaining the intentional export/import asymmetry for `ingestion_metadata` in `_reconstruct_document_paths`.

## Testing
Added comprehensive test coverage:
- `test_internal_fields_not_exposed_on_type`: Verifies that `userLock`, `backendLock`, and `isPublic` are not queryable on IngestionSourceType
- `test_integrity_error_fallback_skips_vanished_row`: Verifies graceful handling of the race condition where a row vanishes between IntegrityError and the fallback `.get()`

https://claude.ai/code/session_01N3UzyoDrjnxBF4XhpG5iyx