### PR TITLE
Fix flaky test_ask_document_malformed_result under pytest-xdist

### DIFF
--- a/opencontractserver/tests/test_pydantic_ai_agents_integration.py
+++ b/opencontractserver/tests/test_pydantic_ai_agents_integration.py
@@ -16,6 +16,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.files.base import ContentFile
 from django.test import TransactionTestCase
+from django.utils import timezone
 
 from opencontractserver.annotations.models import Annotation, AnnotationLabel
 from opencontractserver.corpuses.models import Corpus
@@ -82,6 +83,8 @@ class TestPydanticAIAgentsIntegration(TransactionTestCase):
             creator=self.user,
             is_public=True,
             file_type="text/plain",
+            processing_started=timezone.now(),
+            backend_lock=False,
         )
         self.doc1.txt_extract_file.save(
             "payment_contract.txt", ContentFile(doc1_text.encode("utf-8")), save=True
@@ -96,6 +99,8 @@ class TestPydanticAIAgentsIntegration(TransactionTestCase):
             creator=self.user,
             is_public=True,
             file_type="text/plain",
+            processing_started=timezone.now(),
+            backend_lock=False,
         )
         self.doc2.txt_extract_file.save(
             "service_agreement.txt", ContentFile(doc2_text.encode("utf-8")), save=True
@@ -498,13 +503,17 @@ class TestPydanticAIAgentsEdgeCases(TransactionTestCase):
             is_public=True,
         )
 
-        # Document with minimal content
+        # Document with minimal content — processing_started prevents the
+        # post_save signal from triggering ingest_doc eagerly before
+        # txt_extract_file is saved (flaky under pytest-xdist).
         self.doc = Document.objects.create(
             title="Minimal Doc",
             description="Minimal document for edge cases",
             creator=self.user,
             is_public=True,
             file_type="text/plain",
+            processing_started=timezone.now(),
+            backend_lock=False,
         )
         self.doc.txt_extract_file.save(
             "minimal.txt", ContentFile(b"Short text."), save=True


### PR DESCRIPTION
## Summary
- Set `processing_started=timezone.now()` on `Document.objects.create()` calls in `test_pydantic_ai_agents_integration.py` to prevent the `post_save` signal from triggering `ingest_doc` eagerly before `txt_extract_file` is saved
- This test has been failing across **4 unrelated PRs** (#1247, #1245, #1239, #1235) as a flaky failure, blocking CI

## Root Cause
Under pytest-xdist with `TransactionTestCase`, the session-scoped signal disconnection in `conftest.py` can be unreliable due to test ordering. When signals remain connected, `Document.objects.create()` triggers the processing chain (`extract_thumbnail` → `ingest_doc` → `set_doc_lock_state`) **eagerly** (Celery eager mode). Since `txt_extract_file` is saved on the *next line* after `create()`, the parser finds no text file and raises `DocumentParsingError`.

## Fix
Setting `processing_started` on the Document short-circuits the signal handler (`if created and not instance.processing_started`), preventing the processing chain. This matches the pattern already used by `Corpus.add_document()` for corpus-isolated copies.

## Test plan
- [ ] CI pytest passes (the previously flaky test should now be stable)
- [ ] No other tests affected (change is isolated to test fixtures)