### PR TITLE
Fix flaky tests: prevent auto-ingest signal for Documents without pdf_file

### DIFF
--- a/opencontractserver/tests/test_multimodal_integration.py
+++ b/opencontractserver/tests/test_multimodal_integration.py
@@ -24,6 +24,7 @@ import pytest
 from django.contrib.auth import get_user_model
 from django.core.files.base import ContentFile
 from django.test import TestCase, TransactionTestCase
+from django.utils import timezone
 from PIL import Image
 
 from opencontractserver.corpuses.models import Corpus
@@ -311,11 +312,13 @@ class TestDoclingImageExtraction(TransactionTestCase):
             image_color="blue",
         )
 
-        # Create document
+        # Create document with processing_started set to prevent the
+        # post_save signal from triggering ingest_doc before pdf_file is saved.
         doc = Document.objects.create(
             title="PDF with Image for Docling Test",
             creator=self.user,
             file_type="application/pdf",
+            processing_started=timezone.now(),
         )
         doc.pdf_file.save("test_with_image.pdf", ContentFile(pdf_bytes))
 
@@ -407,11 +410,13 @@ class TestFullMultimodalPipeline(TransactionTestCase):
             chart_title="Quarterly Revenue Growth",
         )
 
-        # 2. Create document and parse
+        # 2. Create document and parse (processing_started prevents auto-ingest
+        # signal from firing before pdf_file is saved)
         doc = Document.objects.create(
             title="Revenue Report",
             creator=self.user,
             file_type="application/pdf",
+            processing_started=timezone.now(),
         )
         doc.pdf_file.save("revenue_report.pdf", ContentFile(pdf_bytes))
 

--- a/opencontractserver/tests/test_structural_annotations_graphql_backwards_compat.py
+++ b/opencontractserver/tests/test_structural_annotations_graphql_backwards_compat.py
@@ -18,6 +18,7 @@ import io
 from django.contrib.auth import get_user_model
 from django.core.management import call_command
 from django.test import TransactionTestCase
+from django.utils import timezone
 from graphene.test import Client
 from graphql_relay import to_global_id
 
@@ -70,6 +71,7 @@ class StructuralAnnotationGraphQLBackwardsCompatibilityTests(TransactionTestCase
             pdf_file_hash="graphql_compat_hash_001",
             creator=self.user,
             page_count=5,
+            processing_started=timezone.now(),
         )
         set_permissions_for_obj_to_user(
             self.user,
@@ -552,6 +554,7 @@ class StructuralAnnotationGraphQLBackwardsCompatibilityTests(TransactionTestCase
             pdf_file_hash=self.doc.pdf_file_hash,  # SAME HASH!
             creator=self.user,
             page_count=5,
+            processing_started=timezone.now(),
         )
         set_permissions_for_obj_to_user(
             self.user,
@@ -710,6 +713,7 @@ class StructuralAnnotationGraphQLBackwardsCompatibilityTests(TransactionTestCase
             title="Document Without Structural",
             pdf_file_hash="empty_doc_hash",
             creator=self.user,
+            processing_started=timezone.now(),
         )
         set_permissions_for_obj_to_user(
             self.user,
@@ -784,6 +788,7 @@ class StructuralRelationshipGraphQLBackwardsCompatibilityTests(TransactionTestCa
             title="Document With Structural Relationships",
             pdf_file_hash="rel_test_hash_001",
             creator=self.user,
+            processing_started=timezone.now(),
         )
         set_permissions_for_obj_to_user(
             self.user,


### PR DESCRIPTION
## Summary
- Fixes 2 intermittently failing backend tests on main caused by the Document `post_save` signal triggering `ingest_doc` synchronously during test setup
- Root cause: `TransactionTestCase` + `CELERY_TASK_EAGER_PROPAGATES=True` means `Document.objects.create()` immediately runs the full ingestion pipeline via `on_commit`. When `pdf_file` is empty (or not yet saved), `chunked_parser.py:165` opens `MEDIA_ROOT` directory instead of a file → `IsADirectoryError`
- Fix: set `processing_started=timezone.now()` on Document creation to skip the `process_doc_on_create_atomic` signal, since these tests don't need automatic ingestion

## Affected tests
- `test_structural_annotations_graphql_backwards_compat.py::StructuralRelationshipGraphQLBackwardsCompatibilityTests::test_structural_relationships_accessible_after_migration`
- `test_multimodal_integration.py::TestDoclingImageExtraction::test_parse_pdf_with_embedded_image`

These failures are also blocking PRs #1236, #1237, and #1239.

## Test plan
- [ ] Backend CI pytest passes (the two previously failing tests should now pass consistently)
- [ ] No other tests regress