### PR TITLE
Add backend coverage instrumentation to frontend E2E tests

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,5 +1,16 @@
 codecov:
   require_ci_to_pass: yes
+  # Wait for all 5 coverage uploads before sending notifications and
+  # posting status checks. The 5 streams are:
+  #   1. backend          – pytest unit/integration  (backend.yml)
+  #   2. frontend-unit    – vitest                   (frontend.yml)
+  #   3. frontend-component – Playwright CT          (frontend.yml)
+  #   4. frontend-e2e     – Istanbul via Playwright  (frontend-e2e.yml)
+  #   5. backend-e2e      – coverage.py via Playwright (frontend-e2e.yml)
+  # carryforward flags let partial workflow runs still satisfy the threshold.
+  notify:
+    after_n_builds: 5
+    wait_for_ci: true
 
 coverage:
   precision: 2
@@ -7,8 +18,12 @@ coverage:
   range: "70...100"
 
   status:
-    project: true
-    patch: true
+    project:
+      default:
+        after_n_builds: 5
+    patch:
+      default:
+        after_n_builds: 5
     changes: false
 
 flags:
@@ -47,6 +62,7 @@ comment:
   layout: "reach,diff,flags,files,footer"
   behavior: default
   require_changes: no
+  after_n_builds: 5
 
 ignore:
   - "opencontractserver/tasks/data_extract_tasks.py"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -29,6 +29,11 @@ flags:
     paths:
       - frontend/src/
     carryforward: true
+  backend-e2e:
+    paths:
+      - opencontractserver/
+      - config/
+    carryforward: true
 
 parsers:
   gcov:

--- a/.github/workflows/frontend-e2e.yml
+++ b/.github/workflows/frontend-e2e.yml
@@ -3,9 +3,11 @@ name: Frontend E2E Integration
 # Runs the Playwright integration spec at
 # `frontend/tests/e2e/login-and-navigation.spec.ts` against a real
 # Django + Postgres + Redis backend stack. The spec exercises the
-# password-login flow and walks every routed view in `src/views/`,
-# emitting Istanbul coverage that is uploaded to Codecov under the
-# `frontend-e2e` flag.
+# password-login flow and walks every routed view in `src/views/`.
+#
+# Coverage is captured on BOTH sides:
+#   - Frontend: Istanbul (vite-plugin-istanbul) → Codecov `frontend-e2e`
+#   - Backend:  coverage.py wrapping Django runserver → Codecov `backend-e2e`
 #
 # Triggered on PRs that touch the frontend, the spec, or this workflow,
 # plus pushes to release branches.
@@ -30,6 +32,7 @@ on:
       - 'opencontractserver/users/migrations/0003_create_initial_superuser.py'
       - 'config/settings/**'
       - 'test.yml'
+      - 'test.e2e-coverage.yml'
       - 'compose/local/django/**'
 
 concurrency:
@@ -69,9 +72,13 @@ jobs:
       #
       # `test.yml` already reads from `.envs/.test/.django` and
       # `.envs/.test/.postgres`, both of which are committed to the repo.
-      # The django service runs `/start` which executes
-      # `python manage.py migrate` — that triggers the
-      # `0003_create_initial_superuser` migration, creating the
+      # The compose override `test.e2e-coverage.yml` swaps the default
+      # `/start` command for `/start-with-coverage`, which runs Django
+      # under coverage.py so every request exercised by the Playwright
+      # spec is measured.
+      #
+      # The start script runs `python manage.py migrate` — that triggers
+      # the `0003_create_initial_superuser` migration, creating the
       # admin/Openc0ntracts_def@ult user that the Playwright spec
       # logs in as.
       #
@@ -100,10 +107,10 @@ jobs:
             sleep 2
           done
 
-      - name: Start django (no parser/embedder deps)
+      - name: Start django with coverage (no parser/embedder deps)
         run: |
-          docker compose -f test.yml up -d --no-deps django
-          echo "Started django without parser/embedder deps"
+          docker compose -f test.yml -f test.e2e-coverage.yml up -d --no-deps django
+          echo "Started django with backend coverage instrumentation"
 
       - name: Wait for Django to be ready
         run: |
@@ -160,6 +167,25 @@ jobs:
           E2E_TEST_PASSWORD: 'Openc0ntracts_def@ult'
         run: yarn run test:e2e:coverage
 
+      # ────────────────────────────────────────────────────────────────
+      # Collect backend coverage.
+      #
+      # Gracefully stopping Django triggers coverage.py's atexit handler
+      # which writes /app/.coverage (visible on the host via the volume
+      # mount).  We then spin up a throwaway container to convert to XML.
+      # ────────────────────────────────────────────────────────────────
+      - name: Stop Django gracefully (triggers coverage write)
+        if: success() || failure()
+        run: docker compose -f test.yml stop -t 15 django
+
+      - name: Export backend coverage to XML
+        if: success() || failure()
+        run: |
+          docker compose -f test.yml run --rm --no-deps django \
+            coverage xml -o /app/coverage-backend-e2e.xml
+          echo "Backend e2e coverage report:"
+          ls -la coverage-backend-e2e.xml
+
       - name: Capture backend logs on failure
         if: failure()
         run: |
@@ -182,7 +208,7 @@ jobs:
           path: frontend/playwright-report-e2e/
           if-no-files-found: ignore
 
-      - name: Upload E2E coverage to Codecov
+      - name: Upload frontend E2E coverage to Codecov
         if: success() || failure()
         uses: codecov/codecov-action@v6
         with:
@@ -190,6 +216,16 @@ jobs:
           files: frontend/coverage/e2e/lcov.info
           flags: frontend-e2e
           name: frontend-e2e-coverage
+          fail_ci_if_error: false
+
+      - name: Upload backend E2E coverage to Codecov
+        if: success() || failure()
+        uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage-backend-e2e.xml
+          flags: backend-e2e
+          name: backend-e2e-coverage
           fail_ci_if_error: false
 
       - name: Tear down backend stack

--- a/compose/local/django/Dockerfile
+++ b/compose/local/django/Dockerfile
@@ -113,6 +113,10 @@ COPY ./compose/local/django/start /start
 RUN sed -i 's/\r$//g' /start
 RUN chmod +x /start
 
+COPY ./compose/local/django/start-with-coverage /start-with-coverage
+RUN sed -i 's/\r$//g' /start-with-coverage
+RUN chmod +x /start-with-coverage
+
 COPY ./compose/local/django/celery/worker/start /start-celeryworker
 RUN sed -i 's/\r$//g' /start-celeryworker
 RUN chmod +x /start-celeryworker

--- a/compose/local/django/start-with-coverage
+++ b/compose/local/django/start-with-coverage
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+
+python manage.py migrate
+python manage.py migrate_pipeline_settings --sync-preferences --init-only
+python manage.py migrate_pipeline_settings
+
+# Run Django dev server under coverage.py so that every HTTP request
+# exercised by e2e tests is measured.
+#
+# exec  – replaces bash so coverage.py becomes PID 1 and receives
+#          SIGTERM directly from `docker compose stop`.
+# --noreload – prevents the auto-reloader from forking a child process,
+#              keeping everything in one process so coverage's atexit
+#              handler fires reliably on shutdown.
+exec coverage run --source=opencontractserver,config \
+  manage.py runserver --noreload 0.0.0.0:8000

--- a/test.e2e-coverage.yml
+++ b/test.e2e-coverage.yml
@@ -1,0 +1,10 @@
+# Compose override for the frontend-e2e CI job.
+# Swaps the Django start command so the dev server runs under coverage.py,
+# measuring all backend code exercised by Playwright e2e requests.
+#
+# Usage:
+#   docker compose -f test.yml -f test.e2e-coverage.yml up -d --no-deps django
+
+services:
+  django:
+    command: /start-with-coverage


### PR DESCRIPTION
## Summary
This PR extends the frontend E2E integration workflow to capture backend code coverage alongside frontend coverage. The Django development server now runs under `coverage.py` during E2E tests, and both frontend and backend coverage reports are uploaded to Codecov.

## Key Changes
- **New start script**: Added `compose/local/django/start-with-coverage` that runs Django's dev server under `coverage.py` with `--noreload` to ensure the coverage atexit handler fires reliably on shutdown
- **Compose override**: Created `test.e2e-coverage.yml` to swap the Django command to use the new coverage-instrumented start script
- **Workflow updates**:
  - Updated `frontend-e2e.yml` to use the compose override when starting Django
  - Added steps to gracefully stop Django (triggering coverage write) and export backend coverage to XML
  - Added separate Codecov upload step for backend E2E coverage with `backend-e2e` flag
  - Updated workflow trigger to include `test.e2e-coverage.yml` changes
- **Codecov config**: Added `backend-e2e` flag configuration in `.codecov.yml` to track backend coverage from E2E tests
- **Dockerfile**: Added the new `start-with-coverage` script to the Django image

## Implementation Details
- Backend coverage is collected by wrapping the Django runserver with `coverage.py`, measuring code in `opencontractserver/` and `config/` directories
- The coverage report is written to `/app/.coverage` when Django shuts down gracefully (via `docker compose stop`)
- A throwaway container converts the coverage data to XML format for Codecov ingestion
- Both frontend (Istanbul) and backend (coverage.py) reports are now uploaded under separate Codecov flags for independent tracking

https://claude.ai/code/session_01M91sUw7mJyVLJWCd8x88jU