### PR TITLE
Configure Codecov to wait for all coverage uploads before reporting

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,5 +1,12 @@
 codecov:
   require_ci_to_pass: yes
+  notify:
+    # Wait for all 4 coverage uploads (backend, frontend-unit,
+    # frontend-component, frontend-e2e) before sending notifications.
+    # Carryforward flags count towards this threshold, so partial
+    # workflow runs (e.g. backend-only PRs) still satisfy it.
+    after_n_builds: 4
+    wait_for_ci: true
 
 coverage:
   precision: 2
@@ -7,8 +14,15 @@ coverage:
   range: "70...100"
 
   status:
-    project: true
-    patch: true
+    project:
+      default:
+        # Don't post project status until all 4 uploads have arrived.
+        # Without this, Codecov posts after the first upload with
+        # incomplete data, causing main to report stale coverage.
+        after_n_builds: 4
+    patch:
+      default:
+        after_n_builds: 4
     changes: false
 
 flags:
@@ -42,6 +56,7 @@ comment:
   layout: "reach,diff,flags,files,footer"
   behavior: default
   require_changes: no
+  after_n_builds: 4
 
 ignore:
   - "opencontractserver/tasks/data_extract_tasks.py"


### PR DESCRIPTION
## Summary
Updated the Codecov configuration to wait for all 4 coverage uploads (backend, frontend-unit, frontend-component, frontend-e2e) before sending notifications and posting status checks. This prevents Codecov from reporting incomplete coverage data when only a subset of test suites have completed.

## Key Changes
- Added `notify.after_n_builds: 4` and `notify.wait_for_ci: true` to delay notifications until all uploads arrive
- Updated `coverage.status.project` to require 4 builds before posting project status
- Updated `coverage.status.patch` to require 4 builds before posting patch status
- Added `comment.after_n_builds: 4` to delay comment posting until all uploads complete
- Added explanatory comments documenting the rationale for these settings

## Implementation Details
- The configuration accounts for carryforward flags, so partial workflow runs (e.g., backend-only PRs) still satisfy the threshold
- This prevents the issue where Codecov would post stale coverage data to the main branch after the first upload completes
- All status checks and comments now wait for the complete picture before reporting

https://claude.ai/code/session_01RcoqnyXXVAS2uwM9QpY7hz