### PR TITLE
Add frontend unit tests for utils and hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Frontend unit tests for utils and hooks** (Issue #1267): Added 14 new `*.test.ts(x)` files covering previously-untested utilities and hooks to raise `frontend-unit` coverage on high-ROI pure functions:
+  - **Utils**: `formatters.test.ts`, `arrayUtils.test.ts`, `colorUtils.test.ts`, `parseOutputType.test.ts`, `annotationGuards.test.ts`, `env.test.ts`, `extractUtils.test.ts`, `layout.test.ts`, `persistentVar.test.ts`, `routingLogger.test.ts`, `navigationCircuitBreaker.test.ts`, `performance.test.ts`, `jobNotificationCacheUpdates.test.ts`, `compactAnnotationJson.test.ts`.
+  - **Hooks**: `useAuthReady.test.tsx`, `useFeatureAvailability.test.ts`, `useMessageBadges.test.tsx`, `useBadgeCelebration.test.tsx` (render-hook based with vi.useFakeTimers/MockedProvider).
+  - Adds ~210 new assertions across file-size/date/initial formatting, hex→RGB(A) conversions, Pydantic output-type parsing, per-annotation runtime guards, runtime env coercion, extract status, viewport clamping, session-storage-backed reactive vars, debug logger toggling, navigation circuit breaker tripping/reset/window pruning, performance monitor metric lifecycle, Apollo cache field-level mutation dispatch for job notifications, and v1↔v2 compact annotation JSON round-tripping.
+  - Verification: full unit suite passes (1118/1118) and `tsc --noEmit` is clean.
+
 - **Frontend E2E integration tests with coverage**: Added a Playwright integration spec (`frontend/tests/e2e/login-and-navigation.spec.ts`) that exercises the full Vite + Django + Postgres stack. The spec logs in via the password form against a real backend and walks every routed view in `src/views/` (Discovery, Corpuses, Documents, LabelSets, Annotations, Extracts, GlobalDiscussions, ThreadSearchRoute, PrivacyPolicy, TermsOfService, UserProfile, Login). New supporting files:
   - `frontend/tests/e2e/fixtures.ts` — Playwright fixture that dumps `window.__coverage__` to `frontend/coverage/e2e/.nyc_output/` after every test (mirrors the CT pattern in `tests/utils/coverage.ts`).
   - `frontend/tests/e2e/helpers.ts` — `VIEWS` catalog, `loginViaUI`, `spaNavigate`, and `expectViewVisible` helpers. Uses `history.pushState` + `popstate` dispatch for SPA navigation so the in-memory `authToken` reactive var survives between routes.

--- a/frontend/src/hooks/__tests__/useAuthReady.test.tsx
+++ b/frontend/src/hooks/__tests__/useAuthReady.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react-hooks";
+import { useAuthReady } from "../useAuthReady";
+import { authStatusVar } from "../../graphql/cache";
+
+describe("useAuthReady", () => {
+  afterEach(() => {
+    authStatusVar("LOADING");
+  });
+
+  it("returns false while auth status is LOADING", () => {
+    authStatusVar("LOADING");
+    const { result } = renderHook(() => useAuthReady());
+    expect(result.current).toBe(false);
+  });
+
+  it("returns true once status is AUTHENTICATED", () => {
+    authStatusVar("LOADING");
+    const { result } = renderHook(() => useAuthReady());
+
+    act(() => {
+      authStatusVar("AUTHENTICATED");
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it("returns true once status is ANONYMOUS", () => {
+    authStatusVar("LOADING");
+    const { result } = renderHook(() => useAuthReady());
+
+    act(() => {
+      authStatusVar("ANONYMOUS");
+    });
+
+    expect(result.current).toBe(true);
+  });
+});

--- a/frontend/src/hooks/__tests__/useBadgeCelebration.test.tsx
+++ b/frontend/src/hooks/__tests__/useBadgeCelebration.test.tsx
@@ -1,0 +1,161 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react-hooks";
+
+/**
+ * Mock dependencies before the hook is imported so its module-level
+ * references pick up the stubs.
+ *   - react-toastify: the hook calls `toast(...)` with a BadgeToast element.
+ *   - BadgeToast component: uses icon libraries / styled-components we don't
+ *     want to exercise in a unit test.
+ */
+const toastMock = vi.fn();
+vi.mock("react-toastify", () => ({
+  toast: (...args: unknown[]) => toastMock(...args),
+}));
+
+vi.mock("../../components/badges/BadgeToast", () => ({
+  BadgeToast: (props: any) =>
+    React.createElement("div", { "data-testid": "toast", ...props }),
+}));
+
+import { useBadgeCelebration } from "../useBadgeCelebration";
+import type { BadgeNotification } from "../useBadgeNotifications";
+
+function makeBadge(id: string, isAutoAwarded = false): BadgeNotification {
+  return {
+    id,
+    badgeId: "b-" + id,
+    badgeName: "Badge " + id,
+    badgeDescription: "desc",
+    badgeIcon: "Award",
+    badgeColor: "#ff0000",
+    isAutoAwarded,
+    awardedAt: "2024-01-01T00:00:00Z",
+  };
+}
+
+describe("useBadgeCelebration", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    toastMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("starts with an empty celebration state", () => {
+    const { result } = renderHook(() => useBadgeCelebration([]));
+    expect(result.current.showModal).toBe(false);
+    expect(result.current.currentBadge).toBeNull();
+    expect(result.current.queueLength).toBe(0);
+  });
+
+  it("enqueues and displays a toast after the queue delay", () => {
+    const { result, rerender } = renderHook(
+      ({ badges }) => useBadgeCelebration(badges, { queueDelay: 500 }),
+      { initialProps: { badges: [] as BadgeNotification[] } }
+    );
+
+    rerender({ badges: [makeBadge("1")] });
+
+    // Before the delay, nothing should have toasted yet.
+    expect(toastMock).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(toastMock).toHaveBeenCalledTimes(1);
+    // Single badge (length === 1) should also trigger the modal.
+    expect(result.current.showModal).toBe(true);
+    expect(result.current.currentBadge?.id).toBe("1");
+  });
+
+  it("opens the celebration modal for auto-awarded badges", () => {
+    const { result, rerender } = renderHook(
+      ({ badges }) => useBadgeCelebration(badges, { queueDelay: 100 }),
+      { initialProps: { badges: [] as BadgeNotification[] } }
+    );
+    rerender({
+      badges: [makeBadge("a", true), makeBadge("b", false)],
+    });
+
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    expect(result.current.showModal).toBe(true);
+    expect(result.current.currentBadge?.id).toBe("a");
+  });
+
+  it("dedupes badges already shown", () => {
+    const { rerender } = renderHook(
+      ({ badges }) => useBadgeCelebration(badges, { queueDelay: 10 }),
+      { initialProps: { badges: [makeBadge("1")] as BadgeNotification[] } }
+    );
+
+    act(() => {
+      vi.runAllTimers();
+    });
+    expect(toastMock).toHaveBeenCalledTimes(1);
+
+    // Providing the same badge again should not re-toast.
+    rerender({ badges: [makeBadge("1")] });
+    act(() => {
+      vi.runAllTimers();
+    });
+    expect(toastMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("respects showToast=false option", () => {
+    const { rerender } = renderHook(
+      ({ badges }) =>
+        useBadgeCelebration(badges, { showToast: false, queueDelay: 10 }),
+      { initialProps: { badges: [] as BadgeNotification[] } }
+    );
+    rerender({ badges: [makeBadge("x")] });
+    act(() => {
+      vi.runAllTimers();
+    });
+    expect(toastMock).not.toHaveBeenCalled();
+  });
+
+  it("closeModal clears modal state", () => {
+    const { result, rerender } = renderHook(
+      ({ badges }) => useBadgeCelebration(badges, { queueDelay: 10 }),
+      { initialProps: { badges: [] as BadgeNotification[] } }
+    );
+    rerender({ badges: [makeBadge("m", true)] });
+    act(() => {
+      vi.runAllTimers();
+    });
+    expect(result.current.showModal).toBe(true);
+
+    act(() => {
+      result.current.closeModal();
+    });
+    expect(result.current.showModal).toBe(false);
+    expect(result.current.currentBadge).toBeNull();
+  });
+
+  it("dismissAll empties queue and modal state", () => {
+    const { result, rerender } = renderHook(
+      ({ badges }) => useBadgeCelebration(badges, { queueDelay: 1000 }),
+      { initialProps: { badges: [] as BadgeNotification[] } }
+    );
+    rerender({
+      badges: [makeBadge("a"), makeBadge("b"), makeBadge("c")],
+    });
+    // Queue has been appended, but modal hasn't opened yet (delay pending).
+    expect(result.current.queueLength).toBe(3);
+
+    act(() => {
+      result.current.dismissAll();
+    });
+    expect(result.current.queueLength).toBe(0);
+    expect(result.current.showModal).toBe(false);
+    expect(result.current.currentBadge).toBeNull();
+  });
+});

--- a/frontend/src/hooks/__tests__/useFeatureAvailability.test.ts
+++ b/frontend/src/hooks/__tests__/useFeatureAvailability.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { renderHook } from "@testing-library/react-hooks";
+import { useFeatureAvailability } from "../useFeatureAvailability";
+
+describe("useFeatureAvailability", () => {
+  it("reports features that require a corpus as unavailable without one", () => {
+    const { result } = renderHook(() => useFeatureAvailability());
+    expect(result.current.hasCorpus).toBe(false);
+    expect(result.current.isFeatureAvailable("CHAT")).toBe(false);
+    expect(result.current.isFeatureAvailable("ANNOTATIONS")).toBe(false);
+  });
+
+  it("treats corpus-free features as available without a corpus", () => {
+    const { result } = renderHook(() => useFeatureAvailability());
+    expect(result.current.isFeatureAvailable("NOTES")).toBe(true);
+    expect(result.current.isFeatureAvailable("SEARCH")).toBe(true);
+  });
+
+  it("marks corpus-gated features available when corpus is present", () => {
+    const { result } = renderHook(() => useFeatureAvailability("corpus-1"));
+    expect(result.current.hasCorpus).toBe(true);
+    expect(result.current.isFeatureAvailable("CHAT")).toBe(true);
+    expect(result.current.isFeatureAvailable("ANNOTATIONS")).toBe(true);
+  });
+
+  it("getFeatureStatus returns message when feature is unavailable", () => {
+    const { result } = renderHook(() => useFeatureAvailability());
+    const status = result.current.getFeatureStatus("CHAT");
+    expect(status.available).toBe(false);
+    expect(status.message).toBe("Add to corpus to enable AI chat");
+  });
+
+  it("getFeatureStatus omits message when feature is available", () => {
+    const { result } = renderHook(() => useFeatureAvailability("c1"));
+    const status = result.current.getFeatureStatus("CHAT");
+    expect(status.available).toBe(true);
+    expect(status.message).toBeUndefined();
+  });
+
+  it("memoizes the returned object when corpusId is stable", () => {
+    const { result, rerender } = renderHook(
+      ({ cid }) => useFeatureAvailability(cid),
+      { initialProps: { cid: "c1" } }
+    );
+    const first = result.current;
+    rerender({ cid: "c1" });
+    expect(result.current).toBe(first);
+  });
+
+  it("returns a new object when corpusId changes", () => {
+    const { result, rerender } = renderHook(
+      ({ cid }) => useFeatureAvailability(cid),
+      { initialProps: { cid: "c1" as string | undefined } }
+    );
+    const first = result.current;
+    rerender({ cid: "c2" });
+    expect(result.current).not.toBe(first);
+    expect(result.current.hasCorpus).toBe(true);
+
+    rerender({ cid: undefined });
+    expect(result.current.hasCorpus).toBe(false);
+  });
+});

--- a/frontend/src/hooks/__tests__/useMessageBadges.test.tsx
+++ b/frontend/src/hooks/__tests__/useMessageBadges.test.tsx
@@ -1,0 +1,132 @@
+import { describe, it, expect } from "vitest";
+import React from "react";
+import { renderHook } from "@testing-library/react-hooks";
+import { MockedProvider } from "@apollo/client/testing";
+import { InMemoryCache } from "@apollo/client";
+import { useMessageBadges } from "../useMessageBadges";
+import { GET_USER_BADGES } from "../../graphql/queries";
+
+function createWrapper(mocks: any[]) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <MockedProvider
+        mocks={mocks}
+        addTypename={false}
+        cache={new InMemoryCache({ addTypename: false })}
+      >
+        <>{children}</>
+      </MockedProvider>
+    );
+  };
+}
+
+describe("useMessageBadges", () => {
+  it("skips the query and returns an empty map when no userIds", () => {
+    const { result } = renderHook(() => useMessageBadges([]), {
+      wrapper: createWrapper([]),
+    });
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.badgesByUser.size).toBe(0);
+  });
+
+  it("returns loading=true while the query is in flight", () => {
+    const mocks = [
+      {
+        request: {
+          query: GET_USER_BADGES,
+          variables: { corpusId: undefined, limit: 5 },
+        },
+        result: { data: { userBadges: { edges: [] } } },
+        delay: 100,
+      },
+    ];
+
+    const { result } = renderHook(() => useMessageBadges(["u1"]), {
+      wrapper: createWrapper(mocks),
+    });
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.badgesByUser.size).toBe(0);
+  });
+
+  it("groups badges by user id once data resolves", async () => {
+    const mocks = [
+      {
+        request: {
+          query: GET_USER_BADGES,
+          variables: { corpusId: "corpus-1", limit: 10 },
+        },
+        result: {
+          data: {
+            userBadges: {
+              edges: [
+                {
+                  node: {
+                    id: "b1",
+                    user: { id: "u1", username: "alice" },
+                  },
+                },
+                {
+                  node: {
+                    id: "b2",
+                    user: { id: "u1", username: "alice" },
+                  },
+                },
+                {
+                  node: {
+                    id: "b3",
+                    user: { id: "u2", username: "bob" },
+                  },
+                },
+                // Not in our userIds - should be filtered out.
+                {
+                  node: {
+                    id: "b4",
+                    user: { id: "u99", username: "ignored" },
+                  },
+                },
+                null,
+              ],
+            },
+          },
+        },
+      },
+    ];
+
+    const { result, waitFor } = renderHook(
+      () => useMessageBadges(["u1", "u2"], "corpus-1", 5),
+      { wrapper: createWrapper(mocks) }
+    );
+
+    await waitFor(() => !result.current.loading);
+
+    expect(result.current.badgesByUser.get("u1")?.length).toBe(2);
+    expect(result.current.badgesByUser.get("u2")?.length).toBe(1);
+    expect(result.current.badgesByUser.has("u99")).toBe(false);
+  });
+
+  it("caps the number of badges returned per user", async () => {
+    const edges = Array.from({ length: 7 }, (_, i) => ({
+      node: { id: `b${i}`, user: { id: "u1", username: "alice" } },
+    }));
+
+    const mocks = [
+      {
+        request: {
+          query: GET_USER_BADGES,
+          variables: { corpusId: undefined, limit: 3 },
+        },
+        result: { data: { userBadges: { edges } } },
+      },
+    ];
+
+    const { result, waitFor } = renderHook(
+      () => useMessageBadges(["u1"], null, 3),
+      { wrapper: createWrapper(mocks) }
+    );
+
+    await waitFor(() => !result.current.loading);
+    expect(result.current.badgesByUser.get("u1")?.length).toBe(3);
+  });
+});

--- a/frontend/src/utils/__tests__/annotationGuards.test.ts
+++ b/frontend/src/utils/__tests__/annotationGuards.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { isTokenAnnotation, isSpanAnnotation } from "../annotationGuards";
+import { LabelType, RawServerAnnotationType } from "../../types/graphql-api";
+
+/**
+ * Build a minimal annotation that satisfies the type signature. Only the
+ * discriminator fields matter for the guards.
+ */
+function makeAnnotation(
+  overrides: Partial<RawServerAnnotationType>
+): RawServerAnnotationType {
+  return {
+    id: "ann-1",
+    annotationLabel: {
+      id: "lbl-1",
+      labelType: LabelType.TokenLabel,
+    } as RawServerAnnotationType["annotationLabel"],
+    ...overrides,
+  } as RawServerAnnotationType;
+}
+
+describe("annotationGuards", () => {
+  describe("isTokenAnnotation", () => {
+    it("returns true when annotationType is TokenLabel", () => {
+      const ann = makeAnnotation({
+        annotationType: LabelType.TokenLabel,
+        annotationLabel: { labelType: LabelType.SpanLabel } as any,
+      });
+      expect(isTokenAnnotation(ann)).toBe(true);
+    });
+
+    it("returns true when nested annotationLabel.labelType is TokenLabel", () => {
+      const ann = makeAnnotation({
+        annotationType: undefined,
+        annotationLabel: { labelType: LabelType.TokenLabel } as any,
+      });
+      expect(isTokenAnnotation(ann)).toBe(true);
+    });
+
+    it("returns false for span-only annotations", () => {
+      const ann = makeAnnotation({
+        annotationType: LabelType.SpanLabel,
+        annotationLabel: { labelType: LabelType.SpanLabel } as any,
+      });
+      expect(isTokenAnnotation(ann)).toBe(false);
+    });
+  });
+
+  describe("isSpanAnnotation", () => {
+    it("returns true when annotationType is SpanLabel", () => {
+      const ann = makeAnnotation({
+        annotationType: LabelType.SpanLabel,
+        annotationLabel: { labelType: LabelType.TokenLabel } as any,
+      });
+      expect(isSpanAnnotation(ann)).toBe(true);
+    });
+
+    it("returns true when nested annotationLabel.labelType is SpanLabel", () => {
+      const ann = makeAnnotation({
+        annotationType: undefined,
+        annotationLabel: { labelType: LabelType.SpanLabel } as any,
+      });
+      expect(isSpanAnnotation(ann)).toBe(true);
+    });
+
+    it("returns false for token-only annotations", () => {
+      const ann = makeAnnotation({
+        annotationType: LabelType.TokenLabel,
+        annotationLabel: { labelType: LabelType.TokenLabel } as any,
+      });
+      expect(isSpanAnnotation(ann)).toBe(false);
+    });
+  });
+});

--- a/frontend/src/utils/__tests__/arrayUtils.test.ts
+++ b/frontend/src/utils/__tests__/arrayUtils.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { arraysEqualUnordered, arraysEqualOrdered } from "../arrayUtils";
+
+describe("arrayUtils", () => {
+  describe("arraysEqualUnordered", () => {
+    it("returns true for empty arrays", () => {
+      expect(arraysEqualUnordered([], [])).toBe(true);
+    });
+
+    it("returns true when elements match regardless of order", () => {
+      expect(arraysEqualUnordered(["a", "b", "c"], ["c", "a", "b"])).toBe(true);
+    });
+
+    it("returns false when lengths differ", () => {
+      expect(arraysEqualUnordered(["a"], ["a", "b"])).toBe(false);
+    });
+
+    it("returns false when elements differ", () => {
+      expect(arraysEqualUnordered(["a", "b"], ["a", "c"])).toBe(false);
+    });
+
+    it("treats duplicates by position after sort", () => {
+      expect(arraysEqualUnordered(["a", "a", "b"], ["a", "b", "b"])).toBe(
+        false
+      );
+      expect(arraysEqualUnordered(["a", "a", "b"], ["b", "a", "a"])).toBe(true);
+    });
+  });
+
+  describe("arraysEqualOrdered", () => {
+    it("returns true for identical arrays", () => {
+      expect(arraysEqualOrdered(["a", "b"], ["a", "b"])).toBe(true);
+    });
+
+    it("returns false when order differs", () => {
+      expect(arraysEqualOrdered(["a", "b"], ["b", "a"])).toBe(false);
+    });
+
+    it("returns false when lengths differ", () => {
+      expect(arraysEqualOrdered([], ["a"])).toBe(false);
+    });
+
+    it("returns true for two empty arrays", () => {
+      expect(arraysEqualOrdered([], [])).toBe(true);
+    });
+  });
+});

--- a/frontend/src/utils/__tests__/colorUtils.test.ts
+++ b/frontend/src/utils/__tests__/colorUtils.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "vitest";
+import {
+  isValidHexColor,
+  normalizeHexColor,
+  hexToRgb,
+  hexToRgba,
+  computeAnnotationBoxShadow,
+  blendColors,
+} from "../colorUtils";
+
+describe("colorUtils", () => {
+  describe("isValidHexColor", () => {
+    it("accepts 3-digit hex with or without hash", () => {
+      expect(isValidHexColor("#fff")).toBe(true);
+      expect(isValidHexColor("abc")).toBe(true);
+    });
+
+    it("accepts 6-digit hex with or without hash", () => {
+      expect(isValidHexColor("#FF0000")).toBe(true);
+      expect(isValidHexColor("ff00aa")).toBe(true);
+    });
+
+    it("rejects invalid strings", () => {
+      expect(isValidHexColor("invalid")).toBe(false);
+      expect(isValidHexColor("#gggggg")).toBe(false);
+      expect(isValidHexColor("")).toBe(false);
+      expect(isValidHexColor("#ff")).toBe(false);
+      expect(isValidHexColor("#fffff")).toBe(false);
+    });
+  });
+
+  describe("normalizeHexColor", () => {
+    it("expands 3-digit to 6-digit", () => {
+      expect(normalizeHexColor("#abc")).toBe("#aabbcc");
+      expect(normalizeHexColor("abc")).toBe("#aabbcc");
+    });
+
+    it("passes through 6-digit unchanged (with hash prefix)", () => {
+      expect(normalizeHexColor("#FF0000")).toBe("#FF0000");
+      expect(normalizeHexColor("FF0000")).toBe("#FF0000");
+    });
+  });
+
+  describe("hexToRgb", () => {
+    it("parses 6-digit hex", () => {
+      expect(hexToRgb("#FF0000")).toEqual({ r: 255, g: 0, b: 0 });
+      expect(hexToRgb("00ff00")).toEqual({ r: 0, g: 255, b: 0 });
+    });
+
+    it("expands and parses 3-digit hex", () => {
+      expect(hexToRgb("#F00")).toEqual({ r: 255, g: 0, b: 0 });
+      expect(hexToRgb("0f0")).toEqual({ r: 0, g: 255, b: 0 });
+    });
+  });
+
+  describe("hexToRgba", () => {
+    it("builds rgba from valid hex", () => {
+      expect(hexToRgba("#FF0000", 0.5)).toBe("rgba(255, 0, 0, 0.5)");
+      expect(hexToRgba("#F00", 1)).toBe("rgba(255, 0, 0, 1)");
+    });
+
+    it("falls back to default blue when hex is null/undefined", () => {
+      expect(hexToRgba(null, 0.5)).toBe("rgba(74, 144, 226, 0.5)");
+      expect(hexToRgba(undefined, 0.25)).toBe("rgba(74, 144, 226, 0.25)");
+    });
+
+    it("falls back when hex is invalid", () => {
+      expect(hexToRgba("not-a-color", 0.5)).toBe("rgba(74, 144, 226, 0.5)");
+    });
+
+    it("honours custom fallback color", () => {
+      expect(hexToRgba(null, 1, { r: 1, g: 2, b: 3 })).toBe("rgba(1, 2, 3, 1)");
+    });
+  });
+
+  describe("computeAnnotationBoxShadow", () => {
+    it("produces three shadow layers for unselected", () => {
+      const shadow = computeAnnotationBoxShadow(255, 0, 0, false);
+      expect((shadow.match(/rgba\(/g) ?? []).length).toBe(3);
+      expect(shadow).toContain("rgba(255, 0, 0");
+      expect(shadow).toContain("inset");
+    });
+
+    it("produces three shadow layers for selected", () => {
+      const shadow = computeAnnotationBoxShadow(0, 128, 255, true);
+      expect((shadow.match(/rgba\(/g) ?? []).length).toBe(3);
+      expect(shadow).toContain("rgba(0, 128, 255");
+    });
+
+    it("differs between selected and unselected states", () => {
+      const unselected = computeAnnotationBoxShadow(10, 20, 30, false);
+      const selected = computeAnnotationBoxShadow(10, 20, 30, true);
+      expect(unselected).not.toBe(selected);
+    });
+  });
+
+  describe("blendColors", () => {
+    it("returns black for empty array", () => {
+      expect(blendColors([])).toBe("rgb(0, 0, 0)");
+    });
+
+    it("returns the single color unchanged for single-color input", () => {
+      expect(blendColors(["#abcdef"])).toBe("#abcdef");
+    });
+
+    it("averages two colors", () => {
+      expect(blendColors(["#FF0000", "#0000FF"])).toBe("rgb(128, 0, 128)");
+    });
+
+    it("averages three colors, rounding", () => {
+      expect(blendColors(["#FF0000", "#00FF00", "#0000FF"])).toBe(
+        "rgb(85, 85, 85)"
+      );
+    });
+  });
+});

--- a/frontend/src/utils/__tests__/compactAnnotationJson.test.ts
+++ b/frontend/src/utils/__tests__/compactAnnotationJson.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from "vitest";
+import {
+  encodeTokenRanges,
+  decodeTokenRanges,
+  isCompactFormat,
+  isSpanFormat,
+  compactAnnotationJson,
+  expandAnnotationJson,
+  iterPageAnnotations,
+  hasAnyTokens,
+} from "../compactAnnotationJson";
+
+describe("compactAnnotationJson", () => {
+  describe("encodeTokenRanges / decodeTokenRanges", () => {
+    it("round-trips a mixture of singletons and ranges", () => {
+      const tokens = [1, 2, 3, 5, 7, 8, 9];
+      const encoded = encodeTokenRanges(tokens);
+      expect(encoded).toBe("1-3,5,7-9");
+      expect(decodeTokenRanges(encoded)).toEqual(tokens);
+    });
+
+    it("dedupes, sorts, and drops negatives", () => {
+      expect(encodeTokenRanges([3, 1, 2, 2, -1])).toBe("1-3");
+    });
+
+    it("returns empty strings/arrays for empty inputs", () => {
+      expect(encodeTokenRanges([])).toBe("");
+      expect(decodeTokenRanges("")).toEqual([]);
+    });
+
+    it("handles single-token ranges", () => {
+      expect(encodeTokenRanges([5])).toBe("5");
+      expect(decodeTokenRanges("5")).toEqual([5]);
+    });
+
+    it("skips malformed range segments", () => {
+      // "abc" → NaN parts → skipped; "3" survives.
+      expect(decodeTokenRanges("abc,3,foo-bar")).toEqual([3]);
+    });
+  });
+
+  describe("isCompactFormat", () => {
+    it("detects v2 objects", () => {
+      expect(isCompactFormat({ v: 2, p: {} })).toBe(true);
+    });
+
+    it("rejects v1 and malformed shapes", () => {
+      expect(isCompactFormat({})).toBe(false);
+      expect(isCompactFormat({ v: 2 } as any)).toBe(false);
+      expect(isCompactFormat({ v: 1, p: {} } as any)).toBe(false);
+    });
+  });
+
+  describe("isSpanFormat", () => {
+    it("detects numeric start/end pairs", () => {
+      expect(isSpanFormat({ start: 0, end: 5 })).toBe(true);
+    });
+
+    it("tolerates extra fields", () => {
+      expect(isSpanFormat({ start: 0, end: 5, confidence: 0.9 } as any)).toBe(
+        true
+      );
+    });
+
+    it("rejects missing or non-numeric fields", () => {
+      expect(isSpanFormat({} as any)).toBe(false);
+      expect(isSpanFormat({ start: "0", end: "5" } as any)).toBe(false);
+    });
+  });
+
+  describe("compactAnnotationJson / expandAnnotationJson", () => {
+    const v1 = {
+      "0": {
+        bounds: { top: 1, left: 2, right: 3, bottom: 4 },
+        tokensJsons: [
+          { pageIndex: 0, tokenIndex: 5 },
+          { pageIndex: 0, tokenIndex: 6 },
+        ],
+        rawText: "hello",
+      },
+    };
+
+    it("compacts a v1 doc and expand round-trips", () => {
+      const compact = compactAnnotationJson(v1 as any);
+      expect(compact.v).toBe(2);
+      expect(compact.p["0"].b).toEqual([1, 2, 3, 4]);
+      expect(compact.p["0"].t).toBe("5-6");
+
+      const v1Again = expandAnnotationJson(compact, "hello") as any;
+      expect(v1Again["0"].bounds).toEqual(v1["0"].bounds);
+      expect(v1Again["0"].tokensJsons).toEqual(v1["0"].tokensJsons);
+      expect(v1Again["0"].rawText).toBe("hello");
+    });
+
+    it("passes span annotations through unchanged", () => {
+      const span = { start: 0, end: 10 };
+      expect(expandAnnotationJson(span as any)).toBe(span);
+    });
+
+    it("returns v1 input unchanged", () => {
+      expect(expandAnnotationJson(v1 as any)).toBe(v1);
+    });
+
+    it("passes null/undefined through", () => {
+      expect(expandAnnotationJson(null)).toBeNull();
+      expect(expandAnnotationJson(undefined)).toBeUndefined();
+    });
+
+    it("fills missing bounds with zeros", () => {
+      const compact = { v: 2 as const, p: { "0": { b: [] as any, t: "1" } } };
+      const expanded = expandAnnotationJson(compact, "") as any;
+      expect(expanded["0"].bounds).toEqual({
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+      });
+    });
+  });
+
+  describe("iterPageAnnotations", () => {
+    it("yields empty array for span annotations", () => {
+      expect(iterPageAnnotations({ start: 0, end: 3 }, "text")).toEqual([]);
+    });
+
+    it("yields empty array for falsy inputs", () => {
+      expect(iterPageAnnotations(null)).toEqual([]);
+      expect(iterPageAnnotations("string" as any)).toEqual([]);
+    });
+
+    it("iterates v2 compact pages", () => {
+      const pages = iterPageAnnotations(
+        { v: 2, p: { "3": { b: [1, 2, 3, 4], t: "1,5-6" } } },
+        "raw"
+      );
+      expect(pages).toHaveLength(1);
+      expect(pages[0].pageIndex).toBe(3);
+      expect(pages[0].bounds).toEqual({ top: 1, left: 2, right: 3, bottom: 4 });
+      expect(pages[0].tokenIndices).toEqual([1, 5, 6]);
+      expect(pages[0].rawText).toBe("raw");
+    });
+
+    it("iterates v1 legacy pages", () => {
+      const pages = iterPageAnnotations(
+        {
+          "0": {
+            bounds: { top: 1, left: 2, right: 3, bottom: 4 },
+            tokensJsons: [{ pageIndex: 0, tokenIndex: 7 }],
+            rawText: "per-page-text",
+          },
+        },
+        "fallback"
+      );
+      expect(pages).toHaveLength(1);
+      expect(pages[0].pageIndex).toBe(0);
+      expect(pages[0].tokenIndices).toEqual([7]);
+      expect(pages[0].rawText).toBe("per-page-text");
+    });
+  });
+
+  describe("hasAnyTokens", () => {
+    it("returns true for span annotations", () => {
+      expect(hasAnyTokens({ start: 0, end: 5 })).toBe(true);
+    });
+
+    it("returns true when any page has tokens", () => {
+      expect(
+        hasAnyTokens({ v: 2, p: { "0": { b: [0, 0, 0, 0], t: "1" } } })
+      ).toBe(true);
+    });
+
+    it("returns false for empty multipage annotations", () => {
+      expect(hasAnyTokens({ v: 2, p: {} })).toBe(false);
+    });
+
+    it("returns false for invalid inputs", () => {
+      expect(hasAnyTokens(null)).toBe(false);
+      expect(hasAnyTokens("text" as any)).toBe(false);
+    });
+  });
+});

--- a/frontend/src/utils/__tests__/env.test.ts
+++ b/frontend/src/utils/__tests__/env.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, afterEach, beforeEach } from "vitest";
+import { getRuntimeEnv } from "../env";
+
+describe("getRuntimeEnv", () => {
+  let originalWindowEnv: unknown;
+
+  beforeEach(() => {
+    originalWindowEnv = (window as any)._env_;
+  });
+
+  afterEach(() => {
+    (window as any)._env_ = originalWindowEnv;
+  });
+
+  it("falls back to default values when nothing is injected", () => {
+    (window as any)._env_ = {};
+    const env = getRuntimeEnv();
+
+    expect(env.REACT_APP_APPLICATION_DOMAIN).toBe("");
+    expect(env.REACT_APP_API_ROOT_URL).toBe("http://localhost:8000");
+    expect(env.REACT_APP_POSTHOG_HOST).toBe("https://us.i.posthog.com");
+    expect(env.REACT_APP_USE_AUTH0).toBe(false);
+    expect(env.REACT_APP_USE_ANALYZERS).toBe(false);
+    expect(env.REACT_APP_ALLOW_IMPORTS).toBe(false);
+  });
+
+  it("reads string values from window._env_", () => {
+    (window as any)._env_ = {
+      REACT_APP_APPLICATION_DOMAIN: "auth.example.com",
+      REACT_APP_API_ROOT_URL: "https://api.example.com",
+      REACT_APP_AUDIENCE: "aud",
+      REACT_APP_POSTHOG_API_KEY: "phc_key",
+    };
+
+    const env = getRuntimeEnv();
+    expect(env.REACT_APP_APPLICATION_DOMAIN).toBe("auth.example.com");
+    expect(env.REACT_APP_API_ROOT_URL).toBe("https://api.example.com");
+    expect(env.REACT_APP_AUDIENCE).toBe("aud");
+    expect(env.REACT_APP_POSTHOG_API_KEY).toBe("phc_key");
+  });
+
+  it("coerces truthy boolean-like strings", () => {
+    (window as any)._env_ = {
+      REACT_APP_USE_AUTH0: "true",
+      REACT_APP_USE_ANALYZERS: "1",
+      REACT_APP_ALLOW_IMPORTS: "YES",
+    };
+
+    const env = getRuntimeEnv();
+    expect(env.REACT_APP_USE_AUTH0).toBe(true);
+    expect(env.REACT_APP_USE_ANALYZERS).toBe(true);
+    expect(env.REACT_APP_ALLOW_IMPORTS).toBe(true);
+  });
+
+  it("coerces native booleans", () => {
+    (window as any)._env_ = {
+      REACT_APP_USE_AUTH0: true,
+      REACT_APP_USE_ANALYZERS: false,
+    };
+    const env = getRuntimeEnv();
+    expect(env.REACT_APP_USE_AUTH0).toBe(true);
+    expect(env.REACT_APP_USE_ANALYZERS).toBe(false);
+  });
+
+  it("returns false for falsy boolean-like strings", () => {
+    (window as any)._env_ = {
+      REACT_APP_USE_AUTH0: "false",
+      REACT_APP_USE_ANALYZERS: "0",
+      REACT_APP_ALLOW_IMPORTS: "no",
+    };
+
+    const env = getRuntimeEnv();
+    expect(env.REACT_APP_USE_AUTH0).toBe(false);
+    expect(env.REACT_APP_USE_ANALYZERS).toBe(false);
+    expect(env.REACT_APP_ALLOW_IMPORTS).toBe(false);
+  });
+
+  it("coerces non-string values to strings", () => {
+    (window as any)._env_ = {
+      REACT_APP_APPLICATION_CLIENT_ID: 12345,
+    };
+    const env = getRuntimeEnv();
+    expect(env.REACT_APP_APPLICATION_CLIENT_ID).toBe("12345");
+  });
+});

--- a/frontend/src/utils/__tests__/extractUtils.test.ts
+++ b/frontend/src/utils/__tests__/extractUtils.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { getExtractStatus, formatExtractDate } from "../extractUtils";
+import {
+  EXTRACT_STATUS,
+  EXTRACT_STATUS_COLORS,
+} from "../../assets/configurations/constants";
+import type { ExtractType } from "../../types/graphql-api";
+
+function makeExtract(overrides: Partial<ExtractType>): ExtractType {
+  return {
+    id: "ext-1",
+    name: "Test",
+    ...overrides,
+  } as ExtractType;
+}
+
+describe("extractUtils", () => {
+  describe("getExtractStatus", () => {
+    it("returns RUNNING when started but not finished and no error", () => {
+      const info = getExtractStatus(
+        makeExtract({ started: "2024-01-01", finished: null, error: null })
+      );
+      expect(info.label).toBe(EXTRACT_STATUS.RUNNING);
+      expect(info.color).toBe(EXTRACT_STATUS_COLORS[EXTRACT_STATUS.RUNNING]);
+    });
+
+    it("returns COMPLETED when finished is truthy", () => {
+      const info = getExtractStatus(
+        makeExtract({
+          started: "2024-01-01",
+          finished: "2024-01-02",
+        })
+      );
+      expect(info.label).toBe(EXTRACT_STATUS.COMPLETED);
+    });
+
+    it("returns FAILED when error is set and not finished", () => {
+      const info = getExtractStatus(
+        makeExtract({ started: null, finished: null, error: "boom" })
+      );
+      expect(info.label).toBe(EXTRACT_STATUS.FAILED);
+    });
+
+    it("returns NOT_STARTED when nothing is set", () => {
+      const info = getExtractStatus(
+        makeExtract({ started: null, finished: null, error: null })
+      );
+      expect(info.label).toBe(EXTRACT_STATUS.NOT_STARTED);
+    });
+
+    it("prefers COMPLETED over FAILED when both finished and error are set", () => {
+      const info = getExtractStatus(
+        makeExtract({
+          started: "2024-01-01",
+          finished: "2024-01-02",
+          error: "ignored",
+        })
+      );
+      expect(info.label).toBe(EXTRACT_STATUS.COMPLETED);
+    });
+  });
+
+  describe("formatExtractDate", () => {
+    it("produces a non-empty localized string", () => {
+      const result = formatExtractDate("2024-01-15T12:00:00Z");
+      expect(result.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/frontend/src/utils/__tests__/formatters.test.ts
+++ b/frontend/src/utils/__tests__/formatters.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  formatFileSize,
+  formatRelativeTime,
+  formatCompactRelativeTime,
+  getInitials,
+  formatShortDate,
+  formatSettingLabel,
+  formatCellValue,
+} from "../formatters";
+import { EXTRACT_GRID_CELL_TRUNCATE_LENGTH } from "../../assets/configurations/constants";
+
+describe("formatters", () => {
+  describe("formatFileSize", () => {
+    it("returns empty string for null/undefined", () => {
+      expect(formatFileSize(null)).toBe("");
+      expect(formatFileSize(undefined)).toBe("");
+    });
+
+    it("formats bytes below 1 KB", () => {
+      expect(formatFileSize(0)).toBe("0 B");
+      expect(formatFileSize(512)).toBe("512 B");
+      expect(formatFileSize(1023)).toBe("1023 B");
+    });
+
+    it("formats kilobytes with one decimal", () => {
+      expect(formatFileSize(1024)).toBe("1.0 KB");
+      expect(formatFileSize(1536)).toBe("1.5 KB");
+    });
+
+    it("formats megabytes with one decimal", () => {
+      expect(formatFileSize(1024 * 1024)).toBe("1.0 MB");
+      expect(formatFileSize(Math.round(2.3 * 1024 * 1024))).toBe("2.3 MB");
+    });
+  });
+
+  describe("formatRelativeTime", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-01-15T12:00:00Z"));
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("returns empty string for missing or invalid input", () => {
+      expect(formatRelativeTime(null)).toBe("");
+      expect(formatRelativeTime(undefined)).toBe("");
+      expect(formatRelativeTime("")).toBe("");
+      expect(formatRelativeTime("not a date")).toBe("");
+    });
+
+    it("returns 'Just now' when under an hour", () => {
+      expect(formatRelativeTime("2026-01-15T11:30:00Z")).toBe("Just now");
+    });
+
+    it("returns hours ago when within a day", () => {
+      expect(formatRelativeTime("2026-01-15T07:00:00Z")).toBe("5 hours ago");
+    });
+
+    it("returns days ago when within a week", () => {
+      expect(formatRelativeTime("2026-01-12T12:00:00Z")).toBe("3 days ago");
+    });
+
+    it("falls back to localeDateString beyond a week", () => {
+      const result = formatRelativeTime("2025-12-01T12:00:00Z");
+      // toLocaleDateString output varies between environments — just assert non-empty
+      expect(result.length).toBeGreaterThan(0);
+      expect(result).not.toBe("Just now");
+    });
+  });
+
+  describe("formatCompactRelativeTime", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-01-15T12:00:00Z"));
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("returns empty string for missing or invalid input", () => {
+      expect(formatCompactRelativeTime(null)).toBe("");
+      expect(formatCompactRelativeTime(undefined)).toBe("");
+      expect(formatCompactRelativeTime("")).toBe("");
+      expect(formatCompactRelativeTime("nope")).toBe("");
+    });
+
+    it("returns 'Just now' for very recent timestamps", () => {
+      expect(formatCompactRelativeTime("2026-01-15T11:59:50Z")).toBe(
+        "Just now"
+      );
+    });
+
+    it("returns minutes format for under an hour", () => {
+      expect(formatCompactRelativeTime("2026-01-15T11:45:00Z")).toBe("15m ago");
+    });
+
+    it("returns hours format for under a day", () => {
+      expect(formatCompactRelativeTime("2026-01-15T09:00:00Z")).toBe("3h ago");
+    });
+
+    it("returns days format for under a month", () => {
+      expect(formatCompactRelativeTime("2026-01-10T12:00:00Z")).toBe("5d ago");
+    });
+
+    it("falls back to locale date for over a month", () => {
+      const result = formatCompactRelativeTime("2025-10-01T12:00:00Z");
+      expect(result.length).toBeGreaterThan(0);
+      expect(result).not.toMatch(/ago$/);
+    });
+  });
+
+  describe("getInitials", () => {
+    it("defaults to 'U' when name is missing", () => {
+      expect(getInitials()).toBe("U");
+      expect(getInitials(null)).toBe("U");
+      expect(getInitials("")).toBe("U");
+    });
+
+    it("takes first letter before @ for emails", () => {
+      expect(getInitials("jane@example.com")).toBe("J");
+    });
+
+    it("takes first two initials for multi-word names", () => {
+      expect(getInitials("Jane Doe")).toBe("JD");
+      expect(getInitials("alice bob carol")).toBe("AB");
+    });
+
+    it("handles single-word names", () => {
+      expect(getInitials("alice")).toBe("A");
+    });
+  });
+
+  describe("formatShortDate", () => {
+    it("returns empty string on bad input", () => {
+      expect(formatShortDate(null)).toBe("");
+      expect(formatShortDate(undefined)).toBe("");
+      expect(formatShortDate("")).toBe("");
+      expect(formatShortDate("garbage")).toBe("");
+    });
+
+    it("returns a non-empty formatted string for valid input", () => {
+      const result = formatShortDate("2023-10-05T00:00:00Z");
+      expect(result.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("formatSettingLabel", () => {
+    it("uses description when provided", () => {
+      expect(formatSettingLabel("api_key", "API Token")).toBe("API Token");
+    });
+
+    it("trims description whitespace", () => {
+      expect(formatSettingLabel("x", "  Label  ")).toBe("Label");
+    });
+
+    it("falls back to title-cased snake_case name", () => {
+      expect(formatSettingLabel("api_key")).toBe("Api Key");
+      expect(formatSettingLabel("max_retries", "")).toBe("Max Retries");
+      expect(formatSettingLabel("single")).toBe("Single");
+    });
+
+    it("ignores whitespace-only description", () => {
+      expect(formatSettingLabel("retry_count", "   ")).toBe("Retry Count");
+    });
+  });
+
+  describe("formatCellValue", () => {
+    it("returns em-dash for null/undefined", () => {
+      expect(formatCellValue(null)).toBe("\u2014");
+      expect(formatCellValue(undefined)).toBe("\u2014");
+    });
+
+    it("returns 'Yes'/'No' for booleans", () => {
+      expect(formatCellValue(true)).toBe("Yes");
+      expect(formatCellValue(false)).toBe("No");
+    });
+
+    it("stringifies numbers and strings", () => {
+      expect(formatCellValue(42)).toBe("42");
+      expect(formatCellValue("hello")).toBe("hello");
+    });
+
+    it("JSON-encodes small objects", () => {
+      expect(formatCellValue({ a: 1 })).toBe('{"a":1}');
+    });
+
+    it("truncates large objects with an ellipsis", () => {
+      const big: Record<string, string> = {};
+      // Ensure serialized length exceeds the truncation threshold.
+      for (let i = 0; i < EXTRACT_GRID_CELL_TRUNCATE_LENGTH; i++) {
+        big[`k${i}`] = `v${i}`;
+      }
+      const result = formatCellValue(big);
+      expect(result.endsWith("\u2026")).toBe(true);
+      expect(result.length).toBe(EXTRACT_GRID_CELL_TRUNCATE_LENGTH + 1);
+    });
+  });
+});

--- a/frontend/src/utils/__tests__/jobNotificationCacheUpdates.test.ts
+++ b/frontend/src/utils/__tests__/jobNotificationCacheUpdates.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { updateCacheForJobNotification } from "../jobNotificationCacheUpdates";
+import { toGlobalId } from "../idValidation";
+import type { ApolloCache } from "@apollo/client";
+
+function createMockCache() {
+  const modifyCalls: Array<{ id: string; fields: Record<string, unknown> }> =
+    [];
+
+  const identify = vi.fn(
+    (obj: { __typename: string; id: string }) => `${obj.__typename}:${obj.id}`
+  );
+  const modify = vi.fn((args: any) => {
+    modifyCalls.push({ id: args.id, fields: args.fields });
+    return true;
+  });
+
+  return {
+    cache: { identify, modify } as unknown as ApolloCache<unknown>,
+    identify,
+    modify,
+    modifyCalls,
+  };
+}
+
+describe("updateCacheForJobNotification", () => {
+  let harness: ReturnType<typeof createMockCache>;
+
+  beforeEach(() => {
+    harness = createMockCache();
+  });
+
+  it("handles DOCUMENT_PROCESSED and flips backendLock to false", () => {
+    const handled = updateCacheForJobNotification(
+      harness.cache,
+      "DOCUMENT_PROCESSED" as any,
+      { document_id: 42 }
+    );
+    expect(handled).toBe(true);
+    expect(harness.identify).toHaveBeenCalledWith({
+      __typename: "DocumentType",
+      id: toGlobalId("DocumentType", 42),
+    });
+    expect(harness.modifyCalls[0].fields.backendLock).toBeTypeOf("function");
+    expect((harness.modifyCalls[0].fields.backendLock as () => unknown)()).toBe(
+      false
+    );
+  });
+
+  it("handles EXTRACT_COMPLETE and sets a finished timestamp", () => {
+    const handled = updateCacheForJobNotification(
+      harness.cache,
+      "EXTRACT_COMPLETE" as any,
+      { extract_id: 7 }
+    );
+    expect(handled).toBe(true);
+    const finished = harness.modifyCalls[0].fields.finished as () => string;
+    expect(typeof finished()).toBe("string");
+    expect(Number.isNaN(Date.parse(finished()))).toBe(false);
+  });
+
+  it("handles ANALYSIS_COMPLETE setting status and analysisCompleted", () => {
+    const handled = updateCacheForJobNotification(
+      harness.cache,
+      "ANALYSIS_COMPLETE" as any,
+      { analysis_id: 9 }
+    );
+    expect(handled).toBe(true);
+    const fields = harness.modifyCalls[0].fields as Record<
+      string,
+      () => unknown
+    >;
+    expect(fields.status()).toBe("COMPLETED");
+    expect(typeof fields.analysisCompleted()).toBe("string");
+  });
+
+  it("handles ANALYSIS_FAILED setting status=FAILED", () => {
+    updateCacheForJobNotification(harness.cache, "ANALYSIS_FAILED" as any, {
+      analysis_id: 1,
+    });
+    const fields = harness.modifyCalls[0].fields as Record<
+      string,
+      () => unknown
+    >;
+    expect(fields.status()).toBe("FAILED");
+  });
+
+  it("handles EXPORT_COMPLETE clearing backendLock and setting finished", () => {
+    updateCacheForJobNotification(harness.cache, "EXPORT_COMPLETE" as any, {
+      export_id: 3,
+    });
+    const fields = harness.modifyCalls[0].fields as Record<
+      string,
+      () => unknown
+    >;
+    expect(fields.backendLock()).toBe(false);
+    expect(typeof fields.finished()).toBe("string");
+  });
+
+  it("returns false when the id is missing", () => {
+    expect(
+      updateCacheForJobNotification(
+        harness.cache,
+        "EXTRACT_COMPLETE" as any,
+        {}
+      )
+    ).toBe(false);
+    expect(harness.modify).not.toHaveBeenCalled();
+  });
+
+  it("returns false for unknown notification types", () => {
+    expect(
+      updateCacheForJobNotification(harness.cache, "UNKNOWN_TYPE" as any, {
+        document_id: 1,
+      })
+    ).toBe(false);
+  });
+
+  it("skips modify when cache cannot identify the object", () => {
+    const identify = vi.fn(() => undefined);
+    const modify = vi.fn();
+    const cache = { identify, modify } as unknown as ApolloCache<unknown>;
+
+    const handled = updateCacheForJobNotification(
+      cache,
+      "DOCUMENT_PROCESSED" as any,
+      { document_id: 100 }
+    );
+    // The function still returns true because the id was provided, but
+    // modify must not have been invoked.
+    expect(handled).toBe(true);
+    expect(modify).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/utils/__tests__/layout.test.ts
+++ b/frontend/src/utils/__tests__/layout.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, afterEach, beforeEach } from "vitest";
+import { determineCardColCount, clampMenuPosition } from "../layout";
+
+describe("layout utilities", () => {
+  describe("determineCardColCount", () => {
+    it.each([
+      [320, 1],
+      [600, 2],
+      [900, 3],
+      [1100, 4],
+      [1440, 5],
+      [1700, 6],
+      [2200, 7],
+      [3000, 8],
+    ])("width=%i returns %i columns", (width, expected) => {
+      expect(determineCardColCount(width)).toBe(expected);
+    });
+  });
+
+  describe("clampMenuPosition", () => {
+    let originalWidth: number;
+    let originalHeight: number;
+
+    beforeEach(() => {
+      originalWidth = window.innerWidth;
+      originalHeight = window.innerHeight;
+      Object.defineProperty(window, "innerWidth", {
+        value: 1000,
+        writable: true,
+        configurable: true,
+      });
+      Object.defineProperty(window, "innerHeight", {
+        value: 800,
+        writable: true,
+        configurable: true,
+      });
+    });
+
+    afterEach(() => {
+      Object.defineProperty(window, "innerWidth", {
+        value: originalWidth,
+        writable: true,
+        configurable: true,
+      });
+      Object.defineProperty(window, "innerHeight", {
+        value: originalHeight,
+        writable: true,
+        configurable: true,
+      });
+    });
+
+    it("places menu to the right/below the cursor when space allows", () => {
+      const pos = clampMenuPosition(100, 100, 200, 200, 10, 10);
+      expect(pos.x).toBe(110);
+      expect(pos.y).toBe(110);
+    });
+
+    it("flips left when the menu would overflow the right edge", () => {
+      const pos = clampMenuPosition(900, 100, 200, 200, 10, 10);
+      // 900 + 10 + 200 = 1110 > 990 (1000 - 10), so flip
+      expect(pos.x).toBeLessThan(900);
+    });
+
+    it("flips above when the menu would overflow the bottom edge", () => {
+      const pos = clampMenuPosition(100, 700, 200, 200, 10, 10);
+      expect(pos.y).toBeLessThan(700);
+    });
+
+    it("honours minEdgeGap as a floor", () => {
+      const pos = clampMenuPosition(0, 0, 200, 200, 10, 15);
+      expect(pos.x).toBeGreaterThanOrEqual(15);
+      expect(pos.y).toBeGreaterThanOrEqual(15);
+    });
+
+    it("uses default menu dimensions when not provided", () => {
+      // Should not throw and should return numeric coords
+      const pos = clampMenuPosition(500, 400);
+      expect(typeof pos.x).toBe("number");
+      expect(typeof pos.y).toBe("number");
+    });
+  });
+});

--- a/frontend/src/utils/__tests__/navigationCircuitBreaker.test.ts
+++ b/frontend/src/utils/__tests__/navigationCircuitBreaker.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { navigationCircuitBreaker } from "../navigationCircuitBreaker";
+
+describe("navigationCircuitBreaker", () => {
+  let alertSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    navigationCircuitBreaker.reset();
+    alertSpy = vi
+      .spyOn(window, "alert")
+      .mockImplementation(() => undefined as any);
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    navigationCircuitBreaker.reset();
+    alertSpy.mockRestore();
+    errorSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
+  it("records navigation events and allows them under the limit", () => {
+    expect(navigationCircuitBreaker.recordNavigation("/a", "test")).toBe(true);
+    expect(navigationCircuitBreaker.recordNavigation("/b", "test")).toBe(true);
+
+    const status = navigationCircuitBreaker.getStatus();
+    expect(status.tripped).toBe(false);
+    expect(status.eventCount).toBe(2);
+    expect(status.events[0].url).toBe("/a");
+  });
+
+  it("trips on loop threshold (same URL repeated)", () => {
+    navigationCircuitBreaker.recordNavigation("/loop", "test");
+    navigationCircuitBreaker.recordNavigation("/loop", "test");
+    // Third hit on same URL should trip the breaker.
+    const result = navigationCircuitBreaker.recordNavigation("/loop", "test");
+    expect(result).toBe(false);
+    expect(navigationCircuitBreaker.getStatus().tripped).toBe(true);
+    expect(alertSpy).toHaveBeenCalled();
+  });
+
+  it("trips when too many navigations occur in the window", () => {
+    // 6 unique URLs in window — exceeds MAX_NAVIGATIONS (5).
+    const results = [
+      navigationCircuitBreaker.recordNavigation("/a", "t"),
+      navigationCircuitBreaker.recordNavigation("/b", "t"),
+      navigationCircuitBreaker.recordNavigation("/c", "t"),
+      navigationCircuitBreaker.recordNavigation("/d", "t"),
+      navigationCircuitBreaker.recordNavigation("/e", "t"),
+      navigationCircuitBreaker.recordNavigation("/f", "t"),
+    ];
+    expect(results.slice(0, 5).every((r) => r === true)).toBe(true);
+    expect(results[5]).toBe(false);
+    expect(navigationCircuitBreaker.getStatus().tripped).toBe(true);
+  });
+
+  it("trips on ping-pong between two URLs", () => {
+    navigationCircuitBreaker.recordNavigation("/x", "t");
+    navigationCircuitBreaker.recordNavigation("/y", "t");
+    navigationCircuitBreaker.recordNavigation("/x", "t");
+    const result = navigationCircuitBreaker.recordNavigation("/y", "t");
+    // Either loop threshold (2 x "/x" in last four with /y twice hits
+    // LOOP_THRESHOLD=3? no, we only have 2 /x. So the ping-pong path trips here)
+    expect(result).toBe(false);
+    expect(navigationCircuitBreaker.getStatus().tripped).toBe(true);
+  });
+
+  it("blocks further navigations once tripped", () => {
+    // Trip via loop
+    navigationCircuitBreaker.recordNavigation("/z", "t");
+    navigationCircuitBreaker.recordNavigation("/z", "t");
+    navigationCircuitBreaker.recordNavigation("/z", "t");
+    expect(navigationCircuitBreaker.getStatus().tripped).toBe(true);
+
+    const result = navigationCircuitBreaker.recordNavigation("/new", "test");
+    expect(result).toBe(false);
+  });
+
+  it("drops events that fall outside the 3-second window", () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+      navigationCircuitBreaker.recordNavigation("/stale", "t");
+
+      // Jump past WINDOW_MS (3000)
+      vi.setSystemTime(new Date("2026-01-01T00:00:05Z"));
+      navigationCircuitBreaker.recordNavigation("/fresh", "t");
+
+      const status = navigationCircuitBreaker.getStatus();
+      // Only the fresh event survives.
+      expect(status.eventCount).toBe(1);
+      expect(status.events[0].url).toBe("/fresh");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("reset clears history and untrips", () => {
+    navigationCircuitBreaker.recordNavigation("/r", "t");
+    navigationCircuitBreaker.recordNavigation("/r", "t");
+    navigationCircuitBreaker.recordNavigation("/r", "t");
+    expect(navigationCircuitBreaker.getStatus().tripped).toBe(true);
+
+    navigationCircuitBreaker.reset();
+    const status = navigationCircuitBreaker.getStatus();
+    expect(status.tripped).toBe(false);
+    expect(status.eventCount).toBe(0);
+  });
+
+  it("is exposed on window for debugging", () => {
+    expect((window as any).navigationCircuitBreaker).toBe(
+      navigationCircuitBreaker
+    );
+  });
+});

--- a/frontend/src/utils/__tests__/parseOutputType.test.ts
+++ b/frontend/src/utils/__tests__/parseOutputType.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import { parseOutputType, parsePydanticModel } from "../parseOutputType";
+
+describe("parseOutputType", () => {
+  describe("primitive types", () => {
+    it("parses int", () => {
+      expect(parseOutputType("int")).toEqual({ type: "number" });
+    });
+
+    it("parses float", () => {
+      expect(parseOutputType("float")).toEqual({ type: "number" });
+    });
+
+    it("parses str", () => {
+      expect(parseOutputType("str")).toEqual({ type: "string" });
+    });
+
+    it("parses bool", () => {
+      expect(parseOutputType("bool")).toEqual({ type: "boolean" });
+    });
+
+    it("trims whitespace", () => {
+      expect(parseOutputType("  str  ")).toEqual({ type: "string" });
+    });
+  });
+
+  describe("object types", () => {
+    it("parses a single-line object with typed fields", () => {
+      expect(parseOutputType("name: str")).toEqual({
+        type: "object",
+        properties: { name: { type: "string" } },
+      });
+    });
+
+    it("parses a multi-line object with mixed primitives", () => {
+      const schema = parseOutputType("age: int\nname: str\nactive: bool");
+      expect(schema).toEqual({
+        type: "object",
+        properties: {
+          age: { type: "number" },
+          name: { type: "string" },
+          active: { type: "boolean" },
+        },
+      });
+    });
+
+    it("skips blank lines", () => {
+      const schema = parseOutputType("\nname: str\n\nage: int\n");
+      expect(schema).toEqual({
+        type: "object",
+        properties: {
+          name: { type: "string" },
+          age: { type: "number" },
+        },
+      });
+    });
+
+    it("defaults unknown types to string", () => {
+      const schema = parseOutputType("field: Decimal");
+      expect(schema).toEqual({
+        type: "object",
+        properties: { field: { type: "string" } },
+      });
+    });
+  });
+
+  describe("error cases", () => {
+    it("rejects default values", () => {
+      expect(() => parseOutputType("name: str = 'foo'")).toThrow(
+        /default values/
+      );
+    });
+
+    it("rejects lines with too many colons", () => {
+      expect(() => parseOutputType("a: b: c")).toThrow(/line 1/);
+    });
+
+    it("rejects bare primitives that are unknown", () => {
+      expect(() => parseOutputType("nonsense")).toThrow(
+        /Invalid model or primitive type/
+      );
+    });
+  });
+});
+
+describe("parsePydanticModel", () => {
+  it("returns an empty list for empty input", () => {
+    expect(parsePydanticModel("")).toEqual([]);
+  });
+
+  it("skips class declarations and returns typed fields", () => {
+    const model = `class Example(BaseModel):\n    name: str\n    age: int`;
+    const fields = parsePydanticModel(model);
+    expect(fields).toHaveLength(2);
+    expect(fields[0].fieldName).toBe("name");
+    expect(fields[0].fieldType).toBe("str");
+    expect(fields[1].fieldName).toBe("age");
+    expect(fields[1].fieldType).toBe("int");
+    // id should be a string (Math.random-derived)
+    expect(typeof fields[0].id).toBe("string");
+  });
+
+  it("ignores blank lines", () => {
+    const fields = parsePydanticModel("\n\nname: str\n\n");
+    expect(fields).toHaveLength(1);
+    expect(fields[0].fieldName).toBe("name");
+  });
+});

--- a/frontend/src/utils/__tests__/performance.test.ts
+++ b/frontend/src/utils/__tests__/performance.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  performanceMonitor,
+  usePerformanceTracking,
+  navigationTiming,
+} from "../performance";
+
+// The PerformanceMonitor only records when NODE_ENV === "development".
+// In tests NODE_ENV is "test", so we toggle the private `enabled` field
+// to verify both branches without needing to mutate process.env.
+const monitor = performanceMonitor as unknown as { enabled: boolean };
+
+describe("performance utilities", () => {
+  let originalEnabled: boolean;
+  let debugSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    originalEnabled = monitor.enabled;
+    monitor.enabled = true;
+    performanceMonitor.clearMetrics();
+    debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    monitor.enabled = originalEnabled;
+    performanceMonitor.clearMetrics();
+    debugSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
+  describe("start/end/getMetrics", () => {
+    it("records duration between start and end", () => {
+      performanceMonitor.startMetric("m1", { foo: "bar" });
+      performanceMonitor.endMetric("m1", { baz: "qux" });
+
+      const metrics = performanceMonitor.getMetrics();
+      expect(metrics).toHaveLength(1);
+      const [m] = metrics;
+      expect(m.name).toBe("m1");
+      expect(m.duration).toBeGreaterThanOrEqual(0);
+      expect(m.metadata).toEqual({ foo: "bar", baz: "qux" });
+    });
+
+    it("warns and is a no-op when endMetric is called without a start", () => {
+      performanceMonitor.endMetric("never-started");
+      expect(warnSpy).toHaveBeenCalled();
+    });
+
+    it("clearMetrics removes all records", () => {
+      performanceMonitor.startMetric("a");
+      performanceMonitor.endMetric("a");
+      expect(performanceMonitor.getMetrics()).toHaveLength(1);
+      performanceMonitor.clearMetrics();
+      expect(performanceMonitor.getMetrics()).toHaveLength(0);
+    });
+
+    it("is a no-op when disabled", () => {
+      monitor.enabled = false;
+      performanceMonitor.startMetric("skip-me");
+      performanceMonitor.endMetric("skip-me");
+      expect(performanceMonitor.getMetrics()).toHaveLength(0);
+    });
+  });
+
+  describe("trackAsync", () => {
+    it("measures a successful operation", async () => {
+      const result = await performanceMonitor.trackAsync("ok", async () => 42);
+      expect(result).toBe(42);
+      const [m] = performanceMonitor.getMetrics();
+      expect(m.metadata).toMatchObject({ success: true });
+    });
+
+    it("records failure and rethrows", async () => {
+      await expect(
+        performanceMonitor.trackAsync("fail", async () => {
+          throw new Error("boom");
+        })
+      ).rejects.toThrow("boom");
+
+      const [m] = performanceMonitor.getMetrics();
+      expect(m.metadata).toMatchObject({ success: false });
+      expect(m.metadata?.error).toContain("boom");
+    });
+  });
+
+  describe("usePerformanceTracking", () => {
+    it("returns bound start/end/track helpers", async () => {
+      const api = usePerformanceTracking("ui-load");
+      api.start({ variant: "a" });
+      api.end({ cached: true });
+
+      const [m] = performanceMonitor.getMetrics();
+      expect(m.name).toBe("ui-load");
+      expect(m.metadata).toMatchObject({ variant: "a", cached: true });
+
+      performanceMonitor.clearMetrics();
+      const value = await api.track(async () => "done", { attempt: 1 });
+      expect(value).toBe("done");
+      const [tracked] = performanceMonitor.getMetrics();
+      expect(tracked.metadata).toMatchObject({ attempt: 1, success: true });
+    });
+  });
+
+  describe("navigationTiming", () => {
+    it("tracks navigation start/complete", () => {
+      navigationTiming.trackNavigation("/a", "/b");
+      navigationTiming.completeNavigation(true);
+      const [m] = performanceMonitor.getMetrics();
+      expect(m.name).toBe("navigation");
+      expect(m.metadata).toMatchObject({ from: "/a", to: "/b", success: true });
+    });
+
+    it("tracks slug resolution start/complete", () => {
+      navigationTiming.trackSlugResolution("corpus", "my-corpus");
+      navigationTiming.completeSlugResolution("corpus", true);
+      const metrics = performanceMonitor.getMetrics();
+      const slug = metrics.find((m) => m.name === "slug-resolution-corpus");
+      expect(slug).toBeDefined();
+      expect(slug?.metadata).toMatchObject({
+        slug: "my-corpus",
+        found: true,
+      });
+    });
+  });
+});

--- a/frontend/src/utils/__tests__/persistentVar.test.ts
+++ b/frontend/src/utils/__tests__/persistentVar.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { persistentVar } from "../persistentVar";
+
+describe("persistentVar", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    sessionStorage.clear();
+  });
+
+  it("uses the default value when nothing is stored", () => {
+    const rv = persistentVar<number>("persistent.counter", 7);
+    expect(rv()).toBe(7);
+  });
+
+  it("hydrates from sessionStorage when a value exists", () => {
+    sessionStorage.setItem("persistent.saved", JSON.stringify({ n: 3 }));
+    const rv = persistentVar<{ n: number }>("persistent.saved", { n: 0 });
+    expect(rv()).toEqual({ n: 3 });
+  });
+
+  it("persists changes back to sessionStorage", () => {
+    const rv = persistentVar<string>("persistent.text", "initial");
+    rv("updated");
+    expect(sessionStorage.getItem("persistent.text")).toBe(
+      JSON.stringify("updated")
+    );
+  });
+
+  it("removes the storage entry when value is set to null or undefined", () => {
+    sessionStorage.setItem("persistent.clearable", JSON.stringify("keep"));
+    const rv = persistentVar<string | null>("persistent.clearable", "keep");
+    rv(null);
+    expect(sessionStorage.getItem("persistent.clearable")).toBeNull();
+  });
+
+  it("falls back to default value on malformed stored JSON", () => {
+    sessionStorage.setItem("persistent.bad", "{not json");
+    const rv = persistentVar<string>("persistent.bad", "fallback");
+    expect(rv()).toBe("fallback");
+  });
+
+  it("treats literal 'undefined' and 'null' strings as missing", () => {
+    sessionStorage.setItem("persistent.undef", "undefined");
+    const rv = persistentVar<string>("persistent.undef", "default");
+    expect(rv()).toBe("default");
+
+    sessionStorage.setItem("persistent.nul", "null");
+    const rv2 = persistentVar<string>("persistent.nul", "default");
+    expect(rv2()).toBe("default");
+  });
+});

--- a/frontend/src/utils/__tests__/routingLogger.test.ts
+++ b/frontend/src/utils/__tests__/routingLogger.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { routingLogger } from "../routingLogger";
+
+describe("routingLogger", () => {
+  let debugSpy: ReturnType<typeof vi.spyOn>;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    window.DEBUG_ROUTING = false;
+  });
+
+  afterEach(() => {
+    debugSpy.mockRestore();
+    logSpy.mockRestore();
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+    window.DEBUG_ROUTING = false;
+  });
+
+  it("swallows debug logs when DEBUG_ROUTING is disabled", () => {
+    routingLogger.debug("invisible", { k: "v" });
+    expect(debugSpy).not.toHaveBeenCalled();
+  });
+
+  it("emits debug logs when DEBUG_ROUTING is enabled", () => {
+    routingLogger.enableDebug();
+    routingLogger.debug("visible", "arg");
+    expect(debugSpy).toHaveBeenCalledWith("visible", "arg");
+  });
+
+  it("always emits info/warn/error", () => {
+    routingLogger.info("i");
+    routingLogger.warn("w");
+    routingLogger.error("e");
+    expect(logSpy).toHaveBeenCalledWith("i");
+    expect(warnSpy).toHaveBeenCalledWith("w");
+    expect(errorSpy).toHaveBeenCalledWith("e");
+  });
+
+  it("reports status via getStatus", () => {
+    routingLogger.disableDebug();
+    expect(routingLogger.getStatus()).toEqual({ debugEnabled: false });
+    routingLogger.enableDebug();
+    expect(routingLogger.getStatus()).toEqual({ debugEnabled: true });
+  });
+
+  it("exposes itself on window", () => {
+    expect((window as any).routingLogger).toBe(routingLogger);
+  });
+});


### PR DESCRIPTION
Closes #1267

## Summary
- Adds 18 new `*.test.ts(x)` files targeting previously-untested utilities and hooks in `frontend/src/utils/` and `frontend/src/hooks/` — the highest-ROI area called out in the issue.
- ~210 new assertions covering pure helpers (formatters, array/color utils, parseOutputType, env, extractUtils, layout, compactAnnotationJson, annotationGuards, persistentVar) and stateful singletons (routingLogger, navigationCircuitBreaker, performanceMonitor, jobNotificationCacheUpdates).
- Hook coverage via `@testing-library/react-hooks` `renderHook`: `useAuthReady`, `useFeatureAvailability`, `useMessageBadges` (Apollo `MockedProvider`), `useBadgeCelebration` (mocks `react-toastify` + `BadgeToast`, drives `vi.useFakeTimers()` through the queue/modal state machine).

## Files added
**Utils** (`frontend/src/utils/__tests__/`):
`formatters.test.ts`, `arrayUtils.test.ts`, `colorUtils.test.ts`, `parseOutputType.test.ts`, `annotationGuards.test.ts`, `env.test.ts`, `extractUtils.test.ts`, `layout.test.ts`, `persistentVar.test.ts`, `routingLogger.test.ts`, `navigationCircuitBreaker.test.ts`, `performance.test.ts`, `jobNotificationCacheUpdates.test.ts`, `compactAnnotationJson.test.ts`.

**Hooks** (`frontend/src/hooks/__tests__/`):
`useAuthReady.test.tsx`, `useFeatureAvailability.test.ts`, `useMessageBadges.test.tsx`, `useBadgeCelebration.test.tsx`.

## Conventions followed
- Tests live in `src/**/__tests__/*.test.ts(x)` per `test:coverage:unit` glob.
- No production code touched — pure additive test coverage.
- `CHANGELOG.md` updated under `[Unreleased] → Added` with file-path breakdown.
- TypeScript strict-check clean (`tsc --noEmit`).
- Prettier-clean.

## Test plan
- [x] `yarn test:unit run` — full suite: **1118/1118** passed (72 files).
- [x] `yarn tsc --noEmit` — clean.
- [x] `yarn prettier --check` on new files — clean.
- [ ] Codecov `frontend-unit` flag delta on main (will be visible post-merge).