### PR TITLE
Fix typo in RelationGroup id type declaration

### DIFF
--- a/frontend/src/components/annotator/types/annotations.ts
+++ b/frontend/src/components/annotator/types/annotations.ts
@@ -28,7 +28,7 @@ export class RelationGroup {
     public sourceIds: string[],
     public targetIds: string[],
     public label: AnnotationLabelType,
-    public id: string | string = uuidv4(),
+    public id: string = uuidv4(),
     public structural: boolean = false
   ) {
     this.id = id;


### PR DESCRIPTION
## Summary
- Fix redundant `string | string` union type on the `id` parameter of the `RelationGroup` constructor in `frontend/src/components/annotator/types/annotations.ts:31`.

Closes #1293

## Test plan
- [x] Type-check: change is a no-op at runtime; `string | string` collapses to `string`, so no behavior change.
