### PR TITLE
Fix: forced-by-selected-relation now applies regardless of showStructural

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Forced-by-selected-relation visibility now respects explicit user selection regardless of `showStructural`** (Issue #1294): In `frontend/src/components/annotator/hooks/useVisibleAnnotations.ts:54-62`, the IDs forced visible by a selected relation were previously only merged into `forcedIds` inside the `if (showStructural)` branch. With structural annotations toggled off, clicking a relation in the sidebar failed to highlight its member annotations — making the relation sidebar effectively unusable in that mode. Moved the `forcedBySelectedRelationIds` merge outside the structural branch so explicit user selection always wins (consistent with the existing `forcedBySelection` treatment). Structural-relationships auto-forcing (`showStructuralRelationships`) remains gated on `showStructural`, since that path is implicit rather than user-initiated.
+  - Updated `frontend/src/components/annotator/hooks/__tests__/useVisibleAnnotations.test.tsx`: replaced the pinning test that documented the bug ("does NOT apply forced-by-selected-relation when showStructural is false") with two assertions verifying the corrected behavior — forced-by-selected-relation now applies to both non-structural annotations (overriding a label filter) and structural annotations when `showStructural` is false. All 16 tests in the file pass; `tsc --noEmit` clean.
+
 ### Added
 
 - **Extracts DataGrid & Detail component test coverage** (Issue #1282): Expanded Playwright component tests for the two biggest uncovered files in `frontend/src/components/extracts/`. Previously at 32.5% and 23.0% line coverage respectively (~990 uncovered lines combined); the new tests exercise the high-signal branches listed in the issue.

--- a/frontend/src/components/annotator/hooks/__tests__/useVisibleAnnotations.test.tsx
+++ b/frontend/src/components/annotator/hooks/__tests__/useVisibleAnnotations.test.tsx
@@ -305,9 +305,9 @@ describe("useVisibleAnnotations", () => {
       expect(ids).toEqual(["src", "tgt"]); // "other" still filtered out
     });
 
-    it("does NOT apply forced-by-selected-relation when showStructural is false", () => {
-      // Per implementation: selected-relation IDs are added to forcedIds only
-      // inside the `if (showStructural)` block.
+    it("applies forced-by-selected-relation even when showStructural is false", () => {
+      // Selecting a relation is an explicit user gesture — its member
+      // annotations must be visible regardless of the structural toggle.
       const src = makeAnnot({ id: "src" });
       const tgt = makeAnnot({ id: "tgt" });
       const rel = new RelationGroup(["src"], ["tgt"], labelA, "rel-1");
@@ -321,7 +321,7 @@ describe("useVisibleAnnotations", () => {
             showStructuralRelationships: false,
             showSelectedOnly: false,
           },
-          controls: { spanLabelsToView: [labelB] }, // excludes both
+          controls: { spanLabelsToView: [labelB] }, // would exclude both
           selection: {
             selectedAnnotations: [],
             selectedRelations: [rel],
@@ -330,7 +330,34 @@ describe("useVisibleAnnotations", () => {
       );
 
       const { result } = renderHook(() => useVisibleAnnotations());
-      expect(result.current).toHaveLength(0);
+      expect(result.current.map((x) => x.id).sort()).toEqual(["src", "tgt"]);
+    });
+
+    it("applies forced-by-selected-relation to structural annotations when showStructural is false", () => {
+      // Same rationale: explicit relation selection overrides structural hiding,
+      // even for structural members.
+      const src = makeAnnot({ id: "src", structural: true });
+      const tgt = makeAnnot({ id: "tgt", structural: true });
+      const rel = new RelationGroup(["src"], ["tgt"], labelA, "rel-1");
+
+      primeMocks(
+        defaultState({
+          annotations: [src, tgt],
+          relations: [rel],
+          display: {
+            showStructural: false,
+            showStructuralRelationships: false,
+            showSelectedOnly: false,
+          },
+          selection: {
+            selectedAnnotations: [],
+            selectedRelations: [rel],
+          },
+        })
+      );
+
+      const { result } = renderHook(() => useVisibleAnnotations());
+      expect(result.current.map((x) => x.id).sort()).toEqual(["src", "tgt"]);
     });
   });
 

--- a/frontend/src/components/annotator/hooks/useVisibleAnnotations.ts
+++ b/frontend/src/components/annotator/hooks/useVisibleAnnotations.ts
@@ -53,8 +53,11 @@ export function useVisibleAnnotations(): (
 
     const forcedIds = new Set(forcedBySelection);
 
+    /* selecting a relation is an explicit user gesture — its member
+       annotations must be visible regardless of the structural toggle */
+    forcedBySelectedRelationIds.forEach((id) => forcedIds.add(id));
+
     if (showStructural) {
-      forcedBySelectedRelationIds.forEach((id) => forcedIds.add(id));
       forcedByRelationships.forEach((id) => forcedIds.add(id));
     }
 


### PR DESCRIPTION
Closes #1294

## Summary

- Moves the forced-by-selected-relation merge in `frontend/src/components/annotator/hooks/useVisibleAnnotations.ts` out of the `if (showStructural)` branch so selecting a relation in the sidebar always highlights its members.
- Selecting a relation is an explicit user gesture — treating it like `forcedBySelection` (which already overrides the structural toggle for a single annotation) makes the relation sidebar usable when `showStructural` is off.
- The implicit auto-forcing from `showStructuralRelationships` remains gated on `showStructural`, since that path is not user-initiated.

## Test plan

- [x] Replaced the pinning test in `frontend/src/components/annotator/hooks/__tests__/useVisibleAnnotations.test.tsx` that documented the old behavior (`"does NOT apply forced-by-selected-relation when showStructural is false"`) with two new assertions verifying the fix:
  - forced-by-selected-relation applies to non-structural members even when `showStructural` is false (overriding an unrelated label filter)
  - forced-by-selected-relation applies to structural members even when `showStructural` is false
- [x] `yarn test:unit run useVisibleAnnotations.test.tsx` → 16/16 pass
- [x] `yarn tsc --noEmit -p tsconfig.json` → clean
- [x] CHANGELOG.md updated under `[Unreleased] / Fixed`
