### PR TITLE
Fix Backend CI mypy failure from django-stubs 6.0.3 upgrade

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
         # major breakages (e.g. pypdf 7, openai 3) for the same reason.
         additional_dependencies:
           # --- Type stubs -----------------------------------------------
-          - django-stubs==6.0.2
+          - django-stubs==6.0.3
           - djangorestframework-stubs==3.16.9
           - types-requests==2.33.0.20260408
           - types-PyYAML==6.0.12.20260408

--- a/opencontractserver/documents/management/commands/validate_v3_migration.py
+++ b/opencontractserver/documents/management/commands/validate_v3_migration.py
@@ -298,9 +298,11 @@ class Command(BaseCommand):
         )
 
         if verbose:
-            for dup in duplicates[:5]:
+            for content_hash, count in duplicates.values_list(
+                "content_hash", "count"
+            )[:5]:
                 self.stdout.write(
-                    f"    - Hash {dup['content_hash'][:16]}...: {dup['count']} duplicates"
+                    f"    - Hash {content_hash[:16]}...: {count} duplicates"
                 )
 
         return {"passed": False, "duplicate_hashes": duplicate_count}


### PR DESCRIPTION
## Summary

Backend CI `linter` job has been failing on `main` and every PR branched off it since the 2026-04-23 batch of merges. Root cause is a two-PR interaction:

1. **#1343** (`Wire mypy into pre-commit and CI`) captured a per-module ignore-errors baseline in `mypy.ini` at **django-stubs 6.0.2** — every file with a type error at that moment was added to the allow-list.
2. **#1340** (`Bump django-stubs 6.0.2 → 6.0.3`) merged ~10 seconds later. 6.0.3 tightens the typing of `.values().annotate()` chains, surfacing a new error in [`validate_v3_migration.py:303`](https://github.com/Open-Source-Legal/OpenContracts/blob/main/opencontractserver/documents/management/commands/validate_v3_migration.py#L303) — a file that happened to be type-clean under 6.0.2 and was therefore **not** in the baseline.

Exact CI error:
```
opencontractserver/documents/management/commands/validate_v3_migration.py:303: error:
  Value of type "StructuralAnnotationSet@AnnotatedWith[TypedDict({'count': int})]"
  is not indexable  [index]
Found 1 error in 1 file (checked 953 source files)
```

This also exposed the exact **hook/CI drift** the comment above `additional_dependencies` in `.pre-commit-config.yaml` explicitly warns against: the mirrors-mypy hook was still pinned to `django-stubs==6.0.2` while CI's `Run mypy` step pulls 6.0.3 from `requirements/local.txt`. Pre-commit therefore did not catch the error that CI does.

## Fix

- **`validate_v3_migration.py`**: switch the preview loop from indexing into an annotated `.values()` queryset to unpacking a `.values_list("content_hash", "count")` tuple. Functionally identical (same rows, same display), and the tuple form type-checks cleanly under both 6.0.2 and 6.0.3.
- **`.pre-commit-config.yaml`**: bump the hook's `django-stubs==6.0.2` pin to `==6.0.3` so it matches `requirements/local.txt` and the hook can no longer pass while CI fails on the same code.

## Why not just allow-list the file?

Adding `validate_v3_migration` to `mypy.ini`'s ignore-list would unblock CI with a one-line change, but it silences the whole module permanently and works against the baseline's graduation philosophy (shrink the allow-list, don't grow it). The refactor is two lines net and strictly better code.

## Test plan

- [ ] Backend CI `linter` job passes on this PR (authoritative signal — CI is the environment that caught the regression)
- [ ] `python -m mypy --config-file mypy.ini opencontractserver config` exits 0 under `django-stubs==6.0.3`
- [ ] Pre-commit `mypy` hook passes locally after the `additional_dependencies` bump
- [ ] `validate_v3_migration --verbose` still prints the duplicate-hash preview correctly (manual sanity — behaviour unchanged)

## Follow-ups (out of scope)

- None of the other ~357 baselined modules are re-exercised by this PR; a separate graduation pass against 6.0.3 may surface additional errors that should be fixed (not re-baselined).