### PR TITLE
Fix remaining lint errors on main

### DIFF
--- a/frontend/.prettierignore
+++ b/frontend/.prettierignore
@@ -13,6 +13,7 @@ node_modules/
 # Generated files
 *.min.js
 *.min.css
+public/env-config.js
 
 # Playwright cache
 playwright/.cache/

--- a/opencontractserver/documents/management/commands/validate_v3_migration.py
+++ b/opencontractserver/documents/management/commands/validate_v3_migration.py
@@ -9,6 +9,7 @@ Usage:
 """
 
 import logging
+from typing import cast
 
 from django.core.management.base import BaseCommand
 from django.db.models import Count
@@ -298,9 +299,14 @@ class Command(BaseCommand):
         )
 
         if verbose:
-            for content_hash, count in duplicates.values_list(
-                "content_hash", "count"
-            )[:5]:
+            # django-stubs 6.0.3 mistypes `.values().annotate().values_list()`
+            # chains as the annotated model rather than a tuple iterable, so
+            # materialise with an explicit cast. Functionally identical.
+            top_duplicates = cast(
+                list[tuple[str, int]],
+                list(duplicates.values_list("content_hash", "count")[:5]),
+            )
+            for content_hash, count in top_duplicates:
                 self.stdout.write(
                     f"    - Hash {content_hash[:16]}...: {count} duplicates"
                 )


### PR DESCRIPTION
## Summary
- **mypy**: `validate_v3_migration.py` still fails type checking under django-stubs 6.0.3 after PR #1367 — `.values_list()` on an annotated `ValuesQuerySet` is typed as the annotated model (not a tuple iterable). Fix by materialising the slice via `cast(list[tuple[str, int]], list(...))` so the for-loop destructures a concrete tuple. Functionally identical.
- **prettier**: `public/env-config.js` is a gitignored build artefact generated by `env.sh` at container start. It tripped `yarn lint` locally but never exists in CI. Add it to `.prettierignore` so the ignore surface matches `.gitignore`.

## Test plan
- [x] `pre-commit run --all-files` — all hooks pass (black, isort, flake8, mypy, pyupgrade, etc.)
- [x] `yarn lint` in `frontend/` — prettier clean
- [ ] Backend CI `linter` job passes