### PR TITLE
Fix CI: remove resurrected User.__init__ mutating Field.validators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`User.__init__` shared-state mutation re-introduced by branch merge** (`opencontractserver/users/models.py:172-180` removed): PR #1374 (commit `50ed6740`) deleted the `User.__init__` override that mutated `Field.validators[0]` on every instantiation, but a subsequent merge (`b68c1cb4 → 6d2cddbf`) resurrected the override along with its mypy-narrowing changes. The current main on commit `6d2cddbf` therefore reproduced the original `#1358` bug: `User(...)` rebound `username_field.validators[0]` and clobbered any third-party validator prepended to the list. Removed the `__init__` override entirely; the class-body declaration `validators=[UserUnicodeUsernameValidator()]` on the `username` field (still present from PR #1374) is the canonical and only declaration. Also dropped the now-unused `Field` import. Regression coverage from PR #1374 (`opencontractserver/tests/test_user_username_validator.py`) was already on main and is what surfaced the regression in CI.
+
 ### Security
 
 - **Cross-corpus structural-annotation leak in `CoreAnnotationVectorStore`** (`opencontractserver/llms/vector_stores/core_vector_stores.py:296-326,371-413`): The corpus-wide retrieval path (`corpus_id` set, `document_id=None`) returned every structural annotation in the database regardless of corpus. Two collaborating defects caused the leak:

--- a/opencontractserver/users/models.py
+++ b/opencontractserver/users/models.py
@@ -12,7 +12,7 @@ from django.contrib.auth.models import (
     Group,
 )
 from django.contrib.auth.models import UserManager as DjangoUserManager
-from django.db.models import Field, Q, QuerySet
+from django.db.models import Q, QuerySet
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
@@ -168,16 +168,6 @@ class User(AbstractUser):
 
     def __str__(self) -> str:
         return f"{self.username}: {self.email}"
-
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        username_field = self._meta.get_field("username")
-        # ``get_field`` is typed as ``Field | ForeignObjectRel``; the
-        # username field is always a plain ``Field``, but narrow here so
-        # mypy can see ``.validators`` without a cast.
-        if isinstance(username_field, Field):
-            username_field.validators[0] = UserUnicodeUsernameValidator()
-
-        super().__init__(*args, **kwargs)
 
     def get_absolute_url(self) -> str:
         """Get url for user's detail view.


### PR DESCRIPTION
## Summary

- Backend CI on `main` (`6d2cddbf`) is failing on two regression tests in `opencontractserver/tests/test_user_username_validator.py`. PR #1374 fixed `#1358` by deleting `User.__init__`, but merge commit `b68c1cb4` (from the auth/users mypy graduation, issue #1333) carried a mypy-typed copy forward and resurrected the bug — every `User(...)` call rebinds `username_field.validators[0]`, clobbering anything third-party prepended and changing validator identity each instantiation.
- This PR removes the `__init__` override (and the now-unused `Field` import). The class-body `validators=[UserUnicodeUsernameValidator()]` declaration on `User.username` (still present from #1374) is the canonical and only binding.
- Frontend CI failure (`CamlArticleEditor.ct.tsx:306 › ArrowDown then Enter inserts the extract-grid component marker`) was already fixed on `main` by `27241450` and is green on the in-progress run — no frontend changes needed here.

## Test plan

- [ ] Backend CI passes the two regression tests:
  - `test_validators_list_stable_across_instantiations`
  - `test_third_party_prepend_does_not_corrupt_username_validator`
- [ ] `test_username_field_has_opencontracts_validator` still passes (unchanged invariant).
- [ ] `test_permissive_characters_accepted` still passes (`\`, `|`, `*` accepted).
- [ ] Pre-commit (black / isort / flake8 / mypy) clean — confirmed locally.