### PR TITLE
Add E2E tests for threads and discussions feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **`frontend/tests/e2e/threads-discussions.spec.ts`** — full-stack Playwright E2E spec covering the discussions feature end-to-end. Anonymous pass renders `/discussions` (filter pills, search box, "Corpus Discussions" section header) and `/threads` (search route). Authenticated pass logs in, creates a corpus, opens its inline discussions view via `?view=discussions`, fills the `CreateThreadForm` modal (title, description, ProseMirror initial message), posts a top-level reply through the `ReplyForm` composer, navigates back to the thread list, then confirms the new thread surfaces in the global `/discussions` "Corpus Discussions" section and the thread-detail content survives a click-through from there. Adds three reusable helpers to `frontend/tests/e2e/helpers.ts` (`openCorpusDiscussionsViaUI`, `createThreadViaUI`, `postThreadReplyViaUI`) so future thread-related specs don't have to re-implement the modal + ProseMirror plumbing. Picked up automatically by the existing `frontend-e2e.yml` workflow — no CI changes required because that workflow already triggers on `frontend/**` paths and runs every `e2e/**/*.spec.ts` file.
+- **E2E spec for threads/discussions** (`frontend/tests/e2e/threads-discussions.spec.ts`):
+  - Anonymous pass renders `/discussions` (filter pills, search box, "Corpus Discussions" section header) and `/threads` (search route) without authentication.
+  - Authenticated pass logs in, creates a per-run corpus (suffixed with `Date.now()` to avoid collisions across retries), opens its inline discussions view via `?view=discussions`, fills the `CreateThreadForm` modal (title, optional description, ProseMirror initial message), posts a top-level reply through the `ReplyForm` composer, navigates back to the thread list, and confirms the new thread surfaces in the global `/discussions` "Corpus Discussions" section before clicking through to the detail.
+  - Picked up automatically by the existing `frontend-e2e.yml` workflow — no CI changes required.
+- **Three reusable E2E helpers** in `frontend/tests/e2e/helpers.ts`:
+  - `openCorpusDiscussionsViaUI` — SPA-navigates to a corpus and opens its inline discussions view; waits on the "All" filter pill as the readiness signal.
+  - `createThreadViaUI` — clicks the `aria-label="Create new discussion"` CTA, fills the modal (scoped via the `#thread-title` anchor), submits the composer, and waits for the thread-detail header.
+  - `postThreadReplyViaUI` — types into the bottom `ReplyForm` ProseMirror editor and clicks Send, returning once the new message text is visible.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`frontend/tests/e2e/threads-discussions.spec.ts`** — full-stack Playwright E2E spec covering the discussions feature end-to-end. Anonymous pass renders `/discussions` (filter pills, search box, "Corpus Discussions" section header) and `/threads` (search route). Authenticated pass logs in, creates a corpus, opens its inline discussions view via `?view=discussions`, fills the `CreateThreadForm` modal (title, description, ProseMirror initial message), posts a top-level reply through the `ReplyForm` composer, navigates back to the thread list, then confirms the new thread surfaces in the global `/discussions` "Corpus Discussions" section and the thread-detail content survives a click-through from there. Adds three reusable helpers to `frontend/tests/e2e/helpers.ts` (`openCorpusDiscussionsViaUI`, `createThreadViaUI`, `postThreadReplyViaUI`) so future thread-related specs don't have to re-implement the modal + ProseMirror plumbing. Picked up automatically by the existing `frontend-e2e.yml` workflow — no CI changes required because that workflow already triggers on `frontend/**` paths and runs every `e2e/**/*.spec.ts` file.
+
 ### Fixed
 
 - **Shared-protocol contract drift surfaced by PR #1400 follow-up review** (Issue #1408):

--- a/frontend/tests/e2e/helpers.ts
+++ b/frontend/tests/e2e/helpers.ts
@@ -1093,8 +1093,11 @@ export async function openCorpusDiscussionsViaUI(
 }
 
 /**
- * Click the "+New Discussion" button (or "+New" when the corpus header is
- * hidden), fill the create-thread modal, and submit.
+ * Click the "+New Discussion" CTA, fill the create-thread modal, and
+ * submit. The visible label flips between "New Discussion" (full header)
+ * and "New" (embedded mode), but both share the stable
+ * `aria-label="Create new discussion"` accessibility name — that is the
+ * selector we anchor on.
  *
  * On success, CorpusDiscussionsView's onSuccess handler closes the modal
  * AND navigates to the new thread (sets ?thread=<id>), so this helper
@@ -1105,13 +1108,14 @@ export async function openCorpusDiscussionsViaUI(
 export async function createThreadViaUI(
   page: Page,
   title: string,
-  description: string,
+  description: string | undefined,
   initialMessage: string
 ): Promise<void> {
-  // The header CTA is "+New Discussion"; in embedded mode it shrinks to "+New".
-  // Both share the same gradient style and are the only buttons that match.
+  // The CreateButton renders aria-label="Create new discussion" in both
+  // header and embedded modes (CorpusDiscussionsView.tsx:525, :540), so
+  // accessible-name matching is stable across viewports.
   await page
-    .getByRole("button", { name: /^(New Discussion|New)$/i })
+    .getByRole("button", { name: /Create new discussion/i })
     .first()
     .click();
 
@@ -1120,22 +1124,29 @@ export async function createThreadViaUI(
     timeout: 10_000,
   });
 
-  await page.fill("#thread-title", title);
+  // Scope all subsequent modal interactions to the form container that
+  // owns #thread-title. This keeps the locators robust if a future preview
+  // pane adds another ProseMirror to the page tree.
+  const modal = page
+    .locator("div")
+    .filter({ has: page.locator("#thread-title") })
+    .first();
+
+  await modal.locator("#thread-title").fill(title);
   if (description) {
-    await page.fill("#thread-description", description);
+    await modal.locator("#thread-description").fill(description);
   }
 
   // The MessageComposer is built on TipTap (ProseMirror). Fill the
-  // contenteditable .ProseMirror element via keyboard.type — `.fill()`
-  // does not reliably trigger TipTap's onUpdate hook in all browsers.
-  const editor = page.locator(".ProseMirror").first();
+  // contenteditable .ProseMirror via keyboard.type — `.fill()` does not
+  // reliably trigger TipTap's onUpdate hook in all browsers.
+  const editor = modal.locator(".ProseMirror").first();
   await expect(editor).toBeVisible({ timeout: 10_000 });
   await editor.click();
   await page.keyboard.type(initialMessage);
 
-  // Submit — the only button labeled exactly "Send" is the composer's
-  // SendButton at the bottom of the modal.
-  await page
+  // Submit — the modal hosts exactly one composer SendButton.
+  await modal
     .getByRole("button", { name: /^Send$/i })
     .first()
     .click();
@@ -1162,16 +1173,18 @@ export async function postThreadReplyViaUI(
   page: Page,
   replyContent: string
 ): Promise<void> {
-  // ThreadDetail renders ONE composer at the bottom (ReplyForm). When in
-  // the modal phase there can be a separate composer; once we are on the
-  // thread detail view, .ProseMirror.last() targets the reply form.
+  // ThreadDetail renders the ReplyForm composer at the bottom of the
+  // page. There is no second ProseMirror at this stage — the create
+  // modal is gone — so `.last()` deterministically picks the reply
+  // composer regardless of any deep-link reply context that might
+  // render an additional ReplyContext header above it.
   const replyEditor = page.locator(".ProseMirror").last();
   await expect(replyEditor).toBeVisible({ timeout: 10_000 });
   await replyEditor.click();
   await page.keyboard.type(replyContent);
 
-  // The reply composer's Send button is the only one in the bottom region.
-  // After click, the message list refetches and the new message renders.
+  // The reply composer's Send button is the only one on the page in
+  // thread-detail mode. After click, the message list refetches.
   await page
     .getByRole("button", { name: /^Send$/i })
     .last()

--- a/frontend/tests/e2e/helpers.ts
+++ b/frontend/tests/e2e/helpers.ts
@@ -1047,3 +1047,138 @@ export async function waitForDocumentReady(
     }
   }).toPass({ timeout: timeoutMs, intervals: [5_000, 10_000, 15_000] });
 }
+
+/**
+ * Open a corpus's inline Discussions view by:
+ *   1. SPA-navigating to /corpuses
+ *   2. Clicking the corpus card so CentralRouteManager loads it into
+ *      `openedCorpus` and updates the URL to /c/<user>/<corpus>
+ *   3. Re-using the resulting URL with `?view=discussions` appended so
+ *      CorpusHome renders <CorpusDiscussionsInlineView>.
+ *
+ * Waits for the Discussions toolbar (the "All" filter pill) to be visible
+ * before returning so callers can immediately click "New Discussion".
+ *
+ * Caller must already be authenticated.
+ */
+export async function openCorpusDiscussionsViaUI(
+  page: Page,
+  corpusTitle: string
+): Promise<void> {
+  await spaNavigate(page, "/corpuses");
+  await expectViewVisible(page, { kind: "text", text: /Your\s+corpuses/i });
+
+  await expect(page.getByText(corpusTitle).first()).toBeVisible({
+    timeout: 15_000,
+  });
+  await page.getByText(corpusTitle).first().click();
+
+  // The corpus URL is slug-based: /c/<user>/<corpus>. Wait for it to settle
+  // before reading + appending the view param. We anchor on the URL pattern
+  // rather than visible text because CorpusHome's landing copy varies based
+  // on whether a Readme.CAML article exists.
+  await expect(page).toHaveURL(/\/c\/[^/]+\/[^/?#]+/, { timeout: 15_000 });
+  const url = new URL(page.url());
+  url.searchParams.set("view", "discussions");
+  // Strip the origin so spaNavigate sees a path+query string.
+  await spaNavigate(page, url.pathname + url.search);
+
+  // The CorpusDiscussionsView toolbar always renders the "All" filter pill
+  // even when there are zero threads. Use it as the "view is ready" signal.
+  // Match by visible label only — the count span is an SVG-icon-free child
+  // whose textual interpolation varies (`All0` vs `All 0`) across browsers.
+  await expect(
+    page.getByRole("button", { name: /^All\b/i }).first()
+  ).toBeVisible({ timeout: 20_000 });
+}
+
+/**
+ * Click the "+New Discussion" button (or "+New" when the corpus header is
+ * hidden), fill the create-thread modal, and submit.
+ *
+ * On success, CorpusDiscussionsView's onSuccess handler closes the modal
+ * AND navigates to the new thread (sets ?thread=<id>), so this helper
+ * waits for the thread detail header to render before returning.
+ *
+ * Caller must already be on the corpus discussions view.
+ */
+export async function createThreadViaUI(
+  page: Page,
+  title: string,
+  description: string,
+  initialMessage: string
+): Promise<void> {
+  // The header CTA is "+New Discussion"; in embedded mode it shrinks to "+New".
+  // Both share the same gradient style and are the only buttons that match.
+  await page
+    .getByRole("button", { name: /^(New Discussion|New)$/i })
+    .first()
+    .click();
+
+  // CreateThreadForm modal title.
+  await expect(page.getByText(/Start New Discussion/i)).toBeVisible({
+    timeout: 10_000,
+  });
+
+  await page.fill("#thread-title", title);
+  if (description) {
+    await page.fill("#thread-description", description);
+  }
+
+  // The MessageComposer is built on TipTap (ProseMirror). Fill the
+  // contenteditable .ProseMirror element via keyboard.type — `.fill()`
+  // does not reliably trigger TipTap's onUpdate hook in all browsers.
+  const editor = page.locator(".ProseMirror").first();
+  await expect(editor).toBeVisible({ timeout: 10_000 });
+  await editor.click();
+  await page.keyboard.type(initialMessage);
+
+  // Submit — the only button labeled exactly "Send" is the composer's
+  // SendButton at the bottom of the modal.
+  await page
+    .getByRole("button", { name: /^Send$/i })
+    .first()
+    .click();
+
+  // The mutation onSuccess closes the modal and routes to ?thread=<id>.
+  // The thread title appears in the ThreadDetail header.
+  await expect(page.getByText(/Start New Discussion/i)).not.toBeVisible({
+    timeout: 15_000,
+  });
+  await expect(page.getByRole("heading", { name: title }).first()).toBeVisible({
+    timeout: 15_000,
+  });
+}
+
+/**
+ * Post a top-level reply to the currently-open thread via the bottom
+ * ReplyForm composer. Returns once the new message text is visible in
+ * the thread (proving the GraphQL mutation refetched the thread).
+ *
+ * Caller must already be on the thread detail view (with a visible
+ * ReplyForm — i.e. the thread is not locked).
+ */
+export async function postThreadReplyViaUI(
+  page: Page,
+  replyContent: string
+): Promise<void> {
+  // ThreadDetail renders ONE composer at the bottom (ReplyForm). When in
+  // the modal phase there can be a separate composer; once we are on the
+  // thread detail view, .ProseMirror.last() targets the reply form.
+  const replyEditor = page.locator(".ProseMirror").last();
+  await expect(replyEditor).toBeVisible({ timeout: 10_000 });
+  await replyEditor.click();
+  await page.keyboard.type(replyContent);
+
+  // The reply composer's Send button is the only one in the bottom region.
+  // After click, the message list refetches and the new message renders.
+  await page
+    .getByRole("button", { name: /^Send$/i })
+    .last()
+    .click();
+
+  // Wait for the new message text to appear in the discussion list.
+  await expect(page.getByText(replyContent).first()).toBeVisible({
+    timeout: 15_000,
+  });
+}

--- a/frontend/tests/e2e/threads-discussions.spec.ts
+++ b/frontend/tests/e2e/threads-discussions.spec.ts
@@ -1,0 +1,220 @@
+/**
+ * E2E integration test: threads and discussions.
+ *
+ * Exercises the full discussion-thread user journey end-to-end against
+ * the real Vite + Django + Postgres stack:
+ *
+ *   1. Anonymous /discussions and /threads pages render with their
+ *      empty-state chrome (filter pills, search box, section headers).
+ *   2. An authenticated user creates a corpus, opens its inline
+ *      discussions view, creates a new thread via the modal, posts a
+ *      reply, and verifies the message round-trips through the
+ *      `createThread` + `createThreadMessage` GraphQL mutations.
+ *   3. The newly-created thread shows up in the global /discussions feed
+ *      under "Corpus Discussions" — proving the GET_CONVERSATIONS query
+ *      with `hasCorpus=true` returns it.
+ *
+ * Spec ordering: this file's name sorts AFTER `corpus-workflow` and
+ * BEFORE `view-interactions`. The tests are self-contained — we create
+ * our own corpus rather than relying on data from other specs — so it
+ * is safe to run in isolation as well as in the workflow's full sweep.
+ */
+
+import { test, expect } from "./fixtures";
+import {
+  TEST_USER,
+  loginViaUI,
+  spaNavigate,
+  expectViewVisible,
+  createCorpusViaUI,
+  openCorpusDiscussionsViaUI,
+  createThreadViaUI,
+  postThreadReplyViaUI,
+} from "./helpers";
+
+const CORPUS_TITLE = "E2E Discussions Corpus";
+const CORPUS_DESCRIPTION = "Corpus created by the threads/discussions spec.";
+
+const THREAD_TITLE = "Question about contract clauses";
+const THREAD_DESCRIPTION =
+  "Looking for guidance on how this clause is typically interpreted.";
+const THREAD_INITIAL_MESSAGE =
+  "What does the indemnification clause typically cover in vendor contracts?";
+const THREAD_REPLY_MESSAGE =
+  "In my experience, indemnification covers third-party IP claims and data breach liabilities.";
+
+test.describe("Threads and discussions", () => {
+  /* ─────────────────────────────────────────────────────────────────────
+   * Anonymous coverage pass.
+   *
+   * The discussion list and thread search routes are public — they
+   * surface only the user's visible/public threads but the page chrome
+   * itself renders for anyone. Hit each route once with no auth so the
+   * Istanbul coverage trace records their initial mounts.
+   * ────────────────────────────────────────────────────────────────── */
+  test.describe("anonymous user", () => {
+    test("renders /discussions filter chrome and section headers", async ({
+      page,
+    }) => {
+      await page.goto("/discussions");
+
+      // Page heading.
+      await expect(
+        page.getByRole("heading", { name: /^Discussions$/ }).first()
+      ).toBeVisible({ timeout: 20_000 });
+
+      // FilterTabs render four buttons — ensure the tablist is present
+      // even with zero data. We just check the "All" tab as a smoke
+      // signal; the per-tab labels live in the rendered DOM as plain
+      // text inside <button>s.
+      await expect(page.getByText(/^All$/).first()).toBeVisible();
+
+      // SearchBox placeholder as a stable identifier for the search input.
+      await expect(
+        page.getByPlaceholder(/Search discussions/i).first()
+      ).toBeVisible();
+
+      // The three section headers always render in the "all" tab even
+      // when their counts are zero. Only check the first to avoid
+      // ordering flakes.
+      await expect(page.getByText(/Corpus Discussions/i).first()).toBeVisible({
+        timeout: 10_000,
+      });
+    });
+
+    test("renders /threads search route", async ({ page }) => {
+      await page.goto("/threads");
+
+      await expect(
+        page.getByRole("heading", { name: /Search Discussions/i }).first()
+      ).toBeVisible({ timeout: 20_000 });
+
+      // ThreadSearch's SearchBar exposes its placeholder; this is the
+      // most stable handle for the input.
+      await expect(
+        page.getByPlaceholder(/Search discussions by keywords/i).first()
+      ).toBeVisible();
+    });
+  });
+
+  /* ─────────────────────────────────────────────────────────────────────
+   * Authenticated flow.
+   *
+   * One serial test that walks the entire create-thread / post-reply /
+   * verify-listing journey. SPA-navigation (history.pushState +
+   * popstate) preserves the in-memory authToken across views — a
+   * full page.goto would tear down the React tree and lose it.
+   * ────────────────────────────────────────────────────────────────── */
+  test.describe("authenticated user", () => {
+    test("creates a corpus thread, replies, and sees it in the global feed", async ({
+      page,
+    }) => {
+      // ── Step 1: Login ────────────────────────────────────────────
+      await test.step("login", async () => {
+        await loginViaUI(page, TEST_USER.username, TEST_USER.password);
+      });
+
+      // ── Step 2: Create a corpus to host the discussion ───────────
+      await test.step("create corpus to host thread", async () => {
+        await createCorpusViaUI(page, CORPUS_TITLE, CORPUS_DESCRIPTION);
+      });
+
+      // ── Step 3: Open corpus discussions view ─────────────────────
+      await test.step("open corpus discussions inline view", async () => {
+        await openCorpusDiscussionsViaUI(page, CORPUS_TITLE);
+      });
+
+      // ── Step 4: Create a thread via the modal ────────────────────
+      await test.step("create new thread via modal", async () => {
+        await createThreadViaUI(
+          page,
+          THREAD_TITLE,
+          THREAD_DESCRIPTION,
+          THREAD_INITIAL_MESSAGE
+        );
+
+        // The thread description appears in the ThreadDetail header
+        // (compact mode), and the initial message shows up in the
+        // message list immediately after creation.
+        await expect(
+          page.getByText(THREAD_INITIAL_MESSAGE).first()
+        ).toBeVisible({ timeout: 15_000 });
+      });
+
+      // ── Step 5: Reply to the thread ──────────────────────────────
+      await test.step("post a reply to the thread", async () => {
+        await postThreadReplyViaUI(page, THREAD_REPLY_MESSAGE);
+
+        // After the reply, the thread should now show two messages.
+        // The header summary text reads "N messages" (or "1 message").
+        await expect(page.getByText(/\b2\s+messages\b/i)).toBeVisible({
+          timeout: 15_000,
+        });
+      });
+
+      // ── Step 6: Back to thread list and verify it's listed ───────
+      await test.step("return to thread list and verify entry", async () => {
+        // The compact ThreadDetail header has a back button with
+        // aria-label="Back to discussions".
+        await page
+          .getByRole("button", { name: /Back to discussions/i })
+          .first()
+          .click();
+
+        // The list view reuses ThreadList; each card has
+        // role="article" + aria-label="Thread: <title>".
+        await expect(
+          page.getByRole("article", {
+            name: new RegExp(`Thread:\\s*${THREAD_TITLE}`, "i"),
+          })
+        ).toBeVisible({ timeout: 15_000 });
+      });
+
+      // ── Step 7: Confirm thread shows in global /discussions feed ─
+      await test.step("verify thread surfaces in global discussions", async () => {
+        await spaNavigate(page, "/discussions");
+
+        await expectViewVisible(page, {
+          kind: "anyText",
+          texts: [/^Discussions$/i, /Search discussions/i],
+        });
+
+        // The "Corpus Discussions" section is server-filtered by
+        // hasCorpus=true. Our newly-created thread MUST appear there.
+        // ThreadListItem renders the title as a heading-ish styled
+        // <ThreadTitle> — match by visible text + the role="article"
+        // wrapper that ThreadListItem provides.
+        await expect(
+          page.getByRole("article", {
+            name: new RegExp(`Thread:\\s*${THREAD_TITLE}`, "i"),
+          })
+        ).toBeVisible({ timeout: 20_000 });
+      });
+
+      // ── Step 8: Click the thread from the global feed ────────────
+      await test.step("open the thread by clicking from the global feed", async () => {
+        // Clicking a ThreadListItem navigates to the corpus thread URL
+        // (ThreadListItem builds a slug-based href via getCorpusThreadUrl).
+        // Since it's an SPA navigation, the in-memory authToken survives.
+        await page
+          .getByRole("article", {
+            name: new RegExp(`Thread:\\s*${THREAD_TITLE}`, "i"),
+          })
+          .first()
+          .click();
+
+        // We land back on the thread detail; both messages should be
+        // fetched via GET_THREAD_DETAIL and visible.
+        await expect(
+          page.getByRole("heading", { name: THREAD_TITLE }).first()
+        ).toBeVisible({ timeout: 20_000 });
+        await expect(
+          page.getByText(THREAD_INITIAL_MESSAGE).first()
+        ).toBeVisible();
+        await expect(
+          page.getByText(THREAD_REPLY_MESSAGE).first()
+        ).toBeVisible();
+      });
+    });
+  });
+});

--- a/frontend/tests/e2e/threads-discussions.spec.ts
+++ b/frontend/tests/e2e/threads-discussions.spec.ts
@@ -32,16 +32,18 @@ import {
   postThreadReplyViaUI,
 } from "./helpers";
 
-const CORPUS_TITLE = "E2E Discussions Corpus";
+// Per-run suffix prevents collisions when the same Postgres database is
+// reused across CI retries or local re-runs. Mirrors the pattern used in
+// `extract-pdf-workflow.spec.ts`.
+const RUN_ID = Date.now();
+const CORPUS_TITLE = `E2E Discussions Corpus ${RUN_ID}`;
 const CORPUS_DESCRIPTION = "Corpus created by the threads/discussions spec.";
 
-const THREAD_TITLE = "Question about contract clauses";
+const THREAD_TITLE = `Question about contract clauses ${RUN_ID}`;
 const THREAD_DESCRIPTION =
   "Looking for guidance on how this clause is typically interpreted.";
-const THREAD_INITIAL_MESSAGE =
-  "What does the indemnification clause typically cover in vendor contracts?";
-const THREAD_REPLY_MESSAGE =
-  "In my experience, indemnification covers third-party IP claims and data breach liabilities.";
+const THREAD_INITIAL_MESSAGE = `What does the indemnification clause typically cover in vendor contracts? (${RUN_ID})`;
+const THREAD_REPLY_MESSAGE = `In my experience, indemnification covers third-party IP claims and data breach liabilities. (${RUN_ID})`;
 
 test.describe("Threads and discussions", () => {
   /* ─────────────────────────────────────────────────────────────────────
@@ -145,9 +147,14 @@ test.describe("Threads and discussions", () => {
       await test.step("post a reply to the thread", async () => {
         await postThreadReplyViaUI(page, THREAD_REPLY_MESSAGE);
 
-        // After the reply, the thread should now show two messages.
-        // The header summary text reads "N messages" (or "1 message").
-        await expect(page.getByText(/\b2\s+messages\b/i)).toBeVisible({
+        // Both the original initial message and the reply must be
+        // individually visible after the GraphQL refetch — that's a
+        // direct check on the thread state rather than coupling to the
+        // exact "N messages" header phrasing.
+        await expect(
+          page.getByText(THREAD_INITIAL_MESSAGE).first()
+        ).toBeVisible({ timeout: 15_000 });
+        await expect(page.getByText(THREAD_REPLY_MESSAGE).first()).toBeVisible({
           timeout: 15_000,
         });
       });


### PR DESCRIPTION
## Summary

This PR adds comprehensive end-to-end Playwright tests for the discussions and threads feature, covering both anonymous and authenticated user workflows.

## Key Changes

- **New E2E spec file** (`frontend/tests/e2e/threads-discussions.spec.ts`):
  - Anonymous coverage pass: validates that `/discussions` and `/threads` routes render their UI chrome (filter pills, search box, section headers) without authentication
  - Authenticated workflow: comprehensive serial test that exercises the full user journey:
    - User login
    - Corpus creation (with a `Date.now()` suffix to keep titles unique across CI retries)
    - Opening corpus discussions inline view via `?view=discussions` query parameter
    - Creating a new thread with title, description, and initial message via modal
    - Posting a reply to the thread
    - Verifying the thread appears in the global `/discussions` feed under "Corpus Discussions"
    - Navigating back to the thread from the global feed and confirming all messages are present

- **New helper functions** in `frontend/tests/e2e/helpers.ts`:
  - `openCorpusDiscussionsViaUI()` — navigates to a corpus and opens its inline discussions view
  - `createThreadViaUI()` — clicks the `aria-label="Create new discussion"` CTA, fills and submits the create-thread modal (locators scoped to the modal via the `#thread-title` anchor), and waits for the thread-detail header
  - `postThreadReplyViaUI()` — posts a reply to an open thread via the bottom reply composer

- **CHANGELOG.md** — documented the new E2E test addition in bullet form per the repo's Keep-a-Changelog convention

## Implementation Details

- Tests are self-contained and create their own per-run corpus rather than relying on shared test data, making them safe to run in isolation or as part of the full test suite
- Uses SPA navigation (`spaNavigate`) to preserve in-memory auth tokens across views, avoiding full page reloads that would lose authentication state
- Selects the create-thread CTA by its stable accessibility name (`aria-label="Create new discussion"`), not the visible text — the visible label flips between "New Discussion" and "New" based on layout
- Includes detailed step annotations and comments explaining the test flow and GraphQL mutations being exercised
- Properly waits for async operations (mutations, refetches) before asserting on results