### PR TITLE
Document Auth0 namespace mismatch failure mode in admin claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- **Auth0 admin-claim namespace mismatch** (`docs/configuration/authentication.md`): documented a silent failure mode where the Post-Login Action's `namespace` constant doesn't match `AUTH0_ADMIN_CLAIM_NAMESPACE` (e.g. `https://opencontracts.opensource.legal/` vs the default `https://contracts.opensource.legal/`). When the namespaces don't match byte-for-byte, the backend's fail-closed sync (`config/graphql_auth0_auth/utils.py:sync_admin_claims_from_payload`) treats the claims as missing and overwrites `is_staff` / `is_superuser` to `False` on every authenticated request, so the frontend admin link in the user dropdown never appears even though `app_metadata.is_superuser = true` is set in Auth0. Added a `!!! danger` callout to the Post-Login Action setup section and expanded the "Admin claim missing, defaulting to False" troubleshooting entry with the namespace-mismatch case and a `!!! info` note explaining why missing claims revoke admin instead of being ignored.
+
 ### Fixed
 
 - **GraphQL POST 403 storm when Auth0 token is empty** (Issue #1431): production logs were filling with `Forbidden (CSRF token missing.): /graphql/` because the React frontend always sent `Authorization: ""` whenever the Auth0 access token was momentarily missing (startup race, silent-refresh failure, post-expiry re-mount), and `conditional_csrf_exempt` only bypassed CSRF when the header was *truthy*. An empty header fell through to Django's session/CSRF path even though the frontend never carries a CSRF token. Two-sided fix:

--- a/docs/configuration/authentication.md
+++ b/docs/configuration/authentication.md
@@ -207,6 +207,27 @@ exports.onExecutePostLogin = async (event, api) => {
     Creating and deploying the Action is not enough. You must drag it into the
     Login Flow and click Apply, otherwise it will not execute.
 
+!!! danger "The `namespace` value MUST match `AUTH0_ADMIN_CLAIM_NAMESPACE` exactly"
+    The `namespace` constant in the Action above is the key under which claims
+    are written into the access token. The Django backend reads claims at
+    `AUTH0_ADMIN_CLAIM_NAMESPACE` (default `https://contracts.opensource.legal/`).
+    If the two strings differ by even one character — including a typo
+    (`opencontracts` vs `contracts`), a missing trailing slash, or `http` vs
+    `https` — the backend will not find the claims, will treat them as missing,
+    and will **overwrite `is_staff` / `is_superuser` to `False` on the user**
+    (fail-closed sync, see `config/graphql_auth0_auth/utils.py`).
+
+    Symptom: an Auth0 user with `app_metadata.is_superuser = true` logs in and
+    the frontend admin links (e.g. the admin link in the user dropdown) do not
+    appear, and `User.is_superuser` in the Django shell flips back to `False`
+    shortly after each login.
+
+    Fix: either change the Action's `namespace` to match the backend, or set
+    `AUTH0_ADMIN_CLAIM_NAMESPACE` in the backend env to match the Action.
+    To verify, decode your access token at jwt.io and confirm the claim keys
+    are byte-for-byte identical to `AUTH0_ADMIN_CLAIM_NAMESPACE` + `is_staff` /
+    `is_superuser`.
+
 #### Step 6: Grant Admin Access to Auth0 Users
 
 To give an Auth0 user admin access:
@@ -430,18 +451,37 @@ shows "Auth0 unavailable" or clicking it logs "Auth0 client not initialized".
 
 **Symptom**: Django logs show `Admin claim is_staff missing; defaulting to False`
 and the user is denied admin access even though they authenticated successfully.
+Equivalently, the frontend admin link in the user dropdown does not appear for
+a user that has `app_metadata.is_superuser = true` in Auth0, and
+`User.is_superuser` in the Django shell keeps flipping back to `False` after
+each authenticated request.
 
 **Likely causes**:
 
-1. **Post-Login Action not deployed or not in the flow**: Go to
+1. **Namespace mismatch between the Action and the backend**: The Post-Login
+   Action's `namespace` constant must match `AUTH0_ADMIN_CLAIM_NAMESPACE`
+   byte-for-byte. A common pitfall is using `https://opencontracts.opensource.legal/`
+   in the Action while the backend default is `https://contracts.opensource.legal/`
+   (note: `opencontracts` vs `contracts`). Other common typos: missing trailing
+   slash, `http` vs `https`. Decode your access token at jwt.io and confirm
+   the claim key matches exactly.
+2. **Post-Login Action not deployed or not in the flow**: Go to
    **Actions > Flows > Login** and verify the Action is dragged into the flow
    and **Apply** has been clicked.
-2. **Missing `app_metadata`**: The user needs `is_staff: true` (and optionally
+3. **Missing `app_metadata`**: The user needs `is_staff: true` (and optionally
    `is_superuser: true`) in their `app_metadata`. Go to
    **User Management > Users > (your user) > app_metadata** and set it.
-3. **Stale token**: The claims are set at login time. If you added `app_metadata`
+4. **Stale token**: The claims are set at login time. If you added `app_metadata`
    after the user logged in, they need to log out and log back in to get a new
    token with the updated claims.
+
+!!! info "Why missing claims revoke admin instead of being ignored"
+    The backend sync is fail-closed: a claim that is missing or invalid is
+    treated as `False` and the user's Django flag is overwritten. This prevents
+    privilege retention if a user is removed from Auth0 admin, but it also
+    means a misconfigured namespace will silently strip admin from every
+    authenticated request. See `sync_admin_claims_from_payload()` in
+    `config/graphql_auth0_auth/utils.py`.
 
 ### User created but has no email
 

--- a/docs/configuration/authentication.md
+++ b/docs/configuration/authentication.md
@@ -214,8 +214,12 @@ exports.onExecutePostLogin = async (event, api) => {
     If the two strings differ by even one character — including a typo
     (`opencontracts` vs `contracts`), a missing trailing slash, or `http` vs
     `https` — the backend will not find the claims, will treat them as missing,
-    and will **overwrite `is_staff` / `is_superuser` to `False` on the user**
-    (fail-closed sync, see `config/graphql_auth0_auth/utils.py`).
+    and will **set `is_staff` / `is_superuser` to `False` on the user on each
+    sync cycle** (fail-closed sync; cached for 5 minutes per user via
+    `_sync_admin_claims_cached`, so freshly logged-in users may have a brief
+    window of elevated privileges before the next cache miss).
+    See `sync_admin_claims_from_payload()` in
+    `config/graphql_auth0_auth/utils.py`.
 
     Symptom: an Auth0 user with `app_metadata.is_superuser = true` logs in and
     the frontend admin links (e.g. the admin link in the user dropdown) do not
@@ -226,7 +230,9 @@ exports.onExecutePostLogin = async (event, api) => {
     `AUTH0_ADMIN_CLAIM_NAMESPACE` in the backend env to match the Action.
     To verify, decode your access token at jwt.io and confirm the claim keys
     are byte-for-byte identical to `AUTH0_ADMIN_CLAIM_NAMESPACE` + `is_staff` /
-    `is_superuser`.
+    `is_superuser`. After the fix, the 5-minute claim cache means it can take
+    up to that long for the change to propagate — clear the Django cache or
+    restart the worker to apply it immediately.
 
 #### Step 6: Grant Admin Access to Auth0 Users
 
@@ -450,11 +456,12 @@ shows "Auth0 unavailable" or clicking it logs "Auth0 client not initialized".
 ### Admin claim missing, defaulting to False
 
 **Symptom**: Django logs show `Admin claim is_staff missing; defaulting to False`
-and the user is denied admin access even though they authenticated successfully.
-Equivalently, the frontend admin link in the user dropdown does not appear for
-a user that has `app_metadata.is_superuser = true` in Auth0, and
-`User.is_superuser` in the Django shell keeps flipping back to `False` after
-each authenticated request.
+(emitted at `INFO` level — bump `config.graphql_auth0_auth.utils` to `INFO` or
+lower if you don't see it on production logging defaults) and the user is denied
+admin access even though they authenticated successfully. Equivalently, the
+frontend admin link in the user dropdown does not appear for a user that has
+`app_metadata.is_superuser = true` in Auth0, and `User.is_superuser` in the
+Django shell keeps flipping back to `False` after each sync cycle.
 
 **Likely causes**:
 
@@ -474,13 +481,27 @@ each authenticated request.
 4. **Stale token**: The claims are set at login time. If you added `app_metadata`
    after the user logged in, they need to log out and log back in to get a new
    token with the updated claims.
+5. **Stale 5-minute claim cache after fixing the namespace**: Sync results are
+   cached for `ADMIN_CLAIMS_CACHE_TTL` (300 seconds) per user via
+   `_sync_admin_claims_cached()`. After correcting the namespace env var, the
+   fix won't propagate for users whose claims were synced in the last 5 minutes.
+   Clear the Django cache (`cache.clear()` in a management shell) or restart the
+   worker, then have the affected user log out and back in.
+
+!!! tip "Diagnostic: confirm the namespace at runtime"
+    Set the log level for `config.graphql_auth0_auth.utils` to `DEBUG`. The
+    `sync_admin_claims` debug lines print the exact namespace the backend is
+    using and the keys present in the decoded token, so a side-by-side comparison
+    rules namespace mismatch in or out without needing jwt.io.
 
 !!! info "Why missing claims revoke admin instead of being ignored"
     The backend sync is fail-closed: a claim that is missing or invalid is
-    treated as `False` and the user's Django flag is overwritten. This prevents
+    treated as `False` and the user's Django flag is set to `False` (only when
+    the current value differs, so cached writes are a no-op). This prevents
     privilege retention if a user is removed from Auth0 admin, but it also
-    means a misconfigured namespace will silently strip admin from every
-    authenticated request. See `sync_admin_claims_from_payload()` in
+    means a misconfigured namespace will silently strip admin on each sync
+    cycle (at most once every 5 minutes per user). See
+    `sync_admin_claims_from_payload()` in
     `config/graphql_auth0_auth/utils.py`.
 
 ### User created but has no email


### PR DESCRIPTION
## Summary
Added comprehensive documentation for a silent failure mode in Auth0 admin-claim synchronization where a namespace mismatch between the Post-Login Action and the backend configuration causes admin privileges to be silently revoked on every authenticated request.

## Changes
- **Added danger callout** in the Post-Login Action setup section (`docs/configuration/authentication.md`) warning that the `namespace` constant must match `AUTH0_ADMIN_CLAIM_NAMESPACE` byte-for-byte, with concrete examples of common typos (`opencontracts` vs `contracts`, missing trailing slash, `http` vs `https`)
- **Expanded troubleshooting section** for "Admin claim missing" symptom to include namespace mismatch as the first and most likely cause, with diagnostic steps (decoding JWT at jwt.io)
- **Added info callout** explaining the fail-closed sync behavior: missing or invalid claims are treated as `False`, which prevents privilege retention but also means misconfigured namespaces silently strip admin from every request
- **Updated CHANGELOG.md** to document the new documentation additions

## Implementation Details
The documentation clarifies that when `namespace` in the Action doesn't match `AUTH0_ADMIN_CLAIM_NAMESPACE` in the backend (default `https://contracts.opensource.legal/`), the `sync_admin_claims_from_payload()` function in `config/graphql_auth0_auth/utils.py` treats the claims as missing and overwrites `is_staff`/`is_superuser` to `False` on every authenticated request. This results in the frontend admin link never appearing despite `app_metadata.is_superuser = true` being set in Auth0.

The documentation provides both preventive guidance (during initial setup) and diagnostic/remediation steps for users experiencing this issue.

https://claude.ai/code/session_01Tt8NVvRGS51xMGb9J8PzdN