### PR TITLE
Filter disabled embedders from superuser dropdown selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Preferred Embedder dropdown showed disabled embedders for superusers** (`frontend/src/components/widgets/CRUD/EmbedderSelector.tsx`, `frontend/src/graphql/queries.ts`): the create/edit corpus form's `EmbedderSelector` listed every embedder returned by `pipelineComponents.embedders`. The backend resolver in `config/graphql/pipeline_queries.py` only filters by configured/preferred class names for non-superusers, so a superuser saw embedders that `PipelineSettings.enabled_components` had explicitly disallowed and could pick one the rest of the system would refuse to use. The `enabled` flag was already computed and exposed on `PipelineComponentType` but the `GET_EMBEDDERS` query did not request it. Added `enabled` to the query and filter `embedder.enabled !== false` on the client (`undefined` from older backends still passes through). Test mocks in `frontend/tests/EmbedderSelector.ct.tsx` and `frontend/tests/corpus-modal.ct.tsx` updated, and a new test case verifies a `enabled: false` embedder is omitted from the dropdown.
+
 ### Added
 
 - **Loud guardrail against the `system_prompt=` foot-gun in pydantic-ai** (Issue #1451): `pydantic_ai.Agent` accepts both `system_prompt=` and `instructions=`, but the `system_prompt` value is *only* materialised into the model request when `message_history` is `None`. OpenContracts' `chat()` flow always persists the user's HUMAN message before calling `Agent.run()`, so `message_history` is never empty in practice and any `system_prompt=` argument is silently dropped — the LLM runs without any system instruction. CLAUDE.md pitfall #14 documented the workaround (use `instructions=`), but a future pydantic-ai bump that renames or re-precedences these parameters could re-introduce the regression silently.

--- a/frontend/src/components/widgets/CRUD/EmbedderSelector.tsx
+++ b/frontend/src/components/widgets/CRUD/EmbedderSelector.tsx
@@ -66,7 +66,12 @@ export const EmbedderSelector = ({
     onChange?.({ preferredEmbedder: value ?? null });
   };
 
-  const embedders = data?.pipelineComponents?.embedders || [];
+  // Superusers receive every registered embedder from the backend regardless
+  // of PipelineSettings.enabled_components, so filter the disabled ones out
+  // client-side to match what the rest of the system will actually accept.
+  const embedders = (data?.pipelineComponents?.embedders || []).filter(
+    (embedder: PipelineComponentType) => embedder.enabled !== false
+  );
   const hasEmbedders = embedders.length > 0;
 
   const options = embedders.map((embedder: PipelineComponentType) => ({

--- a/frontend/src/graphql/queries.ts
+++ b/frontend/src/graphql/queries.ts
@@ -2816,6 +2816,7 @@ export const GET_EMBEDDERS = gql`
         inputSchema
         vectorSize
         className
+        enabled
       }
     }
   }

--- a/frontend/tests/EmbedderSelector.ct.tsx
+++ b/frontend/tests/EmbedderSelector.ct.tsx
@@ -19,6 +19,7 @@ const embeddersMock = {
             inputSchema: null,
             vectorSize: 384,
             className: "DefaultEmbedder",
+            enabled: true,
           },
           {
             name: "large_embedder",
@@ -30,6 +31,7 @@ const embeddersMock = {
             inputSchema: null,
             vectorSize: 1024,
             className: "LargeEmbedder",
+            enabled: true,
           },
         ],
       },
@@ -139,6 +141,74 @@ test.describe("EmbedderSelector", () => {
       1
     );
     await expect(options.filter({ hasText: "Large Embedder" })).toHaveCount(1);
+
+    await component.unmount();
+  });
+
+  test("filters out embedders disabled in pipeline settings", async ({
+    mount,
+    page,
+  }) => {
+    const mixedMock = {
+      request: { query: GET_EMBEDDERS },
+      result: {
+        data: {
+          pipelineComponents: {
+            embedders: [
+              {
+                name: "default_embedder",
+                moduleName:
+                  "opencontractserver.pipeline.embedders.DefaultEmbedder",
+                title: "Default Embedder",
+                description: "Standard text embedding model",
+                author: "OpenContracts",
+                componentType: "embedder",
+                inputSchema: null,
+                vectorSize: 384,
+                className: "DefaultEmbedder",
+                enabled: true,
+              },
+              {
+                name: "disabled_embedder",
+                moduleName:
+                  "opencontractserver.pipeline.embedders.DisabledEmbedder",
+                title: "Disabled Embedder",
+                description: "Should not appear in the dropdown",
+                author: "OpenContracts",
+                componentType: "embedder",
+                inputSchema: null,
+                vectorSize: 768,
+                className: "DisabledEmbedder",
+                enabled: false,
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    const component = await mount(
+      <EmbedderSelectorTestWrapper mocks={[mixedMock, { ...mixedMock }]} />
+    );
+
+    await expect(component.locator(".oc-dropdown__placeholder")).toHaveText(
+      "Choose a preferred embedder",
+      { timeout: 5000 }
+    );
+
+    await component.locator(".oc-dropdown__trigger").click();
+
+    const menu = page.locator(".oc-dropdown__menu");
+    await expect(menu).toBeVisible();
+
+    const options = menu.locator(".oc-dropdown__option");
+    await expect(options).toHaveCount(1);
+    await expect(options.filter({ hasText: "Default Embedder" })).toHaveCount(
+      1
+    );
+    await expect(options.filter({ hasText: "Disabled Embedder" })).toHaveCount(
+      0
+    );
 
     await component.unmount();
   });

--- a/frontend/tests/corpus-modal.ct.tsx
+++ b/frontend/tests/corpus-modal.ct.tsx
@@ -23,6 +23,7 @@ const mockEmbedder = {
   description: "Default text embedder",
   author: "OpenContracts",
   vectorSize: 768,
+  enabled: true,
 };
 
 const mockCorpus: CorpusType = {


### PR DESCRIPTION
## Summary
Fixed an issue where the Preferred Embedder dropdown in the create/edit corpus form displayed embedders that were disabled in `PipelineSettings.enabled_components` when accessed by superusers. The backend resolver only filters embedders for non-superusers, so superusers could select embedders that the rest of the system would reject.

## Changes
- **Updated `GET_EMBEDDERS` GraphQL query** (`frontend/src/graphql/queries.ts`): Added the `enabled` field to the query to expose the embedder's enabled status from the backend
- **Added client-side filtering** (`frontend/src/components/widgets/CRUD/EmbedderSelector.tsx`): Filter out embedders where `enabled === false` before rendering the dropdown options. Includes a comment explaining why this filtering is necessary for superusers
- **Updated test mocks** (`frontend/tests/EmbedderSelector.ct.tsx`, `frontend/tests/corpus-modal.ct.tsx`): Added `enabled: true` to existing embedder mock objects to match the updated schema
- **Added test case** (`frontend/tests/EmbedderSelector.ct.tsx`): New test verifies that disabled embedders are filtered out and don't appear in the dropdown menu
- **Updated CHANGELOG.md**: Documented the fix with implementation details

## Implementation Details
- The filter uses `embedder.enabled !== false` to maintain backward compatibility with older backends that may not include the `enabled` field (treating `undefined` as enabled)
- The fix is applied client-side since the backend resolver's filtering logic differs between superusers and regular users

https://claude.ai/code/session_01WsgqRqmwDTCtcToHVY8a9M