### PR TITLE
Allow anonymous access to supportedMimeTypes GraphQL query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`supportedMimeTypes` GraphQL query is now accessible to anonymous users** (`config/graphql/pipeline_queries.py:205`). Removed the `@login_required` decorator from `resolve_supported_mime_types` so that uploaders, landing pages, and other unauthenticated UI surfaces can advertise the accepted file formats without forcing a login. The data returned is derived purely from the pipeline registry and exposes no user-specific information. Test updated: `opencontractserver/tests/test_pipeline_component_queries.py::test_supported_mime_types_allows_anonymous`.
+
 ### Added
 
 - **Server-derived `me.canImportCorpus` field** (`config/graphql/user_types.py:43-60`). A new boolean on `UserType` that mirrors the backend permission check enforced by `UploadCorpusImportZip` / `ImportZipToCorpus`: returns `false` for anonymous users and for usage-capped users when `USAGE_CAPPED_USER_CAN_IMPORT_CORPUS` is disabled, otherwise `true`. Exposed through `GET_ME` (`frontend/src/graphql/queries.ts`) so the frontend can gate corpus-import UI without re-implementing the rule. Tests: `opencontractserver/tests/test_user_can_import_corpus.py` covers the three states (capped+disabled, capped+enabled, uncapped).

--- a/config/graphql/pipeline_queries.py
+++ b/config/graphql/pipeline_queries.py
@@ -202,7 +202,6 @@ class PipelineQueryMixin:
         "(parser and embedder) are covered.",
     )
 
-    @login_required
     def resolve_supported_mime_types(
         self, info: graphene.ResolveInfo
     ) -> list[SupportedMimeTypeType]:
@@ -210,7 +209,9 @@ class PipelineQueryMixin:
         Resolver for the supported_mime_types query.
 
         Derives supported file types from the pipeline component registry
-        rather than static configuration.
+        rather than static configuration. Available to anonymous users so
+        that uploaders/landing pages can advertise accepted file formats
+        without requiring login.
         """
         entries = get_supported_mime_types()
         return [

--- a/opencontractserver/tests/test_pipeline_component_queries.py
+++ b/opencontractserver/tests/test_pipeline_component_queries.py
@@ -650,15 +650,18 @@ class TestPostProcessor(BasePostProcessor):
         self.assertTrue(docx_entry["stageCoverage"]["thumbnailer"])
         self.assertTrue(docx_entry["fullySupported"])
 
-    def test_supported_mime_types_requires_auth(self):
-        """Test that supportedMimeTypes requires authentication."""
+    def test_supported_mime_types_allows_anonymous(self):
+        """Test that supportedMimeTypes is accessible to anonymous users."""
         query = """
         query {
             supportedMimeTypes {
                 mimetype
+                fileType
             }
         }
         """
         client = Client(schema, context_value=TestContext(AnonymousUser()))
         result = client.execute(query)
-        self.assertIsNotNone(result.get("errors"))
+        self.assertIsNone(result.get("errors"))
+        mime_types = result["data"]["supportedMimeTypes"]
+        self.assertGreater(len(mime_types), 0)


### PR DESCRIPTION
## Summary
Removed authentication requirement from the `supportedMimeTypes` GraphQL query to allow anonymous users to discover supported file formats. This enables uploaders, landing pages, and other unauthenticated UI surfaces to advertise accepted file types without forcing users to log in first.

## Changes
- **Removed `@login_required` decorator** from `resolve_supported_mime_types` in `config/graphql/pipeline_queries.py`
  - Updated docstring to clarify the query is now available to anonymous users
  - Noted that returned data is derived purely from the pipeline registry with no user-specific information exposed

- **Updated test** in `opencontractserver/tests/test_pipeline_component_queries.py`
  - Renamed `test_supported_mime_types_requires_auth` to `test_supported_mime_types_allows_anonymous`
  - Changed assertion from expecting errors to expecting successful query execution
  - Added validation that results contain mime type data
  - Added `fileType` field to test query

- **Updated CHANGELOG.md** with details of the change

## Implementation Details
The `supportedMimeTypes` query returns static, non-sensitive data derived from the pipeline component registry (MIME types and file type information). Since this data contains no user-specific information and is needed for UI surfaces that precede authentication, removing the login requirement is safe and improves user experience.

https://claude.ai/code/session_016xEHXqHVYSGdX3stcgYiFd