### PR TITLE
Fix Discover search crash on null annotation/note documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Discover search crash on null annotation/note documents** (`frontend/src/views/DiscoverSearchResults.tsx:467-469, 600-603` and `frontend/src/utils/navigationUtils.ts:326-342, 358-400`). Running a search on the Discover view could throw `TypeError: can't access property "slug", e is null` when the backend returned an annotation or note edge whose `document` field was null (e.g., document filtered out by visibility or recently soft-deleted). `getDocumentUrl` accessed `document.slug` directly, and the section render lists never filtered for the missing relation. Fix: filter edges with `node.document == null` out of the annotation and note lists, and widen `getDocumentUrl` / `getCorpusUrl` to accept nullable inputs and fall through to the existing `"#"` no-op return path instead of throwing.
+
 ### Added
 
 - **Server-derived `me.canImportCorpus` field** (`config/graphql/user_types.py:43-60`). A new boolean on `UserType` that mirrors the backend permission check enforced by `UploadCorpusImportZip` / `ImportZipToCorpus`: returns `false` for anonymous users and for usage-capped users when `USAGE_CAPPED_USER_CAN_IMPORT_CORPUS` is disabled, otherwise `true`. Exposed through `GET_ME` (`frontend/src/graphql/queries.ts`) so the frontend can gate corpus-import UI without re-implementing the rule. Tests: `opencontractserver/tests/test_user_can_import_corpus.py` covers the three states (capped+disabled, capped+enabled, uncapped).

--- a/frontend/src/utils/navigationUtils.ts
+++ b/frontend/src/utils/navigationUtils.ts
@@ -324,14 +324,17 @@ export function buildQueryParams(params: QueryParams): string {
  * @returns Full corpus URL with query string, or "#" if slugs missing
  */
 export function getCorpusUrl(
-  corpus: Pick<CorpusType, "id" | "slug"> & {
-    creator?: Pick<UserType, "id" | "slug"> | null;
-  },
+  corpus:
+    | (Pick<CorpusType, "id" | "slug"> & {
+        creator?: Pick<UserType, "id" | "slug"> | null;
+      })
+    | null
+    | undefined,
   queryParams?: QueryParams
 ): string {
   // Always use slug-based URL with /c/ prefix
   // If slugs are missing, we can't generate a valid URL
-  if (!corpus.slug || !corpus.creator?.slug) {
+  if (!corpus?.slug || !corpus.creator?.slug) {
     console.warn("Cannot generate corpus URL without slugs:", corpus);
     return "#"; // Return a safe fallback that won't navigate
   }
@@ -356,10 +359,15 @@ export function getCorpusUrl(
  * optional avoids forcing callers to synthesize a dummy value.
  */
 export function getDocumentUrl(
-  document: Pick<DocumentType, "slug"> &
-    Partial<Pick<DocumentType, "id">> & {
-      creator?: (Pick<UserType, "slug"> & Partial<Pick<UserType, "id">>) | null;
-    },
+  document:
+    | (Pick<DocumentType, "slug"> &
+        Partial<Pick<DocumentType, "id">> & {
+          creator?:
+            | (Pick<UserType, "slug"> & Partial<Pick<UserType, "id">>)
+            | null;
+        })
+    | null
+    | undefined,
   corpus?:
     | (Pick<CorpusType, "slug"> &
         Partial<Pick<CorpusType, "id">> & {
@@ -376,13 +384,13 @@ export function getDocumentUrl(
   if (
     corpus?.slug &&
     corpus?.creator?.slug &&
-    document.slug &&
-    document.creator?.slug
+    document?.slug &&
+    document?.creator?.slug
   ) {
     basePath = `/d/${corpus.creator.slug}/${corpus.slug}/${document.slug}`;
   }
   // Standalone document URL
-  else if (document.slug && document.creator?.slug) {
+  else if (document?.slug && document.creator?.slug) {
     basePath = `/d/${document.creator.slug}/${document.slug}`;
   }
   // Can't generate URL without slugs

--- a/frontend/src/views/DiscoverSearchResults.tsx
+++ b/frontend/src/views/DiscoverSearchResults.tsx
@@ -464,7 +464,12 @@ const AnnotationsSection: React.FC<AnnotationsSectionProps> = ({
     skip: !query,
   });
 
-  const rows = data?.searchAnnotationsForMention.edges ?? [];
+  // Drop edges whose annotation lost its parent document — without a
+  // document we can't build a URL or render the meta row, and the
+  // backend can null it out for visibility/soft-delete reasons.
+  const rows = (data?.searchAnnotationsForMention.edges ?? []).filter(
+    (e): e is NonNullable<typeof e> => Boolean(e?.node && e.node.document)
+  );
 
   return (
     <Section
@@ -597,7 +602,11 @@ const NotesSection: React.FC<NotesSectionProps> = ({ query, limit }) => {
     skip: !query,
   });
 
-  const rows = data?.searchNotesForMention.edges ?? [];
+  // Drop edges whose note has lost its parent document — without it
+  // there's no routeable target and the meta row would crash on null.
+  const rows = (data?.searchNotesForMention.edges ?? []).filter(
+    (e): e is NonNullable<typeof e> => Boolean(e?.node && e.node.document)
+  );
 
   return (
     <Section


### PR DESCRIPTION
## Summary
Fixed a crash in the Discover search view that occurred when the backend returned annotation or note edges with null `document` fields (e.g., due to visibility filtering or soft-deletes). The fix involves both defensive filtering of search results and making URL-building functions more robust to null inputs.

## Key Changes

- **Navigation utilities (`navigationUtils.ts`)**: Widened `getCorpusUrl()` and `getDocumentUrl()` to accept `null` or `undefined` inputs by adding union types. Updated null-checks to use optional chaining (`?.`) instead of direct property access, allowing these functions to gracefully return `"#"` instead of throwing when given incomplete data.

- **Search results filtering (`DiscoverSearchResults.tsx`)**: Added explicit filtering in both `AnnotationsSection` and `NotesSection` to drop edges where `node.document` is null. This prevents rendering attempts on incomplete data and ensures only valid, routeable results are displayed.

- **Documentation**: Updated CHANGELOG.md with details of the fix and affected code locations.

## Implementation Details

The root cause was that when a document was filtered out or soft-deleted on the backend, the GraphQL edge could still be returned with a null `document` field. The frontend code assumed `document` was always present and tried to access `document.slug` directly, causing a `TypeError`.

The fix uses a two-pronged approach:
1. **Upstream filtering**: Remove problematic edges before they reach the render layer
2. **Defensive coding**: Make URL builders handle null/undefined gracefully with optional chaining and union types

This ensures the UI remains stable even when the backend returns incomplete relations.

https://claude.ai/code/session_01KcM5ooo7DzwidHKw1PayHB