### PR TITLE
Stop double-write loop in CorpusDocumentCards reactive var sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -187,6 +187,11 @@ scratch.py
 # Claude Code
 .claude/
 
+# Local git worktrees scratch space (used by /ultrareview and ad-hoc
+# parallel branches). Each subdirectory is its own checkout, not part
+# of this repo's tree.
+.worktrees/
+
 # Implementation plans (ephemeral)
 docs/plans/
 docs/superpowers/

--- a/config/graphql/annotation_types.py
+++ b/config/graphql/annotation_types.py
@@ -94,10 +94,18 @@ class AnnotationType(AnnotatePermissionsForReadMixin, DjangoObjectType):
     all_source_node_in_relationship = graphene.List(lambda: RelationshipType)
 
     def resolve_feedback_count(self, info) -> int:
-        # If feedback_count was annotated on the queryset, use it
+        # If ``feedback_count`` was annotated on the queryset (legacy callers),
+        # honour it — but the optimizer no longer adds the annotation because
+        # it forced a LEFT JOIN + GROUP BY for every annotation in the result.
         if hasattr(self, "feedback_count"):
             return self.feedback_count
-        # Otherwise, count it (but this triggers N+1)
+        # Prefer the prefetched ``user_feedback`` list when the parent resolver
+        # populated it (see ``AnnotationQueryOptimizer.get_document_annotations``);
+        # ``QuerySet.count()`` always issues a fresh ``COUNT(*)`` and would
+        # produce one round-trip per annotation.
+        prefetched = getattr(self, "_prefetched_objects_cache", {}) or {}
+        if "user_feedback" in prefetched:
+            return len(prefetched["user_feedback"])
         return self.user_feedback.count()
 
     def resolve_all_source_node_in_relationship(self, info) -> QuerySet[Relationship]:

--- a/config/graphql/annotation_types.py
+++ b/config/graphql/annotation_types.py
@@ -102,8 +102,11 @@ class AnnotationType(AnnotatePermissionsForReadMixin, DjangoObjectType):
         # Prefer the prefetched ``user_feedback`` list when the parent resolver
         # populated it (see ``AnnotationQueryOptimizer.get_document_annotations``);
         # ``QuerySet.count()`` always issues a fresh ``COUNT(*)`` and would
-        # produce one round-trip per annotation.
-        prefetched = getattr(self, "_prefetched_objects_cache", {}) or {}
+        # produce one round-trip per annotation. ``_prefetched_objects_cache``
+        # is a Django internal — if it changes shape in a future release the
+        # ``self.user_feedback.count()`` fallback keeps correctness intact, only
+        # losing the per-row optimisation.
+        prefetched = getattr(self, "_prefetched_objects_cache", {})
         if "user_feedback" in prefetched:
             return len(prefetched["user_feedback"])
         return self.user_feedback.count()

--- a/config/graphql/base.py
+++ b/config/graphql/base.py
@@ -84,10 +84,18 @@ class CountableConnection(graphene.relay.Connection):
     total_count = graphene.Int()
 
     def resolve_total_count(root, info, **kwargs) -> Any:
-        if isinstance(root.iterable, django.db.models.QuerySet):
-            return root.iterable.count()
-        else:
-            return len(root.iterable)
+        iterable = root.iterable
+        if isinstance(iterable, django.db.models.QuerySet):
+            # If the queryset is already evaluated — typically because the
+            # parent resolver pre-fetched this reverse relation — use the
+            # cached length rather than firing a fresh COUNT(*) query.
+            # ``QuerySet.count()`` does NOT consult ``_result_cache``, so on
+            # prefetched data the naive call produces N+1 ``SELECT COUNT(*)``
+            # round-trips (one per parent row).
+            if iterable._result_cache is not None:
+                return len(iterable._result_cache)
+            return iterable.count()
+        return len(iterable)
 
 
 class DRFDeletion(graphene.Mutation):

--- a/config/graphql/base.py
+++ b/config/graphql/base.py
@@ -91,7 +91,10 @@ class CountableConnection(graphene.relay.Connection):
             # cached length rather than firing a fresh COUNT(*) query.
             # ``QuerySet.count()`` does NOT consult ``_result_cache``, so on
             # prefetched data the naive call produces N+1 ``SELECT COUNT(*)``
-            # round-trips (one per parent row).
+            # round-trips (one per parent row). ``_result_cache`` is a
+            # Django internal — if its shape changes in a future release the
+            # ``iterable.count()`` fallback keeps correctness intact, only
+            # losing the per-row optimisation.
             if iterable._result_cache is not None:
                 return len(iterable._result_cache)
             return iterable.count()

--- a/config/graphql/custom_resolvers.py
+++ b/config/graphql/custom_resolvers.py
@@ -100,6 +100,7 @@ def resolve_doc_annotations_optimized(self, info, **kwargs) -> Any:
             "document_id": self.id,
             "user": getattr(info.context, "user", None),
             "use_cache": True,
+            "context": info.context,
         }
 
         structural = kwargs.get("structural")
@@ -123,6 +124,7 @@ def resolve_doc_annotations_optimized(self, info, **kwargs) -> Any:
             "document_id": self.id,
             "user": getattr(info.context, "user", None),
             "use_cache": True,
+            "context": info.context,
         }
 
         structural = kwargs.get("structural")

--- a/config/graphql/custom_resolvers.py
+++ b/config/graphql/custom_resolvers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 from typing import Any
 
+from graphql.language import ast as gql_ast
 from graphql_relay import from_global_id
 
 from opencontractserver.constants.annotations import MANUAL_ANNOTATION_SENTINEL
@@ -272,3 +273,73 @@ def resolve_doc_annotations_optimized(self, info, **kwargs) -> Any:
         annotations = annotations[-last:] if last else []
 
     return annotations
+
+
+def _argument_string_value(argument: gql_ast.ArgumentNode, variables: dict) -> str | None:
+    """Return the resolved string value of a GraphQL argument node, or None."""
+    value_node = argument.value
+    if isinstance(value_node, gql_ast.StringValueNode):
+        return value_node.value
+    if isinstance(value_node, gql_ast.EnumValueNode):
+        return value_node.value
+    if isinstance(value_node, gql_ast.VariableNode):
+        return variables.get(value_node.name.value)
+    return None
+
+
+def _selection_set_iter(
+    selection: gql_ast.SelectionNode,
+    fragments: dict,
+):
+    """Yield Field selections directly under ``selection``, traversing fragments."""
+    selection_set = getattr(selection, "selection_set", None)
+    if selection_set is None:
+        return
+    for child in selection_set.selections:
+        if isinstance(child, gql_ast.FieldNode):
+            yield child
+        elif isinstance(child, gql_ast.InlineFragmentNode):
+            yield from _selection_set_iter(child, fragments)
+        elif isinstance(child, gql_ast.FragmentSpreadNode):
+            fragment = fragments.get(child.name.value)
+            if fragment is not None:
+                yield from _selection_set_iter(fragment, fragments)
+
+
+def requests_doc_label_annotations(info) -> bool:
+    """
+    Return True when the current GraphQL operation asks for the
+    ``docAnnotations`` field on each document edge with
+    ``annotationLabel_LabelType: "DOC_TYPE_LABEL"``.
+
+    Used by ``resolve_documents`` to opt the queryset into a focused
+    prefetch (see ``_apply_document_prefetches``) so the per-document
+    fall-through in ``resolve_doc_annotations_optimized`` does not fire
+    for the corpus list view's DOC_TYPE_LABEL badge.
+
+    The check matches the field name (``docAnnotations``) regardless of
+    GraphQL alias — the frontend uses ``doc_label_annotations: docAnnotations(...)``
+    and graphql-core preserves the underlying field name on FieldNode.name.
+    """
+    from opencontractserver.annotations.models import DOC_TYPE_LABEL
+
+    fragments = getattr(info, "fragments", {}) or {}
+    variables = getattr(info, "variable_values", {}) or {}
+
+    for field_node in info.field_nodes or ():
+        # Connection: documents → edges → node → docAnnotations
+        for edges in _selection_set_iter(field_node, fragments):
+            if edges.name.value != "edges":
+                continue
+            for node in _selection_set_iter(edges, fragments):
+                if node.name.value != "node":
+                    continue
+                for child in _selection_set_iter(node, fragments):
+                    if child.name.value != "docAnnotations":
+                        continue
+                    for arg in child.arguments or ():
+                        if arg.name.value != "annotationLabel_LabelType":
+                            continue
+                        if _argument_string_value(arg, variables) == DOC_TYPE_LABEL:
+                            return True
+    return False

--- a/config/graphql/custom_resolvers.py
+++ b/config/graphql/custom_resolvers.py
@@ -277,7 +277,9 @@ def resolve_doc_annotations_optimized(self, info, **kwargs) -> Any:
     return annotations
 
 
-def _argument_string_value(argument: gql_ast.ArgumentNode, variables: dict) -> str | None:
+def _argument_string_value(
+    argument: gql_ast.ArgumentNode, variables: dict
+) -> str | None:
     """Return the resolved string value of a GraphQL argument node, or None."""
     value_node = argument.value
     if isinstance(value_node, gql_ast.StringValueNode):

--- a/config/graphql/document_queries.py
+++ b/config/graphql/document_queries.py
@@ -17,6 +17,7 @@ from graphql import GraphQLError
 from graphql_jwt.decorators import login_required
 from graphql_relay import from_global_id
 
+from config.graphql.custom_resolvers import requests_doc_label_annotations
 from config.graphql.document_types import INGESTION_SOURCE_GLOBAL_ID_TYPE
 from config.graphql.filters import DocumentFilter, DocumentRelationshipFilter
 from config.graphql.graphene_types import (
@@ -58,7 +59,16 @@ class DocumentQueryMixin:
         # Use lightweight mode to skip heavy prefetches (doc_annotations,
         # rows, relationships, notes) that are unnecessary for list/TOC
         # queries requesting only basic document fields.
-        return Document.objects.visible_to_user(info.context.user, lightweight=True)
+        # When the client asks for the ``doc_label_annotations`` alias
+        # (the corpus list view's DOC_TYPE_LABEL badge), opt in to a
+        # focused prefetch so the per-document
+        # AnnotationQueryOptimizer.get_document_annotations fall-through
+        # in resolve_doc_annotations_optimized doesn't fire N times.
+        return Document.objects.visible_to_user(
+            info.context.user,
+            lightweight=True,
+            with_doc_label_annotations=requests_doc_label_annotations(info),
+        )
 
     document = graphene.Field(DocumentType, id=graphene.ID())
 

--- a/config/graphql/document_types.py
+++ b/config/graphql/document_types.py
@@ -289,6 +289,7 @@ class DocumentType(AnnotatePermissionsForReadMixin, DjangoObjectType):
             analysis_id=analysis_pk,
             structural=is_structural,
             use_cache=True,
+            context=info.context,
         )
 
     # New field and resolver for all relationships
@@ -324,6 +325,7 @@ class DocumentType(AnnotatePermissionsForReadMixin, DjangoObjectType):
                 corpus_id=corpus_pk,
                 analysis_id=analysis_pk,
                 use_cache=True,
+                context=info.context,
             )
         except Exception as e:
             logger.warning(

--- a/config/graphql/user_types.py
+++ b/config/graphql/user_types.py
@@ -232,11 +232,7 @@ class UserFeedbackType(AnnotatePermissionsForReadMixin, DjangoObjectType):
         instance = getattr(queryset, "instance", None)
         cache_name = getattr(queryset, "prefetch_cache_name", None)
         prefetched = getattr(instance, "_prefetched_objects_cache", None) or {}
-        if (
-            instance is not None
-            and cache_name is not None
-            and cache_name in prefetched
-        ):
+        if instance is not None and cache_name is not None and cache_name in prefetched:
             return queryset
 
         if issubclass(type(queryset), QuerySet):

--- a/config/graphql/user_types.py
+++ b/config/graphql/user_types.py
@@ -222,6 +222,23 @@ class UserFeedbackType(AnnotatePermissionsForReadMixin, DjangoObjectType):
     def get_queryset(cls, queryset, info) -> Any:
         from django.db.models import QuerySet
 
+        # When the parent resolver prefetched the reverse relation
+        # (see ``AnnotationQueryOptimizer.get_document_annotations`` which
+        # registers a ``Prefetch("user_feedback", ...)``), the manager passed
+        # in here has its parent's ``_prefetched_objects_cache`` populated.
+        # Re-applying ``.visible_to_user(...)`` invalidates that cache and
+        # forces a fresh SELECT per parent row — the original N+1 storm we
+        # were trying to eliminate. Detect the prefetch and pass through.
+        instance = getattr(queryset, "instance", None)
+        cache_name = getattr(queryset, "prefetch_cache_name", None)
+        prefetched = getattr(instance, "_prefetched_objects_cache", None) or {}
+        if (
+            instance is not None
+            and cache_name is not None
+            and cache_name in prefetched
+        ):
+            return queryset
+
         if issubclass(type(queryset), QuerySet):
             return queryset.visible_to_user(info.context.user)
         elif "RelatedManager" in str(type(queryset)):

--- a/config/graphql/user_types.py
+++ b/config/graphql/user_types.py
@@ -229,6 +229,10 @@ class UserFeedbackType(AnnotatePermissionsForReadMixin, DjangoObjectType):
         # Re-applying ``.visible_to_user(...)`` invalidates that cache and
         # forces a fresh SELECT per parent row — the original N+1 storm we
         # were trying to eliminate. Detect the prefetch and pass through.
+        # ``instance``, ``prefetch_cache_name``, and ``_prefetched_objects_cache``
+        # are Django RelatedManager internals — if their shape changes in a
+        # future release the fallback (re-applying ``visible_to_user``) keeps
+        # correctness intact, only losing the per-row optimisation.
         instance = getattr(queryset, "instance", None)
         cache_name = getattr(queryset, "prefetch_cache_name", None)
         prefetched = getattr(instance, "_prefetched_objects_cache", None) or {}

--- a/frontend/src/components/documents/CorpusDocumentCards.tsx
+++ b/frontend/src/components/documents/CorpusDocumentCards.tsx
@@ -223,26 +223,47 @@ export const CorpusDocumentCards = ({
     [document_ids]
   );
 
-  // Update the global reactive var with current view document IDs for toolbar's Select All functionality
+  // Update the global reactive var with current view document IDs for toolbar's Select All functionality.
+  // CRITICAL: Do NOT return a cleanup that resets the var here. Returning
+  // `() => currentViewDocumentIds([])` from this effect makes every
+  // dep change fire two writes (cleanup → []  then  body → new ids),
+  // which re-renders every subscriber twice per change. Worse, subscribers
+  // (e.g. FolderDocumentBrowser via useReactiveVar) re-render this
+  // component, and any reference instability in the dep used to feed an
+  // infinite reload loop. Only write when the value actually changed,
+  // and put the unmount-only reset in a separate `[]`-deps effect below.
   useEffect(() => {
-    currentViewDocumentIds(document_ids);
-
-    // Clear on unmount
-    return () => {
-      currentViewDocumentIds([]);
-    };
+    const current = currentViewDocumentIds();
+    const next = document_ids;
+    if (
+      current.length !== next.length ||
+      current.some((id, i) => id !== next[i])
+    ) {
+      currentViewDocumentIds(next);
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [document_ids_key]);
+  useEffect(
+    () => () => {
+      currentViewDocumentIds([]);
+    },
+    []
+  );
 
-  // Sync loading state to reactive var for toolbar to disable Select All while loading
+  // Sync loading state to reactive var. Same rule: no cleanup-then-set on
+  // dep change, and skip identical writes so we don't notify subscribers
+  // for no-op transitions.
   useEffect(() => {
-    documentsLoadingVar(documents_loading);
-
-    // Clear on unmount
-    return () => {
-      documentsLoadingVar(false);
-    };
+    if (documentsLoadingVar() !== documents_loading) {
+      documentsLoadingVar(documents_loading);
+    }
   }, [documents_loading]);
+  useEffect(
+    () => () => {
+      documentsLoadingVar(false);
+    },
+    []
+  );
 
   const handleRemoveContracts = (delete_ids: string[]) => {
     removeDocumentsFromCorpus({

--- a/frontend/src/components/modals/AddToCorpusModal.tsx
+++ b/frontend/src/components/modals/AddToCorpusModal.tsx
@@ -175,6 +175,7 @@ export const AddToCorpusModal: React.FC<AddToCorpusModalProps> = ({
             icon
             title
             creator {
+              id
               email
             }
             description

--- a/frontend/src/graphql/landing-queries.ts
+++ b/frontend/src/graphql/landing-queries.ts
@@ -146,6 +146,7 @@ export const GET_RECENT_DISCUSSIONS = gql`
             title
             slug
             creator {
+              id
               slug
             }
           }
@@ -270,6 +271,7 @@ export const GET_DISCOVERY_DATA = gql`
             title
             slug
             creator {
+              id
               slug
             }
           }

--- a/frontend/src/graphql/mutations.ts
+++ b/frontend/src/graphql/mutations.ts
@@ -2452,6 +2452,7 @@ export const CREATE_THREAD = gql`
           title
           slug
           creator {
+            id
             slug
           }
         }
@@ -2460,6 +2461,7 @@ export const CREATE_THREAD = gql`
           title
           slug
           creator {
+            id
             slug
           }
         }

--- a/frontend/src/graphql/queries.ts
+++ b/frontend/src/graphql/queries.ts
@@ -43,6 +43,14 @@ export interface RequestDocumentsOutputs {
   };
 }
 
+// NOTE: The shape of this query is matched by ``requests_doc_label_annotations``
+// in config/graphql/custom_resolvers.py (it walks the AST looking for
+// ``documents → edges → node → docAnnotations(annotationLabel_LabelType:
+// "DOC_TYPE_LABEL")``) so the resolver can opt into a focused doc-label
+// prefetch. Restructuring the connection (extra wrapping levels, renames, or
+// moving docAnnotations into a fragment at the top level) silently disables
+// that optimisation and returns the per-row N+1 — update the AST helper there
+// in lockstep with any structural change.
 export const GET_DOCUMENTS = gql`
   query (
     $inCorpusWithId: String

--- a/frontend/src/graphql/queries.ts
+++ b/frontend/src/graphql/queries.ts
@@ -84,6 +84,7 @@ export const GET_DOCUMENTS = gql`
           isPublic
           myPermissions
           creator {
+            id
             slug
           }
           is_selected @client
@@ -377,6 +378,7 @@ export const SEARCH_DOCUMENTS = gql`
           isPublic
           myPermissions
           creator {
+            id
             slug
           }
           is_selected @client
@@ -642,6 +644,7 @@ export const GET_CORPUSES = gql`
           icon
           title
           creator {
+            id
             email
             slug
           }
@@ -2075,6 +2078,7 @@ export const GET_EXTRACT_GRID_EMBED = gql`
         id
         slug
         creator {
+          id
           slug
         }
       }
@@ -2102,6 +2106,7 @@ export const GET_EXTRACT_GRID_EMBED = gql`
           title
           slug
           creator {
+            id
             slug
           }
         }
@@ -2632,6 +2637,7 @@ export const SEARCH_CORPUSES_FOR_MENTION = gql`
           slug
           title
           creator {
+            id
             slug
           }
         }
@@ -2693,6 +2699,7 @@ export const SEARCH_DOCUMENTS_FOR_MENTION = gql`
           slug
           title
           creator {
+            id
             slug
           }
           pathRecords(first: 1) {
@@ -2703,6 +2710,7 @@ export const SEARCH_DOCUMENTS_FOR_MENTION = gql`
                   slug
                   title
                   creator {
+                    id
                     slug
                   }
                 }
@@ -3621,6 +3629,7 @@ export const GET_CORPUS_CONVERSATIONS = gql`
             totalCount
           }
           creator {
+            id
             email
           }
         }
@@ -3648,6 +3657,7 @@ export const GET_CORPUS_CHAT_MESSAGES = gql`
           createdAt
           data
           creator {
+            id
             email
           }
         }
@@ -4392,6 +4402,7 @@ export const SEARCH_CONVERSATIONS = gql`
             title
             slug
             creator {
+              id
               slug
             }
           }
@@ -4400,6 +4411,7 @@ export const SEARCH_CONVERSATIONS = gql`
             title
             slug
             creator {
+              id
               slug
             }
           }
@@ -5095,6 +5107,7 @@ export const GET_DOCUMENT_RELATIONSHIPS = gql`
             icon
             slug
             creator {
+              id
               slug
             }
           }
@@ -5106,6 +5119,7 @@ export const GET_DOCUMENT_RELATIONSHIPS = gql`
             icon
             slug
             creator {
+              id
               slug
             }
           }
@@ -5119,6 +5133,7 @@ export const GET_DOCUMENT_RELATIONSHIPS = gql`
             id
             slug
             creator {
+              id
               slug
             }
           }
@@ -5188,6 +5203,7 @@ export const GET_CORPUS_DOCUMENTS_FOR_TOC = gql`
           icon
           fileType
           creator {
+            id
             slug
           }
         }
@@ -5222,6 +5238,7 @@ export const GET_CORPUS_ARTICLE = gql`
           txtExtractFile
           modified
           creator {
+            id
             email
           }
         }
@@ -5244,6 +5261,7 @@ export interface GetCorpusArticleOutput {
         txtExtractFile: string | null;
         modified: string;
         creator: {
+          id: string;
           email: string;
         };
       };

--- a/frontend/src/views/Corpuses.tsx
+++ b/frontend/src/views/Corpuses.tsx
@@ -2032,9 +2032,17 @@ export const Corpuses = () => {
     }
   }, [metadataCorpusId]); // Only depend on ID, not the full object
 
-  useEffect(() => {
-    refetch_documents();
-  }, [selected_metadata_id_to_filter_on]);
+  // NOTE: A previous version of this effect called ``refetch_documents()``
+  // whenever ``selected_metadata_id_to_filter_on`` changed. ``refetch_documents``
+  // is the ``refetch`` of a ``useLazyQuery`` that fires the query *immediately*
+  // — including on mount, when the dependency starts as ``undefined``. That
+  // produced a duplicate ``GET_DOCUMENTS`` network call on every corpus open
+  // (with no ``inFolderId``), racing against the per-folder ``GET_DOCUMENTS``
+  // already issued by ``CorpusDocumentCards``. The list there is authoritative
+  // and re-runs on its own when ``selected_metadata_id_to_filter_on`` changes
+  // (its variables include ``hasAnnotationsWithIds``), so this effect is
+  // redundant — and the duplicate response merging into the same cache nodes
+  // was contributing to the document-list reload loop.
 
   // Fetch corpus stats - with proper ID validation
   // Handle both string and number IDs, convert to string for GraphQL

--- a/frontend/tests/AddToCorpusModal.ct.tsx
+++ b/frontend/tests/AddToCorpusModal.ct.tsx
@@ -26,6 +26,7 @@ const GET_EDITABLE_CORPUSES = gql`
           icon
           title
           creator {
+            id
             email
           }
           description
@@ -46,7 +47,7 @@ const mockCorpuses = [
     id: "Q29ycHVzVHlwZTox",
     icon: "folder",
     title: "Contract Analysis",
-    creator: { email: "admin@example.com" },
+    creator: { id: "VXNlclR5cGU6MQ==", email: "admin@example.com" },
     description: "A corpus for analyzing contracts",
     documentCount: 15,
     labelSet: { id: "TGFiZWxTZXRUeXBlOjE=", title: "Legal Terms" },
@@ -56,7 +57,7 @@ const mockCorpuses = [
     id: "Q29ycHVzVHlwZToy",
     icon: null,
     title: "NDA Collection",
-    creator: { email: "user@example.com" },
+    creator: { id: "VXNlclR5cGU6Mg==", email: "user@example.com" },
     description: "Collection of non-disclosure agreements",
     documentCount: 8,
     labelSet: null,
@@ -64,7 +65,15 @@ const mockCorpuses = [
   },
 ];
 
-// Query with empty search term (initial load)
+// Query with empty search term (initial load).
+// The modal's ``useEffect(() => refetch(), [open, refetch])`` re-fires
+// whenever Apollo's ``useQuery`` returns a new ``refetch`` reference, and
+// ``notifyOnNetworkStatusChange: true`` causes that on every network state
+// change. Combined with React 18's double-render in the CT harness, the
+// modal can issue many ``GetEditableCorpuses`` requests per mount.
+// ``result`` as a callback + ``maxUsageCount: Number.POSITIVE_INFINITY`` is
+// the Apollo-recommended way to make a mock re-supply itself indefinitely
+// instead of being consumed once and triggering "No more mocked responses".
 const getCorpusesMock = {
   request: {
     query: GET_EDITABLE_CORPUSES,
@@ -83,11 +92,8 @@ const getCorpusesMock = {
       },
     },
   },
+  maxUsageCount: Number.POSITIVE_INFINITY,
 };
-
-// Duplicate for refetches
-const getCorpusesMockDuplicate = { ...getCorpusesMock };
-const getCorpusesMockTriplicate = { ...getCorpusesMock };
 
 // Empty results mock
 const getCorpusesEmptyMock = {
@@ -108,6 +114,7 @@ const getCorpusesEmptyMock = {
       },
     },
   },
+  maxUsageCount: Number.POSITIVE_INFINITY,
 };
 
 test.describe("AddToCorpusModal - Rendering", () => {
@@ -116,14 +123,7 @@ test.describe("AddToCorpusModal - Rendering", () => {
     page,
   }) => {
     const component = await mount(
-      <MockedProvider
-        mocks={[
-          getCorpusesMock,
-          getCorpusesMockDuplicate,
-          getCorpusesMockTriplicate,
-        ]}
-        addTypename={false}
-      >
+      <MockedProvider mocks={[getCorpusesMock]} addTypename={false}>
         <AddToCorpusModal
           documentId={DOCUMENT_ID}
           open={true}
@@ -187,14 +187,7 @@ test.describe("AddToCorpusModal - Behavior", () => {
     page,
   }) => {
     const component = await mount(
-      <MockedProvider
-        mocks={[
-          getCorpusesMock,
-          getCorpusesMockDuplicate,
-          getCorpusesMockTriplicate,
-        ]}
-        addTypename={false}
-      >
+      <MockedProvider mocks={[getCorpusesMock]} addTypename={false}>
         <AddToCorpusModal
           documentId={DOCUMENT_ID}
           open={true}
@@ -227,14 +220,7 @@ test.describe("AddToCorpusModal - Behavior", () => {
     let closeCalled = false;
 
     const component = await mount(
-      <MockedProvider
-        mocks={[
-          getCorpusesMock,
-          getCorpusesMockDuplicate,
-          getCorpusesMockTriplicate,
-        ]}
-        addTypename={false}
-      >
+      <MockedProvider mocks={[getCorpusesMock]} addTypename={false}>
         <AddToCorpusModal
           documentId={DOCUMENT_ID}
           open={true}
@@ -257,14 +243,7 @@ test.describe("AddToCorpusModal - Behavior", () => {
     page,
   }) => {
     const component = await mount(
-      <MockedProvider
-        mocks={[
-          getCorpusesEmptyMock,
-          { ...getCorpusesEmptyMock },
-          { ...getCorpusesEmptyMock },
-        ]}
-        addTypename={false}
-      >
+      <MockedProvider mocks={[getCorpusesEmptyMock]} addTypename={false}>
         <AddToCorpusModal
           documentId={DOCUMENT_ID}
           open={true}

--- a/opencontractserver/agents/models.py
+++ b/opencontractserver/agents/models.py
@@ -49,7 +49,12 @@ class AgentConfigurationManager(BaseVisibilityManager):
     def get_queryset(self):
         return AgentConfigurationQuerySet(self.model, using=self._db)
 
-    def visible_to_user(self, user=None, lightweight: bool = False):
+    def visible_to_user(
+        self,
+        user=None,
+        lightweight: bool = False,
+        with_doc_label_annotations: bool = False,
+    ):
         return self.get_queryset().visible_to_user(user, lightweight=lightweight)
 
 
@@ -224,7 +229,12 @@ class AgentActionResultManager(BaseVisibilityManager):
     def get_queryset(self):
         return AgentActionResultQuerySet(self.model, using=self._db)
 
-    def visible_to_user(self, user=None, lightweight: bool = False):
+    def visible_to_user(
+        self,
+        user=None,
+        lightweight: bool = False,
+        with_doc_label_annotations: bool = False,
+    ):
         return self.get_queryset().visible_to_user(user, lightweight=lightweight)
 
 

--- a/opencontractserver/annotations/query_optimizer.py
+++ b/opencontractserver/annotations/query_optimizer.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from opencontractserver.analyzer.models import Analysis
     from opencontractserver.extracts.models import Extract
 
-from django.db.models import Count, Exists, OuterRef, Q, QuerySet, Value
+from django.db.models import Count, Exists, OuterRef, Prefetch, Q, QuerySet, Value
 
 
 class AnnotationQueryOptimizer:
@@ -27,7 +27,11 @@ class AnnotationQueryOptimizer:
 
     @classmethod
     def _compute_effective_permissions(
-        cls, user, document_id: int, corpus_id: Optional[int] = None
+        cls,
+        user,
+        document_id: int,
+        corpus_id: Optional[int] = None,
+        context=None,
     ) -> tuple[bool, bool, bool, bool, bool]:
         """
         Compute effective permissions based on document and corpus.
@@ -36,6 +40,15 @@ class AnnotationQueryOptimizer:
         - If corpus.allow_comments is True, any readable annotation is commentable
         - Otherwise, standard MIN(doc_comment, corpus_comment) logic applies
 
+        ``context`` is the GraphQL request context. When provided, results are
+        cached on ``context._effective_perms_cache`` keyed by
+        ``(user_id, document_id, corpus_id)`` so subsequent resolvers in the
+        same request reuse the answer instead of re-running the 10
+        ``user_has_permission_for_obj`` round-trips and the
+        ``Document``/``Corpus`` ``.get()`` lookups. The cache is also primed
+        with the fetched ORM instances so other resolvers inside this request
+        can avoid re-fetching them.
+
         Returns: (can_read, can_create, can_update, can_delete, can_comment)
         """
         from opencontractserver.corpuses.models import Corpus
@@ -43,101 +56,167 @@ class AnnotationQueryOptimizer:
         from opencontractserver.types.enums import PermissionTypes
         from opencontractserver.utils.permissioning import user_has_permission_for_obj
 
+        cache_key = (
+            getattr(user, "id", None),
+            document_id,
+            corpus_id,
+        )
+        perms_cache = None
+        if context is not None:
+            perms_cache = getattr(context, "_effective_perms_cache", None)
+            if perms_cache is None:
+                perms_cache = {}
+                context._effective_perms_cache = perms_cache
+            cached = perms_cache.get(cache_key)
+            if cached is not None:
+                return cached
+
+        def _store(result: tuple[bool, bool, bool, bool, bool]) -> tuple[
+            bool, bool, bool, bool, bool
+        ]:
+            if perms_cache is not None:
+                perms_cache[cache_key] = result
+            return result
+
         # Superusers have all permissions
         if user.is_superuser:
-            return True, True, True, True, True
+            return _store((True, True, True, True, True))
+
+        document = cls._get_document_for_request(document_id, context)
+        if document is None:
+            return _store((False, False, False, False, False))
 
         # Anonymous users only have read access to public documents/corpuses
         if user.is_anonymous:
-            try:
-                document = Document.objects.get(id=document_id)
-                doc_read = document.is_public
-            except Document.DoesNotExist:
-                return False, False, False, False, False
-
-            if not doc_read:
-                return False, False, False, False, False
+            if not document.is_public:
+                return _store((False, False, False, False, False))
 
             if corpus_id:
-                try:
-                    corpus = Corpus.objects.get(id=corpus_id)
-                    corpus_read = corpus.is_public
-                except Corpus.DoesNotExist:
-                    return False, False, False, False, False
+                corpus = cls._get_corpus_for_request(corpus_id, context)
+                if corpus is None or not corpus.is_public:
+                    return _store((False, False, False, False, False))
 
-                if not corpus_read:
-                    return False, False, False, False, False
+            return _store((True, False, False, False, False))
 
-            # Anonymous users only get read permission
-            return True, False, False, False, False
-
-        # First check document permissions (primary)
-        try:
-            document = Document.objects.get(id=document_id)
-            doc_read = user_has_permission_for_obj(user, document, PermissionTypes.READ)
-            doc_create = user_has_permission_for_obj(
-                user, document, PermissionTypes.CREATE
-            )
-            doc_update = user_has_permission_for_obj(
-                user, document, PermissionTypes.UPDATE
-            )
-            doc_delete = user_has_permission_for_obj(
-                user, document, PermissionTypes.DELETE
-            )
-            doc_comment = user_has_permission_for_obj(
-                user, document, PermissionTypes.COMMENT
-            )
-        except Document.DoesNotExist:
-            return False, False, False, False, False
-
-        # If no document read permission, no access at all
+        # Authenticated user — document permissions first
+        doc_read = user_has_permission_for_obj(user, document, PermissionTypes.READ)
         if not doc_read:
-            return False, False, False, False, False
+            return _store((False, False, False, False, False))
 
-        # If no corpus, use document permissions only
+        doc_create = user_has_permission_for_obj(
+            user, document, PermissionTypes.CREATE
+        )
+        doc_update = user_has_permission_for_obj(
+            user, document, PermissionTypes.UPDATE
+        )
+        doc_delete = user_has_permission_for_obj(
+            user, document, PermissionTypes.DELETE
+        )
+        doc_comment = user_has_permission_for_obj(
+            user, document, PermissionTypes.COMMENT
+        )
+
         if not corpus_id:
-            return doc_read, doc_create, doc_update, doc_delete, doc_comment
-
-        # Check corpus permissions and apply most restrictive
-        try:
-            corpus = Corpus.objects.get(id=corpus_id)
-            corpus_read = user_has_permission_for_obj(
-                user, corpus, PermissionTypes.READ
-            )
-            corpus_create = user_has_permission_for_obj(
-                user, corpus, PermissionTypes.CREATE
-            )
-            corpus_update = user_has_permission_for_obj(
-                user, corpus, PermissionTypes.UPDATE
-            )
-            corpus_delete = user_has_permission_for_obj(
-                user, corpus, PermissionTypes.DELETE
-            )
-            corpus_comment = user_has_permission_for_obj(
-                user, corpus, PermissionTypes.COMMENT
+            return _store(
+                (doc_read, doc_create, doc_update, doc_delete, doc_comment)
             )
 
-            # Compute final read permission
-            final_read = doc_read and corpus_read
+        corpus = cls._get_corpus_for_request(corpus_id, context)
+        if corpus is None:
+            # Corpus doesn't exist or isn't visible — fall back to document perms.
+            return _store(
+                (doc_read, doc_create, doc_update, doc_delete, doc_comment)
+            )
 
-            # BACON MODE: If corpus allows comments, readable = commentable
-            if corpus.allow_comments:
-                final_comment = final_read  # Can see it? Can comment on it.
-            else:
-                # Standard restrictive model
-                final_comment = doc_comment and corpus_comment
+        corpus_read = user_has_permission_for_obj(
+            user, corpus, PermissionTypes.READ
+        )
+        corpus_create = user_has_permission_for_obj(
+            user, corpus, PermissionTypes.CREATE
+        )
+        corpus_update = user_has_permission_for_obj(
+            user, corpus, PermissionTypes.UPDATE
+        )
+        corpus_delete = user_has_permission_for_obj(
+            user, corpus, PermissionTypes.DELETE
+        )
+        corpus_comment = user_has_permission_for_obj(
+            user, corpus, PermissionTypes.COMMENT
+        )
 
-            # Return computed permissions
-            return (
+        final_read = doc_read and corpus_read
+
+        # BACON MODE: If corpus allows comments, readable = commentable.
+        if corpus.allow_comments:
+            final_comment = final_read
+        else:
+            final_comment = doc_comment and corpus_comment
+
+        return _store(
+            (
                 final_read,
                 doc_create and corpus_create,
                 doc_update and corpus_update,
                 doc_delete and corpus_delete,
                 final_comment,
             )
+        )
+
+    @staticmethod
+    def _get_document_for_request(document_id: int, context):
+        """
+        Return the ``Document`` for ``document_id``, caching the instance on
+        ``context._document_instance_cache`` so the same request never fetches
+        the same row twice.
+        """
+        from opencontractserver.documents.models import Document
+
+        if context is None:
+            try:
+                return Document.objects.get(id=document_id)
+            except Document.DoesNotExist:
+                return None
+
+        cache = getattr(context, "_document_instance_cache", None)
+        if cache is None:
+            cache = {}
+            context._document_instance_cache = cache
+        if document_id in cache:
+            return cache[document_id]
+        try:
+            instance = Document.objects.get(id=document_id)
+        except Document.DoesNotExist:
+            instance = None
+        cache[document_id] = instance
+        return instance
+
+    @staticmethod
+    def _get_corpus_for_request(corpus_id: int, context):
+        """
+        Return the ``Corpus`` for ``corpus_id``, caching the instance on
+        ``context._corpus_instance_cache``. Mirror of
+        ``_get_document_for_request``.
+        """
+        from opencontractserver.corpuses.models import Corpus
+
+        if context is None:
+            try:
+                return Corpus.objects.get(id=corpus_id)
+            except Corpus.DoesNotExist:
+                return None
+
+        cache = getattr(context, "_corpus_instance_cache", None)
+        if cache is None:
+            cache = {}
+            context._corpus_instance_cache = cache
+        if corpus_id in cache:
+            return cache[corpus_id]
+        try:
+            instance = Corpus.objects.get(id=corpus_id)
         except Corpus.DoesNotExist:
-            # Corpus doesn't exist, use document permissions
-            return doc_read, doc_create, doc_update, doc_delete, doc_comment
+            instance = None
+        cache[corpus_id] = instance
+        return instance
 
     @classmethod
     def get_document_annotations(
@@ -151,6 +230,7 @@ class AnnotationQueryOptimizer:
         structural: Optional[bool] = None,  # Filter for structural annotations
         use_cache: bool = True,  # Kept for backward compatibility, ignored
         check_current_version: bool = True,  # NEW: Check if document is current and has active path
+        context=None,
     ) -> QuerySet:
         """
         Get annotations with permission filtering and optimized queries.
@@ -159,13 +239,21 @@ class AnnotationQueryOptimizer:
         IMPORTANT: Returns annotations from BOTH:
         1. Direct document annotations (document FK) - corpus-specific annotations
         2. Structural annotations via document's structural_annotation_set (structural_set FK) - shared annotations
+
+        ``context`` is the GraphQL request context. When provided, the
+        permission check, the parent ``Document`` fetch, and the
+        ``Corpus`` fetch are cached for the lifetime of the request, so
+        sibling resolvers (``allAnnotations`` / ``allRelationships`` /
+        ``docAnnotations``) don't repeat the work for the same
+        ``(user, document, corpus)`` tuple.
         """
         from opencontractserver.annotations.models import Annotation
-        from opencontractserver.documents.models import Document
 
-        # Compute effective permissions once
+        # Compute effective permissions once (cached on context if available)
         can_read, can_create, can_update, can_delete, can_comment = (
-            cls._compute_effective_permissions(user, document_id, corpus_id)
+            cls._compute_effective_permissions(
+                user, document_id, corpus_id, context=context
+            )
         )
         # No read permission = no annotations
         if not can_read:
@@ -186,14 +274,21 @@ class AnnotationQueryOptimizer:
                 # Document is deleted or not current in corpus
                 return Annotation.objects.none()
 
-        # Fetch document to check for structural_annotation_set
-        # Use select_related for efficiency to avoid N+1 queries
-        try:
-            document = Document.objects.select_related("structural_annotation_set").get(
-                pk=document_id
-            )
-        except Document.DoesNotExist:
+        # Fetch the document (request-cached if ``context`` is provided so we
+        # don't re-fetch the row that ``_compute_effective_permissions`` and
+        # parent resolvers have already loaded). Use ``structural_annotation_set``
+        # via select_related when we miss the cache so the structural-set
+        # branch below stays a single round-trip.
+        document = cls._get_document_for_request(document_id, context)
+        if document is None:
             return Annotation.objects.none()
+        if document.structural_annotation_set_id and not hasattr(
+            document, "_structural_annotation_set_loaded"
+        ):
+            # The cached fetch above wasn't ``select_related`` — make sure we
+            # don't trigger an extra round-trip when the FK is dereferenced
+            # later by accessing the ID only (which is already on the row).
+            pass
 
         # Build base filter for annotations from BOTH sources:
         # 1. Direct document annotations (corpus-specific, user-created)
@@ -344,20 +439,43 @@ class AnnotationQueryOptimizer:
             ).values_list("sources__id", flat=True)
             qs = qs.filter(id__in=datacell_annotation_ids)
 
-        # Optimize query with prefetches and annotate feedback count
-        # Also annotate with computed permissions for backwards compatibility
-        qs = (
-            qs.select_related("annotation_label", "creator", "analysis")
-            .annotate(
-                feedback_count=Count("user_feedback"),
-                # Store computed permissions for GraphQL myPermissions field
-                _can_read=Value(can_read),
-                _can_create=Value(can_create),
-                _can_update=Value(can_update),
-                _can_delete=Value(can_delete),
-                _can_comment=Value(can_comment),
+        # Optimize query with prefetches and annotate computed permissions for
+        # the GraphQL ``myPermissions`` field. Permission values are constant
+        # for the whole queryset (computed once above) so they're cheap.
+        #
+        # NB: previously this also did ``.annotate(feedback_count=Count(...))``
+        # plus ``.distinct()``. Both were per-row costs paid for every
+        # annotation in the response, even when no feedback exists:
+        #   - the Count forced a LEFT JOIN user_feedback + GROUP BY
+        #     annotation.id, which Postgres has to materialise/sort with
+        #     ``select_related`` joins also live
+        #   - the distinct then ran a sort/hash unique pass on the joined
+        #     row set
+        # Neither was necessary: the filters above don't introduce
+        # duplicates (no M2M JOINs — analysis/extract visibility uses
+        # subqueries), and ``feedback_count`` is now computed from the
+        # prefetched ``user_feedback`` list in
+        # ``AnnotationType.resolve_feedback_count``.
+        from opencontractserver.feedback.models import UserFeedback
+
+        qs = qs.select_related(
+            "annotation_label", "creator", "analysis"
+        ).prefetch_related(
+            Prefetch(
+                "user_feedback",
+                queryset=UserFeedback.objects.only(
+                    "id",
+                    "approved",
+                    "rejected",
+                    "commented_annotation_id",
+                ),
             )
-            .distinct()
+        ).annotate(
+            _can_read=Value(can_read),
+            _can_create=Value(can_create),
+            _can_update=Value(can_update),
+            _can_delete=Value(can_delete),
+            _can_comment=Value(can_comment),
         )
 
         return qs
@@ -692,6 +810,7 @@ class RelationshipQueryOptimizer:
         extract_id: Optional[int] = None,
         strict_extract_mode: bool = False,
         use_cache: bool = True,  # Ignored
+        context=None,
     ) -> QuerySet:
         """
         Get relationships with optimized prefetching.
@@ -700,27 +819,31 @@ class RelationshipQueryOptimizer:
         IMPORTANT: Returns relationships from BOTH:
         1. Direct document relationships (document FK) - corpus-specific relationships
         2. Structural relationships via document's structural_annotation_set (structural_set FK) - shared relationships
+
+        ``context`` allows the request-level caches in
+        ``AnnotationQueryOptimizer._compute_effective_permissions`` /
+        ``_get_document_for_request`` to be shared with the annotation resolver
+        in the same GraphQL operation.
         """
         from opencontractserver.annotations.models import Relationship
-        from opencontractserver.documents.models import Document
 
-        # Use unified permission check from AnnotationQueryOptimizer
+        # Use unified permission check from AnnotationQueryOptimizer.
+        # Pass context so the result is cached for the rest of the request.
         can_read, can_create, can_update, can_delete, can_comment = (
             AnnotationQueryOptimizer._compute_effective_permissions(
-                user, document_id, corpus_id
+                user, document_id, corpus_id, context=context
             )
         )
 
         if not can_read:
             return Relationship.objects.none()
 
-        # Fetch document to check for structural_annotation_set
-        # Use select_related for efficiency
-        try:
-            document = Document.objects.select_related("structural_annotation_set").get(
-                pk=document_id
-            )
-        except Document.DoesNotExist:
+        # Fetch document via the request cache (same instance as the annotation
+        # resolver uses, when both run in the same GraphQL request).
+        document = AnnotationQueryOptimizer._get_document_for_request(
+            document_id, context
+        )
+        if document is None:
             return Relationship.objects.none()
 
         # Build base filter for relationships from BOTH sources:

--- a/opencontractserver/annotations/query_optimizer.py
+++ b/opencontractserver/annotations/query_optimizer.py
@@ -51,8 +51,6 @@ class AnnotationQueryOptimizer:
 
         Returns: (can_read, can_create, can_update, can_delete, can_comment)
         """
-        from opencontractserver.corpuses.models import Corpus
-        from opencontractserver.documents.models import Document
         from opencontractserver.types.enums import PermissionTypes
         from opencontractserver.utils.permissioning import user_has_permission_for_obj
 
@@ -71,9 +69,9 @@ class AnnotationQueryOptimizer:
             if cached is not None:
                 return cached
 
-        def _store(result: tuple[bool, bool, bool, bool, bool]) -> tuple[
-            bool, bool, bool, bool, bool
-        ]:
+        def _store(
+            result: tuple[bool, bool, bool, bool, bool],
+        ) -> tuple[bool, bool, bool, bool, bool]:
             if perms_cache is not None:
                 perms_cache[cache_key] = result
             return result
@@ -103,34 +101,22 @@ class AnnotationQueryOptimizer:
         if not doc_read:
             return _store((False, False, False, False, False))
 
-        doc_create = user_has_permission_for_obj(
-            user, document, PermissionTypes.CREATE
-        )
-        doc_update = user_has_permission_for_obj(
-            user, document, PermissionTypes.UPDATE
-        )
-        doc_delete = user_has_permission_for_obj(
-            user, document, PermissionTypes.DELETE
-        )
+        doc_create = user_has_permission_for_obj(user, document, PermissionTypes.CREATE)
+        doc_update = user_has_permission_for_obj(user, document, PermissionTypes.UPDATE)
+        doc_delete = user_has_permission_for_obj(user, document, PermissionTypes.DELETE)
         doc_comment = user_has_permission_for_obj(
             user, document, PermissionTypes.COMMENT
         )
 
         if not corpus_id:
-            return _store(
-                (doc_read, doc_create, doc_update, doc_delete, doc_comment)
-            )
+            return _store((doc_read, doc_create, doc_update, doc_delete, doc_comment))
 
         corpus = cls._get_corpus_for_request(corpus_id, context)
         if corpus is None:
             # Corpus doesn't exist or isn't visible — fall back to document perms.
-            return _store(
-                (doc_read, doc_create, doc_update, doc_delete, doc_comment)
-            )
+            return _store((doc_read, doc_create, doc_update, doc_delete, doc_comment))
 
-        corpus_read = user_has_permission_for_obj(
-            user, corpus, PermissionTypes.READ
-        )
+        corpus_read = user_has_permission_for_obj(user, corpus, PermissionTypes.READ)
         corpus_create = user_has_permission_for_obj(
             user, corpus, PermissionTypes.CREATE
         )
@@ -458,24 +444,26 @@ class AnnotationQueryOptimizer:
         # ``AnnotationType.resolve_feedback_count``.
         from opencontractserver.feedback.models import UserFeedback
 
-        qs = qs.select_related(
-            "annotation_label", "creator", "analysis"
-        ).prefetch_related(
-            Prefetch(
-                "user_feedback",
-                queryset=UserFeedback.objects.only(
-                    "id",
-                    "approved",
-                    "rejected",
-                    "commented_annotation_id",
-                ),
+        qs = (
+            qs.select_related("annotation_label", "creator", "analysis")
+            .prefetch_related(
+                Prefetch(
+                    "user_feedback",
+                    queryset=UserFeedback.objects.only(
+                        "id",
+                        "approved",
+                        "rejected",
+                        "commented_annotation_id",
+                    ),
+                )
             )
-        ).annotate(
-            _can_read=Value(can_read),
-            _can_create=Value(can_create),
-            _can_update=Value(can_update),
-            _can_delete=Value(can_delete),
-            _can_comment=Value(can_comment),
+            .annotate(
+                _can_read=Value(can_read),
+                _can_create=Value(can_create),
+                _can_update=Value(can_update),
+                _can_delete=Value(can_delete),
+                _can_comment=Value(can_comment),
+            )
         )
 
         return qs

--- a/opencontractserver/annotations/query_optimizer.py
+++ b/opencontractserver/annotations/query_optimizer.py
@@ -154,12 +154,19 @@ class AnnotationQueryOptimizer:
         Return the ``Document`` for ``document_id``, caching the instance on
         ``context._document_instance_cache`` so the same request never fetches
         the same row twice.
+
+        ``structural_annotation_set`` is ``select_related`` so the FK
+        dereference inside ``get_document_annotations`` (which builds a query
+        spanning the document's structural set) stays on the original SELECT
+        instead of triggering a follow-up round-trip per request.
         """
         from opencontractserver.documents.models import Document
 
         if context is None:
             try:
-                return Document.objects.get(id=document_id)
+                return Document.objects.select_related("structural_annotation_set").get(
+                    id=document_id
+                )
             except Document.DoesNotExist:
                 return None
 
@@ -170,7 +177,9 @@ class AnnotationQueryOptimizer:
         if document_id in cache:
             return cache[document_id]
         try:
-            instance = Document.objects.get(id=document_id)
+            instance = Document.objects.select_related("structural_annotation_set").get(
+                id=document_id
+            )
         except Document.DoesNotExist:
             instance = None
         cache[document_id] = instance
@@ -262,19 +271,13 @@ class AnnotationQueryOptimizer:
 
         # Fetch the document (request-cached if ``context`` is provided so we
         # don't re-fetch the row that ``_compute_effective_permissions`` and
-        # parent resolvers have already loaded). Use ``structural_annotation_set``
-        # via select_related when we miss the cache so the structural-set
-        # branch below stays a single round-trip.
+        # parent resolvers have already loaded). The cached fetcher
+        # ``_get_document_for_request`` uses ``select_related(
+        # "structural_annotation_set")`` so the structural-set branch below
+        # never triggers a follow-up round-trip on FK dereference.
         document = cls._get_document_for_request(document_id, context)
         if document is None:
             return Annotation.objects.none()
-        if document.structural_annotation_set_id and not hasattr(
-            document, "_structural_annotation_set_loaded"
-        ):
-            # The cached fetch above wasn't ``select_related`` — make sure we
-            # don't trigger an extra round-trip when the FK is dereferenced
-            # later by accessing the ID only (which is already on the row).
-            pass
 
         # Build base filter for annotations from BOTH sources:
         # 1. Direct document annotations (corpus-specific, user-created)

--- a/opencontractserver/corpuses/managers.py
+++ b/opencontractserver/corpuses/managers.py
@@ -136,6 +136,7 @@ class CorpusActionExecutionManager(BaseVisibilityManager):
         self,
         user: AbstractBaseUser | None = None,
         lightweight: bool = False,
+        with_doc_label_annotations: bool = False,
     ) -> CorpusActionExecutionQuerySet:
         """
         Override to return our custom QuerySet type while preserving permission
@@ -143,9 +144,9 @@ class CorpusActionExecutionManager(BaseVisibilityManager):
 
         This allows chaining: .visible_to_user(user).for_corpus(id).pending()
 
-        ``lightweight`` is forwarded to ``BaseVisibilityManager`` for
-        signature parity but has no effect on this model (no heavy
-        prefetches involved).
+        ``lightweight`` and ``with_doc_label_annotations`` are forwarded to
+        ``BaseVisibilityManager`` for signature parity but have no effect on
+        this model (no heavy prefetches involved).
         """
         # Get the base filtered queryset from parent
         base_qs = super().visible_to_user(user, lightweight=lightweight)

--- a/opencontractserver/shared/Managers.py
+++ b/opencontractserver/shared/Managers.py
@@ -61,7 +61,9 @@ def _apply_document_prefetches(
     so this short-circuits the per-document
     ``AnnotationQueryOptimizer.get_document_annotations`` call that the
     list-view badge query (``GET_DOCUMENTS`` with ``annotateDocLabels: true``)
-    otherwise triggers per row.
+    otherwise triggers per row. The flag is only consulted in lightweight
+    mode — the full prefetch path already loads every doc_annotation, so a
+    focused prefetch on top would be redundant work.
     """
     queryset = queryset.select_related("creator", "user_lock", "parent")
 

--- a/opencontractserver/shared/Managers.py
+++ b/opencontractserver/shared/Managers.py
@@ -32,16 +32,55 @@ logger = logging.getLogger(__name__)
 
 
 def _apply_document_prefetches(
-    queryset: QuerySet, user: Optional[User], lightweight: bool = False
+    queryset: QuerySet,
+    user: Optional[User],
+    lightweight: bool = False,
+    with_doc_label_annotations: bool = False,
 ) -> QuerySet:
     """
     Apply Document-specific select_related and prefetch_related optimizations.
 
     Shared by BaseVisibilityManager (for generic model dispatch) and
     DocumentManager (for custom permission filtering) to avoid duplication.
+
+    ``lightweight`` skips ONLY the heavy per-document fan-outs (full
+    doc_annotations, rows, source/target relationships, notes). Cheap JOINs
+    (creator, parent, user_lock) and user-scoped guardian permission prefetches
+    are applied unconditionally because the corresponding GraphQL fields
+    (``creator``, ``myPermissions``, version metadata) are commonly requested
+    even on list views — leaving them unprefetched produces an N+1 storm where
+    every list row issues 2-3 extra round trips. See
+    ``resolve_my_permissions`` in
+    ``config/graphql/permissioning/permission_annotator/mixins.py`` for the
+    consumer of ``_prefetched_user_perms``.
+
+    ``with_doc_label_annotations`` opts in to a focused prefetch of the
+    document's ``DOC_TYPE_LABEL`` annotations into
+    ``_prefetched_doc_annotations``. ``resolve_doc_annotations_optimized``
+    (config/graphql/custom_resolvers.py) prefers that attribute when present,
+    so this short-circuits the per-document
+    ``AnnotationQueryOptimizer.get_document_annotations`` call that the
+    list-view badge query (``GET_DOCUMENTS`` with ``annotateDocLabels: true``)
+    otherwise triggers per row.
     """
+    queryset = queryset.select_related("creator", "user_lock", "parent")
+
+    if user and not user.is_anonymous and not user.is_superuser:
+        from opencontractserver.documents.models import DocumentUserObjectPermission
+
+        queryset = queryset.prefetch_related(
+            Prefetch(
+                "documentuserobjectpermission_set",
+                queryset=DocumentUserObjectPermission.objects.filter(
+                    user_id=user.id
+                ).select_related("permission"),
+                to_attr="_prefetched_user_perms",
+            ),
+            "documentgroupobjectpermission_set__permission",
+            "documentgroupobjectpermission_set__group",
+        )
+
     if not lightweight:
-        queryset = queryset.select_related("creator", "user_lock")
         from opencontractserver.annotations.models import Annotation
 
         queryset = queryset.prefetch_related(
@@ -57,23 +96,18 @@ def _apply_document_prefetches(
             "target_relationships",
             "notes",
         )
+    elif with_doc_label_annotations:
+        from opencontractserver.annotations.models import DOC_TYPE_LABEL, Annotation
 
-        if user and not user.is_anonymous and not user.is_superuser:
-            from opencontractserver.documents.models import (
-                DocumentUserObjectPermission,
+        queryset = queryset.prefetch_related(
+            Prefetch(
+                "doc_annotations",
+                queryset=Annotation.objects.filter(
+                    annotation_label__label_type=DOC_TYPE_LABEL
+                ).select_related("annotation_label", "corpus"),
+                to_attr="_prefetched_doc_annotations",
             )
-
-            queryset = queryset.prefetch_related(
-                Prefetch(
-                    "documentuserobjectpermission_set",
-                    queryset=DocumentUserObjectPermission.objects.filter(
-                        user_id=user.id
-                    ).select_related("permission"),
-                    to_attr="_prefetched_user_perms",
-                ),
-                "documentgroupobjectpermission_set__permission",
-                "documentgroupobjectpermission_set__group",
-            )
+        )
 
     return queryset
 
@@ -91,7 +125,12 @@ class BaseVisibilityManager(Manager):
     more specific permission requirements.
     """
 
-    def visible_to_user(self, user=None, lightweight=False) -> QuerySet:
+    def visible_to_user(
+        self,
+        user=None,
+        lightweight: bool = False,
+        with_doc_label_annotations: bool = False,
+    ) -> QuerySet:
         """
         Returns queryset filtered to only objects visible to the user.
 
@@ -193,7 +232,12 @@ class BaseVisibilityManager(Manager):
                 # Document counts are now computed via DocumentPath subqueries
             elif model_name.upper() == "DOCUMENT":
                 logger.debug("Applying Document specific optimizations")
-                queryset = _apply_document_prefetches(queryset, user, lightweight)
+                queryset = _apply_document_prefetches(
+                    queryset,
+                    user,
+                    lightweight,
+                    with_doc_label_annotations=with_doc_label_annotations,
+                )
             # Add elif blocks here for other models needing specific optimizations
 
             # Apply distinct *after* optimizations only when necessary.
@@ -287,11 +331,17 @@ class DocumentManager(BaseVisibilityManager):
         return DocumentQuerySet(self.model, using=self._db)
 
     def visible_to_user(
-        self, user: Optional[Any] = None, lightweight: bool = False
+        self,
+        user: Optional[Any] = None,
+        lightweight: bool = False,
+        with_doc_label_annotations: bool = False,
     ) -> QuerySet:
         """
         Delegate permission filtering to DocumentQuerySet (which includes
         public-corpus logic) then apply the shared prefetch optimisations.
+
+        See ``_apply_document_prefetches`` for the meaning of
+        ``with_doc_label_annotations``.
         """
         from django.contrib.auth.models import AnonymousUser
 
@@ -299,7 +349,12 @@ class DocumentManager(BaseVisibilityManager):
             user = AnonymousUser()
 
         queryset = self.get_queryset().visible_to_user(user)
-        return _apply_document_prefetches(queryset, user, lightweight)
+        return _apply_document_prefetches(
+            queryset,
+            user,
+            lightweight,
+            with_doc_label_annotations=with_doc_label_annotations,
+        )
 
     def search_by_embedding(
         self, query_vector: list[float], embedder_path: str, top_k: int = 10

--- a/opencontractserver/tests/permissioning/test_permissioned_querysets.py
+++ b/opencontractserver/tests/permissioning/test_permissioned_querysets.py
@@ -547,6 +547,21 @@ class CorpusGetDocumentsAndCountTest(TestCase):
         self.assertEqual(self.corpus.document_count(), 0)
 
 
+def _prefetch_lookup_names(qs) -> set[str]:
+    """
+    Collect the lookup paths from a queryset's ``_prefetch_related_lookups``.
+
+    Entries can be raw strings (``"foo__bar"``) or ``Prefetch`` instances
+    (which expose the path as ``prefetch_through``); normalise to a set of
+    string paths so tests can assert membership without caring which form
+    a given prefetch was registered as.
+    """
+    return {
+        item if isinstance(item, str) else item.prefetch_through
+        for item in qs._prefetch_related_lookups
+    }
+
+
 class DocumentManagerVisibleToUserTest(TestCase):
     """Tests for DocumentManager.visible_to_user() with lightweight flag."""
 
@@ -567,13 +582,34 @@ class DocumentManagerVisibleToUserTest(TestCase):
         )
         self.doc, _, _ = self.corpus.add_document(document=source, user=self.owner)
 
-    def test_lightweight_skips_prefetch(self):
-        """lightweight=True skips select_related and prefetch_related."""
+    def test_lightweight_skips_heavy_prefetch_but_keeps_cheap_joins(self):
+        """
+        lightweight=True keeps cheap select_related JOINs (creator, parent,
+        user_lock) and the user-scoped guardian permission prefetches because
+        the GraphQL fields that consume them (``creator``, ``myPermissions``,
+        version metadata) are commonly requested even on list views — leaving
+        them unprefetched produces an N+1 storm.
+
+        It still skips the heavy per-document fan-outs: full doc_annotations
+        prefetch, ``rows``, source/target relationships, and ``notes``.
+        """
         qs = Document.objects.visible_to_user(self.viewer, lightweight=True)
-        # The queryset should still work and return results
         self.assertIn(self.doc.pk, qs.values_list("pk", flat=True))
-        # No select_related should have been added (Django uses False when empty)
-        self.assertFalse(qs.query.select_related)
+
+        # Cheap JOINs are present in lightweight mode.
+        self.assertIn("creator", qs.query.select_related)
+        self.assertIn("user_lock", qs.query.select_related)
+        self.assertIn("parent", qs.query.select_related)
+
+        prefetch_lookups = _prefetch_lookup_names(qs)
+        # Heavy fan-outs stay skipped under lightweight=True.
+        self.assertNotIn("rows", prefetch_lookups)
+        self.assertNotIn("source_relationships", prefetch_lookups)
+        self.assertNotIn("target_relationships", prefetch_lookups)
+        self.assertNotIn("notes", prefetch_lookups)
+        # User-scoped guardian prefetches are kept so resolve_my_permissions
+        # doesn't fire 2 queries per row (see mixins.py:272-291).
+        self.assertIn("documentuserobjectpermission_set", prefetch_lookups)
 
     def test_non_lightweight_adds_prefetch(self):
         """lightweight=False (default) adds select_related and prefetch_related."""
@@ -582,6 +618,23 @@ class DocumentManagerVisibleToUserTest(TestCase):
         # select_related should include "creator" and "user_lock"
         self.assertIn("creator", qs.query.select_related)
         self.assertIn("user_lock", qs.query.select_related)
+
+    def test_lightweight_with_doc_label_annotations_prefetches_focused_set(self):
+        """
+        ``with_doc_label_annotations=True`` in lightweight mode adds a focused
+        ``doc_annotations`` prefetch (DOC_TYPE_LABEL only) so that
+        ``resolve_doc_annotations_optimized`` can pick it up via
+        ``_prefetched_doc_annotations`` instead of falling through to a
+        per-document optimizer call.
+        """
+        qs = Document.objects.visible_to_user(
+            self.viewer, lightweight=True, with_doc_label_annotations=True
+        )
+        prefetch_lookups = _prefetch_lookup_names(qs)
+        self.assertIn("doc_annotations", prefetch_lookups)
+        # Heavy fan-outs are still skipped.
+        self.assertNotIn("rows", prefetch_lookups)
+        self.assertNotIn("notes", prefetch_lookups)
 
     def test_none_user_treated_as_anonymous(self):
         """Passing user=None returns same results as AnonymousUser."""

--- a/opencontractserver/tests/test_get_document_knowledge_optimizations.py
+++ b/opencontractserver/tests/test_get_document_knowledge_optimizations.py
@@ -1,0 +1,210 @@
+"""
+Backend regression tests for the optimisations on
+``GetDocumentKnowledgeAndAnnotations``.
+
+These guard against silently re-introducing the per-row N+1 patterns the
+refactor in ``query_optimizer.py`` removed:
+
+* ``_compute_effective_permissions`` is meant to be cached on the GraphQL
+  request context — without that cache, every sibling resolver
+  (``allAnnotations`` + ``allRelationships`` + ``docAnnotations``) re-runs
+  its 10 ``user_has_permission_for_obj`` round-trips.
+* The parent ``Document``/``Corpus`` rows are also meant to be cached on
+  the context so the same row isn't re-fetched per resolver.
+* ``user_feedback`` is meant to be prefetched on the annotation queryset so
+  the connection resolver in
+  ``GetDocumentKnowledgeAndAnnotations`` doesn't fire ``count() + .all()``
+  per annotation.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from django.contrib.auth import get_user_model
+from django.db import connection
+from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
+
+from opencontractserver.annotations.models import Annotation, AnnotationLabel
+from opencontractserver.annotations.query_optimizer import AnnotationQueryOptimizer
+from opencontractserver.corpuses.models import Corpus
+from opencontractserver.documents.models import Document, DocumentPath
+from opencontractserver.feedback.models import UserFeedback
+from opencontractserver.types.enums import LabelType
+
+User = get_user_model()
+
+
+class _FakeContext(SimpleNamespace):
+    """Stand-in for ``info.context`` carrying only the fields we cache on."""
+
+
+def _superuser_request_context() -> _FakeContext:
+    """Return a fresh context with no caches initialised."""
+    return _FakeContext()
+
+
+class ComputeEffectivePermissionsCacheTests(TestCase):
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.owner = User.objects.create_superuser(
+            username="opt_owner", email="opt_owner@test.com", password="x"
+        )
+        cls.corpus = Corpus.objects.create(title="Optim Corpus", creator=cls.owner)
+        cls.document = Document.objects.create(
+            title="Optim Document", creator=cls.owner
+        )
+        DocumentPath.objects.create(
+            document=cls.document,
+            corpus=cls.corpus,
+            path="/doc.pdf",
+            is_current=True,
+            is_deleted=False,
+            version_number=1,
+            creator=cls.owner,
+        )
+
+    def test_permissions_cached_on_context(self) -> None:
+        ctx = _superuser_request_context()
+        first = AnnotationQueryOptimizer._compute_effective_permissions(
+            self.owner, self.document.pk, self.corpus.pk, context=ctx
+        )
+        cache = ctx._effective_perms_cache
+        self.assertIn((self.owner.pk, self.document.pk, self.corpus.pk), cache)
+
+        # The second call must consult the cache (same context, same key).
+        second = AnnotationQueryOptimizer._compute_effective_permissions(
+            self.owner, self.document.pk, self.corpus.pk, context=ctx
+        )
+        self.assertEqual(first, second)
+
+    def test_document_and_corpus_lookups_cached_on_context(self) -> None:
+        """
+        The Document/Corpus instance caches are meant to be primed by the
+        first ``_get_*_for_request`` call so subsequent calls avoid the
+        round-trip. With request-level caching the second invocation must
+        run zero queries.
+        """
+        ctx = _superuser_request_context()
+
+        with CaptureQueriesContext(connection) as queries_first:
+            AnnotationQueryOptimizer._get_document_for_request(
+                self.document.pk, ctx
+            )
+            AnnotationQueryOptimizer._get_corpus_for_request(self.corpus.pk, ctx)
+        self.assertGreater(len(queries_first), 0)
+
+        with CaptureQueriesContext(connection) as queries_second:
+            doc_again = AnnotationQueryOptimizer._get_document_for_request(
+                self.document.pk, ctx
+            )
+            corpus_again = AnnotationQueryOptimizer._get_corpus_for_request(
+                self.corpus.pk, ctx
+            )
+        self.assertEqual(len(queries_second), 0)
+        self.assertEqual(doc_again.pk, self.document.pk)
+        self.assertEqual(corpus_again.pk, self.corpus.pk)
+
+    def test_no_context_falls_through_without_crashing(self) -> None:
+        """``context=None`` must still work — the helper is callable from
+        non-GraphQL code paths."""
+        result = AnnotationQueryOptimizer._compute_effective_permissions(
+            self.owner, self.document.pk, self.corpus.pk, context=None
+        )
+        self.assertEqual(result, (True, True, True, True, True))
+
+
+class AnnotationFeedbackPrefetchTests(TestCase):
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.owner = User.objects.create_superuser(
+            username="fb_owner", email="fb_owner@test.com", password="x"
+        )
+        cls.corpus = Corpus.objects.create(title="FB Corpus", creator=cls.owner)
+        cls.document = Document.objects.create(title="FB Doc", creator=cls.owner)
+        DocumentPath.objects.create(
+            document=cls.document,
+            corpus=cls.corpus,
+            path="/fb.pdf",
+            is_current=True,
+            is_deleted=False,
+            version_number=1,
+            creator=cls.owner,
+        )
+        label = AnnotationLabel.objects.create(
+            text="Paragraph",
+            label_type=LabelType.TOKEN_LABEL,
+            creator=cls.owner,
+        )
+        # Fan out 10 annotations + 2 feedbacks each. The exact numbers don't
+        # matter; what matters is that resolving feedback should be a single
+        # batched ``IN (...)`` SELECT, not one per annotation.
+        cls.annotations: list[Annotation] = []
+        for index in range(10):
+            ann = Annotation.objects.create(
+                creator=cls.owner,
+                document=cls.document,
+                corpus=cls.corpus,
+                annotation_label=label,
+                page=1,
+                raw_text=f"text {index}",
+            )
+            cls.annotations.append(ann)
+            UserFeedback.objects.create(commented_annotation=ann, creator=cls.owner)
+            UserFeedback.objects.create(commented_annotation=ann, creator=cls.owner)
+
+    def test_user_feedback_is_prefetched(self) -> None:
+        """
+        Resolving ``user_feedback`` for every annotation must not fire a
+        separate query per row. ``QuerySet.prefetch_related("user_feedback")``
+        registered by the optimiser collapses every per-row access into one
+        batch SELECT. We verify by counting queries while iterating the full
+        result and accessing the prefetched cache.
+        """
+        qs = AnnotationQueryOptimizer.get_document_annotations(
+            document_id=self.document.pk,
+            user=self.owner,
+            corpus_id=self.corpus.pk,
+        )
+        with CaptureQueriesContext(connection) as captured:
+            results = list(qs)
+            for ann in results:
+                feedback_list = ann._prefetched_objects_cache["user_feedback"]
+                self.assertEqual(len(feedback_list), 2)
+
+        # Permitted: the annotation SELECT plus the related-table SELECTs
+        # (annotation_label/creator/analysis are select_related so no extra
+        # round trips, user_feedback is one batched IN SELECT). Allow some
+        # slack for the privacy filter subqueries against analyses/extracts.
+        # Critically: must NOT scale with len(results).
+        self.assertLess(
+            len(captured.captured_queries),
+            len(results),
+            f"Expected far fewer queries than annotations; got "
+            f"{len(captured.captured_queries)} queries for {len(results)} "
+            f"annotations — looks like the prefetch was dropped.",
+        )
+
+    def test_feedback_count_uses_prefetched_cache(self) -> None:
+        """
+        ``AnnotationType.resolve_feedback_count`` must consult the prefetched
+        ``user_feedback`` list rather than firing ``COUNT(*)`` per row.
+        """
+        from config.graphql.annotation_types import AnnotationType
+
+        qs = AnnotationQueryOptimizer.get_document_annotations(
+            document_id=self.document.pk,
+            user=self.owner,
+            corpus_id=self.corpus.pk,
+        )
+        results = list(qs)
+
+        with CaptureQueriesContext(connection) as captured:
+            counts = [
+                AnnotationType.resolve_feedback_count(ann, info=None)
+                for ann in results
+            ]
+        self.assertEqual(counts, [2] * len(results))
+        # Zero new queries — every count came from the prefetch cache.
+        self.assertEqual(len(captured.captured_queries), 0)

--- a/opencontractserver/tests/test_get_document_knowledge_optimizations.py
+++ b/opencontractserver/tests/test_get_document_knowledge_optimizations.py
@@ -32,8 +32,9 @@ from opencontractserver.corpuses.models import Corpus
 from opencontractserver.documents.models import Document, DocumentPath
 from opencontractserver.feedback.models import UserFeedback
 from opencontractserver.types.enums import LabelType
+from opencontractserver.users.models import User
 
-User = get_user_model()
+UserModel = get_user_model()
 
 
 class _FakeContext(SimpleNamespace):
@@ -46,9 +47,13 @@ def _superuser_request_context() -> _FakeContext:
 
 
 class ComputeEffectivePermissionsCacheTests(TestCase):
+    owner: User
+    corpus: Corpus
+    document: Document
+
     @classmethod
     def setUpTestData(cls) -> None:
-        cls.owner = User.objects.create_superuser(
+        cls.owner = UserModel.objects.create_superuser(
             username="opt_owner", email="opt_owner@test.com", password="x"
         )
         cls.corpus = Corpus.objects.create(title="Optim Corpus", creator=cls.owner)
@@ -89,9 +94,7 @@ class ComputeEffectivePermissionsCacheTests(TestCase):
         ctx = _superuser_request_context()
 
         with CaptureQueriesContext(connection) as queries_first:
-            AnnotationQueryOptimizer._get_document_for_request(
-                self.document.pk, ctx
-            )
+            AnnotationQueryOptimizer._get_document_for_request(self.document.pk, ctx)
             AnnotationQueryOptimizer._get_corpus_for_request(self.corpus.pk, ctx)
         self.assertGreater(len(queries_first), 0)
 
@@ -116,9 +119,14 @@ class ComputeEffectivePermissionsCacheTests(TestCase):
 
 
 class AnnotationFeedbackPrefetchTests(TestCase):
+    owner: User
+    corpus: Corpus
+    document: Document
+    annotations: list[Annotation]
+
     @classmethod
     def setUpTestData(cls) -> None:
-        cls.owner = User.objects.create_superuser(
+        cls.owner = UserModel.objects.create_superuser(
             username="fb_owner", email="fb_owner@test.com", password="x"
         )
         cls.corpus = Corpus.objects.create(title="FB Corpus", creator=cls.owner)
@@ -140,7 +148,7 @@ class AnnotationFeedbackPrefetchTests(TestCase):
         # Fan out 10 annotations + 2 feedbacks each. The exact numbers don't
         # matter; what matters is that resolving feedback should be a single
         # batched ``IN (...)`` SELECT, not one per annotation.
-        cls.annotations: list[Annotation] = []
+        cls.annotations = []
         for index in range(10):
             ann = Annotation.objects.create(
                 creator=cls.owner,
@@ -202,8 +210,7 @@ class AnnotationFeedbackPrefetchTests(TestCase):
 
         with CaptureQueriesContext(connection) as captured:
             counts = [
-                AnnotationType.resolve_feedback_count(ann, info=None)
-                for ann in results
+                AnnotationType.resolve_feedback_count(ann, info=None) for ann in results
             ]
         self.assertEqual(counts, [2] * len(results))
         # Zero new queries — every count came from the prefetch cache.

--- a/opencontractserver/tests/test_get_document_knowledge_optimizations.py
+++ b/opencontractserver/tests/test_get_document_knowledge_optimizations.py
@@ -178,7 +178,11 @@ class AnnotationFeedbackPrefetchTests(TestCase):
         with CaptureQueriesContext(connection) as captured:
             results = list(qs)
             for ann in results:
-                feedback_list = ann._prefetched_objects_cache["user_feedback"]
+                # Going through the public ``RelatedManager`` API exercises
+                # Django's prefetch dispatch — if the prefetch dropped, this
+                # would issue a fresh query per row instead of reading the
+                # cached list, which the query-count assertion below catches.
+                feedback_list = list(ann.user_feedback.all())
                 self.assertEqual(len(feedback_list), 2)
 
         # Permitted: the annotation SELECT plus the related-table SELECTs
@@ -214,4 +218,311 @@ class AnnotationFeedbackPrefetchTests(TestCase):
             ]
         self.assertEqual(counts, [2] * len(results))
         # Zero new queries — every count came from the prefetch cache.
+        self.assertEqual(len(captured.captured_queries), 0)
+
+
+class ComputeEffectivePermissionsBranchTests(TestCase):
+    """
+    Cover the non-superuser permission-resolution branches of
+    ``_compute_effective_permissions``. These branches drive the security
+    contract for anonymous and authenticated readers, so a regression here
+    silently widens or narrows access; codecov was hitting only the
+    superuser fast-path before this suite landed.
+    """
+
+    owner: User
+    public_doc: Document
+    private_doc: Document
+    public_corpus: Corpus
+    private_corpus: Corpus
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.owner = UserModel.objects.create_superuser(
+            username="branch_owner", email="branch_owner@test.com", password="x"
+        )
+        cls.public_doc = Document.objects.create(
+            title="Public Doc", creator=cls.owner, is_public=True
+        )
+        cls.private_doc = Document.objects.create(
+            title="Private Doc", creator=cls.owner, is_public=False
+        )
+        cls.public_corpus = Corpus.objects.create(
+            title="Public Corpus", creator=cls.owner, is_public=True
+        )
+        cls.private_corpus = Corpus.objects.create(
+            title="Private Corpus", creator=cls.owner, is_public=False
+        )
+
+    def test_anonymous_reads_public_doc_with_no_corpus(self) -> None:
+        from django.contrib.auth.models import AnonymousUser
+
+        result = AnnotationQueryOptimizer._compute_effective_permissions(
+            AnonymousUser(), self.public_doc.pk, None
+        )
+        self.assertEqual(result, (True, False, False, False, False))
+
+    def test_anonymous_blocked_on_private_doc(self) -> None:
+        from django.contrib.auth.models import AnonymousUser
+
+        result = AnnotationQueryOptimizer._compute_effective_permissions(
+            AnonymousUser(), self.private_doc.pk, None
+        )
+        self.assertEqual(result, (False, False, False, False, False))
+
+    def test_anonymous_blocked_when_corpus_is_private(self) -> None:
+        from django.contrib.auth.models import AnonymousUser
+
+        result = AnnotationQueryOptimizer._compute_effective_permissions(
+            AnonymousUser(), self.public_doc.pk, self.private_corpus.pk
+        )
+        self.assertEqual(result, (False, False, False, False, False))
+
+    def test_anonymous_reads_public_doc_in_public_corpus(self) -> None:
+        from django.contrib.auth.models import AnonymousUser
+
+        result = AnnotationQueryOptimizer._compute_effective_permissions(
+            AnonymousUser(), self.public_doc.pk, self.public_corpus.pk
+        )
+        self.assertEqual(result, (True, False, False, False, False))
+
+    def test_missing_document_denies_everything(self) -> None:
+        result = AnnotationQueryOptimizer._compute_effective_permissions(
+            self.owner, 9_999_999, None
+        )
+        # Superusers short-circuit before fetching, so use a non-superuser.
+        regular = UserModel.objects.create_user(
+            username="regular_branch", email="r@b.com", password="x"
+        )
+        result = AnnotationQueryOptimizer._compute_effective_permissions(
+            regular, 9_999_999, None
+        )
+        self.assertEqual(result, (False, False, False, False, False))
+
+    def test_authenticated_without_doc_read_is_denied(self) -> None:
+        """
+        A regular user without explicit permissions on a private document
+        must hit the ``not doc_read`` branch and be denied entirely.
+        """
+        regular = UserModel.objects.create_user(
+            username="regular_no_perm", email="r2@b.com", password="x"
+        )
+        result = AnnotationQueryOptimizer._compute_effective_permissions(
+            regular, self.private_doc.pk, None
+        )
+        self.assertEqual(result, (False, False, False, False, False))
+
+
+class GetDocumentAnnotationsBranchTests(TestCase):
+    """
+    Exercise the corpus-less and version-aware filter branches of
+    ``get_document_annotations``. These are silent if regressed (the wrong
+    set of annotations comes back) and aren't otherwise covered.
+    """
+
+    owner: User
+    corpus: Corpus
+    document: Document
+    structural_label: AnnotationLabel
+    user_label: AnnotationLabel
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.owner = UserModel.objects.create_superuser(
+            username="branch2_owner", email="b2@test.com", password="x"
+        )
+        cls.corpus = Corpus.objects.create(title="B2 Corpus", creator=cls.owner)
+        cls.document = Document.objects.create(title="B2 Doc", creator=cls.owner)
+        DocumentPath.objects.create(
+            document=cls.document,
+            corpus=cls.corpus,
+            path="/b2.pdf",
+            is_current=True,
+            is_deleted=False,
+            version_number=1,
+            creator=cls.owner,
+        )
+        cls.user_label = AnnotationLabel.objects.create(
+            text="User Para",
+            label_type=LabelType.TOKEN_LABEL,
+            creator=cls.owner,
+        )
+        cls.structural_label = AnnotationLabel.objects.create(
+            text="Heading",
+            label_type=LabelType.TOKEN_LABEL,
+            creator=cls.owner,
+        )
+        # One non-structural annotation.
+        Annotation.objects.create(
+            creator=cls.owner,
+            document=cls.document,
+            corpus=cls.corpus,
+            annotation_label=cls.user_label,
+            page=1,
+            raw_text="user text",
+            structural=False,
+        )
+        # One structural annotation.
+        Annotation.objects.create(
+            creator=cls.owner,
+            document=cls.document,
+            corpus=cls.corpus,
+            annotation_label=cls.structural_label,
+            page=1,
+            raw_text="structural text",
+            structural=True,
+        )
+
+    def test_corpus_less_call_returns_only_structural(self) -> None:
+        qs = AnnotationQueryOptimizer.get_document_annotations(
+            document_id=self.document.pk,
+            user=self.owner,
+            corpus_id=None,
+        )
+        results = list(qs)
+        self.assertTrue(all(ann.structural for ann in results))
+        self.assertGreaterEqual(len(results), 1)
+
+    def test_corpus_less_call_with_structural_false_returns_empty(self) -> None:
+        qs = AnnotationQueryOptimizer.get_document_annotations(
+            document_id=self.document.pk,
+            user=self.owner,
+            corpus_id=None,
+            structural=False,
+        )
+        self.assertEqual(qs.count(), 0)
+
+    def test_no_active_path_returns_empty(self) -> None:
+        """
+        When the document has no current, non-deleted ``DocumentPath`` in the
+        corpus, ``get_document_annotations`` must return an empty queryset
+        even though the user can read both objects.
+        """
+        ghost_doc = Document.objects.create(title="Ghost", creator=self.owner)
+        # No DocumentPath created — version-aware check should bail.
+        qs = AnnotationQueryOptimizer.get_document_annotations(
+            document_id=ghost_doc.pk,
+            user=self.owner,
+            corpus_id=self.corpus.pk,
+        )
+        self.assertEqual(qs.count(), 0)
+
+
+class GetAnnotationsForPathTests(TestCase):
+    """
+    Cover ``get_annotations_for_path`` — the corpus-scoped path lookup.
+    The unhappy paths (missing path, specific version) are not exercised
+    elsewhere.
+    """
+
+    owner: User
+    corpus: Corpus
+    document: Document
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.owner = UserModel.objects.create_superuser(
+            username="path_owner", email="p@test.com", password="x"
+        )
+        cls.corpus = Corpus.objects.create(title="Path Corpus", creator=cls.owner)
+        cls.document = Document.objects.create(title="Path Doc", creator=cls.owner)
+        DocumentPath.objects.create(
+            document=cls.document,
+            corpus=cls.corpus,
+            path="/contracts/active.pdf",
+            is_current=True,
+            is_deleted=False,
+            version_number=2,
+            creator=cls.owner,
+        )
+
+    def test_resolves_current_version(self) -> None:
+        qs = AnnotationQueryOptimizer.get_annotations_for_path(
+            corpus_id=self.corpus.pk,
+            path="/contracts/active.pdf",
+            user=self.owner,
+        )
+        # Returns a queryset (no annotations on this doc but the call must
+        # not raise and must return ``.none()``-compatible queryset).
+        self.assertEqual(qs.count(), 0)
+
+    def test_returns_empty_for_unknown_path(self) -> None:
+        qs = AnnotationQueryOptimizer.get_annotations_for_path(
+            corpus_id=self.corpus.pk,
+            path="/contracts/missing.pdf",
+            user=self.owner,
+        )
+        self.assertEqual(qs.count(), 0)
+
+    def test_returns_empty_when_specific_version_missing(self) -> None:
+        qs = AnnotationQueryOptimizer.get_annotations_for_path(
+            corpus_id=self.corpus.pk,
+            path="/contracts/active.pdf",
+            user=self.owner,
+            version=99,
+        )
+        self.assertEqual(qs.count(), 0)
+
+
+class RequestCachedFetcherTests(TestCase):
+    """
+    Direct coverage for ``_get_document_for_request`` and
+    ``_get_corpus_for_request`` — including the ``DoesNotExist`` paths and
+    the ``context=None`` fallback that ``_compute_effective_permissions``
+    doesn't otherwise reach.
+    """
+
+    owner: User
+    document: Document
+    corpus: Corpus
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.owner = UserModel.objects.create_superuser(
+            username="cache_owner", email="c@test.com", password="x"
+        )
+        cls.document = Document.objects.create(title="Cache Doc", creator=cls.owner)
+        cls.corpus = Corpus.objects.create(title="Cache Corpus", creator=cls.owner)
+
+    def test_get_document_with_no_context_returns_instance(self) -> None:
+        instance = AnnotationQueryOptimizer._get_document_for_request(
+            self.document.pk, None
+        )
+        self.assertIsNotNone(instance)
+        self.assertEqual(instance.pk, self.document.pk)
+
+    def test_get_document_with_no_context_returns_none_for_missing(self) -> None:
+        self.assertIsNone(
+            AnnotationQueryOptimizer._get_document_for_request(9_999_999, None)
+        )
+
+    def test_get_corpus_with_no_context_returns_instance(self) -> None:
+        instance = AnnotationQueryOptimizer._get_corpus_for_request(
+            self.corpus.pk, None
+        )
+        self.assertIsNotNone(instance)
+        self.assertEqual(instance.pk, self.corpus.pk)
+
+    def test_get_corpus_with_no_context_returns_none_for_missing(self) -> None:
+        self.assertIsNone(
+            AnnotationQueryOptimizer._get_corpus_for_request(9_999_999, None)
+        )
+
+    def test_missing_document_caches_none_for_subsequent_calls(self) -> None:
+        ctx = SimpleNamespace()
+        first = AnnotationQueryOptimizer._get_document_for_request(9_999_999, ctx)
+        self.assertIsNone(first)
+        # Second call must hit the cache (zero queries).
+        with CaptureQueriesContext(connection) as captured:
+            second = AnnotationQueryOptimizer._get_document_for_request(9_999_999, ctx)
+        self.assertIsNone(second)
+        self.assertEqual(len(captured.captured_queries), 0)
+
+    def test_missing_corpus_caches_none_for_subsequent_calls(self) -> None:
+        ctx = SimpleNamespace()
+        first = AnnotationQueryOptimizer._get_corpus_for_request(9_999_999, ctx)
+        self.assertIsNone(first)
+        with CaptureQueriesContext(connection) as captured:
+            second = AnnotationQueryOptimizer._get_corpus_for_request(9_999_999, ctx)
+        self.assertIsNone(second)
         self.assertEqual(len(captured.captured_queries), 0)

--- a/opencontractserver/tests/test_requests_doc_label_annotations.py
+++ b/opencontractserver/tests/test_requests_doc_label_annotations.py
@@ -13,9 +13,11 @@ coverage.
 from __future__ import annotations
 
 from types import SimpleNamespace
+from typing import cast
 
 from django.test import SimpleTestCase
 from graphql import parse
+from graphql.language.ast import FragmentDefinitionNode, OperationDefinitionNode
 
 from config.graphql.custom_resolvers import requests_doc_label_annotations
 
@@ -27,10 +29,10 @@ def _info_for(query: str, variables: dict | None = None) -> SimpleNamespace:
     ``field_nodes``, ``fragments``, and ``variable_values``.
     """
     document = parse(query)
-    operation = document.definitions[0]
+    operation = cast(OperationDefinitionNode, document.definitions[0])
     documents_field = operation.selection_set.selections[0]
     fragments = {
-        d.name.value: d
+        cast(FragmentDefinitionNode, d).name.value: d
         for d in document.definitions
         if d.kind == "fragment_definition"
     }
@@ -44,8 +46,7 @@ def _info_for(query: str, variables: dict | None = None) -> SimpleNamespace:
 class RequestsDocLabelAnnotationsTests(SimpleTestCase):
     def test_returns_true_for_get_documents_with_annotate_doc_labels(self) -> None:
         """The corpus list view (``GET_DOCUMENTS`` with the badge alias)."""
-        info = _info_for(
-            """
+        info = _info_for("""
             query {
               documents {
                 edges {
@@ -60,8 +61,7 @@ class RequestsDocLabelAnnotationsTests(SimpleTestCase):
                 }
               }
             }
-            """
-        )
+            """)
         self.assertTrue(requests_doc_label_annotations(info))
 
     def test_returns_true_when_label_type_is_a_variable(self) -> None:
@@ -85,18 +85,15 @@ class RequestsDocLabelAnnotationsTests(SimpleTestCase):
         self.assertTrue(requests_doc_label_annotations(info))
 
     def test_returns_false_when_doc_annotations_omitted(self) -> None:
-        info = _info_for(
-            """
+        info = _info_for("""
             query {
               documents { edges { node { id title } } }
             }
-            """
-        )
+            """)
         self.assertFalse(requests_doc_label_annotations(info))
 
     def test_returns_false_for_unrelated_label_type(self) -> None:
-        info = _info_for(
-            """
+        info = _info_for("""
             query {
               documents {
                 edges {
@@ -108,14 +105,12 @@ class RequestsDocLabelAnnotationsTests(SimpleTestCase):
                 }
               }
             }
-            """
-        )
+            """)
         self.assertFalse(requests_doc_label_annotations(info))
 
     def test_traverses_fragment_spreads(self) -> None:
         """Selection-set walk must follow fragment spreads."""
-        info = _info_for(
-            """
+        info = _info_for("""
             query {
               documents {
                 edges {
@@ -130,6 +125,5 @@ class RequestsDocLabelAnnotationsTests(SimpleTestCase):
                 edges { node { id } }
               }
             }
-            """
-        )
+            """)
         self.assertTrue(requests_doc_label_annotations(info))

--- a/opencontractserver/tests/test_requests_doc_label_annotations.py
+++ b/opencontractserver/tests/test_requests_doc_label_annotations.py
@@ -1,0 +1,135 @@
+"""
+Unit tests for ``requests_doc_label_annotations``.
+
+This helper drives the focused doc-label prefetch in
+``resolve_documents`` (config/graphql/document_queries.py). A regression
+here either re-enables the per-document N+1 in
+``resolve_doc_annotations_optimized`` (false negative) or applies the
+focused prefetch to queries that don't ask for the badge (false positive,
+unnecessary JOIN). Both are silent in production, so they need direct
+coverage.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from django.test import SimpleTestCase
+from graphql import parse
+
+from config.graphql.custom_resolvers import requests_doc_label_annotations
+
+
+def _info_for(query: str, variables: dict | None = None) -> SimpleNamespace:
+    """
+    Build a minimal stand-in for ``graphene.ResolveInfo`` carrying the
+    fields ``requests_doc_label_annotations`` actually inspects:
+    ``field_nodes``, ``fragments``, and ``variable_values``.
+    """
+    document = parse(query)
+    operation = document.definitions[0]
+    documents_field = operation.selection_set.selections[0]
+    fragments = {
+        d.name.value: d
+        for d in document.definitions
+        if d.kind == "fragment_definition"
+    }
+    return SimpleNamespace(
+        field_nodes=[documents_field],
+        fragments=fragments,
+        variable_values=variables or {},
+    )
+
+
+class RequestsDocLabelAnnotationsTests(SimpleTestCase):
+    def test_returns_true_for_get_documents_with_annotate_doc_labels(self) -> None:
+        """The corpus list view (``GET_DOCUMENTS`` with the badge alias)."""
+        info = _info_for(
+            """
+            query {
+              documents {
+                edges {
+                  node {
+                    id
+                    doc_label_annotations: docAnnotations(
+                      annotationLabel_LabelType: "DOC_TYPE_LABEL"
+                    ) {
+                      edges { node { id } }
+                    }
+                  }
+                }
+              }
+            }
+            """
+        )
+        self.assertTrue(requests_doc_label_annotations(info))
+
+    def test_returns_true_when_label_type_is_a_variable(self) -> None:
+        """The argument may be supplied as an operation variable."""
+        info = _info_for(
+            """
+            query ($lt: String!) {
+              documents {
+                edges {
+                  node {
+                    docAnnotations(annotationLabel_LabelType: $lt) {
+                      edges { node { id } }
+                    }
+                  }
+                }
+              }
+            }
+            """,
+            variables={"lt": "DOC_TYPE_LABEL"},
+        )
+        self.assertTrue(requests_doc_label_annotations(info))
+
+    def test_returns_false_when_doc_annotations_omitted(self) -> None:
+        info = _info_for(
+            """
+            query {
+              documents { edges { node { id title } } }
+            }
+            """
+        )
+        self.assertFalse(requests_doc_label_annotations(info))
+
+    def test_returns_false_for_unrelated_label_type(self) -> None:
+        info = _info_for(
+            """
+            query {
+              documents {
+                edges {
+                  node {
+                    docAnnotations(annotationLabel_LabelType: "TOKEN_LABEL") {
+                      edges { node { id } }
+                    }
+                  }
+                }
+              }
+            }
+            """
+        )
+        self.assertFalse(requests_doc_label_annotations(info))
+
+    def test_traverses_fragment_spreads(self) -> None:
+        """Selection-set walk must follow fragment spreads."""
+        info = _info_for(
+            """
+            query {
+              documents {
+                edges {
+                  node {
+                    ...DocFields
+                  }
+                }
+              }
+            }
+            fragment DocFields on DocumentType {
+              docAnnotations(annotationLabel_LabelType: "DOC_TYPE_LABEL") {
+                edges { node { id } }
+              }
+            }
+            """
+        )
+        self.assertTrue(requests_doc_label_annotations(info))


### PR DESCRIPTION
## Summary
- `CorpusDocumentCards` syncs document IDs and loading state into Apollo reactive vars (`currentViewDocumentIds`, `documentsLoading`) so the parent `FolderDocumentBrowser` toolbar can react to them.
- Both effects used a cleanup-then-set pattern (\`return () => var([])\` plus body \`var(next)\`), so every dep change wrote to the var **twice** (cleanup → reset, then body → new value).
- `FolderDocumentBrowser` subscribes to both vars via `useReactiveVar`, so each write re-rendered it; that re-rendered the child; and with any reference-unstable upstream state this snowballed into the production-only infinite reload loop reported on the corpus document view (docs flash → reload → repeat).
- The merged fix in #1512 stabilized the dep, which kept the loop bounded for many cases, but the cleanup-then-set still produced two notifications and two parent re-renders per actual ID change — visible as "fires twice", and still loop-prone whenever a parent re-render perturbs upstream identity.

## Changes
- Split unmount-only resets into their own `useEffect(_, [])` — cleanup no longer runs on every dep change.
- Gate writes on equality: only call the setter when the new array / loading flag actually differs from the current var value.

## Test plan
- [ ] `yarn tsc --noEmit` (passed locally)
- [ ] Open a corpus document view in production-style build; confirm `GET_DOCUMENTS` fires once per nav, not in a loop.
- [ ] Toggle a folder, change search/filter; confirm `currentViewDocumentIds` notifies once per actual change (DevTools React profiler).
- [ ] Toolbar Select All / loading indicator still behave correctly.