### PR TITLE
Fix discovery search FieldError and prune dead Dependabot entry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,14 +23,6 @@ updates:
 
   # Enable version updates for Docker
   - package-ecosystem: "docker"
-    # Look for a `Dockerfile` in the `compose/local/node` directory
-    directory: "compose/local/node/"
-    # Check for updates to GitHub Actions every weekday
-    schedule:
-      interval: "daily"
-
-  # Enable version updates for Docker
-  - package-ecosystem: "docker"
     # Look for a `Dockerfile` in the `compose/production/django` directory
     directory: "compose/production/django/"
     # Check for updates to GitHub Actions every weekday

--- a/opencontractserver/discovery/views.py
+++ b/opencontractserver/discovery/views.py
@@ -851,6 +851,10 @@ def _search_global(query: str, limit: int, user) -> JsonResponse:
         public_corpus_ids = Corpus.objects.visible_to_user(user).values_list(
             "id", flat=True
         )
+        # Don't chain ``.only(...)``: DocumentManager unconditionally
+        # ``select_related``s creator/user_lock/parent (cheap JOINs that
+        # GraphQL list views need), which makes deferring those FK columns
+        # raise FieldError.
         matching_docs = list(
             Document.objects.visible_to_user(user, lightweight=True)
             .filter(
@@ -859,7 +863,6 @@ def _search_global(query: str, limit: int, user) -> JsonResponse:
                 path_records__is_deleted=False,
             )
             .filter(Q(title__icontains=query) | Q(description__icontains=query))
-            .only("slug", "title", "description", "modified")
             .distinct()
             .order_by("-modified")[:doc_limit]
         )


### PR DESCRIPTION
## Summary
- Backend CI on main (3715dc82b, run [25320809661](https://github.com/Open-Source-Legal/OpenContracts/actions/runs/25320809661)) was failing 10 `SearchApiTest` tests with `Field Document.parent cannot be both deferred and traversed using select_related at the same time.` — caused by `_search_global` chaining `.only("slug", "title", "description", "modified")` after `Document.objects.visible_to_user(user, lightweight=True)`, which since 85e7156d7 unconditionally `select_related`s `creator`/`user_lock`/`parent` to keep GraphQL list views off the N+1 path. Drop the `.only(...)` — search is bounded by `MAX_SEARCH_RESULTS`, so the column-trim micro-opt is negligible vs. the now-unavoidable JOINs.
- Dependabot Docker updater was failing daily because `.github/dependabot.yml` still referenced `compose/local/node/`, which has been deleted. Remove the dead entry.

## Test plan
- [x] `docker compose -f test.yml run --rm django pytest opencontractserver/discovery/tests/test_discovery_views.py` — 56 passed (was 10 failing).
- [x] `docker compose -f test.yml run --rm django pytest opencontractserver/tests/permissioning/test_permissioned_querysets.py` — 32 passed; confirms the manager-level lightweight contract still holds.
- [ ] Backend CI green on this branch.