### PR TITLE
typing: graduate opencontractserver.utils.* chunk 1 from mypy baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Type-checking: graduated `opencontractserver.utils.*` chunk 1 from mypy baseline** (issue #1480, sub-issue of #1447). Removed `[mypy-…]` ignore blocks for `utils.analysis`, `utils.analyzer`, `utils.cleanup`, `utils.corpus_forking`, `utils.embeddings`, and `utils.etl` and fixed all surfaced errors. Notable production fixes uncovered by typing:
+    - `opencontractserver/utils/cleanup.py:34` — `delete_analysis_and_annotations` was calling `Analysis.annotations.filter(...)` on the class-level reverse descriptor (would fail at runtime with `AttributeError`); now correctly uses `analysis.annotations.all().delete()`.
+    - `opencontractserver/utils/analyzer.py:204` — `run_analysis` now raises `ValueError` early when `analyzer.host_gremlin` is `None` instead of crashing on `gremlin.url` later.
+    - `opencontractserver/utils/analyzer.py:272` — Submission-response logging used `f"{submission_response.content}"` which produced `b'…'` rather than the response body; switched to `!r` for safe bytes formatting.
+    - `opencontractserver/utils/analyzer.py:install_analyzers` and `opencontractserver/tasks/analyzer_tasks.py:install_analyzer_task` — return type corrected from `list[int]` to `list[str]` (Analyzer PKs are CharField).
+    - `opencontractserver/utils/embeddings.py` — `get_embedder` / `aget_embedder` parameter and return types now reflect that any of `corpus_id`, `mimetype_or_enum`, `embedder_class`, and `embedder_path` may be `None`. Removed an outdated `# type: ignore[attr-defined]` on `embed_text`.
+    - `opencontractserver/utils/etl.py:404` — Renamed inner PDF-burn-in loop variable from `page` to `pdf_page` so it no longer collides with the `PageAnnotationData` `page` from `iter_page_annotations`. Color tuple is now an explicit `tuple[float, float, float]` instead of variable-length.
+- Pruned 52 corresponding lines from `docs/typing/mypy_baseline.txt`.
+
 ### Fixed
 
 - **`PipelineSettings.get_parser_kwargs` now merges encrypted secrets** (`opencontractserver/documents/models.py:1260`, issue #1515). The runtime path that resolves parser configuration in `opencontractserver/tasks/doc_tasks.py:424` previously returned only `parser_kwargs[parser_class_path]` and silently dropped any secret stored under `encrypted_secrets[parser_class_path]`. Parsers like `LlamaParseParser` whose API key lives only in `encrypted_secrets` (the documented secure location) were invoked with an empty `api_key=""` placeholder and failed with `"LlamaParse API key not configured"`. Fix: `get_parser_kwargs` now overlays decrypted `encrypted_secrets[parser_class_path]` on top of `parser_kwargs[parser_class_path]`, with secrets winning on key collision. Operators may keep `parser_kwargs.api_key = ""` as a schema marker without clobbering the real secret. The merged dict is built fresh on every call so a long-lived `PipelineSettings` reference does not retain decrypted secrets in memory. Regression tests in `opencontractserver/tests/test_pipeline_settings.py` cover merge, secret-wins, secret-only, no-mutation, and log-redaction.

--- a/docs/typing/mypy_baseline.txt
+++ b/docs/typing/mypy_baseline.txt
@@ -6705,58 +6705,6 @@ opencontractserver/tests/websocket/test_unified_agent_consumer.py:752: error: Ca
 opencontractserver/tests/websocket/test_unified_agent_consumer.py:785: error: Cannot assign to a method  [method-assign]
 opencontractserver/tests/websocket/test_unified_agent_consumer.py:790: error: Cannot assign to a method  [method-assign]
 opencontractserver/users/tasks.py:5: error: Library stubs not installed for "requests"  [import-untyped]
-opencontractserver/utils/analysis.py:44: error: Argument 2 to "set_permissions_for_obj_to_user" has incompatible type "Analysis"; expected "type[Model]"  [arg-type]
-opencontractserver/utils/analyzer.py:134: error: Argument 2 to "set_permissions_for_obj_to_user" has incompatible type "AnnotationLabel"; expected "type[Model]"  [arg-type]
-opencontractserver/utils/analyzer.py:142: error: Incompatible return value type (got "dict[str, int]", expected "dict[str | int, str | int]")  [return-value]
-opencontractserver/utils/analyzer.py:142: note: Perhaps you need a type annotation for "label_id_map"? Suggestion: "dict[str | int, str | int]"
-opencontractserver/utils/analyzer.py:178: error: Argument "creating_user_id" to "install_labels_for_analyzer" has incompatible type "int"; expected "str"  [arg-type]
-opencontractserver/utils/analyzer.py:186: error: Incompatible return value type (got "list[str]", expected "list[int]")  [return-value]
-opencontractserver/utils/analyzer.py:267: error: Item "None" of "GremlinEngine | None" has no attribute "url"  [union-attr]
-opencontractserver/utils/analyzer.py:270: error: Item "None" of "GremlinEngine | None" has no attribute "url"  [union-attr]
-opencontractserver/utils/analyzer.py:280: error: Item "None" of "GremlinEngine | None" has no attribute "url"  [union-attr]
-opencontractserver/utils/analyzer.py:310: error: Argument "creating_user_id" to "install_labels_for_analyzer" has incompatible type "str | int"; expected "str"  [arg-type]
-opencontractserver/utils/analyzer.py:327: error: Unsupported left operand type for + ("None")  [operator]
-opencontractserver/utils/analyzer.py:327: note: Left operand is of type "str | None"
-opencontractserver/utils/analyzer.py:328: error: Argument 1 to "len" has incompatible type "str | None"; expected "Sized"  [arg-type]
-opencontractserver/utils/analyzer.py:366: error: Unsupported left operand type for + ("None")  [operator]
-opencontractserver/utils/analyzer.py:366: note: Left operand is of type "str | None"
-opencontractserver/utils/analyzer.py:367: error: Argument 1 to "len" has incompatible type "str | None"; expected "Sized"  [arg-type]
-opencontractserver/utils/analyzer.py:6: error: Library stubs not installed for "requests"  [import-untyped]
-opencontractserver/utils/analyzer.py:93: error: Argument 2 to "set_permissions_for_obj_to_user" has incompatible type "LabelSet"; expected "type[Model]"  [arg-type]
-opencontractserver/utils/cleanup.py:34: error: "ReverseManyToOneDescriptor[Annotation]" has no attribute "filter"  [attr-defined]
-opencontractserver/utils/corpus_forking.py:12: error: Variable "opencontractserver.utils.corpus_forking.User" is not valid as a type  [valid-type]
-opencontractserver/utils/corpus_forking.py:12: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases
-opencontractserver/utils/corpus_forking.py:59: error: User? has no attribute "id"  [attr-defined]
-opencontractserver/utils/embeddings.py:127: error: Incompatible return value type (got "tuple[type | None, str | None]", expected "tuple[type[BaseEmbedder], str]")  [return-value]
-opencontractserver/utils/embeddings.py:14: error: Incompatible default for parameter "corpus_id" (default has type "None", parameter has type "int | str")  [assignment]
-opencontractserver/utils/embeddings.py:14: note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True
-opencontractserver/utils/embeddings.py:14: note: Use https://github.com/hauntsaninja/no_implicit_optional to automatically upgrade your codebase
-opencontractserver/utils/embeddings.py:158: error: Argument "mimetype_or_enum" to "get_embedder" has incompatible type "str | FileTypeEnum | None"; expected "str | FileTypeEnum"  [arg-type]
-opencontractserver/utils/embeddings.py:158: error: Argument 1 to "get_embedder" has incompatible type "int | None"; expected "int | str"  [arg-type]
-opencontractserver/utils/embeddings.py:15: error: Incompatible default for parameter "mimetype_or_enum" (default has type "None", parameter has type "str | FileTypeEnum")  [assignment]
-opencontractserver/utils/embeddings.py:15: note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True
-opencontractserver/utils/embeddings.py:15: note: Use https://github.com/hauntsaninja/no_implicit_optional to automatically upgrade your codebase
-opencontractserver/utils/embeddings.py:171: error: Unused "type: ignore" comment  [unused-ignore]
-opencontractserver/utils/etl.py:193: error: Incompatible types (expression has type "dict[str, dict[str, Any | str]]", TypedDict item "text_labels" has type "dict[str | int, AnnotationLabelPythonType]")  [typeddict-item]
-opencontractserver/utils/etl.py:194: error: Incompatible types (expression has type "dict[str, dict[str, Any | str]]", TypedDict item "doc_labels" has type "dict[str | int, AnnotationLabelPythonType]")  [typeddict-item]
-opencontractserver/utils/etl.py:231: error: Incompatible types in assignment (expression has type "str | None", variable has type "str")  [assignment]
-opencontractserver/utils/etl.py:231: error: Value of type variable "AnyOrLiteralStr" of "basename" cannot be "str | None"  [type-var]
-opencontractserver/utils/etl.py:242: error: Argument 1 to "open" of "Storage" has incompatible type "str | None"; expected "str"  [arg-type]
-opencontractserver/utils/etl.py:249: error: Argument 1 to "open" of "Storage" has incompatible type "str | None"; expected "str"  [arg-type]
-opencontractserver/utils/etl.py:250: error: Incompatible types in assignment (expression has type "list[dict[str, Any]]", variable has type "list[PawlsPagePythonType]")  [assignment]
-opencontractserver/utils/etl.py:305: error: Incompatible types (expression has type "str | None", TypedDict item "title" has type "str")  [typeddict-item]
-opencontractserver/utils/etl.py:313: error: Need type annotation for "page_highlights" (hint: "page_highlights: dict[<type>, <type>] = ...")  [var-annotated]
-opencontractserver/utils/etl.py:374: error: Value of "labelled_text" has incompatible type "list[dict[str, Any]]"; expected "list[OpenContractsAnnotationPythonType]"  [typeddict-item]
-opencontractserver/utils/etl.py:398: error: Incompatible types in assignment (expression has type "PageObject", variable has type "PageAnnotationData")  [assignment]
-opencontractserver/utils/etl.py:399: error: "PageAnnotationData" has no attribute "mediabox"  [attr-defined]
-opencontractserver/utils/etl.py:424: error: Argument "color" to "createHighlight" has incompatible type "tuple[float, ...]"; expected "tuple[float, float, float]"  [arg-type]
-opencontractserver/utils/etl.py:433: error: Argument 1 to "add_page" of "PdfWriter" has incompatible type "PageAnnotationData"; expected "PageObject"  [arg-type]
-opencontractserver/utils/etl.py:462: error: Variable "typing.TypedDict" is not valid as a type  [valid-type]
-opencontractserver/utils/etl.py:462: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases
-opencontractserver/utils/etl.py:587: error: No overload variant of "create_model" matches argument types "str", "dict[str, tuple[type, EllipsisType]]"  [call-overload]
-opencontractserver/utils/etl.py:587: note:     def [ModelT: BaseModel] create_model(str, /, *, __config__: ConfigDict | None = ..., __doc__: str | None = ..., __base__: type[ModelT] | tuple[type[ModelT], ...], __module__: str = ..., __validators__: dict[str, Callable[..., Any]] | None = ..., __cls_kwargs__: dict[str, Any] | None = ..., __qualname__: str | None = ..., **field_definitions: Any | tuple[Any, Any]) -> type[ModelT]
-opencontractserver/utils/etl.py:587: note:     def create_model(str, /, *, __config__: ConfigDict | None = ..., __doc__: str | None = ..., __base__: None = ..., __module__: str = ..., __validators__: dict[str, Callable[..., Any]] | None = ..., __cls_kwargs__: dict[str, Any] | None = ..., __qualname__: str | None = ..., **field_definitions: Any | tuple[Any, Any]) -> type[BaseModel]
-opencontractserver/utils/etl.py:587: note: Possible overload variants:
 opencontractserver/utils/export_v2.py:112: error: Incompatible return value type (got "dict[str, Any]", expected "StructuralAnnotationSetExport | None")  [return-value]
 opencontractserver/utils/export_v2.py:184: error: Incompatible return value type (got "list[dict[str, Any]]", expected "list[CorpusFolderExport]")  [return-value]
 opencontractserver/utils/export_v2.py:229: error: Incompatible types in assignment (expression has type "str | None", variable has type "str")  [assignment]

--- a/mypy.ini
+++ b/mypy.ini
@@ -923,25 +923,7 @@ disable_error_code = django-manager-missing
 [mypy-opencontractserver.documents.models]
 disable_error_code = django-manager-missing
 
-# --- opencontractserver.utils (18 files) ---
-
-[mypy-opencontractserver.utils.analysis]
-ignore_errors = True
-
-[mypy-opencontractserver.utils.analyzer]
-ignore_errors = True
-
-[mypy-opencontractserver.utils.cleanup]
-ignore_errors = True
-
-[mypy-opencontractserver.utils.corpus_forking]
-ignore_errors = True
-
-[mypy-opencontractserver.utils.embeddings]
-ignore_errors = True
-
-[mypy-opencontractserver.utils.etl]
-ignore_errors = True
+# --- opencontractserver.utils (12 files) ---
 
 [mypy-opencontractserver.utils.export_v2]
 ignore_errors = True

--- a/opencontractserver/tasks/analyzer_tasks.py
+++ b/opencontractserver/tasks/analyzer_tasks.py
@@ -74,7 +74,7 @@ def request_gremlin_manifest(gremlin_id: str | int) -> list[AnalyzerManifest]:
 def install_analyzer_task(
     analyzer_manifests: list[AnalyzerManifest],
     gremlin_id: int,
-) -> list[int]:
+) -> list[str]:
     # logger.info(f"install_analyzer_task() - analyzer_manifests: {analyzer_manifests}")
 
     gremlin = GremlinEngine.objects.get(id=gremlin_id)

--- a/opencontractserver/utils/analyzer.py
+++ b/opencontractserver/utils/analyzer.py
@@ -46,12 +46,12 @@ def get_django_file_field_url(
 
 def install_labels_for_analyzer(
     analyzer_id: int | str,
-    creating_user_id: str,
+    creating_user_id: str | int,
     doc_labels: list[AnnotationLabelPythonType],
     text_labels: list[AnnotationLabelPythonType],
     label_set: OpenContractsLabelSetType,
     install_label_set: bool | None = None,
-) -> dict[str | int, str | int]:
+) -> dict[str, int]:
     """
     When an analysis is run, we need to have labels in the local OpenContracts database to link to
     the annotations. This utility will, given a Gremlin analyzers label metadata, check to see if they exist,
@@ -106,7 +106,7 @@ def install_labels_for_analyzer(
     combined_labels: list[AnnotationLabelPythonType] = [*doc_labels, *text_labels]
 
     # We need to be able to map the local label ids to the ids in the analyzer
-    label_id_map = {}
+    label_id_map: dict[str, int] = {}
 
     for label_data in combined_labels:
 
@@ -144,7 +144,7 @@ def install_labels_for_analyzer(
 
 def install_analyzers(
     gremlin_id: int, analyzer_manifests: list[AnalyzerManifest]
-) -> list[int]:
+) -> list[str]:
     """
     When setting up a new Gremlin Engine, this task will be used to ping the engine
     for a manifest of its installed analyzers and then create database entries for these
@@ -202,6 +202,10 @@ def run_analysis(
     analysis = Analysis.objects.get(id=analysis_id)
     analyzer = analysis.analyzer
     gremlin = analyzer.host_gremlin
+    if gremlin is None:
+        raise ValueError(
+            f"run_analysis() - analyzer {analyzer.id} has no host_gremlin configured"
+        )
 
     # If we're analyzing an entire corpus and we didn't override docs
     if analysis.analyzed_corpus and (
@@ -270,7 +274,7 @@ def run_analysis(
         logger.info(f"Post job to: {gremlin.url}/api/jobs/submit")
         logger.info(
             f"submit_corpus_documents_to_analyzer() - submission response {submission_response} "
-            f"{submission_response.content}"
+            f"{submission_response.content!r}"
         )
 
         with transaction.atomic():
@@ -324,9 +328,7 @@ def import_annotations_from_analysis(
 
         with transaction.atomic():
             analysis.import_log = (
-                analysis.import_log + "\n" + message
-                if (analysis and len(analysis.import_log) > 0)
-                else message
+                analysis.import_log + "\n" + message if analysis.import_log else message
             )
             analysis.save()
 
@@ -364,7 +366,7 @@ def import_annotations_from_analysis(
                 with transaction.atomic():
                     analysis.import_log = (
                         analysis.import_log + "\n" + message
-                        if len(analysis.import_log) > 0
+                        if analysis.import_log
                         else message
                     )
                     analysis.save()

--- a/opencontractserver/utils/cleanup.py
+++ b/opencontractserver/utils/cleanup.py
@@ -31,7 +31,7 @@ def delete_analysis_and_annotations(analysis_pk: str | int = -1) -> bool:
         with transaction.atomic():
 
             # Bulk update actual annotations
-            Analysis.annotations.filter(analysis_id=analysis_pk).delete()
+            analysis.annotations.all().delete()
             analysis.delete()
 
     except Exception as e:

--- a/opencontractserver/utils/corpus_forking.py
+++ b/opencontractserver/utils/corpus_forking.py
@@ -1,4 +1,4 @@
-from django.contrib.auth import get_user_model
+from typing import TYPE_CHECKING
 
 from opencontractserver.corpuses.models import Corpus
 from opencontractserver.tasks import fork_corpus
@@ -6,10 +6,11 @@ from opencontractserver.types.enums import PermissionTypes
 from opencontractserver.utils.corpus_collector import collect_corpus_objects
 from opencontractserver.utils.permissioning import set_permissions_for_obj_to_user
 
-User = get_user_model()
+if TYPE_CHECKING:
+    from opencontractserver.users.models import User
 
 
-def build_fork_corpus_task(corpus_pk_to_fork: str, user: User):
+def build_fork_corpus_task(corpus_pk_to_fork: str, user: "User"):
     """
     Build a Celery task to fork a corpus.
 

--- a/opencontractserver/utils/embeddings.py
+++ b/opencontractserver/utils/embeddings.py
@@ -11,10 +11,10 @@ logger.setLevel(logging.DEBUG)
 
 
 def get_embedder(
-    corpus_id: int | str = None,
-    mimetype_or_enum: Union[str, FileTypeEnum] = None,
+    corpus_id: Optional[Union[int, str]] = None,
+    mimetype_or_enum: Optional[Union[str, FileTypeEnum]] = None,
     embedder_path: Optional[str] = None,
-) -> tuple[type[BaseEmbedder], str]:
+) -> tuple[Optional[type[BaseEmbedder]], Optional[str]]:
     """
     Get the appropriate embedder for a corpus.
 
@@ -168,9 +168,7 @@ def generate_embeddings_from_text(
             embedder_instance = embedder_class()
 
             logger.debug(f"Embedding text with {embedder_class.__name__}")
-            # ``embedder_class`` is dynamically loaded; mypy cannot resolve
-            # ``embed_text`` on the abstract base before the runtime check.
-            vector = embedder_instance.embed_text(text)  # type: ignore[attr-defined]
+            vector = embedder_instance.embed_text(text)
             return embedder_path, vector
         except Exception as e:
             logger.error(
@@ -199,10 +197,10 @@ def calculate_embedding_for_text(
 
 
 async def aget_embedder(
-    corpus_id: int | str | None = None,
-    mimetype_or_enum: Union[str, FileTypeEnum, None] = None,
+    corpus_id: Optional[Union[int, str]] = None,
+    mimetype_or_enum: Optional[Union[str, FileTypeEnum]] = None,
     embedder_path: Optional[str] = None,
-) -> tuple[type[BaseEmbedder], str]:
+) -> tuple[Optional[type[BaseEmbedder]], Optional[str]]:
     """
     Async version of `get_embedder`.
 

--- a/opencontractserver/utils/etl.py
+++ b/opencontractserver/utils/etl.py
@@ -5,12 +5,12 @@ import logging
 import os
 import traceback
 import uuid
+from typing import Any, cast
 
 from django.contrib.auth import get_user_model
 from django.core.files.storage import default_storage
 from django.db.models import Q
 from pydantic import TypeAdapter, ValidationError, create_model
-from typing_extensions import TypedDict
 
 from opencontractserver.annotations.compact_json import (
     compact_annotation_json,
@@ -33,9 +33,10 @@ from opencontractserver.types.dicts import (
     BoundingBoxPythonType,
     LabelLookupPythonType,
     OpenContractDocExport,
+    OpenContractsAnnotationPythonType,
     PawlsPagePythonType,
 )
-from opencontractserver.types.enums import AnnotationFilterMode
+from opencontractserver.types.enums import AnnotationFilterMode, LabelType
 from opencontractserver.utils.compact_pawls import expand_pawls_pages
 
 logger = logging.getLogger(__name__)
@@ -156,8 +157,8 @@ def build_label_lookups(
     # Pull the corresponding AnnotationLabel objects
     labels = AnnotationLabel.objects.filter(pk__in=all_label_ids)
 
-    text_labels = {}
-    doc_labels = {}
+    text_labels: dict[str | int, AnnotationLabelPythonType] = {}
+    doc_labels: dict[str | int, AnnotationLabelPythonType] = {}
 
     # Export all label types: TOKEN_LABEL, SPAN_LABEL, and RELATIONSHIP_LABEL
     # go into text_labels; DOC_TYPE_LABEL goes into doc_labels.
@@ -175,7 +176,7 @@ def build_label_lookups(
             "description": tl.description,
             "icon": tl.icon,
             "text": tl.text,
-            "label_type": tl.label_type,
+            "label_type": LabelType(tl.label_type),
         }
 
     for dl in doc_type_labels_queryset:
@@ -186,7 +187,7 @@ def build_label_lookups(
             "description": dl.description,
             "icon": dl.icon,
             "text": dl.text,
-            "label_type": DOC_TYPE_LABEL,
+            "label_type": LabelType.DOC_TYPE_LABEL,
         }
 
     return {
@@ -234,7 +235,9 @@ def build_document_export(
 
         doc = Document.objects.get(pk=doc_id)
         doc_name: str = (
-            os.path.basename(doc.pdf_file.name) if doc.pdf_file else "document"
+            os.path.basename(doc.pdf_file.name)
+            if doc.pdf_file and doc.pdf_file.name
+            else "document"
         )
 
         corpus = Corpus.objects.get(pk=corpus_id)
@@ -245,17 +248,26 @@ def build_document_export(
 
         extracted_document_content_json = ""
         try:
-            with default_storage.open(doc.txt_extract_file.name) as content_file:
-                extracted_document_content_json = content_file.read().decode("utf-8")
+            txt_extract_name = doc.txt_extract_file.name
+            if txt_extract_name:
+                with default_storage.open(txt_extract_name) as content_file:
+                    extracted_document_content_json = content_file.read().decode(
+                        "utf-8"
+                    )
         except Exception as e:
             logger.warning(f"Could not export doc text for doc {doc_id}: {e}")
 
         pawls_tokens: list[PawlsPagePythonType] = []
         try:
-            with default_storage.open(doc.pawls_parse_file.name) as pawls_file:
-                pawls_tokens = expand_pawls_pages(
-                    json.loads(pawls_file.read().decode("utf-8"))
-                )
+            pawls_parse_name = doc.pawls_parse_file.name
+            if pawls_parse_name:
+                with default_storage.open(pawls_parse_name) as pawls_file:
+                    pawls_tokens = cast(
+                        list[PawlsPagePythonType],
+                        expand_pawls_pages(
+                            json.loads(pawls_file.read().decode("utf-8"))
+                        ),
+                    )
         except Exception as e:
             logger.warning(f"Could not export pawls tokens for doc {doc_id}: {e}")
 
@@ -308,7 +320,7 @@ def build_document_export(
         doc_annotation_json: OpenContractDocExport = {
             "doc_labels": [],
             "labelled_text": [],
-            "title": doc.title,
+            "title": doc.title or "",
             "description": doc.description,
             "content": extracted_document_content_json,
             "pawls_file_content": pawls_tokens,
@@ -316,8 +328,8 @@ def build_document_export(
             "file_type": doc.file_type,
         }
 
-        page_highlights = {}
-        page_sizes = {}
+        page_highlights: dict[str, dict[int, list[dict[str, int | float]]]] = {}
+        page_sizes: dict[int, Any] = {}
 
         if pawls_tokens:
             page_sizes = {
@@ -377,7 +389,9 @@ def build_document_export(
                         }
 
         doc_annotation_json["doc_labels"] = labels_for_doc
-        doc_annotation_json["labelled_text"] = labelled_text
+        doc_annotation_json["labelled_text"] = cast(
+            list[OpenContractsAnnotationPythonType], labelled_text
+        )
 
         # PDF-specific processing: burn annotations into PDF
         base64_encoded_message = ""
@@ -401,8 +415,8 @@ def build_document_export(
                 logger.debug("Page_sizes: %s", page_sizes)
 
                 for i in range(0, total_page_count):
-                    page = pdf_input.pages[i]
-                    page_box = page.mediabox
+                    pdf_page = pdf_input.pages[i]
+                    page_box = pdf_page.mediabox
 
                     page_height = page_box.upper_left[1]
                     page_width = page_box.lower_right[0]
@@ -419,6 +433,12 @@ def build_document_export(
                             label = text_labels[f"{label_id}"]
 
                             for rect in page_highlights[f"{i + 1}"][label_id]:
+                                hex_color = label["color"].lstrip("#")
+                                color: tuple[float, float, float] = (
+                                    int(hex_color[0:2], 16) / 256,
+                                    int(hex_color[2:4], 16) / 256,
+                                    int(hex_color[4:6], 16) / 256,
+                                )
                                 highlight = createHighlight(
                                     round(x_scale * rect["left"]),
                                     round(float(page_height) - y_scale * rect["top"]),
@@ -427,16 +447,14 @@ def build_document_export(
                                         float(page_height) - y_scale * rect["bottom"]
                                     ),
                                     {"author": "Label:", "contents": label["text"]},
-                                    color=tuple(
-                                        int(label["color"].lstrip("#")[i : i + 2], 16)
-                                        / 256
-                                        for i in (0, 2, 4)
-                                    ),
+                                    color=color,
                                 )
 
-                                add_highlight_to_new_page(highlight, page, pdf_output)
+                                add_highlight_to_new_page(
+                                    highlight, pdf_page, pdf_output
+                                )
 
-                    pdf_output.add_page(page)
+                    pdf_output.add_page(pdf_page)
 
                 pdf_output.write(annotated_pdf_bytes)
                 base64_encoded_data = base64.b64encode(annotated_pdf_bytes.getvalue())
@@ -465,7 +483,7 @@ def build_document_export(
         return "", "", None, {}, {}
 
 
-def is_dict_instance_of_typed_dict(instance: dict, typed_dict: type[TypedDict]):
+def is_dict_instance_of_typed_dict(instance: dict, typed_dict: Any) -> bool:
     # validate with pydantic
     try:
         TypeAdapter(typed_dict).validate_python(instance)
@@ -523,7 +541,7 @@ def parse_model_or_primitive(value: str) -> type:
     elif ":" in value:
         logger.info("Value appears to be a model definition, attempting to parse...")
         try:
-            props = {}
+            props: dict[str, Any] = {}
             lines = value.split("\n")
             logger.debug(f"Split model definition into {len(lines)} lines")
 


### PR DESCRIPTION
## Summary

Removes `[mypy-...]` `ignore_errors` blocks for the first six `opencontractserver.utils.*` modules and fixes all surfaced errors so pre-commit `mypy` runs clean across the full project surface (1032 source files: `Success: no issues found`).

Modules graduated (per #1480 acceptance criteria):

- `opencontractserver.utils.analysis`
- `opencontractserver.utils.analyzer`
- `opencontractserver.utils.cleanup`
- `opencontractserver.utils.corpus_forking`
- `opencontractserver.utils.embeddings`
- `opencontractserver.utils.etl`

Pruned 52 corresponding lines from `docs/typing/mypy_baseline.txt` (6813 → 6761).

## Notable production bugs uncovered by typing

- **`utils/cleanup.py:34`** — `delete_analysis_and_annotations` called `Analysis.annotations.filter(...)` on the **class-level** reverse descriptor, which has no `.filter()` method and would `AttributeError` at runtime. Replaced with the instance's reverse manager: `analysis.annotations.all().delete()` (the `analysis_id=` filter on the descriptor was redundant anyway since the manager is already scoped to the instance).
- **`utils/analyzer.py:run_analysis`** — now raises `ValueError` early when `analyzer.host_gremlin` is `None`, instead of crashing later on `gremlin.url` with a less helpful traceback. `Analyzer.host_gremlin` is a nullable FK.
- **`utils/analyzer.py:272`** — submission-response logging used `f"{submission_response.content}"` for bytes content, which produces `b'...'`. Switched to `!r` for explicit, type-safe formatting.
- **`utils/analyzer.py:install_analyzers`** and **`tasks/analyzer_tasks.py:install_analyzer_task`** — return type corrected from `list[int]` to `list[str]`. `Analyzer.id` is a `CharField`, so PKs are strings; the previous annotation was wrong.
- **`utils/embeddings.py`** — `get_embedder` / `aget_embedder` parameter and return types now reflect that `corpus_id`, `mimetype_or_enum`, `embedder_class`, and `embedder_path` may be `None`. Removed an outdated `# type: ignore[attr-defined]` on `embed_text` (the method exists on `BaseEmbedder`).
- **`utils/etl.py`** — inner PDF-burn-in loop variable renamed from `page` to `pdf_page` so it no longer collides with the `PageAnnotationData` `page` from `iter_page_annotations` (mypy was inferring the wrong type for the second binding). Color tuple is now an explicit `tuple[float, float, float]` literal instead of a variable-length generator-tuple. Optional `FileField.name` accesses are guarded so `default_storage.open(None)` can no longer be called.

## Test plan

- [x] `python -m mypy --config-file mypy.ini opencontractserver config` — `Success: no issues found in 1032 source files`
- [x] `black --check` clean on all modified files
- [x] `isort --check-only` clean on all modified files
- [x] `flake8` clean on all modified files
- [x] `pyupgrade --py39-plus` no-op on all modified files
- [ ] CI backend `linter` job (mypy) passes on PR
- [ ] CI backend test suite passes on PR (changes include behaviour-preserving runtime fixes; impacted suites: `test_etl_utils`, `test_analysis_annotation_import`, `test_corpus_forking`, `test_embeddings_task`, `test_corpus_export*`)

Closes #1480

---
_Generated by [Claude Code](https://claude.ai/code/session_01EhZb2q8rvMZDdURTjnQRuB)_