### PR TITLE
Fix Backend CI: remove redundant cast in get_embedder

### DIFF
--- a/opencontractserver/utils/embeddings.py
+++ b/opencontractserver/utils/embeddings.py
@@ -129,7 +129,7 @@ def get_embedder(
         f"Return embedder class: {embedder_class}, embedder path: {embedder_path}"
     )
 
-    return cast(Optional[type[BaseEmbedder]], embedder_class), embedder_path
+    return embedder_class, embedder_path
 
 
 def generate_embeddings_from_text(


### PR DESCRIPTION
## Summary

- Backend CI on `main` has been failing for the last 5+ commits at the `linter` step, with a single mypy error in `opencontractserver/utils/embeddings.py:132`:
  > `error: Redundant cast to "type[BaseEmbedder] | None"  [redundant-cast]`
- Removes the redundant `cast(Optional[type[BaseEmbedder]], embedder_class)` from the return statement. mypy infers the type correctly from the assignments throughout `get_embedder`, and the function's return-type annotation already pins it.
- Fixing the linter unblocks the gated `pytest` job, which in turn restores fresh backend coverage uploads to Codecov (the Codecov "failures" the user sees on `main` are downstream of this — the pytest step has been silently skipping since the cast was introduced).

## Verification

- `pre-commit run --all-files` → all hooks pass (mypy in particular)
- `pre-commit run mypy --files opencontractserver/utils/embeddings.py` → Passed

## Test plan

- [x] Local `pre-commit run --all-files` passes
- [ ] Backend CI `linter` job passes on this PR
- [ ] Backend CI `pytest` job runs (no longer skipped by the linter gate)
- [ ] Codecov uploads coverage for this PR