### PR TITLE
Fix two PR #1543 tests with wrong assertion targets blocking main CI

### DIFF
--- a/opencontractserver/tests/test_llms_typing_behavior_guards.py
+++ b/opencontractserver/tests/test_llms_typing_behavior_guards.py
@@ -327,12 +327,23 @@ class TestAddDocumentNoteToolCorpusOptional(TestCase):
         text = (
             _PROJECT_ROOT / "opencontractserver/llms/agents/pydantic_ai_agents.py"
         ).read_text()
+        # Scope the assertion to the body of ``add_document_note_tool`` —
+        # other tools (e.g. ``add_exact_string_annotations``) legitimately
+        # require a corpus, so a global file scan would false-positive.
+        marker = "async def add_document_note_tool"
+        start = text.find(marker)
+        self.assertNotEqual(start, -1, "add_document_note_tool not found in file")
+        # End at the next top-level ``async def`` / ``def`` at the same
+        # indentation level — good enough for a substring scan.
+        body_start = text.find("\n", start)
+        next_def = text.find("\n        async def ", body_start + 1)
+        body = text[body_start:next_def] if next_def != -1 else text[body_start:]
         # The forwarded value must use a ternary that yields ``None`` when
         # ``context.corpus`` is missing; the previous reject-guard form
         # raised ValueError instead.
         self.assertIn(
             "context.corpus.id if context.corpus else None",
-            text,
+            body,
             msg=(
                 "add_document_note_tool no longer forwards None for the "
                 "standalone-document case — agents without a corpus will "
@@ -340,8 +351,8 @@ class TestAddDocumentNoteToolCorpusOptional(TestCase):
             ),
         )
         self.assertNotIn(
-            'requires the agent to be scoped to a corpus"',
-            text,
+            "requires the agent to be scoped to a corpus",
+            body,
             msg=(
                 "add_document_note_tool still rejects standalone-document "
                 "agents; the corpus-required guard should be gone."

--- a/opencontractserver/tests/test_llms_typing_coverage.py
+++ b/opencontractserver/tests/test_llms_typing_coverage.py
@@ -831,8 +831,11 @@ class TestResolveToolsCallerForms(TestCase):
             return arg
 
         sentinel = object()
+        # ``_resolve_tools`` calls ``CoreTool.from_function`` directly; patching
+        # ``ToolAPI.from_function`` (the public wrapper) doesn't intercept the
+        # actual call site.
         with patch(
-            "opencontractserver.llms.api.ToolAPI.from_function",
+            "opencontractserver.llms.api.CoreTool.from_function",
             return_value=sentinel,
         ) as from_fn:
             result = _resolve_tools([my_tool])


### PR DESCRIPTION
## Summary

Two tests added in #1543 have been failing on main and blocking pytest (and therefore codecov) on every PR. Both tests assert against the wrong target:

1. **`test_callable_resolves_via_from_function`** (`test_llms_typing_coverage.py`) patches `opencontractserver.llms.api.ToolAPI.from_function`, but `_resolve_tools` calls `CoreTool.from_function` directly. The mock never intercepts, so `_resolve_tools` returns real `CoreTool` instances and `assertEqual(result, [sentinel])` fails. Patch `CoreTool.from_function` instead.

2. **`test_add_document_note_tool_passes_none_when_corpus_absent`** (`test_llms_typing_behavior_guards.py`) does a global file scan with `assertNotIn("requires the agent to be scoped to a corpus")`, but that string legitimately exists for `add_exact_string_annotations` (a different tool that does require a corpus). Scope the assertion to the body of `add_document_note_tool` by slicing from its `def` to the next `async def` at the same indent level.

## Test plan

- [ ] `pytest opencontractserver/tests/test_llms_typing_coverage.py::TestResolveToolsCallerForms::test_callable_resolves_via_from_function` passes
- [ ] `pytest opencontractserver/tests/test_llms_typing_behavior_guards.py::TestAddDocumentNoteToolCorpusOptional::test_add_document_note_tool_passes_none_when_corpus_absent` passes
- [ ] Backend CI on this PR is green (was red on main and every downstream PR before this fix)