### PR TITLE
Add test for ContentContainer $compact prop padding

### DIFF
--- a/frontend/tests/PageLayout.ct.tsx
+++ b/frontend/tests/PageLayout.ct.tsx
@@ -89,6 +89,17 @@ test.describe("PageLayout primitives - Transient prop overrides", () => {
     expect(maxWidth).toBe("900px");
   });
 
+  test("ContentContainer $compact reduces top padding", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<PageLayoutPropsHarness $compact />);
+    const padding = await page
+      .locator('[data-testid="content-container"]')
+      .evaluate((el) => window.getComputedStyle(el).paddingTop);
+    expect(padding).toBe("32px");
+  });
+
   test("HeroSection / HeroTitle margin-bottom overrides apply", async ({
     mount,
     page,


### PR DESCRIPTION
## Summary
Added a test case to verify that the `$compact` transient prop on `ContentContainer` correctly reduces the top padding to 32px.

## Changes
- Added new test case "ContentContainer $compact reduces top padding" to the PageLayout primitives test suite
- Test verifies that when `$compact` prop is applied to `PageLayoutPropsHarness`, the computed `paddingTop` style of the content container element is "32px"
- Uses Playwright's `evaluate` method to inspect computed styles on the rendered element

## Details
This test ensures the `$compact` transient prop styling behavior is working as expected and helps prevent regressions in the PageLayout component's responsive padding behavior.

https://claude.ai/code/session_01XGKLn7BWMw5e8KDrUwLP1V