### PR TITLE
Polish cookie consent modal styling on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Cookie consent modal visual polish on mobile** (`frontend/src/components/cookies/CookieConsent.tsx`). The mobile presentation of the consent modal was cramped and felt off-brand compared with the rest of the OS Legal surfaces. Reworked mobile styling without touching desktop: `.oc-modal` now uses `display: flex; flex-direction: column` with a `flex-shrink: 0` header, a `flex: 1 1 auto; overflow-y: auto` body, and a `flex-shrink: 0` footer so the Accept button stays anchored above the safe-area inset with a soft top shadow instead of relying purely on `position: sticky`. The body's mobile background switches to `OS_LEGAL_COLORS.background` so the white data cards lift off the surface with their new `OS_LEGAL_SHADOWS.card` shadow. Data list items adopt `accentSurface` + `textPrimary` on mobile (replacing the heavier slate-chip look) to feel brand-cohesive. The demo banner gains a 3px warning-text left bar for clearer hierarchy; the header icon badge gains an inner accent ring; section labels, lead copy, and disclaimer text get tighter mobile sizing. The Accept & Continue footer button is 48px tall with `font-weight: 600` for a comfortable thumb target and visual weight.
+
 ### Fixed
 
 - **Dark mode contrast in CAML article renderer** (`frontend/package.json`). Upgraded `@os-legal/caml` and `@os-legal/caml-react` from 0.1.0 to 0.1.2 to pull in a rendering fix that restores text/background contrast in dark-mode CAML article views. Also updated the `resolutions` entry so both the top-level app and `caml-react`'s own peer resolve to the same 0.1.2 version (previously the stale `^0.1.0` resolution caused `caml-react` to bundle caml 0.1.0 internally despite the dependency version bump).

--- a/frontend/src/assets/configurations/osLegalStyles.ts
+++ b/frontend/src/assets/configurations/osLegalStyles.ts
@@ -456,4 +456,9 @@ export const OS_LEGAL_SHADOWS = {
   cardHover: "0 8px 24px rgba(0, 0, 0, 0.08)",
   /** Drop shadow for centred modal overlays. */
   modalOverlay: "0 25px 50px -12px rgba(15, 23, 42, 0.25)",
+  /**
+   * Upward lift used on sticky mobile modal footers to visually separate them
+   * from the scrolling body above. Negative y-offset + steep spread distance.
+   */
+  footerLiftMobile: "0 -8px 24px -12px rgba(15, 23, 42, 0.18)",
 } as const;

--- a/frontend/src/assets/configurations/osLegalStyles.ts
+++ b/frontend/src/assets/configurations/osLegalStyles.ts
@@ -414,6 +414,8 @@ export const OS_LEGAL_SPACING = {
   iconBadgeDesktop: "40px",
   /** Square dimension for circular icon badges (mobile). */
   iconBadgeMobile: "34px",
+  /** Inline icon dimension inside dense mobile list rows. */
+  iconInlineMobile: "13px",
 } as const;
 
 /**

--- a/frontend/src/assets/configurations/osLegalStyles.ts
+++ b/frontend/src/assets/configurations/osLegalStyles.ts
@@ -405,6 +405,12 @@ export const OS_LEGAL_SPACING = {
 
   /** Border radius for inset list items inside cards. */
   borderRadiusListItem: "6px",
+  /** Border radius for cards rendered on mobile viewports (tighter than
+   *  borderRadiusCard so dense stacks read as a single visual unit). Kept
+   *  semantically distinct from borderRadiusButton even when the values
+   *  happen to match, so future button-radius design tweaks don't bleed
+   *  into card corners. */
+  borderRadiusCardMobile: "8px",
   /** Border radius for full-width empty-state cards (above borderRadiusCard). */
   borderRadiusEmptyState: "16px",
   /** Border-left thickness for callout / disclaimer blocks. */

--- a/frontend/src/components/cookies/CookieConsent.tsx
+++ b/frontend/src/components/cookies/CookieConsent.tsx
@@ -78,6 +78,8 @@ const StyledModalWrapper = styled.div`
       max-height: 100vh;
       max-height: 100dvh;
       border-radius: 0;
+      display: flex;
+      flex-direction: column;
     }
   }
 
@@ -86,7 +88,8 @@ const StyledModalWrapper = styled.div`
     padding: 1.5rem 1.75rem;
 
     @media (max-width: ${MOBILE_VIEW_BREAKPOINT}px) {
-      padding: 1.25rem;
+      padding: 1rem 1.125rem;
+      flex-shrink: 0;
     }
   }
 
@@ -98,7 +101,8 @@ const StyledModalWrapper = styled.div`
     color: ${OS_LEGAL_COLORS.textPrimary};
 
     @media (max-width: ${MOBILE_VIEW_BREAKPOINT}px) {
-      font-size: 1.25rem;
+      font-size: 1.1875rem;
+      letter-spacing: -0.005em;
     }
   }
 
@@ -106,7 +110,11 @@ const StyledModalWrapper = styled.div`
     padding: 1.5rem 1.75rem 1.25rem;
 
     @media (max-width: ${MOBILE_VIEW_BREAKPOINT}px) {
-      padding: 1.25rem;
+      padding: 1rem 1.125rem 1.25rem;
+      flex: 1 1 auto;
+      overflow-y: auto;
+      -webkit-overflow-scrolling: touch;
+      background: ${OS_LEGAL_COLORS.background};
     }
   }
 
@@ -118,8 +126,18 @@ const StyledModalWrapper = styled.div`
     justify-content: flex-end;
 
     @media (max-width: ${MOBILE_VIEW_BREAKPOINT}px) {
-      padding-left: 1.25rem;
-      padding-right: 1.25rem;
+      padding: 0.875rem 1.125rem;
+      padding-bottom: calc(0.875rem + env(safe-area-inset-bottom, 0px));
+      background: ${OS_LEGAL_COLORS.surface};
+      box-shadow: 0 -8px 24px -12px rgba(15, 23, 42, 0.18);
+      flex-shrink: 0;
+
+      button {
+        height: 48px;
+        font-size: 0.9375rem;
+        font-weight: 600;
+        border-radius: ${OS_LEGAL_SPACING.borderRadiusButton};
+      }
     }
   }
 `;
@@ -129,6 +147,10 @@ const HeaderTitleRow = styled.span`
   align-items: center;
   gap: 0.875rem;
   min-width: 0;
+
+  @media (max-width: ${MOBILE_VIEW_BREAKPOINT}px) {
+    gap: 0.625rem;
+  }
 `;
 
 const IconBadge = styled.span`
@@ -141,10 +163,16 @@ const IconBadge = styled.span`
   background: ${OS_LEGAL_COLORS.accentSurface};
   color: ${OS_LEGAL_COLORS.accent};
   flex-shrink: 0;
+  box-shadow: inset 0 0 0 1px ${OS_LEGAL_COLORS.accentMedium};
 
   @media (max-width: ${MOBILE_VIEW_BREAKPOINT}px) {
-    width: ${OS_LEGAL_SPACING.iconBadgeMobile};
-    height: ${OS_LEGAL_SPACING.iconBadgeMobile};
+    width: 32px;
+    height: 32px;
+
+    svg {
+      width: 17px;
+      height: 17px;
+    }
   }
 `;
 
@@ -155,6 +183,7 @@ const DemoBanner = styled.div`
   padding: 0.875rem 1rem;
   background: ${OS_LEGAL_COLORS.warningSurface};
   border: 1px solid ${OS_LEGAL_COLORS.warningBorder};
+  border-left: 3px solid ${OS_LEGAL_COLORS.warningText};
   border-radius: ${OS_LEGAL_SPACING.borderRadiusButton};
   margin-bottom: 1.5rem;
 
@@ -162,6 +191,12 @@ const DemoBanner = styled.div`
     flex-shrink: 0;
     color: ${OS_LEGAL_COLORS.warningText};
     margin-top: 1px;
+  }
+
+  @media (max-width: ${MOBILE_VIEW_BREAKPOINT}px) {
+    padding: 0.75rem 0.875rem;
+    gap: 0.625rem;
+    margin-bottom: 1.125rem;
   }
 `;
 
@@ -171,10 +206,19 @@ const DemoBannerText = styled.p`
   line-height: 1.5;
   color: ${OS_LEGAL_COLORS.warningText};
   ${sansFont}
+
+  @media (max-width: ${MOBILE_VIEW_BREAKPOINT}px) {
+    font-size: 0.8125rem;
+    line-height: 1.45;
+  }
 `;
 
 const LeadSection = styled.section`
   margin: 0 0 1.25rem;
+
+  @media (max-width: ${MOBILE_VIEW_BREAKPOINT}px) {
+    margin: 0 0 1rem;
+  }
 `;
 
 const SectionLabel = styled.h4`
@@ -193,6 +237,11 @@ const SectionLabel = styled.h4`
     flex-shrink: 0;
     color: ${OS_LEGAL_COLORS.accent};
   }
+
+  @media (max-width: ${MOBILE_VIEW_BREAKPOINT}px) {
+    font-size: 0.6875rem;
+    letter-spacing: 0.07em;
+  }
 `;
 
 const LeadBody = styled.p`
@@ -201,6 +250,11 @@ const LeadBody = styled.p`
   line-height: 1.6;
   color: ${OS_LEGAL_COLORS.textSecondary};
   ${sansFont}
+
+  @media (max-width: ${MOBILE_VIEW_BREAKPOINT}px) {
+    font-size: 0.875rem;
+    line-height: 1.55;
+  }
 `;
 
 const TwoColumnGrid = styled.div`
@@ -213,6 +267,10 @@ const TwoColumnGrid = styled.div`
     grid-template-columns: 1fr;
     gap: 0.75rem;
   }
+
+  @media (max-width: ${MOBILE_VIEW_BREAKPOINT}px) {
+    margin-bottom: 1rem;
+  }
 `;
 
 const DataCard = styled.section`
@@ -223,9 +281,20 @@ const DataCard = styled.section`
   background: ${OS_LEGAL_COLORS.surface};
   border: 1px solid ${OS_LEGAL_COLORS.border};
   border-radius: ${OS_LEGAL_SPACING.borderRadiusCard};
+  box-shadow: ${OS_LEGAL_SHADOWS.card};
 
   &.cookie-consent__analytics {
     margin-bottom: 1.25rem;
+  }
+
+  @media (max-width: ${MOBILE_VIEW_BREAKPOINT}px) {
+    padding: 0.875rem 0.875rem 0.9375rem;
+    gap: 0.5rem;
+    border-radius: 10px;
+
+    &.cookie-consent__analytics {
+      margin-bottom: 1rem;
+    }
   }
 `;
 
@@ -235,6 +304,11 @@ const DataCardLead = styled.p`
   line-height: 1.5;
   color: ${OS_LEGAL_COLORS.textSecondary};
   ${sansFont}
+
+  @media (max-width: ${MOBILE_VIEW_BREAKPOINT}px) {
+    font-size: 0.8125rem;
+    line-height: 1.45;
+  }
 `;
 
 const DataList = styled.ul`
@@ -244,6 +318,10 @@ const DataList = styled.ul`
   display: flex;
   flex-direction: column;
   gap: 0.375rem;
+
+  @media (max-width: ${MOBILE_VIEW_BREAKPOINT}px) {
+    gap: 0.3125rem;
+  }
 `;
 
 const DataListItem = styled.li`
@@ -263,6 +341,19 @@ const DataListItem = styled.li`
     flex-shrink: 0;
     color: ${OS_LEGAL_COLORS.accent};
   }
+
+  @media (max-width: ${MOBILE_VIEW_BREAKPOINT}px) {
+    padding: 0.5rem 0.625rem;
+    gap: 0.5rem;
+    font-size: 0.8125rem;
+    background: ${OS_LEGAL_COLORS.accentSurface};
+    color: ${OS_LEGAL_COLORS.textPrimary};
+
+    svg {
+      width: 13px;
+      height: 13px;
+    }
+  }
 `;
 
 const AnalyticsNote = styled.p`
@@ -279,6 +370,10 @@ const DisclaimerBlock = styled.aside`
   border-left: ${OS_LEGAL_SPACING.borderAccentWidth} solid
     ${OS_LEGAL_COLORS.borderHover};
   border-radius: ${OS_LEGAL_SPACING.borderRadiusButton};
+
+  @media (max-width: ${MOBILE_VIEW_BREAKPOINT}px) {
+    padding: 0.625rem 0.75rem;
+  }
 `;
 
 const Disclaimer = styled.p`
@@ -289,6 +384,11 @@ const Disclaimer = styled.p`
   letter-spacing: 0.01em;
   color: ${OS_LEGAL_COLORS.textMuted};
   ${sansFont}
+
+  @media (max-width: ${MOBILE_VIEW_BREAKPOINT}px) {
+    font-size: 0.6875rem;
+    line-height: 1.5;
+  }
 `;
 
 export const CookieConsentDialog = () => {

--- a/frontend/src/components/cookies/CookieConsent.tsx
+++ b/frontend/src/components/cookies/CookieConsent.tsx
@@ -291,10 +291,7 @@ const DataCard = styled.section`
   @media (max-width: ${MOBILE_VIEW_BREAKPOINT}px) {
     padding: 0.875rem 0.875rem 0.9375rem;
     gap: 0.5rem;
-    /* Slightly tighter than borderRadiusCard (12px) — the smaller mobile
-       cards look balanced with a marginally smaller corner radius while
-       still feeling related to the card family. */
-    border-radius: ${OS_LEGAL_SPACING.borderRadiusButton};
+    border-radius: ${OS_LEGAL_SPACING.borderRadiusCardMobile};
     /* Subtle elevation pulls the card off the body background; only
        needed at the higher visual density of the mobile layout. */
     box-shadow: ${OS_LEGAL_SHADOWS.card};

--- a/frontend/src/components/cookies/CookieConsent.tsx
+++ b/frontend/src/components/cookies/CookieConsent.tsx
@@ -113,7 +113,6 @@ const StyledModalWrapper = styled.div`
       padding: 1rem 1.125rem 1.25rem;
       flex: 1 1 auto;
       overflow-y: auto;
-      -webkit-overflow-scrolling: touch;
       background: ${OS_LEGAL_COLORS.background};
     }
   }
@@ -129,7 +128,7 @@ const StyledModalWrapper = styled.div`
       padding: 0.875rem 1.125rem;
       padding-bottom: calc(0.875rem + env(safe-area-inset-bottom, 0px));
       background: ${OS_LEGAL_COLORS.surface};
-      box-shadow: 0 -8px 24px -12px rgba(15, 23, 42, 0.18);
+      box-shadow: ${OS_LEGAL_SHADOWS.footerLiftMobile};
       flex-shrink: 0;
 
       button {
@@ -163,16 +162,14 @@ const IconBadge = styled.span`
   background: ${OS_LEGAL_COLORS.accentSurface};
   color: ${OS_LEGAL_COLORS.accent};
   flex-shrink: 0;
-  box-shadow: inset 0 0 0 1px ${OS_LEGAL_COLORS.accentMedium};
 
   @media (max-width: ${MOBILE_VIEW_BREAKPOINT}px) {
-    width: 32px;
-    height: 32px;
-
-    svg {
-      width: 17px;
-      height: 17px;
-    }
+    width: ${OS_LEGAL_SPACING.iconBadgeMobile};
+    height: ${OS_LEGAL_SPACING.iconBadgeMobile};
+    /* Crisp 1px outline on the smaller mobile badge so the accent ring
+       remains visible against the light surface — desktop badge is large
+       enough not to need it. */
+    box-shadow: inset 0 0 0 1px ${OS_LEGAL_COLORS.accentMedium};
   }
 `;
 
@@ -183,7 +180,6 @@ const DemoBanner = styled.div`
   padding: 0.875rem 1rem;
   background: ${OS_LEGAL_COLORS.warningSurface};
   border: 1px solid ${OS_LEGAL_COLORS.warningBorder};
-  border-left: 3px solid ${OS_LEGAL_COLORS.warningText};
   border-radius: ${OS_LEGAL_SPACING.borderRadiusButton};
   margin-bottom: 1.5rem;
 
@@ -197,6 +193,10 @@ const DemoBanner = styled.div`
     padding: 0.75rem 0.875rem;
     gap: 0.625rem;
     margin-bottom: 1.125rem;
+    /* Add a left accent stripe to make the demo callout pop in the
+       higher-information-density mobile layout. */
+    border-left: ${OS_LEGAL_SPACING.borderAccentWidth} solid
+      ${OS_LEGAL_COLORS.warningText};
   }
 `;
 
@@ -281,7 +281,6 @@ const DataCard = styled.section`
   background: ${OS_LEGAL_COLORS.surface};
   border: 1px solid ${OS_LEGAL_COLORS.border};
   border-radius: ${OS_LEGAL_SPACING.borderRadiusCard};
-  box-shadow: ${OS_LEGAL_SHADOWS.card};
 
   &.cookie-consent__analytics {
     margin-bottom: 1.25rem;
@@ -290,7 +289,13 @@ const DataCard = styled.section`
   @media (max-width: ${MOBILE_VIEW_BREAKPOINT}px) {
     padding: 0.875rem 0.875rem 0.9375rem;
     gap: 0.5rem;
-    border-radius: 10px;
+    /* Slightly tighter than borderRadiusCard (12px) — the smaller mobile
+       cards look balanced with a marginally smaller corner radius while
+       still feeling related to the card family. */
+    border-radius: ${OS_LEGAL_SPACING.borderRadiusButton};
+    /* Subtle elevation pulls the card off the body background; only
+       needed at the higher visual density of the mobile layout. */
+    box-shadow: ${OS_LEGAL_SHADOWS.card};
 
     &.cookie-consent__analytics {
       margin-bottom: 1rem;

--- a/frontend/src/components/cookies/CookieConsent.tsx
+++ b/frontend/src/components/cookies/CookieConsent.tsx
@@ -126,6 +126,8 @@ const StyledModalWrapper = styled.div`
 
     @media (max-width: ${MOBILE_VIEW_BREAKPOINT}px) {
       padding: 0.875rem 1.125rem;
+      /* bottom intentionally overrides the shorthand to extend into the
+         safe-area inset on notched devices */
       padding-bottom: calc(0.875rem + env(safe-area-inset-bottom, 0px));
       background: ${OS_LEGAL_COLORS.surface};
       box-shadow: ${OS_LEGAL_SHADOWS.footerLiftMobile};
@@ -355,8 +357,8 @@ const DataListItem = styled.li`
     color: ${OS_LEGAL_COLORS.textPrimary};
 
     svg {
-      width: 13px;
-      height: 13px;
+      width: ${OS_LEGAL_SPACING.iconInlineMobile};
+      height: ${OS_LEGAL_SPACING.iconInlineMobile};
     }
   }
 `;

--- a/frontend/tests/CookieConsent.ct.tsx
+++ b/frontend/tests/CookieConsent.ct.tsx
@@ -46,4 +46,23 @@ test.describe("CookieConsent - Rendering", () => {
     // Capture screenshot for documentation
     await docScreenshot(page, "cookie-consent--modal--default");
   });
+
+  test("renders cleanly inside a phone viewport", async ({ mount, page }) => {
+    // iPhone 13 logical viewport — below MOBILE_VIEW_BREAKPOINT (600px),
+    // so the mobile-only flex layout, footer lift, and inline icon
+    // sizing all kick in. Catches regressions to mobile styling that
+    // would otherwise only surface on a physical device.
+    await page.setViewportSize({ width: 390, height: 844 });
+    await mount(<CookieConsentHarness />);
+
+    const modal = page.locator('[role="dialog"]');
+    await expect(modal).toBeVisible({ timeout: 5000 });
+
+    // Accept button must still be reachable at the bottom of the modal —
+    // the new mobile flex layout anchors it above the safe-area inset.
+    const acceptBtn = page.getByRole("button", { name: /Accept/ });
+    await expect(acceptBtn).toBeVisible();
+
+    await docScreenshot(page, "cookie-consent--modal--mobile");
+  });
 });


### PR DESCRIPTION
## Summary
Reworked the mobile presentation of the cookie consent modal to improve visual hierarchy, spacing, and usability without affecting desktop styling.

## Key Changes
- **Layout restructuring**: Changed `.oc-modal` to use flexbox (`display: flex; flex-direction: column`) with:
  - Header: `flex-shrink: 0` to maintain fixed size
  - Body: `flex: 1 1 auto; overflow-y: auto` for scrollable content
  - Footer: `flex-shrink: 0` with sticky positioning via flexbox instead of `position: sticky`

- **Visual refinements**:
  - Footer button increased to 48px height with `font-weight: 600` for better touch target
  - Added soft shadow to footer (`box-shadow: 0 -8px 24px -12px rgba(15, 23, 42, 0.18)`)
  - Demo banner now has a 3px left border in warning color for clearer hierarchy
  - Icon badge gains an inset accent ring border and explicit 32px sizing with 17px SVG icons
  - Data list items adopt `accentSurface` background with `textPrimary` text on mobile (lighter, more brand-cohesive than previous slate styling)

- **Spacing adjustments**:
  - Tightened padding throughout: header (1rem 1.125rem), body (1rem 1.125rem 1.25rem), footer (0.875rem 1.125rem)
  - Footer padding includes safe-area inset for notched devices: `calc(0.875rem + env(safe-area-inset-bottom, 0px))`
  - Reduced gaps and margins across sections (demo banner, header title row, data lists)
  - Adjusted font sizes for better mobile readability (e.g., section labels 0.6875rem, lead body 0.875rem)

- **Color and background updates**:
  - Modal body background changed to `OS_LEGAL_COLORS.background` so data cards lift off with new `OS_LEGAL_SHADOWS.card` shadow
  - Footer background set to `OS_LEGAL_COLORS.surface`

## Implementation Details
All changes are scoped to mobile breakpoint (`@media (max-width: ${MOBILE_VIEW_BREAKPOINT}px)`) to preserve existing desktop styling. The flexbox layout ensures the Accept button remains anchored above the safe-area inset without relying on sticky positioning, improving reliability on various mobile browsers.