### PR TITLE
Unbreak CI: pin pydantic-ai-slim with narrow provider extras

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -104,7 +104,12 @@ repos:
           - pandas
           - tiktoken==0.12.0
           - openai>=2.11.0,<3
-          - pydantic-ai>=1.56.0,<2
+          # Mirrors the narrow-extras pin in requirements/base.txt; using the
+          # bare ``pydantic-ai`` meta-package would fan out to all ~20
+          # provider extras and break this hook the moment any one of those
+          # provider SDKs disappears from PyPI (see the mistralai 404 on
+          # 2026-05-12). Keep this extras list in lockstep with base.txt.
+          - pydantic-ai-slim[openai,anthropic,google,mcp]>=1.56.0,<2
           - spacy
           - tokenizers>=0.21,<0.23
           - posthog==7.12.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -55,7 +55,15 @@ pytesseract
 # ``opencontractserver/tests/test_pydantic_ai_factory.py`` pins this behaviour
 # against the version installed; if that test fails on a bump, validate the
 # new precedence semantics before widening this pin.
-pydantic-ai>=1.92.0,<2  # see issue #1451 before bumping the upper bound
+#
+# We deliberately depend on ``pydantic-ai-slim`` with the minimum set of
+# provider extras the codebase actually uses, rather than the meta-package
+# ``pydantic-ai``. ``pydantic-ai`` unconditionally pulls in all ~20 provider
+# extras (including ``mistral``, ``google``, ``groq``, ``cohere``, etc.); any
+# one of those provider SDKs disappearing from PyPI — as ``mistralai`` did
+# on 2026-05-12, where ``pypi.org/pypi/mistralai/json`` started 404ing —
+# breaks the entire install chain. Narrow extras = stable resolves.
+pydantic-ai-slim[openai,anthropic,google,mcp]>=1.92.0,<2  # see issue #1451 before bumping the upper bound
 spacy
 pdfplumber>=0.11.9  # https://github.com/jsvine/pdfplumber - PDF token extraction
 shapely>=2.1.2  # https://github.com/shapely/shapely - spatial operations for bbox intersection


### PR DESCRIPTION
## Summary
- All PRs (including main itself if it re-ran today) started failing in the install step with what looks like a `pydantic` resolution error
- Root cause is actually that `mistralai` has been pulled from PyPI (`https://pypi.org/pypi/mistralai/json` → 404)
- We were depending on the `pydantic-ai` meta-package, whose only non-extra dep unconditionally pulls all ~20 `pydantic-ai-slim` provider extras, including `mistral` → `mistralai>=2.0.0`
- This commit switches to `pydantic-ai-slim[openai,anthropic,google,mcp]>=1.92.0,<2` — only the provider extras this codebase actually uses
- All other providers (mistral, groq, cohere, bedrock, huggingface, vertexai, xai, etc.) are dropped — none are imported anywhere in `opencontractserver/` or `config/`
- Resolves cleanly locally in a `python:3.12-slim` container

Narrowing the extras has the side benefit of making the install surface much more resilient — any one of those 20 provider SDKs disappearing from PyPI in the future will no longer break our install chain.

## Test plan
- [ ] CI install step succeeds (this is the whole point — was failing on every PR before this)
- [ ] Backend pytest still passes (no provider imports actually changed; we never imported the dropped SDKs)
- [ ] Frontend CI unaffected (no frontend deps changed)