### PR TITLE
Docs: Comprehensive WebSocket protocol & discovery system documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,10 +219,11 @@ OpenContracts collects anonymous usage data to guide development priorities: ins
 
 ## Supported Formats
 
-- PDF (full layout and annotation support)
-- Text-based formats (plaintext, Markdown)
+- PDF (full layout and annotation support, via the Docling microservice)
+- DOCX (Word documents, via the [Docxodus](https://github.com/JSv4/Docxodus) microservice — character-offset annotations aligned with WASM rendering)
+- Plain text (`.txt`, split into sentence annotations via spaCy)
 
-**Coming soon:** DOCX viewing and annotation powered by [Docxodus](https://github.com/JSv4/Docxodus).
+See [Supported File Formats](docs/upload_methods/supported_formats.md) for parser details and the `supportedMimeTypes` GraphQL query that exposes the live list to the frontend.
 
 ---
 

--- a/docs/architecture/analyzers.md
+++ b/docs/architecture/analyzers.md
@@ -116,3 +116,29 @@ For complete implementation details, see the decorator source at [`opencontracts
 - Corpus-wide analysis integration
 - Automatic result storage
 - Error handling and retries
+
+## Annotation Review & User Feedback
+
+Analyzer-generated annotations can be reviewed and curated by humans through the
+`UserFeedback` system (`opencontractserver/feedback/models.py`).
+
+Each `UserFeedback` row links to a single `Annotation` and stores:
+
+- `approved` / `rejected` — mutually exclusive boolean flags (enforced via
+  `clean()`).
+- `comment` — free-text reviewer note.
+- `markdown` — long-form reviewer commentary.
+- `metadata` — JSON for tool-specific review data.
+
+The feedback layer is exposed via GraphQL:
+
+| Mutation / Query | Purpose |
+|---|---|
+| `approveAnnotation` | Mark an annotation as reviewer-approved; returns `UserFeedbackType`. |
+| `rejectAnnotation` | Mark an annotation as reviewer-rejected; returns `UserFeedbackType`. |
+| `userFeedback` | Connection of feedback rows visible to the requesting user. |
+
+`UserFeedback` carries its own object-level permissions (`approve`, `reject`,
+`comment`, etc.) and is filtered via the standard `visible_to_user` pattern.
+This makes it suitable both for analyst QA workflows on automated extractions
+and for crowd-sourced annotation review on public corpuses.

--- a/docs/architecture/discovery_system.md
+++ b/docs/architecture/discovery_system.md
@@ -1,0 +1,65 @@
+# Discovery System
+
+The discovery system serves internet-facing endpoints that tell search engines, AI crawlers, and MCP clients what your OpenContracts instance is and what it exposes. It lives in [`opencontractserver/discovery/`](https://github.com/Open-Source-Legal/OpenContracts/tree/main/opencontractserver/discovery) and is wired in via the project's URL routing.
+
+> **Operator note**: These endpoints are public by default. They only return data that is visible to anonymous users (`Corpus.objects.visible_to_user(AnonymousUser())` etc.), but you should still review what your public corpuses contain before exposing the instance to the internet.
+
+## Endpoints
+
+| Path | What it returns | Standard / use case |
+|---|---|---|
+| `/robots.txt` | Standard `robots.txt` directives | Search engine crawler policy |
+| `/llms.txt` | Compact, LLM-friendly site description | [llms.txt](https://llmstxt.org) — an emerging standard that lets AI agents understand a site's content without scraping HTML |
+| `/llms-full.txt` | Longer, full-content variant of `/llms.txt` | Same standard, larger payload |
+| `/sitemap.xml` | XML sitemap of public corpuses and documents | Search engines, AI crawlers |
+| `/.well-known/mcp.json` | MCP server manifest describing the corpus tools available via `/mcp` | [Model Context Protocol](https://modelcontextprotocol.io) discovery — used by Claude, Cursor, and other MCP-aware tools to find your server |
+| `/api/search/` | RESTful search across public corpuses and documents | AI agents and external integrators that don't want to use GraphQL |
+
+All endpoints are cacheable (`@cache_page(DISCOVERY_CACHE_SECONDS)`) and rate-limited per IP. The rate limit value is sourced from `opencontractserver.mcp.config.RATE_LIMIT_REQUESTS` (default 100 requests/minute per IP) and is exposed in the responses as a human-readable hint.
+
+## What the endpoints expose
+
+The endpoints serve **only public data**:
+
+- `Corpus.objects.visible_to_user(AnonymousUser())` — corpuses with `is_public=True`
+- `Document.objects.visible_to_user(AnonymousUser())` (via `DocumentPath` joins to the public corpus set) — current-version documents in public corpuses
+- Corpus and document titles, slugs, descriptions, and aggregate counts (e.g., `active_document_count`)
+
+User identities, private documents, private annotations, and conversation contents are **never** included.
+
+## Constants
+
+Tunable constants live in `opencontractserver/constants/discovery.py`:
+
+| Constant | Purpose |
+|---|---|
+| `DISCOVERY_CACHE_SECONDS` | HTTP cache TTL for all discovery responses |
+| `MAX_PUBLIC_CORPUSES` | Cap on the number of corpuses surfaced in `sitemap.xml` and `llms*.txt` |
+| `MAX_SEARCH_RESULTS` | Cap on `/api/search/` result count |
+
+## Telemetry
+
+Each discovery endpoint hit fires a `discovery_endpoint_served` PostHog event (handled by `config.telemetry.record_event`) with the endpoint name and the requesting user-agent. This is useful for understanding which AI crawlers are actually using your instance.
+
+To opt out, leave `REACT_APP_POSTHOG_API_KEY` unset and the backend will no-op the event call.
+
+## Customisation
+
+To customise the discovery content, edit the view functions in `opencontractserver/discovery/views.py`:
+
+- `robots_txt` — `User-agent` rules, sitemap URL.
+- `llms_txt` / `llms_full_txt` — site description, public corpus listing format.
+- `sitemap_xml` — what gets included in the XML sitemap.
+- `well_known_mcp` — MCP server manifest (server URL, transport, tool list summary).
+- `search_api` — search query semantics, result shape.
+
+Markdown content fed into the `llms*.txt` endpoints is sanitised with `_sanitize_markdown_title` to prevent markdown injection via crafted corpus titles.
+
+## Disabling discovery
+
+To remove the discovery endpoints entirely, drop the `opencontractserver.discovery` URL include from your project's URL configuration. Note that `/.well-known/mcp.json` is the canonical advertise-the-MCP-server endpoint; AI tools that follow the standard will look for it.
+
+## Related
+
+- [MCP Server](../mcp/README.md) — what `/.well-known/mcp.json` actually advertises.
+- [Telemetry – Backend](../telemetry/Backend.md) — `record_event` and PostHog setup.

--- a/docs/architecture/llms/README.md
+++ b/docs/architecture/llms/README.md
@@ -475,11 +475,81 @@ user_msg_id = await agent.store_user_message("Custom user message")
 llm_msg_id = await agent.store_llm_message("Custom LLM response")
 ```
 
+### Context Management
+
+Conversations can outgrow an LLM's context window, both during a single
+high-tool-traffic turn and across many turns of a long-lived thread. The
+framework ships two complementary subsystems for this:
+
+#### Context Guardrails (single-turn protection)
+
+`opencontractserver/llms/context_guardrails.py` provides three layers of
+runtime protection against context overflow:
+
+1. **Token estimation** — heuristics that approximate token counts for prompts,
+   tool outputs, and message history without paying the cost of a real
+   tokeniser.
+2. **Conversation compaction** — old messages are summarised in place when the
+   estimated context budget would be exceeded, preserving recent turns and key
+   instructions verbatim while collapsing older context into a summary.
+3. **Tool-output truncation** — long tool results are clipped (with a marker)
+   before being injected back into the conversation.
+
+The guardrails fire automatically inside the WebSocket consumer's per-turn
+loop. When the budget is exhausted to the point that no further safe
+compaction is possible, the consumer emits an `ASYNC_ERROR` with `error =
+WS_ERROR_CONTEXT_EXHAUSTED` (see `opencontractserver.constants.context_guardrails`).
+
+Tunable constants live in `opencontractserver/constants/context_guardrails.py`.
+
+#### Memory Curation (cross-conversation learning)
+
+`opencontractserver/tasks/memory_tasks.py` is a Celery-based pipeline that
+turns idle conversations into long-term corpus memory:
+
+1. A scheduled task scans for conversations whose latest message is older than
+   the idle threshold and that have not yet been curated.
+2. Each idle conversation is summarised by a curation LLM.
+3. The summary is merged into the corpus's memory document.
+4. The conversation is marked `curated=True` so it is not re-processed.
+
+Memory is then read by agents via the `read_corpus_memory` tool
+(`opencontractserver/llms/tools/core_tools/memory.py`), so a corpus's agents
+gradually accumulate knowledge from prior interactions without inflating
+per-turn context.
+
+Operators should monitor curation cost and tune the idle threshold to balance
+freshness against LLM spend.
+
 ### Tools
 
 The framework provides a unified tool system that works across all supported frameworks. Core tools often have synchronous and asynchronous versions (e.g., `load_document_md_summary` and `aload_document_md_summary`).
 
 #### Built-in Tools
+
+The framework ships a substantial library of built-in tools under
+`opencontractserver/llms/tools/core_tools/`. Highlights:
+
+| Tool family | File | Purpose |
+|---|---|---|
+| Annotations | `annotations.py` | Read / create annotations and labels |
+| Documents | `documents.py` | Document metadata, summaries, file access |
+| Notes | `notes.py` | Read / write per-document notes |
+| Document summaries | `document_summaries.py`, `md_summaries.py` | Generate and read markdown summaries |
+| Page images | `page_images.py` | Vision tools — fetch page images for multimodal models |
+| Search | `search.py`, `document_indexing.py`, `text_extracts.py` | Vector search, keyword search, sourced text-span retrieval |
+| Links | `links.py` | Create / read `OC_URL` link annotations |
+| CAML / corpus articles | `caml_article.py` | Read / write the corpus's markdown "README" article |
+| Memory | `memory.py` | Read the curated corpus memory document |
+| Descriptions | `descriptions.py` | Read / update corpus and document descriptions |
+| **PII** | `pii.py` | Scan documents for PII via the Privacy Filter microservice and persist results as annotations |
+| Privacy Filter client | `_privacy_filter_client.py` | HTTP client for the external Privacy Filter service |
+
+In addition, `opencontractserver/llms/tools/web_search_tools.py` exposes a
+real-time web search tool that agents can call mid-conversation. Set
+`SEARCH_PROVIDER_API_KEY` (or the relevant env var for your provider) to enable
+it. Be aware of the privacy and cost implications before enabling it on
+documents that contain sensitive data.
 
 ```python
 from opencontractserver.llms.tools import create_document_tools # Convenience function
@@ -1298,6 +1368,19 @@ agent = PydanticAIAgent(
 This applies to all three agent creation sites in `pydantic_ai_agents.py`: `PydanticAIDocumentAgent.create()`, `PydanticAICorpusAgent.create()`, and the structured extraction agent in `structured_response()`.
 
 > **Version note**: Verified against pydantic-ai 0.2.20. Future versions may unify these parameters.
+
+**All production tools MUST be async (`a`-prefixed in `core_tools.py`)**
+
+`PydanticAIToolWrapper` accepts both sync and async functions, but the wrapper does **NOT** push sync callables onto a thread pool. A sync function that touches the Django ORM (e.g., `Document.objects.get(...)`) will raise `SynchronousOnlyOperation` the moment it runs inside an async agent loop.
+
+Use the `a`-prefixed async versions defined in `opencontractserver/llms/tools/core_tools/`. The sync versions exist for testing and lightweight helpers only.
+
+**Operational errors become tool error strings; security errors propagate (issue #820)**
+
+The wrapper has a deliberate fault-tolerance contract:
+
+- **Operational exceptions** (network errors, parsing errors, missing data, etc.) are caught and returned to the LLM as an error string. This lets the model recover or apologise gracefully instead of crashing the conversation.
+- **Security exceptions** — specifically `PermissionError` and `ToolConfirmationRequired` — propagate to the consumer. The agent stops; the user sees an approval prompt or an auth error. Tools should raise these explicitly when access is denied or confirmation is needed.
 
 #### Framework Selection
 

--- a/docs/architecture/structural_vs_non_structural_annotations.md
+++ b/docs/architecture/structural_vs_non_structural_annotations.md
@@ -297,6 +297,40 @@ These represent user-specific or analysis-specific interpretations and are natur
 - Document parsing may occur multiple times for same content
 - Mitigated by caching at upload layer when appropriate
 
+## Materialised Subtree Groups (`OC_SUBTREE_GROUP`)
+
+Structural parsing produces a hierarchy of annotations connected by
+`Annotation.parent` self-FKs and explicit `OC_PARENT_CHILD_LABEL_NAME`
+relationships. To make "give me the surrounding block of an annotation hit"
+queries cheap, every non-leaf node also gets a pre-materialised
+`OC_SUBTREE_GROUP` `Relationship` row whose **source** is that ancestor and
+whose **targets** are the ancestor's full transitive descendant set.
+
+Retrieval can then surface the larger block of an annotation hit with a single
+join instead of running a recursive CTE per result.
+
+### Where this happens
+
+`BaseParser.save_parsed_data` calls `build_subtree_groups_for_document` (in
+`opencontractserver/utils/subtree_groups.py`) between the relationship-import
+step and the structural-set migration. The system label `OC_SUBTREE_GROUP` is
+resolved by filter-first / create-as-fallback (ignoring `creator`), so the
+label never silently forks per-user.
+
+### Guardrails
+
+- Groups whose descendant set exceeds `SUBTREE_GROUP_MAX_DESCENDANTS` (default
+  500) are skipped with a warning.
+- The walker prunes branches deeper than `SUBTREE_GROUP_MAX_DEPTH` (default
+  32) and detects cycles defensively via on-stack tracking.
+
+### Re-parse safety
+
+Prior `OC_SUBTREE_GROUP` rows are deleted from both `document`-scoped and
+`structural_set`-scoped tables before re-materialisation, and newly created
+rows are attached directly to the existing `StructuralAnnotationSet` when one
+is already linked to the document — so re-parsing never leaves orphan rows.
+
 ## Migrations
 
 Key migrations implementing this architecture:

--- a/docs/architecture/websocket/protocol.md
+++ b/docs/architecture/websocket/protocol.md
@@ -2,20 +2,42 @@
 
 ## Introduction
 
-OpenContracts uses WebSocket connections to enable real-time streaming communication between the frontend and backend for chat-based interactions. This document provides a comprehensive overview of the WebSocket protocol, message types, and data flow.
+OpenContracts uses WebSocket connections to deliver real-time streaming output from AI agents and real-time push of notifications and thread updates. This document covers the WebSocket URL surface, the auth handshake, the message envelope, and the lifecycle of an agent conversation.
 
-## Protocol Architecture
+The source of truth is [`config/asgi.py`](https://github.com/Open-Source-Legal/OpenContracts/blob/main/config/asgi.py) (routing) and the three consumers under [`config/websocket/consumers/`](https://github.com/Open-Source-Legal/OpenContracts/blob/main/config/websocket/consumers/).
 
-The WebSocket protocol in OpenContracts follows a streaming pattern where:
+## URL Surface
 
-1. **Client initiates connection** with authentication and context
-2. **Client sends queries** as JSON messages
-3. **Server streams responses** using typed message events
-4. **Client updates UI** reactively based on message type
+Three WebSocket endpoints are registered (see `config/asgi.py:85-111`):
 
-## Message Types
+| URL | Consumer | Purpose | Query parameters |
+|---|---|---|---|
+| `ws/agent-chat/` | `UnifiedAgentConsumer` | All AI-agent conversations (document chat, corpus chat, standalone agent chat) | `corpus_id`, `document_id`, `conversation_id`, `agent_id` (all optional, but at least one of `corpus_id` / `document_id` / `agent_id` is required) |
+| `ws/thread-updates/` | `ThreadUpdatesConsumer` | Streaming agent-mention responses inside a discussion thread | `conversation_id` (required) |
+| `ws/notification-updates/` | `NotificationUpdatesConsumer` | Real-time notification push (badges, moderation, agent responses) | none — keyed off the authenticated user |
 
-All WebSocket messages follow a standardized JSON envelope:
+The `UnifiedAgentConsumer` replaces three legacy consumers (`DocumentQueryConsumer`, `CorpusQueryConsumer`, `StandaloneDocumentQueryConsumer`) so context now flows in via query parameters instead of URL path segments.
+
+### Agent selection (UnifiedAgentConsumer)
+
+1. If `agent_id` is supplied → use that specific `AgentConfiguration`.
+2. Else if `document_id` is supplied → use the GLOBAL default-document-agent.
+3. Else if `corpus_id` is supplied → use the GLOBAL default-corpus-agent.
+4. Otherwise → reject the connection.
+
+## Authentication
+
+All three consumers run behind the shared [`JWTAuthMiddleware`](https://github.com/Open-Source-Legal/OpenContracts/blob/main/config/websocket/middleware.py) (wired in `config/asgi.py:120-122`). It accepts:
+
+- **Auth0 JWTs** when `USE_AUTH0=True`. The token is extracted from the `Authorization: Bearer …` header (or from a `token` subprotocol fallback) and verified against the cached JWKS.
+- **Django sessions** otherwise — a `sessionid` cookie is enough.
+- **Anonymous** access is allowed for connections that touch only public resources; per-message permission checks gate any access to private data.
+
+If authentication fails, the connection is closed with code `WS_CLOSE_UNAUTHENTICATED`. Rate-limit violations close with `WS_CLOSE_RATE_LIMITED`.
+
+## Message Envelope
+
+All messages exchanged over `ws/agent-chat/` and `ws/thread-updates/` follow this JSON envelope:
 
 ```typescript
 interface MessageData {
@@ -33,186 +55,103 @@ interface MessageData {
       tool_call_id?: string;
     };
     approval_decision?: string;
+    requesting_agent?: { slug: string; name: string };  // sub-agent attribution
     error?: string;
     [key: string]: any;
   };
 }
 ```
 
-### Core Message Types
+### Core message types
 
-#### ASYNC_START
-- **Purpose**: Signals the beginning of a new LLM response
-- **Content**: Empty string
-- **Data**: Contains `message_id` for tracking
-- **Frontend Action**: Creates new message bubble, sets processing state
+| Type | Direction | Purpose |
+|---|---|---|
+| `ASYNC_START` | server→client | Begins a new LLM response. `data.message_id` identifies the bubble. |
+| `ASYNC_CONTENT` | server→client | Streams partial content for an in-flight message. |
+| `ASYNC_THOUGHT` | server→client | Reasoning / tool-planning trace; appended to the message timeline. |
+| `ASYNC_SOURCES` | server→client | Citation `sources` array; enables source pin / citation UI. |
+| `ASYNC_APPROVAL_NEEDED` | server→client | Sub-agent or tool call needs human approval. Frontend shows the approval modal. `data.requesting_agent` (when present) attributes the request to a `@mentioned` sub-agent rather than the conductor. |
+| `ASYNC_APPROVAL_RESULT` | server→client | Echoes the user's approval decision back. |
+| `ASYNC_RESUME` | server→client | Resumes streaming after an approval gate. |
+| `ASYNC_FINISH` | server→client | Final content + sources + timeline; marks the message complete. |
+| `ASYNC_ERROR` | server→client | LLM/tool error; UI shows error state. |
+| `SYNC_CONTENT` | server→client | One-shot non-streaming message (errors during validation, etc.). |
 
-#### ASYNC_CONTENT
-- **Purpose**: Streams partial content during LLM generation
-- **Content**: Incremental text content
-- **Data**: Contains `message_id` for message identification
-- **Frontend Action**: Appends content to existing message bubble
+The frontend reads these inside `useChatAgentMessageHandler` (`frontend/src/components/knowledge_base/document/right_tray/useChatAgentMessageHandler.ts`).
 
-#### ASYNC_THOUGHT
-- **Purpose**: Shares LLM's internal reasoning or tool planning
-- **Content**: Thought text or reasoning
-- **Data**: Contains `message_id`, `tool_name`, `args` for context
-- **Frontend Action**: Adds timeline entry to message
+### Client → server messages
 
-#### ASYNC_SOURCES
-- **Purpose**: Provides citation sources while streaming
-- **Content**: Empty string
-- **Data**: Contains array of `sources` with annotation metadata
-- **Frontend Action**: Updates source pins, enables citation clicking
+The client sends a JSON payload with the user's prompt:
 
-#### ASYNC_APPROVAL_NEEDED
-- **Purpose**: Requests user approval for tool execution
-- **Content**: Empty string
-- **Data**: Contains `pending_tool_call` with tool details
-- **Frontend Action**: Shows approval modal, pauses processing
-
-#### ASYNC_FINISH
-- **Purpose**: Finalizes the streaming response
-- **Content**: Complete final content
-- **Data**: Contains final `sources`, `timeline`, and `message_id`
-- **Frontend Action**: Marks message complete, re-enables input
-
-#### ASYNC_ERROR
-- **Purpose**: Reports errors during processing
-- **Content**: Empty string
-- **Data**: Contains `error` message and optional metadata
-- **Frontend Action**: Shows error state, re-enables input
-
-#### SYNC_CONTENT
-- **Purpose**: Sends complete non-streaming messages
-- **Content**: Full message content
-- **Data**: Optional sources and metadata
-- **Frontend Action**: Displays as complete message immediately
-
-## Connection Lifecycle
-
-### 1. Connection Establishment
-
-The WebSocket connection is established with specific URL patterns:
-
-**Document Chat:**
-```
-/ws/document/{corpus_id}/{document_id}/
+```json
+{ "query": "What are the key terms in this contract?" }
 ```
 
-**Corpus Chat:**
+For approval gates, the client replies with an approval decision:
+
+```json
+{ "approval_decision": "approve" | "deny", "tool_call_id": "…" }
 ```
-/ws/corpus/{corpus_id}/
-```
 
-Query parameters:
-- `load_from_conversation_id`: Resume existing conversation (optional)
-
-### 2. Authentication
-
-All connections require:
-- Valid Django user session
-- Authentication token in WebSocket scope
-- Access permissions to the target corpus/document
-
-### 3. Message Flow
+## Connection Lifecycle (agent-chat)
 
 ```mermaid
 sequenceDiagram
-    Client->>Server: Connect with auth
-    Server->>Client: Connection accepted
-    Client->>Server: {"query": "user question"}
-    Server->>Client: ASYNC_START
-    Server->>Client: ASYNC_THOUGHT (optional)
-    Server->>Client: ASYNC_CONTENT (streaming)
-    Server->>Client: ASYNC_SOURCES (optional)
-    Server->>Client: ASYNC_FINISH
+    Client->>Middleware: Connect (with JWT or session cookie)
+    Middleware->>Consumer: Accept (or close 4000/4001)
+    Consumer->>Client: Connection accepted
+    Client->>Consumer: {"query": "user question"}
+    Consumer->>Client: ASYNC_START
+    Consumer->>Client: ASYNC_THOUGHT (optional, repeating)
+    Consumer->>Client: ASYNC_CONTENT (streaming tokens)
+    Consumer->>Client: ASYNC_APPROVAL_NEEDED (if a tool call needs human approval)
+    Client->>Consumer: {"approval_decision": "approve"}
+    Consumer->>Client: ASYNC_RESUME
+    Consumer->>Client: ASYNC_SOURCES (optional)
+    Consumer->>Client: ASYNC_FINISH
 ```
 
-### 4. Error Handling
+### Sub-agent delegation
 
-Errors can occur at multiple levels:
+When the user `@mentions` an agent (rich-mention agent delegation), the conductor's per-turn tool surface is rebuilt to include a `delegate_to_<slug>` tool for each mentioned agent. If a sub-agent's tool call needs approval, the `ASYNC_APPROVAL_NEEDED` frame carries `requesting_agent` so the approval modal attributes the request correctly. Pinned sub-agent replies arrive as separate `ChatMessage` rows (with `agentConfiguration` set) and render their own bubble + attribution chip.
 
-**Connection Level:**
-- Authentication failures → Close with code 4000
-- Invalid corpus/document → Error message + close
-- Network issues → Automatic reconnection attempts
+## thread-updates messages
 
-**Message Level:**
-- Malformed JSON → SYNC_CONTENT with error
-- LLM failures → ASYNC_ERROR message
-- Processing errors → SYNC_CONTENT with error
+`ThreadUpdatesConsumer` emits a different set of event types tailored to thread-side mention streaming (`thread_updates.py:205-262`):
 
-## State Management
+- `agent_stream_start` — sub-agent started responding to a mention.
+- `agent_stream_token` — incremental token in the sub-agent's response.
+- `agent_tool_call` — a tool call inside the sub-agent's turn.
+- `agent_stream_complete` — sub-agent finished; a complete `ChatMessage` row is now visible via GraphQL.
+- `agent_stream_error` — sub-agent errored out.
 
-### Backend State
+## notification-updates messages
 
-Each WebSocket consumer maintains:
-- **Agent instance**: Persistent across queries for conversation context
-- **Session ID**: Unique identifier for logging and debugging
-- **User context**: Authentication and permissions
-- **Conversation ID**: Database record for message persistence
+`NotificationUpdatesConsumer` (`notification_updates.py:233-286`) emits:
 
-### Frontend State
+- `notification_created` — new notification (badge award, mention, moderation action, etc.).
+- `notification_updated` — read/dismissed state changed.
+- `notification_deleted` — notification removed.
 
-The frontend manages:
-- **Connection status**: `wsReady`, `wsError` flags
-- **Message state**: Arrays of `ChatMessageProps`
-- **Source state**: Citation metadata in Jotai atoms
-- **Processing state**: Input disable/enable based on streaming
-- **Approval state**: Modal visibility and pending decisions
+## Error Handling
 
-## Security Considerations
+| Error class | Behaviour |
+|---|---|
+| Auth failure | Close with `WS_CLOSE_UNAUTHENTICATED` (per `config/websocket/middleware.py`). |
+| Rate-limit exhaustion | Close with `WS_CLOSE_RATE_LIMITED`. |
+| Invalid context (no `corpus_id` / `document_id` / `agent_id`) | Close immediately. |
+| Malformed JSON in receive | `SYNC_CONTENT` error message. |
+| LLM context exhausted | `ASYNC_ERROR` with `error = WS_ERROR_CONTEXT_EXHAUSTED` (see `opencontractserver.constants.context_guardrails`). |
+| LLM/tool failure | `ASYNC_ERROR` with `data.error` populated. |
 
-### Authentication
-- WebSocket connections inherit Django session authentication
-- Each message validates user permissions
-- Corpus/document access controlled by Django permissions
+## Permissions & Rate Limiting
 
-### Data Validation
-- All incoming JSON payloads are validated
-- Message IDs prevent cross-conversation pollution
-- Source references validated against user permissions
-
-### Rate Limiting
-- WebSocket consumers implement natural backpressure
-- Long-running queries can be cancelled via connection close
-- No explicit rate limiting beyond Django middleware
-
-## Performance Characteristics
-
-### Streaming Benefits
-- Progressive content display improves perceived performance
-- Early source citations enable immediate user interaction
-- Timeline events provide transparency into LLM reasoning
-
-### Resource Management
-- Agent instances reused within sessions for efficiency
-- Database connections pooled via Django ORM
-- Memory cleanup on WebSocket disconnect
-
-### Scalability
-- Each WebSocket consumer runs in isolated async context
-- Horizontal scaling supported via Django Channels
-- Redis backend for multi-server deployments (if configured)
-
-## Debugging and Monitoring
-
-### Logging
-- Session IDs included in all log messages
-- Debug-level logging for message flow
-- Error-level logging for failures with stack traces
-
-### Frontend Debugging
-- Console logging for WebSocket events
-- Message ID tracking for correlation
-- Connection state indicators in UI
-
-### Backend Debugging
-- Consumer lifecycle logging
-- Agent creation and query processing logs
-- Database query logging (if enabled)
+- Per-message permission checks run inside the consumer using `Model.objects.visible_to_user(user)` patterns — the WebSocket connection itself is not a free pass.
+- Rate-limit decorators (`config/ratelimit/decorators.check_ws_rate_limit`) gate connection setup and per-message throughput.
+- The consumer's "agent instance" is reused within a session for conversation continuity, but no state survives a disconnect — reconnection always starts a fresh handshake.
 
 ## Related Documentation
-- [Backend Implementation](./backend.md)
-- [Frontend Implementation](./frontend.md)
+
+- [Backend implementation notes](backend.md)
+- [Frontend implementation notes](frontend.md)
+- [Routing & auth handshake](../../frontend/auth_flow.md)

--- a/docs/configuration/frontend-configuration.md
+++ b/docs/configuration/frontend-configuration.md
@@ -17,7 +17,9 @@ The frontend uses different environment variable prefixes depending on the deplo
 | Local development (Vite) | `VITE_` | `VITE_USE_AUTH0=true` |
 | Production (Docker/K8s) | `OPEN_CONTRACTS_` | `OPEN_CONTRACTS_REACT_APP_USE_AUTH0=true` |
 
-**How it works**: In production, the container entrypoint converts `OPEN_CONTRACTS_REACT_APP_*` environment variables to `REACT_APP_*` on `window._env_`. For example, `OPEN_CONTRACTS_REACT_APP_USE_AUTH0` becomes available as `REACT_APP_USE_AUTH0` in the frontend code.
+**How it works**: In production, the container entrypoint script writes a runtime-loaded file at `frontend/public/env-config.js` that populates `window._env_` with the `REACT_APP_*` variables converted from `OPEN_CONTRACTS_REACT_APP_*`. For example, `OPEN_CONTRACTS_REACT_APP_USE_AUTH0` becomes `window._env_.REACT_APP_USE_AUTH0` in the frontend code. The browser fetches `env-config.js` on every page load, so configuration changes do **not** require a frontend rebuild — only a container restart (or `env-config.js` regeneration) is needed.
+
+See [`frontend/public/env-config.js`](https://github.com/Open-Source-Legal/OpenContracts/blob/main/frontend/public/env-config.js) for the file structure and the [Frontend Telemetry doc](../telemetry/Frontend.md) for how the same mechanism is used to inject PostHog keys.
 
 ## Available Configuration Options
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,80 +1,66 @@
 ![OpenContracts](assets/images/logos/OS_Legal_Logo.png)
 
-# Open Contracts
+# OpenContracts
 
-## The Free and Open Source Document Analytics Platform
+## The open source platform for building knowledge bases that humans and AI agents can work with together
 
 ---
 
-| |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-| --- |--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| CI/CD | [![codecov](https://codecov.io/gh/JSv4/OpenContracts/branch/main/graph/badge.svg?token=RdVsiuaTVz)](https://codecov.io/gh/JSv4/OpenContracts)                                                                                                                                                                                                                                                                                                                  |
+| | |
+| --- | --- |
+| Backend coverage | [![backend](https://codecov.io/gh/Open-Source-Legal/OpenContracts/branch/main/graph/badge.svg?flag=backend&token=RdVsiuaTVz)](https://app.codecov.io/gh/Open-Source-Legal/OpenContracts?flags%5B0%5D=backend) |
+| Frontend coverage | [![frontend](https://codecov.io/gh/Open-Source-Legal/OpenContracts/branch/main/graph/badge.svg?flag=frontend&token=RdVsiuaTVz)](https://app.codecov.io/gh/Open-Source-Legal/OpenContracts?flags%5B0%5D=frontend) |
 | Meta | [![code style - black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black) [![types - Mypy](https://img.shields.io/badge/types-Mypy-blue.svg)](https://github.com/python/mypy) [![imports - isort](https://img.shields.io/badge/imports-isort-ef8336.svg)](https://github.com/pycqa/isort) [![License - MIT](https://img.shields.io/badge/license-MIT-green)](https://opensource.org/licenses/MIT) |
+
+OpenContracts is an MIT-licensed, self-hosted document analytics platform. Teams build knowledge bases from their documents and AI agents work alongside humans to search, analyze, and extend that knowledge.
 
 ## What Does it Do?
 
-OpenContracts is an **MIT Licensed** enterprise document analytics tool. It provides several key features:
+OpenContracts gives you, in one place:
 
-1. **Manage Documents** - Manage document collections (`Corpuses`)
-2. **Custom Metadata Schemas** - Define structured metadata fields with validation for consistent data collection
-3. **Layout Parser** - Automatically extracts layout features from PDFs
-4. **Automatic Vector Embeddings** - generated for uploaded PDFs and extracted layout blocks
-5. **Pluggable microservice analyzer architecture** - to let you analyze documents and automatically annotate them
-6. **Human Annotation Interface** - to manually annotated documents, including multi-page annotations.
-7. **Data Extract** - ask multiple questions across hundreds of documents using complex LLM-powered querying behavior.
-   Our sample implementation uses our battle-tested agent framework for precise data extraction and natural language querying.
-8. **Custom Data Extract** - Custom data extract pipelines can be used on the frontend to query documents in bulk.
+1. **Document collections** organised as **corpuses** with folder hierarchies, fine-grained permissions, full history, and forking.
+2. **Multi-format ingestion** — PDF (layout-faithful, via Docling), DOCX (via [Docxodus](https://github.com/JSv4/Docxodus)), and plain text. See [Supported File Formats](upload_methods/supported_formats.md).
+3. **Pluggable parser / embedder / thumbnailer pipeline** — register your own in Python (see [Pipeline Overview](pipelines/pipeline_overview.md)).
+4. **Custom metadata schemas** — typed fields with validation. See [Metadata Overview](metadata/metadata_overview.md).
+5. **Human annotation interface** — multi-page text annotations, document-level type labels, relationships, notes, and structural annotations (auto-extracted by the parser).
+6. **AI agents** — configurable agents built on PydanticAI that search documents, query annotations, and participate in discussions. See [LLM Framework](architecture/llms/README.md).
+7. **MCP server** — expose your corpus to Claude, Cursor, and any MCP-compatible AI tool via streamable HTTP (and a deprecated SSE transport). See [MCP](mcp/README.md).
+8. **Data extract** — ask multiple questions across hundreds of documents using `Fieldset` / `Column` / `Extract` records. See [Data Extraction](extract_and_retrieval/data_extraction.md).
+9. **Forum-style discussions** — global, per-corpus, and per-document threads with voting, moderation, @-mentions of documents/corpuses/agents, and badge-based reputation. See [Commenting System](commenting_system/README.md).
+10. **Corpus actions** — automation triggers that run a fieldset, analyzer, or agent when a document is added / edited or a discussion thread / message arrives. See [Corpus Actions](corpus_actions/intro_to_corpus_actions.md).
+11. **Document versioning & forking** — version-controlled corpuses; fork a public corpus to build on someone else's work.
+12. **Multimodal search** — combined vector embeddings (pgvector) and full-text search over documents and annotations.
 
 ![Grid Review And Sources.gif](assets/images/gifs/Grid_Review_And_Sources.gif)
 
-![Manual Annotations](assets/images/screenshots/Jumped_To_Annotation.png)
-
 ## Key Docs
 
-1. [Quickstart Guide](quick_start.md) - You'll probably want to get started quickly. Setting up locally should be
-   pretty painless if you're already running Docker.
-2. [Basic Walkthrough](walkthrough/key-concepts.md) - Check out the walkthrough to step through basic usage of the
-   application for document and annotation management.
-3. [Metadata System](metadata/metadata_overview.md) - Learn how to define custom metadata schemas for your documents
-   with comprehensive validation and type safety.
-4. [PDF Annotation Data Format Overview](architecture/PDF-data-layer.md) - You may be interested how we map text to
-   PDFs visually and the underlying data format we're using.
-5. [Vector Store Architecture](extract_and_retrieval/vector_stores.md)
-   We've used the latest open source tooling for vector storage in postgres to make it almost trivially easy to
-   combine structured metadata and vector embeddings with an API-powered application.
-6. [Write Custom Data Extractors](walkthrough/advanced/write-your-own-extractors.md) - Custom data extract tasks are
-   automatically loaded and displayed on the frontend to let users select how to ask questions and extract data from documents.
+1. [Quickstart Guide](quick_start.md) — get running with Docker.
+2. [Key Concepts](walkthrough/key-concepts.md) — the data model and core workflows.
+3. [Metadata System](metadata/metadata_overview.md) — define custom metadata schemas.
+4. [PDF Annotation Data Format](architecture/PDF-data-layer.md) — how text maps to PDF coordinates (PAWLs).
+5. [LLM Framework](architecture/llms/README.md) — PydanticAI integration, tools, agents.
+6. [Vector Store Architecture](extract_and_retrieval/vector_stores.md) — pgvector-backed semantic search.
+7. [Write Custom Data Extractors](walkthrough/advanced/write-your-own-extractors.md) — extend the extraction pipeline.
 
-## Architecture and Data Flows at a Glance
+## Architecture at a Glance
 
-### Core Data Standard
+### Core Data Standard (PAWLs)
 
-The core idea here - besides providing a platform to analyze contracts - is an open and standardized architecture that
-makes data extremely portable. Powering this is a set of data standards to describe the text and layout blocks on a PDF
-page:
+OpenContracts uses a portable text-and-layout format derived from AllenAI's PAWLs project — tokens with bounding boxes per page, so annotations carry both their text and their visual position:
 
 ![Data Format](assets/images/diagrams/pawls-annotation-mapping.svg)
 
-### Robust PDF Processing Pipeline
+### Processing Pipeline
 
-We have a robust PDF processing pipeline that is horizontally scalable and generates our standardized data
-consistently for PDF inputs (We're working on adding additional formats soon):
+The modular pipeline supports custom parsers, embedders, and thumbnail generators. Documents flow through three stages: parse → thumbnail → embed.
 
-![PDF Processor](assets/images/diagrams/PDF-processor-sequence-diagram.png)
+![Pipeline Diagram](assets/images/diagrams/parser_pipeline.svg)
 
-Special thanks to Nlmatics and [nlm-ingestor](https://github.com/nlmatics/nlm-ingestor) for powering the layout parsing
-and extraction.
+## License
 
-## Limitations
-
-At the moment, it only works with PDFs. In the future, it will be able to convert other document types to PDF for
-storage and labeling. PDF is an excellent format for this as it introduces a consistent, repeatable format which we can
-use to generate a text and x-y coordinate layer from scratch.
-
-**Adding OCR and ingestion for other enterprise documents is a priority**.
+OpenContracts is released under the [MIT License](https://github.com/Open-Source-Legal/OpenContracts/blob/main/LICENSE). Build proprietary products on it, embed it in commercial offerings, fork it, ship it — no copyleft strings attached.
 
 ## Acknowledgements
 
-Special thanks to AllenAI's [PAWLS project](https://github.com/allenai/pawls) and Nlmatics
-[nlm-ingestor](https://github.com/nlmatics/nlm-ingestor). They've pioneered a number of features and flows, and we are
-using their code in some parts of the application.
+This project builds on work from [AllenAI PAWLS](https://github.com/allenai/pawls) (PDF annotation data format and concepts).

--- a/docs/permissioning/REMEDIATION_GUIDE.md
+++ b/docs/permissioning/REMEDIATION_GUIDE.md
@@ -5,6 +5,34 @@
 
 ---
 
+## ⚠️ Status Update (post-audit)
+
+**Most of the CRITICAL findings below have been fixed in code.** This document is preserved as the historical audit record. Verification spot-checks:
+
+| Finding (CRITICAL) | Current status in `main` | Code reference |
+|---|---|---|
+| `RemoveRelationships` — no permission check | ✅ Fixed: now uses `Relationship.objects.visible_to_user(user)` + `user_has_permission_for_obj()` | `config/graphql/annotation_mutations.py:725-757` |
+| `UpdateRelations` — no permission check | ✅ Fixed: `visible_to_user()` gate before update | `config/graphql/annotation_mutations.py:937+` |
+| `StartCorpusFork` | ✅ Fixed: `visible_to_user()` + explicit READ check | `config/graphql/corpus_mutations.py` |
+| `DeleteMultipleLabelMutation` | ✅ Fixed: creator-ownership + read-only flag check | `config/graphql/label_mutations.py` |
+| `StartQueryForCorpus`, `StartCorpusExport`, `StartDocumentExtract` | ✅ Fixed | corresponding mutation files |
+
+In addition, the more recent **Auth0 permissioning audit** (recorded in `CHANGELOG.md` under "Security / Auth0 permissioning audit") shipped further defense-in-depth changes:
+
+- `AUTH0_SUPERUSER_SUB_ALLOWLIST` allowlist for `is_superuser` JWT-claim sync (F1)
+- `ADMIN_CLAIMS_CACHE_TTL` tightened from 300 s → 30 s (F2)
+- `AddRelationship` IDOR oracle eliminated; document-ID is now visibility-checked (F3 + F4)
+- `CreateMetadataColumn` / `UpdateMetadataColumn` existence oracles eliminated (F5, F6)
+- `Datacell` mutation broad-except message leaks closed (F7)
+- Bounded JWKS stale-cache fallback (F9)
+- `Analysis.callback_token` now hashed at rest (F10)
+
+The CHANGELOG entry also lists **verified false positives** (e.g., `SetCorpusVisibility`, `AnnotationImagesView`, moderation mutations) — items this guide may have over-stated.
+
+**When reading this document, treat each finding as historical context** and verify the current code state before acting. Open issues (if any) should be tracked separately in GitHub.
+
+---
+
 ## Executive Summary
 
 This guide consolidates and **corrects** the findings from the GraphQL and Task audit reports. After careful code review, the original reports contained several inaccuracies and overstated claims. This guide provides:

--- a/docs/permissioning/read_only_mode.md
+++ b/docs/permissioning/read_only_mode.md
@@ -50,6 +50,19 @@ Read-only mode prevents users from modifying documents and annotations while sti
 
 ## Implementation Patterns
 
+> **Naming note**: the codebase currently mixes two prop names for the same
+> concept:
+> - **`readOnly`** (camelCase) — the standard React convention, used by most
+>   components (`TxtAnnotatorWrapper`, `UnifiedContentFeed`, `HighlightItem`,
+>   `RelationItem`, the styled-component transient prop `$readOnly`, etc.).
+> - **`read_only`** (snake_case) — used by the legacy PDF viewer
+>   (`PDF.tsx`) for historical reasons.
+>
+> When wiring read-only state through a new component, prefer **`readOnly`**.
+> The `read_only` form on `PDF.tsx` is the outlier and is targeted for
+> normalisation; if you touch that component, accept both names during the
+> transition and forward the value to the renderer.
+
 ### Pattern 1: Conditional Rendering
 ```typescript
 // Hide components that have no read-only use case
@@ -72,10 +85,16 @@ Read-only mode prevents users from modifying documents and annotations while sti
 
 ### Pattern 3: Conditional Handlers
 ```typescript
-// Disable handlers in read-only mode
+// Disable handlers in read-only mode (most components — camelCase)
 <HighlightItem
   annotation={annotation}
   onDelete={readOnly ? undefined : handleDelete}
+  readOnly={readOnly}
+/>
+
+// Legacy PDF viewer — snake_case
+<PDF
+  document={document}
   read_only={readOnly}
 />
 ```

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -1,10 +1,23 @@
-### Don't Repeat Yourself
+# Philosophy
 
-OpenContracts is designed not only be a powerful document analysis and annotation platform, it's also envisioned as a
-way to embrace the DRY (Don't Repeat Yourself) principle for legal and legal engineering. You can make a corpus, along
-with all of its labels, documents and annotations "public" (currently, you must do this via a GraphQL mutation).
+## Knowledge is the substrate
 
-Once something is public, it's read-only for everyone other than its original creator. People with read-only access can
-"clone" the corpus to create a private copy of the corpus, its documents and its annotations. They can then edit the
-annotations, add to them, export them, etc. This lets us work from previous document annotations and re-use labels and
-training data.
+Most knowledge lives in documents. Contracts, regulations, research papers, policies — the stuff that governs how organizations actually work. That knowledge is usually trapped: locked in PDFs, scattered across drives, understood fully by a handful of people who happened to read the right things at the right time.
+
+OpenContracts started in 2019 with a simple conviction: that knowledge needed to be carefully curated, and that machine learning systems were only as good as the data underneath them. It was built as a platform for human collaborators — lawyers, researchers, analysts — to annotate documents together and produce gold-standard training data.
+
+Those collaborators mostly never came. The platform was too early, the problem too niche, the value too invisible.
+
+Then large language models arrived, and the world suddenly needed exactly what OpenContracts had been building all along: structured, annotated, version-controlled knowledge bases that AI could actually reason over. The collaborators the platform was designed for finally showed up — they just turned out to be AI agents.
+
+Today, OpenContracts is a self-hosted platform where teams build knowledge bases from their documents and where AI agents work alongside humans to search, analyze, and extend that knowledge. The core conviction hasn't changed. The best AI systems still need carefully curated data. The difference is that now, the curation and the AI happen in the same place.
+
+## DRY for institutional knowledge
+
+The Don't-Repeat-Yourself principle is usually applied to code. We apply it to knowledge. A corpus you have carefully annotated should be sharable — to your team, to your organisation, or to the public. Anyone with read access can fork it to a private copy, refine the annotations, add documents, and share their improvements back.
+
+This is `git` for knowledge: branch it, build on it, share it, restore any prior version, and never lose work.
+
+## Humans first, agents second
+
+OpenContracts is not a "chat with your PDFs" tool. It treats human annotation as the ground truth and builds AI on top — agents reason over real, curated data instead of hallucinating in a vacuum. The quality of an agent's answers is bounded by the quality of the knowledge base underneath, so the platform invests heavily in making annotation, discussion, and review first-class workflows.

--- a/docs/pipelines/docling_parser.md
+++ b/docs/pipelines/docling_parser.md
@@ -73,13 +73,13 @@ DOCLING_ENABLE_OCR = True
 
 ## Microservice Setup
 
-The Docling microservice runs in a separate Docker container:
+The Docling microservice runs in a separate Docker container. The image used in the project's `local.yml` and `production.yml` is `jscrudato/docsling-local`:
 
 ```yaml
-# docker-compose.yml
+# docker-compose.yml (matches local.yml / production.yml)
 services:
   docling-parser:
-    image: opencontracts/docling-parser:latest
+    image: jscrudato/docsling-local
     ports:
       - "8000:8000"
     environment:

--- a/docs/releases/v3.0.0.b3.md
+++ b/docs/releases/v3.0.0.b3.md
@@ -748,7 +748,7 @@ Planned for v3.0.0.b4:
 
 ## Appendix: Auto-Generated Screenshots
 
-All screenshots in this document are **automatically generated** from Playwright component tests via the `docScreenshot()` utility. They are updated on every PR by the `screenshots.yml` CI workflow.
+All screenshots in this document are generated from Playwright component tests via the `docScreenshot()` utility. The `screenshots.yml` workflow is **manual / on-demand** (`workflow_dispatch` only) — trigger it from the Actions tab or via `gh workflow run "Update Documentation Screenshots" -f pr_number=<N>` when you want to refresh the screenshots on a PR.
 
 | Auto Screenshot | Source Test |
 |----------------|------------|
@@ -768,4 +768,4 @@ Never manually edit files in `docs/assets/images/screenshots/auto/` — they are
 ---
 
 *Last updated: December 2025*
-*Questions? Open an issue at https://github.com/JSv4/OpenContracts/issues*
+*Questions? Open an issue at https://github.com/Open-Source-Legal/OpenContracts/issues*

--- a/docs/walkthrough/key-concepts.md
+++ b/docs/walkthrough/key-concepts.md
@@ -1,48 +1,59 @@
+# Key Concepts
+
+This page walks through the core data types and patterns in OpenContracts. It is the recommended starting point for the [walkthrough](step-1-add-documents.md).
+
 ## Data Types
 
-Text annotation data is divided into several concepts:
+OpenContracts organises knowledge into a small set of first-class entities:
 
-1. **Corpuses** (or collections of documents). One document can be in multiple corpuses.
-2. **Documents**. Currently, these are PDFs ONLY.
-3. **Annotations**. These are either document-level annotations (the document type), text-level annotations (highlighted
-   text), or relationships (which apply a label between two annotations). Relationships are currently not
-   well-supported and may be buggy.
-4. **Analyses**. These groups of read-only annotations added by a document analyzer (see more on that below).
+1. **Documents** — uploaded files. PDFs are the primary format (full layout and annotation fidelity via the Docling microservice); DOCX (Docxodus) and plain text (`.txt`) are also supported. See [Supported File Formats](../upload_methods/supported_formats.md).
+2. **Corpuses** — collections of documents. A document can live in zero or more corpuses. Corpuses can be nested into folder hierarchies (`CorpusFolder`), forked from public corpuses, exported, imported, and version-controlled.
+3. **Annotations** — text-level spans (highlighted text), document-level type labels, or token-level spans. Annotations can be created by humans, by analyzers, or by AI agents. Each annotation has a `LabelSet`-scoped `AnnotationLabel`.
+4. **Relationships** — directed edges between annotations, with their own `AnnotationLabel`. Used for cross-references, parent/child structural relationships, and pre-materialised `OC_SUBTREE_GROUP` rows for efficient block-level retrieval.
+5. **Notes** — long-form prose attached to a document or corpus. Distinct from annotations; intended for human-written commentary.
+6. **Conversations & Threads** — persistent chat history. Conversations come in two flavours: `CHAT` (one-on-one chat with an AI agent) and `THREAD` (forum-style discussion). Threads support voting, moderation, @-mentions, and agent participation.
+7. **Analyses** — read-only annotation sets produced by a document analyzer (see [analyzers documentation](../architecture/analyzers.md)).
+8. **Extracts / Fieldsets / Datacells** — structured data extraction across documents. A `Fieldset` defines columns (`Column` rows) with prompts; running it against a corpus produces an `Extract` with one `Datacell` per (document, column).
+9. **Metadata** — typed custom metadata fields with validation, attached to corpuses and documents. See [Metadata Overview](../metadata/metadata_overview.md).
+10. **Badges & Reputation** — gamified recognition tied to community contributions. See [Badge System](../features/badge_system.md).
+11. **Corpus Actions** — automation triggers. Run a fieldset, analyzer, or AI agent automatically when a document is added/edited or a new thread/message arrives. See [Corpus Actions](../corpus_actions/intro_to_corpus_actions.md).
+12. **Agent Configurations** — saved configurations for AI agents (`AgentConfiguration` model) with scope (`GLOBAL` or corpus-scoped), tool allowlists, and approval policies.
 
 ## Permissioning
 
-OpenContracts is built on top of the powerful permissioning framework for Django called `django-guardian`. Each GraphQL
-request can add a field to annotate the object-level permissions the current user has for a given object, and the
-frontend relies on this to determine whether to make some objects and pages read-only and whether certain features
-should be exposed to a given user. The capability of sharing objects with specific users *is* built in, **but**
-is not enabled from the frontend at the moment. Allowing such widespread sharing and user lookups could be a security
-hole and could also unduly tax the system. We'd like to test these capabilities more fully before letting users used them.
+OpenContracts uses [`django-guardian`](https://django-guardian.readthedocs.io/) for per-object permissions, layered with custom queryset managers:
+
+- Each `Model.objects.visible_to_user(user)` returns the queryset of objects the user can see (public + owned + explicitly shared).
+- Annotations and Relationships do **not** carry individual permissions; access is inherited from the document and corpus they live in (effective permission = `min(document_permission, corpus_permission)`).
+- Documents and Corpuses carry direct object-level permissions.
+- Analyses and Extracts use a hybrid model (own permissions + corpus permissions + document filtering).
+- Structural annotations (those bound to a `StructuralAnnotationSet`) are read-only except for superusers.
+
+The full guide is at [Consolidated Permissioning Guide](../permissioning/consolidated_permissioning_guide.md).
+
+## Sharing & Forking
+
+Public visibility is a first-class UI feature: the corpus settings tab exposes a "make public" toggle, the corpus card shows the visibility badge, and anyone can fork a public corpus from the corpus home page. Forking is now implemented as `export-V2 → import-V2` so the fork format is guaranteed to round-trip cleanly (see [Corpus Forking](../architecture/corpus_forking.md)).
+
+Behind the UI, the underlying GraphQL mutations are `setCorpusVisibility` and `startCorpusFork`. The `makeAnalysisPublic` mutation is also available for analysis sharing.
 
 ## GraphQL
 
-### Mutations and Queries
+OpenContracts uses [Graphene](https://graphene-python.org/) to serve GraphQL. The GraphiQL playground lives at the application root URL `/graphql/`:
 
-OpenContracts uses Graphene and GraphQL to serve data to its frontend. You can access the Graphiql playground by going
-to your OpenContracts root url `/graphql` - e.g. `https://contracts.opensource.legal/graphql`. Anonymous users have
-access to any *public* data. To authenticate and access your own data, you either need to use the login mutation to
-create a JWT token *or* login to the admin dashboard to get a Django session and auth cookie that will automatically
-authenticate your requests to the GraphQL endpoint.
+- Local development: `http://localhost:8000/graphql/`
+- Demo / production: e.g., `https://contracts.opensource.legal/graphql/`
 
-If you're not familiar with [GraphQL](https://graphql.org/learn/), it's a very powerful way to expose your backend to
-the user and/or frontend clients to permit the construction of specific queries with specific data shapes. As an
-example, here's a request to get public corpuses and the annotated text and labels in them:
+Anonymous requests can see public data. To act as a user you can either log in to the Django admin (session cookie) or call the `tokenAuth` mutation to obtain a JWT.
 
-![](../assets/images/screenshots/Graph_QL_Request_For_Annotations.png)
+The schema is checked into the repository at [`schema.graphql`](https://github.com/Open-Source-Legal/OpenContracts/blob/main/schema.graphql); GraphiQL's built-in docs explorer is the easiest way to browse types interactively.
 
-Graphiql comes with a built-in documentation browser. Just click "Docs" in the top-right of the screen to start
-browsing. Typically, mutations change things on the server. Queries merely request copies of data from the server.
-We've tried to make our schema fairly self-explanatory, but we do plan to add more descriptions and guidance to our
-API docs.
+## WebSockets
 
-### GraphQL-only features
+Real-time streaming chat is delivered over Django Channels. Three consumer endpoints are exposed (see [WebSocket Protocol](../architecture/websocket/protocol.md)):
 
-Some of our features are currently not accessible via the frontend. Sharing analyses and corpuses to the public, for
-example, can only be achieved via `SetCorpusVisibility` and `makeAnalysisPublic` mutations, and *only* admins have this
-power at the moment. For our current release, we've done this to prevent large numbers of public corpuses being shared
-to cut down on server usage. We'd like to make a fully free and open, collaborative platform with more features to share
-anonymously, but this will require additional effort and compute power.
+- `ws/agent-chat/` — unified agent conversation (document chat, corpus chat, standalone agent chat). Context is supplied via query parameters: `?corpus_id=X`, `?document_id=X`, `?agent_id=X`, `?conversation_id=X`.
+- `ws/thread-updates/` — agent-mention streaming inside discussion threads. Requires `?conversation_id=X`.
+- `ws/notification-updates/` — real-time notification push (badges, moderation events, agent responses).
+
+All WebSocket connections are authenticated by the shared `JWTAuthMiddleware`, which handles both Django session auth and Auth0 JWTs.

--- a/docs/walkthrough/step-4-create-text-annotations.md
+++ b/docs/walkthrough/step-4-create-text-annotations.md
@@ -33,3 +33,37 @@ To view or edit annotations, you need to open a corpus and then open a document 
        2. Or you might want to select multiple snippets of text in a larger block of text, such as where you have multiple
           parties you want to combine into a single annotation:
           ![](../assets/images/screenshots/Select_Multiple_Words_In_Paragraph.png)
+
+## Hyperlink Annotations (`OC_URL`)
+
+You can anchor a clickable hyperlink to highlighted text. Annotations carrying the
+built-in `OC_URL` label render with an underline + external-link icon and open
+their target URL on click (in both the PDF viewer and the text/markdown viewer).
+
+To create a link annotation:
+
+1. Highlight the target text the same way you would for a normal annotation.
+2. In the selection action menu, click **Add link…**
+3. Enter the URL.
+
+The selection is persisted as an `Annotation` with `label.text = "OC_URL"` and a
+`link_url` field. The `OC_URL` `AnnotationLabel` is auto-created per corpus on
+first use, so no labelset configuration is required up front.
+
+### Editing or removing a link
+
+- The pencil icon on an existing `OC_URL` annotation opens a URL-edit modal
+  (instead of the normal label modal).
+- Hold **Shift / Ctrl / Cmd** while clicking a link annotation to fall back to
+  the normal selection toggle — useful when you want to delete or rebind it.
+
+### URL safety
+
+URLs are validated both client-side and server-side via a shared
+`validate_link_url` helper:
+
+- Allowed: `http://`, `https://`, and site-relative paths (`/...`).
+- Rejected: `javascript:`, `data:`, and other dangerous schemes.
+
+External targets open in a new tab with `noopener,noreferrer`; site-relative
+paths navigate within the SPA.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,10 +1,10 @@
 site_name: OpenContracts
 site_description: Open, Extensible Document Analytics Platform
 site_author: John Scrudato IV
-site_url: https://jsv4.github.io/OpenContracts/
-repo_name: JSv4/OpenContracts
-repo_url: https://github.com/JSv4/OpenContracts
-edit_uri: blob/master/docs
+site_url: https://open-source-legal.github.io/OpenContracts/
+repo_name: Open-Source-Legal/OpenContracts
+repo_url: https://github.com/Open-Source-Legal/OpenContracts
+edit_uri: blob/main/docs
 copyright: 'Copyright &copy; John Scrudato 2022-present'
 
 docs_dir: docs
@@ -43,22 +43,15 @@ theme:
 
 nav:
   - Home:
-    - About: index.md
-    - Philosophy: philosophy.md
-    - Quick Start: quick_start.md
-    - System Requirements: requirements.md
-    - How It Works:
-        - System Architecture: architecture/components/Data-flow-diagram.md
-        - PDF Data Layer: architecture/PDF-data-layer.md
-        - Asynchronous Processing: architecture/asynchronous-processing.md
-        - Document Analyzers: architecture/analyzers.md
-        - Automatic Corpus Actions: architecture/opencontract-corpus-actions.md
-        - Annotator Component: architecture/components/annotator/current-state/overview.md
-        - Annotation Creation Logic: architecture/components/annotator/current-state/how-annotations-are-created.md
-        - State Management: architecture/components/annotator/current-state/state-management.md
-        - Virtualized Rendering: architecture/components/annotator/current-state/virtualized-rendering.md
-        - User Handles: architecture/user_handles.md
-    - Acknowledgements: acknowledgements.md
+      - About: index.md
+      - Philosophy: philosophy.md
+      - Quick Start: quick_start.md
+      - System Requirements: requirements.md
+      - Acknowledgements: acknowledgements.md
+  - Releases:
+      - v3.0.0.b4: releases/v3.0.0.b4.md
+      - v3.0.0.b3: releases/v3.0.0.b3.md
+      - v3 Upgrade Guide: migrations/v3_upgrade_guide.md
   - Walkthrough:
       - Key Concepts: walkthrough/key-concepts.md
       - Step 1 - Add Documents: walkthrough/step-1-add-documents.md
@@ -70,6 +63,7 @@ nav:
       - Step 7 - Query a Corpus: walkthrough/step-7-query-corpus.md
       - Step 8 - Data Extract: walkthrough/step-8-data-extract.md
       - Step 9 - Automatic Corpus Actions: walkthrough/step-9-corpus-actions.md
+      - Notes - Add and Edit: walkthrough/add-and-edit-notes.md
       - Advanced:
           - Extraction Tutorial: walkthrough/advanced/extraction_tutorial.md
           - Write Document Analyzers: walkthrough/advanced/register-doc-analyzer.md
@@ -79,49 +73,151 @@ nav:
           - Import and Export Corpuses: walkthrough/advanced/export-import-corpuses.md
           - Generate GraphQL Schema Files: walkthrough/advanced/generate-graphql-schema-files.md
           - PAWLS Token Format: walkthrough/advanced/pawls-token-format.md
+  - Upload Methods:
+      - Overview: upload_methods/index.md
+      - Supported File Formats: upload_methods/supported_formats.md
+      - Single Upload: upload_methods/single_upload.md
+      - Bulk Zip Import: upload_methods/bulk_zip_import.md
+      - Worker Uploads (REST): upload_methods/worker_uploads.md
+      - Annotated Document Import: upload_methods/annotated_document_import.md
+      - Corpus Export / Import: upload_methods/corpus_export_import.md
+      - Annotation Side Effects: upload_methods/annotation_side_effects.md
+      - Worker Uploads Walkthrough: worker_uploads/walkthrough.md
+  - Architecture:
+      - System Data Flow: architecture/components/Data-flow-diagram.md
+      - PDF Data Layer (PAWLs): architecture/PDF-data-layer.md
+      - PAWLs Format Spec: architecture/pawls-format.md
+      - Data Model:
+          - Documents and Annotations: architecture/data_model/documents_and_annotations.md
+          - Annotation JSON: architecture/data_model/annotation_json.md
+      - Asynchronous Processing: architecture/asynchronous-processing.md
+      - Bulk Import: architecture/bulk-import.md
+      - Document Analyzers: architecture/analyzers.md
+      - Corpus Actions: architecture/opencontract-corpus-actions.md
+      - Agent Corpus Actions: architecture/agent_corpus_actions_design.md
+      - Document Versioning: architecture/document_versioning.md
+      - Querying Annotations on Versioned Docs: architecture/querying_annotations_on_versioned_docs.md
+      - Corpus Forking: architecture/corpus_forking.md
+      - Corpus Export Format Spec: architecture/corpus-export-format-spec.md
+      - Corpus Export/Import V2: architecture/corpus_export_import_v2.md
+      - Document & Corpus Lifecycle: architecture/document_corpus_lifecycle.md
+      - Document Folder Service: architecture/document_folder_service.md
+      - Document Annotation Index: architecture/document_annotation_index.md
+      - Structural vs Non-Structural: architecture/structural_vs_non_structural_annotations.md
+      - Embeddings Creation & Retrieval: architecture/embeddings_creation_and_retrieval.md
+      - Multimodal Embeddings: architecture/multimodal-embeddings.md
+      - Query Permission Patterns: architecture/query_permission_patterns.md
+      - Sharing: architecture/sharing.md
+      - Rich Mentions: architecture/rich_mentions.md
+      - User Handles: architecture/user_handles.md
+      - Deep Linking: architecture/deep-linking.md
+      - Social Media Previews: architecture/social-media-previews.md
+      - Annotator Component:
+          - Overview: architecture/components/annotator/current-state/overview.md
+          - How Annotations Are Created: architecture/components/annotator/current-state/how-annotations-are-created.md
+          - State Management: architecture/components/annotator/current-state/state-management.md
+          - Virtualized Rendering: architecture/components/annotator/current-state/virtualized-rendering.md
+          - How Search Works: architecture/components/annotator/current-state/how-search-works.md
+          - Scroll-to-Annotation Flow: architecture/components/annotator/current-state/scroll-to-annotation-flow.md
+          - Sidebar and Zoom: architecture/components/annotator/current-state/sidebar-and-zoom.md
+          - Extract Selection Flow: architecture/components/annotator/current-state/extract-selection-flow.md
+          - Document Knowledge Base Features: architecture/components/annotator/current-state/document-knowledge-base-features.md
+      - LLM Framework:
+          - Overview: architecture/llms/README.md
+      - WebSockets:
+          - Overview: architecture/websocket/README.md
+          - Protocol: architecture/websocket/protocol.md
+          - Backend: architecture/websocket/backend.md
+          - Frontend: architecture/websocket/frontend.md
+  - Pipelines:
+      - Pipeline Overview: pipelines/pipeline_overview.md
+      - Pipeline Configuration: pipelines/pipeline_configuration.md
+      - Docling Parser: pipelines/docling_parser.md
+      - LlamaParse Parser: pipelines/llamaparse_parser.md
+      - Multimodal Embedder: pipelines/multimodal_embedder.md
   - Extract & Retrieval:
       - Overview: extract_and_retrieval/README.md
       - API Reference: extract_and_retrieval/api_reference.md
       - Vector Stores: extract_and_retrieval/vector_stores.md
       - Corpus Queries: extract_and_retrieval/corpus_queries.md
       - Data Extraction: extract_and_retrieval/data_extraction.md
+      - Benchmarking: extract_and_retrieval/benchmarking.md
+      - LegalBench RAG Results: benchmarks/legalbench_rag_results.md
+  - Discussions & Community:
+      - Overview: commenting_system/README.md
+      - Backend Architecture: commenting_system/backend_architecture.md
+      - GraphQL API: commenting_system/graphql_api.md
+      - Notifications: commenting_system/notifications.md
+      - Moderation: commenting_system/moderation.md
+      - Voting & Reputation: commenting_system/voting_and_reputation.md
+      - Leaderboard: commenting_system/LEADERBOARD_IMPLEMENTATION.md
+      - Implementation Guide: commenting_system/IMPLEMENTATION_GUIDE.md
+      - Testing: commenting_system/testing.md
   - Metadata System:
       - Overview: metadata/metadata_overview.md
       - Metadata Fields: metadata/metadata_fields.md
       - API Examples: metadata/metadata_api_examples.md
       - Frontend Requirements: metadata/metadata_frontend_requirements.md
+  - Features:
+      - Badge System: features/badge_system.md
+      - Document Versioning: features/document_versioning.md
+      - Corpus Folders: features/corpus_folders_implementation.md
+      - Corpus Folders API: features/corpus_folders_api_reference.md
+      - Agent Mentions (Plan): features/agent_mentions_implementation_plan.md
+  - MCP:
+      - Overview: mcp/README.md
+  - Corpus Actions:
+      - Introduction: corpus_actions/intro_to_corpus_actions.md
   - Configuration:
       - Choose Docker Stack: configuration/choose-and-configure-docker-stack.md
       - Authentication: configuration/authentication.md
       - Frontend Configuration: configuration/frontend-configuration.md
       - Storage Backend: configuration/choose-storage-backend.md
-  - Pipelines:
-      - Pipeline Overview: pipelines/pipeline_overview.md
-      - Docling Parser: pipelines/docling_parser.md
-  - Frontend:
-      - Routing System: frontend/routing_system.md
-      - Document Rendering: frontend/document_rendering_and_annotation.md
-      - Search Rendering: frontend/search_rendering.md
-      - Read Only Mode: frontend/read_only_mode_inventory.md
-      - Corpus Selection: frontend/corpus-and-document-selection.md
-      - DataGrid:
-          - Custom Cell Rendering: frontend/datagrid/rendering_custom_cells.md
+      - GCP Storage Setup: GCP_STORAGE_SETUP.md
   - Permissions:
       - Overview: permissioning/README.md
       - Consolidated Guide: permissioning/consolidated_permissioning_guide.md
+      - Remediation Guide: permissioning/REMEDIATION_GUIDE.md
       - Read Only Mode: permissioning/read_only_mode.md
       - Corpus Optional Features: permissioning/corpus_optional_features.md
+      - Mention Permissioning Spec: permissioning/mention_permissioning_spec.md
       - Testing Permissions: permissioning/testing_permissions.md
-  - Corpus Actions:
-      - Introduction: corpus_actions/intro_to_corpus_actions.md
+  - Frontend:
+      - Routing System: frontend/routing_system.md
+      - Auth Flow: frontend/auth_flow.md
+      - Layout Architecture: frontend/layout-architecture.md
+      - Document Rendering: frontend/document_rendering_and_annotation.md
+      - Search Rendering: frontend/search_rendering.md
+      - Discussions: frontend/discussions.md
+      - Real-Time Notifications: frontend/real-time-notifications.md
+      - Corpus Selection: frontend/corpus-and-document-selection.md
+      - Corpus Optional Features: frontend/corpus-optional-features.md
+      - Doc Data Query Optimizations: frontend/doc-data-query-optimizations.md
+      - Read Only Mode Inventory: frontend/read_only_mode_inventory.md
+      - "any" Baseline: frontend/any-baseline.md
+      - OS-Legal Style Migration: frontend/os-legal-style-migration-guide.md
+      - DataGrid:
+          - Custom Cell Rendering: frontend/datagrid/rendering_custom_cells.md
   - API Documentation:
       - Smart Label Mutations: api/smart-label-mutations.md
+  - Telemetry:
+      - Backend: telemetry/Backend.md
+      - Frontend: telemetry/Frontend.md
   - Development:
       - Dev Environment: development/environment.md
       - Test Suite: development/test-suite.md
       - Frontend Notes: development/frontend-notes.md
       - Documentation: development/documentation.md
       - Generating GraphQL Schema: development/generating-new-graphql-schema.md
+      - Screenshots: development/screenshots.md
+      - Rate Limiting: development/rate-limiting.md
+      - Rate Limiting Summary: development/rate-limiting-summary.md
+      - E2E VCR: development/e2e_vcr.md
+  - Typing:
+      - Overview: typing/README.md
+  - Analyzer Framework:
+      - Backend: analyzer_framework/backend.md
+      - Frontend: analyzer_framework/frontend.md
 
 plugins:
   # Built-in
@@ -184,7 +280,7 @@ markdown_extensions:
       social_url_shorthand: true
       normalize_issue_symbols: true
       provider: github
-      user: jsv4
+      user: Open-Source-Legal
       repo: OpenContracts
   - pymdownx.mark:
   - pymdownx.progressbar:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,6 +93,7 @@ nav:
       - Asynchronous Processing: architecture/asynchronous-processing.md
       - Bulk Import: architecture/bulk-import.md
       - Document Analyzers: architecture/analyzers.md
+      - Discovery System (llms.txt, MCP, robots.txt): architecture/discovery_system.md
       - Corpus Actions: architecture/opencontract-corpus-actions.md
       - Agent Corpus Actions: architecture/agent_corpus_actions_design.md
       - Document Versioning: architecture/document_versioning.md
@@ -194,7 +195,7 @@ nav:
       - Corpus Optional Features: frontend/corpus-optional-features.md
       - Doc Data Query Optimizations: frontend/doc-data-query-optimizations.md
       - Read Only Mode Inventory: frontend/read_only_mode_inventory.md
-      - "any" Baseline: frontend/any-baseline.md
+      - '"any" Baseline': frontend/any-baseline.md
       - OS-Legal Style Migration: frontend/os-legal-style-migration-guide.md
       - DataGrid:
           - Custom Cell Rendering: frontend/datagrid/rendering_custom_cells.md


### PR DESCRIPTION
## Summary

This PR substantially rewrites and expands the WebSocket protocol documentation and adds new documentation for the discovery system, reflecting the current architecture and recent refactors. It also updates repository metadata (GitHub org migration) and reorganizes the documentation structure.

## Key Changes

### Documentation Updates

**WebSocket Protocol (`docs/architecture/websocket/protocol.md`)**
- Completely rewritten to reflect current architecture:
  - Replaced legacy URL patterns with new unified endpoints (`ws/agent-chat/`, `ws/thread-updates/`, `ws/notification-updates/`)
  - Documented the `UnifiedAgentConsumer` that consolidates three legacy consumers
  - Added detailed authentication flow via `JWTAuthMiddleware` (Auth0 + Django sessions)
  - Replaced narrative message type descriptions with concise table format
  - Added sub-agent delegation and `@mention` flow documentation
  - Documented `ThreadUpdatesConsumer` and `NotificationUpdatesConsumer` event types
  - Added connection lifecycle sequence diagram
  - Clarified error handling and permission/rate-limiting patterns
  - Removed outdated state management and performance sections

**Discovery System (`docs/architecture/discovery_system.md` - NEW)**
- New document covering public-facing endpoints:
  - `/robots.txt`, `/llms.txt`, `/llms-full.txt`, `/sitemap.xml`, `/.well-known/mcp.json`, `/api/search/`
  - Visibility model (anonymous-user-only data exposure)
  - Caching and rate-limiting behavior
  - Telemetry via PostHog events
  - Customization patterns

**LLM Framework (`docs/architecture/llms/README.md`)**
- Added "Context Management" section documenting:
  - Context guardrails (token estimation, conversation compaction, tool-output truncation)
  - Memory curation pipeline (Celery-based cross-conversation learning)
- Expanded "Built-in Tools" section with comprehensive table of tool families and purposes

**Key Concepts (`docs/walkthrough/key-concepts.md`)**
- Expanded data types section with 12 first-class entities (documents, corpuses, annotations, relationships, notes, conversations, threads, analyses, extracts, metadata, badges, corpus actions, agent configurations)
- Clarified permissioning model and sharing patterns
- Updated to reflect current feature set

**Annotation Features**
- Added hyperlink annotations (`OC_URL`) documentation in `docs/walkthrough/step-4-create-text-annotations.md`
- Documented URL validation and safety patterns
- Added structural vs. non-structural annotations section on materialised subtree groups (`OC_SUBTREE_GROUP`)

**Analyzer Feedback**
- Added "Annotation Review & User Feedback" section to `docs/architecture/analyzers.md`
- Documented `UserFeedback` model and GraphQL mutations

**Read-Only Mode**
- Added naming convention clarification (camelCase `readOnly` vs. snake_case `read_only`)
- Documented transition plan for legacy PDF viewer

**Permissioning Audit**
- Added post-audit status update to `docs/permissioning/REMEDIATION_GUIDE.md`
- Documented fixes for CRITICAL findings and Auth0 audit improvements

### Repository Metadata Updates

- Updated `mkdocs.yml`:
  - Changed site URL from `jsv4.github.io` → `open-source-legal.github.io`
  - Changed repo from `JSv4/OpenContracts` → `Open-Source-Legal/OpenContracts`
  - Changed default branch from `master` → `main`
  - Reorganized navigation structure (added Releases, Upload Methods, Pipelines, Discussions & Community sections)
  - Expanded Architecture section with new subsections

- Updated `docs/index.md`:
  - Refreshed tagline and feature descriptions
  - Updated codecov badges to split backend/frontend coverage
  - Updated GitHub org references

- Updated `README.md`:
  - Updated supported formats section
  - Updated GitHub org references

- Updated `docs/philosophy.md`:
  - Expanded with historical context and vision statement

## Notable Implementation Details

- The WebSocket documentation now accurately reflects the

https://claude.ai/code/session_01Gr3mgRAzk2NBWDHVcruvbk