### PR TITLE
Fix four broken tests on main (introduced in #1672)

### DIFF
--- a/opencontractserver/tests/test_analyzer_app_coverage.py
+++ b/opencontractserver/tests/test_analyzer_app_coverage.py
@@ -140,10 +140,12 @@ class HandleAnalysisCompletionTests(TestCase):
 
     def test_silent_when_status_is_completed_enum_value(self) -> None:
         # Documents the known mismatch above — handler doesn't react to the
-        # enum value ``"COMPLETED"`` that Analyses actually take.
+        # enum value ``"COMPLETED"`` that Analyses actually take. The sentinel
+        # must be emitted through the same logger ``assertLogs`` is watching,
+        # otherwise ``assertLogs`` raises because nothing landed on that logger.
+        signals_logger = logging.getLogger("opencontractserver.analyzer.signals")
         with self.assertLogs("opencontractserver.analyzer.signals", level="INFO") as cm:
-            # Emit a sentinel so assertLogs doesn't complain about no logs.
-            logger.info("sentinel")
+            signals_logger.info("sentinel")
             handle_analysis_completion(
                 sender=Analysis,
                 instance=MagicMock(id=8, status=JobStatus.COMPLETED.value),
@@ -580,11 +582,20 @@ class AnalysisCallbackViewHappyPathTests(TransactionTestCase):
     def test_valid_callback_with_valid_body_succeeds(self) -> None:
         # Mint plaintext token + persist hash on the Analysis.
         token = self.analysis.rotate_callback_token()
-        # Body conforms to ``OpenContractsGeneratedCorpusPythonType`` —
-        # both ``annotated_docs`` and ``label_lookup`` are required keys.
-        body: dict[str, dict[Any, Any]] = {
+        # Body must conform to ``OpenContractsGeneratedCorpusPythonType``:
+        # annotated_docs, doc_labels, text_labels, label_set (all required).
+        body: dict[str, Any] = {
             "annotated_docs": {},
-            "label_lookup": {},
+            "doc_labels": {},
+            "text_labels": {},
+            "label_set": {
+                "id": "callback-label-set",
+                "title": "Callback label set",
+                "description": "",
+                "icon_data": None,
+                "icon_name": "",
+                "creator": "callback@test.com",
+            },
         }
 
         with patch(

--- a/opencontractserver/tests/test_pii_scanner_analyzer_task.py
+++ b/opencontractserver/tests/test_pii_scanner_analyzer_task.py
@@ -87,7 +87,11 @@ class _BasePiiScannerAnalyzerTestCase(TransactionTestCase):
         )
 
     def _make_text_doc(self, content: bytes | None = None) -> Document:
-        body = content or SAMPLE_TXT_FILE_ONE_PATH.read_bytes()
+        # ``content or default`` falls through for empty bytes (b"" is
+        # falsy), which silently substituted the sample file when callers
+        # asked for an empty extract — defeating tests that rely on the
+        # empty-text short-circuit. Distinguish None from empty explicitly.
+        body = content if content is not None else SAMPLE_TXT_FILE_ONE_PATH.read_bytes()
         doc = Document.objects.create(
             creator=self.user,
             title="PII Text Doc",
@@ -110,11 +114,6 @@ class _BasePiiScannerAnalyzerTestCase(TransactionTestCase):
         doc.pawls_parse_file.save(
             SAMPLE_PAWLS_FILE_ONE_PATH.name, ContentFile(pawls_json.encode())
         )
-        # The decorator also reads txt_extract_file for the PDF branch when
-        # available, but the persistence path uses pawls. Save a sidecar
-        # txt extract so the decorator's preflight doesn't get None back.
-        doc.txt_extract_file.save("pdf.txt", ContentFile(b"placeholder"))
-        doc, _, _ = self.corpus.add_document(document=doc, user=self.user)
 
         # Build the doc_text the decorator's PlasmaPDF layer will derive so
         # we can compute a valid detection range that maps to real tokens.
@@ -125,6 +124,15 @@ class _BasePiiScannerAnalyzerTestCase(TransactionTestCase):
         with doc.pawls_parse_file.open("r") as f:
             pawls_tokens = expand_pawls_pages(json.load(f))
         layer = build_translation_layer(pawls_tokens)
+
+        # Persist the PlasmaPDF-derived text as the txt extract so the task's
+        # offset validation (which is bounded by ``len(pdf_text_extract)``)
+        # accepts detections whose coords were computed against ``doc_text``.
+        # A "placeholder" sidecar would let preflight pass but cause every
+        # detection past 11 chars to be skipped silently.
+        doc.txt_extract_file.save("pdf.txt", ContentFile(layer.doc_text.encode()))
+        doc, _, _ = self.corpus.add_document(document=doc, user=self.user)
+
         return doc, layer.doc_text
 
     def _make_analysis(self) -> Analysis:


### PR DESCRIPTION
## Summary

Four test failures landed on `main` with #1672 and are now red on every PR's CI. All four are **test-setup bugs, not production regressions** — the production task code in `pii_scanner_privacy_filter` and the analyzer callback view behave correctly; the tests were exercising them incorrectly.

| Test | Cause |
|------|-------|
| `test_silent_when_status_is_completed_enum_value` | Sentinel log emitted through the test-module logger instead of `opencontractserver.analyzer.signals` (the logger `assertLogs` is watching), so `assertLogs` raised "no logs … triggered" even though the sentinel ran. |
| `test_empty_text_extract_returns_failure` | `_make_text_doc(b"")` used `content or default`, which falls through for empty bytes — the helper silently substituted the sample fixture, so the task hit the real privacy-filter service (and timed out on DNS in CI) instead of exercising the empty-text short-circuit. |
| `test_pdf_doc_creates_token_label_annotations` | `_make_pdf_doc` stored a fixed `"placeholder"` string in `txt_extract_file` while detection offsets were computed against the PlasmaPDF-derived `doc_text`. The task's offset bounds check (`end > len(pdf_text_extract)`) silently skipped every detection past byte 11, so no annotation was created. |
| `test_valid_callback_with_valid_body_succeeds` | The test body was asserted to conform to `OpenContractsGeneratedCorpusPythonType` but only sent `annotated_docs` plus a non-existent `label_lookup` key. The TypedDict actually requires `annotated_docs`, `doc_labels`, `text_labels`, and `label_set` — supply all four. |

## Local verification

Full suite (no test selection) on this branch with the production-equivalent invocation:

```
docker compose -f test.yml run --rm django pytest -n auto --dist loadscope --create-db -p no:cacheprovider
# 6958 passed, 15 skipped, 0 failed in 1441.18s (0:24:01)
```

## Note on CI-only flakes

Recent CI runs of `main` also report failures in `PiiScannerKnobTests` (4) and `TestApprovalFlow` (4). The actual error in the CI log is `psycopg2.OperationalError: server closed the connection unexpectedly` raised from inside the `sync_to_async` worker — postgres dropping a backend mid-test, which then cascades to every subsequent test in the same class on that xdist worker. **These do not reproduce locally** in the full-suite run above. The same failure mode is documented in `_close_async_db_connections` (added in #1616) for the MCP test suite; the underlying cause appears to be GHA-runner-specific memory/concurrency pressure on postgres rather than a test logic issue. Out of scope for this PR — worth a separate look if it persists.
