### PR TITLE
PR #1678 follow-ups: Phase B tracking ref, ShimDeprecation tearDown, public_feedback fixture comment

### DIFF
--- a/opencontractserver/shared/QuerySets.py
+++ b/opencontractserver/shared/QuerySets.py
@@ -190,6 +190,11 @@ class UserFeedbackQuerySet(models.QuerySet):
         # ``Annotation.objects.visible_to_user(user)``-based gate in
         # ``UserFeedbackManager.user_can`` so the manager check and the
         # queryset filter answer the same question for the same user.
+        #
+        # ``visible_to_user`` produces a compound subquery here —
+        # acceptable for Phase A correctness, but see issue #1655 for
+        # the Phase B request-scoped permission cache that should wrap
+        # this path before it hits scale.
         visible_annotation_ids = Annotation.objects.visible_to_user(user).values("pk")
         inherited_visibility = Q(commented_annotation_id__in=visible_annotation_ids)
 

--- a/opencontractserver/tests/permissioning/test_authorization_invariants.py
+++ b/opencontractserver/tests/permissioning/test_authorization_invariants.py
@@ -1336,6 +1336,19 @@ class ShimDeprecationWarningTestCase(TransactionTestCase):
             title="Shim Corpus", creator=self.creator, is_public=False
         )
 
+    def tearDown(self):
+        # Mirror ``setUp``'s clear — the shim's dedup set is process-wide,
+        # so a warning emitted by this test would otherwise prevent a
+        # later test (in any test module) from recording the same site.
+        # Clearing on the way out keeps the cross-module invariant
+        # symmetric with the on-the-way-in clear in ``setUp``.
+        from opencontractserver.utils.permissioning import (
+            _user_has_permission_for_obj_warned,
+        )
+
+        _user_has_permission_for_obj_warned.clear()
+        super().tearDown()
+
     def test_shim_emits_deprecation_warning_and_delegates(self):
         import warnings
 

--- a/opencontractserver/tests/test_feedback.py
+++ b/opencontractserver/tests/test_feedback.py
@@ -410,7 +410,13 @@ class TestUserFeedbackVisibility(TestCase):
         )
 
         # Feedback row that is itself ``is_public=True`` — visible to
-        # everyone regardless of the commented annotation.
+        # everyone regardless of the commented annotation. Pairing this
+        # with ``hidden_annotation`` (a fully private annotation with no
+        # inherited-visibility path for non-owners) is intentional: it
+        # asserts the ``is_public=True`` branch on the feedback row alone
+        # grants READ, independent of annotation visibility. Do not
+        # repoint to a visible annotation — that would silently collapse
+        # this row's coverage into the inherited-gate tests.
         cls.public_feedback = UserFeedback.objects.create(
             creator=cls.owner,
             commented_annotation=cls.hidden_annotation,


### PR DESCRIPTION
## Summary

Three doc/test-only polish items from the PR #1678 review thread, captured in issue #1686.

- **`shared/QuerySets.py`** — extend the block comment in `UserFeedbackQuerySet.visible_to_user` to flag the compound subquery cost and point at issue #1655 (Phase B request-scoped permission cache). Matches the existing Phase B reference convention used in `Managers.py:663`, `Managers.py:1097`, `permission_cache.py:72`, and three sites in `utils/permissioning.py`.
- **`tests/permissioning/test_authorization_invariants.py`** — add a `tearDown` to `ShimDeprecationWarningTestCase` that mirrors `setUp`'s clear of `_user_has_permission_for_obj_warned`. The dedup set is process-wide; clearing on the way out prevents forward contamination of tests that run after this class in the same pytest worker. Function-scoped import matches the existing `setUp` style.
- **`tests/test_feedback.py`** — extend the `public_feedback` fixture comment in `TestUserFeedbackVisibility.setUpTestData` to document that the `hidden_annotation` pairing is intentional: it pins the `is_public=True`-on-the-feedback-row branch independent of annotation visibility, and warns future readers not to repoint it (which would silently collapse coverage into the inherited-gate tests).

No production code path is touched.

## Test plan

- [ ] `docker compose -f test.yml run --rm django pytest opencontractserver/tests/permissioning/test_authorization_invariants.py opencontractserver/tests/test_feedback.py -n 4 --dist loadscope --keepdb` — all tests pass
- [ ] `ShimDeprecationWarningTestCase.test_shim_emits_deprecation_warning_and_delegates` still pins the deprecation warning (the `tearDown` is additive)
- [ ] `TestUserFeedbackVisibility` suite stays green (only a comment changes in `setUpTestData`)
- [ ] `pre-commit run --files <three files>` is clean

Closes #1686

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYZNxDb2MJw7Pi1eLyzwSK)_