### PR TITLE
Fix V2 import: folder_path resolution tolerates exporter path conventions

### DIFF
--- a/opencontractserver/tasks/import_tasks_v2.py
+++ b/opencontractserver/tasks/import_tasks_v2.py
@@ -32,6 +32,7 @@ from opencontractserver.documents.models import (
     IngestionSourceCategory,
 )
 from opencontractserver.types.dicts import (
+    CorpusFolderExport,
     DocumentPathExport,
     IngestionSourceExport,
     OpenContractsExportDataJsonPythonType,
@@ -59,6 +60,7 @@ from opencontractserver.utils.packaging import (
 from opencontractserver.utils.permissioning import set_permissions_for_obj_to_user
 
 if TYPE_CHECKING:
+    from opencontractserver.corpuses.models import CorpusFolder
     from opencontractserver.users.models import User as UserModel
 
 logger = logging.getLogger(__name__)
@@ -421,7 +423,9 @@ def _import_corpus(
 
             # Import folders
             folders_data = v2_data.get("folders", [])
-            import_corpus_folders(folders_data, corpus_obj, user_obj)
+            folder_export_id_to_obj = import_corpus_folders(
+                folders_data, corpus_obj, user_obj
+            )
 
             # Import ingestion sources and reconstruct DocumentPaths
             ingestion_sources_data = v2_data.get("ingestion_sources", [])
@@ -435,6 +439,8 @@ def _import_corpus(
                     document_paths_data,
                     corpus_obj,
                     doc_hash_to_corpus_doc,
+                    folders_data,
+                    folder_export_id_to_obj,
                     source_name_map,
                 )
 
@@ -636,10 +642,57 @@ def _import_ingestion_sources(
     return source_map
 
 
+def _build_folder_path_lookup(
+    folders_data: list[CorpusFolderExport],
+    folder_export_id_to_obj: dict[str, CorpusFolder],
+) -> dict[str, CorpusFolder]:
+    """
+    Build a folder-path -> CorpusFolder lookup that tolerates differing path
+    conventions between the exporter and importer.
+
+    The canonical OpenContracts exporter (``utils/export_v2.py``) writes the
+    folder's ``get_path()`` (name-joined, e.g. ``"Filings/10-K"``) into both
+    ``folder.path`` and ``document_paths.folder_path``.  Third-party exporters
+    (e.g. EDGAR scrapers that build the export ZIP themselves) may emit
+    slug-joined or otherwise transformed paths.  Either is acceptable as
+    long as the convention is consistent **within a single export**, because
+    the lookup keys here use the export's own ``folder.path`` field as the
+    source of truth — whatever string the exporter chose will match the
+    string written into ``document_paths.folder_path`` in the same zip.
+
+    Both the export-provided ``path`` and the freshly-imported folder's
+    ``get_path()`` are inserted so canonical exports continue to resolve
+    even when older formats omit the ``path`` field.
+
+    Args:
+        folders_data: Folder dicts as written by the exporter.
+        folder_export_id_to_obj: Map from each folder dict's ``id`` to the
+            ``CorpusFolder`` row created during import (from
+            :func:`import_corpus_folders`).
+
+    Returns:
+        Mapping of every known path representation to its ``CorpusFolder``.
+    """
+    folder_path_to_folder: dict[str, CorpusFolder] = {}
+    for folder_data in folders_data:
+        folder_obj = folder_export_id_to_obj.get(folder_data["id"])
+        if folder_obj is None:
+            # Folder creation failed earlier (already logged by
+            # import_corpus_folders).
+            continue
+        folder_path_to_folder[folder_obj.get_path()] = folder_obj
+        exported_path = folder_data.get("path")
+        if exported_path:
+            folder_path_to_folder[exported_path] = folder_obj
+    return folder_path_to_folder
+
+
 def _reconstruct_document_paths(
     document_paths_data: list[DocumentPathExport],
     corpus_obj: Corpus,
     doc_hash_to_corpus_doc: dict[str, Document],
+    folders_data: list[CorpusFolderExport],
+    folder_export_id_to_obj: dict[str, CorpusFolder],
     source_name_map: dict[str, IngestionSource] | None = None,
 ) -> None:
     """
@@ -655,19 +708,20 @@ def _reconstruct_document_paths(
         corpus_obj: The target corpus.
         doc_hash_to_corpus_doc: Mapping of document_ref (hash or old ID) to
             the imported corpus-isolated Document.
+        folders_data: Folder dicts from the export — used to learn whichever
+            path convention the exporter used so ``document_paths.folder_path``
+            resolves regardless of canonical vs. third-party formatting.
+        folder_export_id_to_obj: Map from export folder id to the imported
+            ``CorpusFolder`` (the return value of ``import_corpus_folders``).
         source_name_map: Mapping of source name -> IngestionSource instance
             (from _import_ingestion_sources).
     """
-    from opencontractserver.corpuses.models import CorpusFolder
     from opencontractserver.documents.models import DocumentPath
 
     if source_name_map is None:
         source_name_map = {}
 
-    # Pre-build a folder path lookup to avoid repeated DB queries + linear
-    # scans inside the loop.
-    all_folders = CorpusFolder.objects.filter(corpus=corpus_obj)
-    folder_path_map = {f.get_path(): f for f in all_folders}
+    folder_path_map = _build_folder_path_lookup(folders_data, folder_export_id_to_obj)
 
     # Pre-build a document -> DocumentPath lookup to avoid N queries in the loop
     path_by_doc_id = {
@@ -711,6 +765,22 @@ def _reconstruct_document_paths(
             folder = folder_path_map.get(folder_path)
             if folder:
                 updates["folder"] = folder
+            else:
+                # Loud failure mode: the exporter pointed this document at a
+                # folder we couldn't resolve, so it would silently land at the
+                # corpus root.  This typically means folder.path and
+                # document_paths.folder_path were written with different
+                # conventions, or the referenced folder failed to import.
+                logger.warning(
+                    "DocumentPath reconstruction: folder_path %r did not "
+                    "resolve to any imported folder in corpus %s (doc %s). "
+                    "Document will remain at corpus root. Known folder paths: "
+                    "%s",
+                    folder_path,
+                    corpus_obj.id,
+                    corpus_doc.id,
+                    sorted(folder_path_map.keys()),
+                )
 
         # Restore ingestion lineage fields
         source_name = path_data.get("ingestion_source_name")

--- a/opencontractserver/tasks/import_tasks_v2.py
+++ b/opencontractserver/tasks/import_tasks_v2.py
@@ -68,6 +68,11 @@ logger.setLevel(logging.DEBUG)
 
 User = get_user_model()
 
+# Cap on how many known folder-path keys we dump into the "unresolved
+# folder_path" warning. Log aggregators (Datadog, CloudWatch) truncate long
+# lines, which could hide the very keys we want a human to compare against.
+_UNRESOLVED_FOLDER_KEY_SAMPLE_SIZE = 20
+
 
 def import_corpus_v2_from_bytes(
     zip_source: IO[bytes],
@@ -661,8 +666,13 @@ def _build_folder_path_lookup(
     string written into ``document_paths.folder_path`` in the same zip.
 
     Both the export-provided ``path`` and the freshly-imported folder's
-    ``get_path()`` are inserted so canonical exports continue to resolve
-    even when older formats omit the ``path`` field.
+    ``get_path()`` are inserted in case either field is absent, empty, or
+    differs from the other under the exporter's chosen convention.
+
+    Collisions between two distinct folders sharing the same lookup key
+    (e.g. one folder's ``exported_path`` equals a sibling's ``get_path()``)
+    are logged at WARNING and the last writer wins — same loud-failure
+    posture as an unresolved ``folder_path``.
 
     Args:
         folders_data: Folder dicts as written by the exporter.
@@ -674,16 +684,29 @@ def _build_folder_path_lookup(
         Mapping of every known path representation to its ``CorpusFolder``.
     """
     folder_path_to_folder: dict[str, CorpusFolder] = {}
+
+    def _register(key: str | None, folder_obj: CorpusFolder) -> None:
+        if not key:
+            return
+        existing = folder_path_to_folder.get(key)
+        if existing is not None and existing is not folder_obj:
+            logger.warning(
+                "Folder path key collision: %r maps to both folder %s and "
+                "folder %s; last writer wins.",
+                key,
+                existing.id,
+                folder_obj.id,
+            )
+        folder_path_to_folder[key] = folder_obj
+
     for folder_data in folders_data:
         folder_obj = folder_export_id_to_obj.get(folder_data["id"])
         if folder_obj is None:
             # Folder creation failed earlier (already logged by
             # import_corpus_folders).
             continue
-        folder_path_to_folder[folder_obj.get_path()] = folder_obj
-        exported_path = folder_data.get("path")
-        if exported_path:
-            folder_path_to_folder[exported_path] = folder_obj
+        _register(folder_obj.get_path(), folder_obj)
+        _register(folder_data.get("path"), folder_obj)
     return folder_path_to_folder
 
 
@@ -771,15 +794,22 @@ def _reconstruct_document_paths(
                 # corpus root.  This typically means folder.path and
                 # document_paths.folder_path were written with different
                 # conventions, or the referenced folder failed to import.
+                # Cap the displayed key list — log aggregators truncate long
+                # lines, which would hide the very keys we want to compare
+                # against.
+                known_keys = sorted(folder_path_map.keys())
+                key_sample = known_keys[:_UNRESOLVED_FOLDER_KEY_SAMPLE_SIZE]
                 logger.warning(
                     "DocumentPath reconstruction: folder_path %r did not "
                     "resolve to any imported folder in corpus %s (doc %s). "
-                    "Document will remain at corpus root. Known folder paths: "
-                    "%s",
+                    "Document will remain at corpus root. Known folder paths "
+                    "(%d total, showing first %d): %s",
                     folder_path,
                     corpus_obj.id,
                     corpus_doc.id,
-                    sorted(folder_path_map.keys()),
+                    len(known_keys),
+                    len(key_sample),
+                    key_sample,
                 )
 
         # Restore ingestion lineage fields

--- a/opencontractserver/tests/test_corpus_export_import_v2.py
+++ b/opencontractserver/tests/test_corpus_export_import_v2.py
@@ -47,7 +47,9 @@ from opencontractserver.corpuses.models import (
 from opencontractserver.documents.models import Document, DocumentPath
 from opencontractserver.tasks.export_tasks_v2 import package_corpus_export_v2
 from opencontractserver.tasks.import_tasks_v2 import (
+    _build_folder_path_lookup,
     _import_v2_relationships,
+    _reconstruct_document_paths,
     import_corpus_v2,
 )
 from opencontractserver.tests._corpus_fixture import build_rich_test_corpus
@@ -1018,6 +1020,258 @@ class TestV2ImportUtilities(TransactionTestCase):
         self.assertEqual(
             relationships.count(), 0
         )  # No relationship due to missing label
+
+
+class TestV2FolderPathReconstruction(TransactionTestCase):
+    """
+    Regression coverage for ``_reconstruct_document_paths`` folder lookup.
+
+    The export side may write either:
+      * ``get_path()``-style (name-joined) paths into both
+        ``folder.path`` and ``document_paths.folder_path`` (canonical
+        ``utils/export_v2.py`` exporter), or
+      * slug-joined / arbitrary paths (third-party exporters such as
+        EDGAR scrapers that build the ZIP themselves).
+
+    Either is fine — the only invariant the importer requires is that
+    ``folder.path`` and ``document_paths.folder_path`` use the **same**
+    convention within a single export.  These tests pin that contract.
+    """
+
+    def setUp(self):
+        self.user = User.objects.create_user(username="reconuser", password="pw")
+        self.labelset = LabelSet.objects.create(title="LS", creator=self.user)
+        self.corpus = Corpus.objects.create(
+            title="Recon Corpus", label_set=self.labelset, creator=self.user
+        )
+
+        # Build a 3-folder hierarchy that mirrors the EDGAR-style export:
+        # one ``8-K/A`` name contains a slash to also lock down the
+        # ambiguity it would create for any naive get_path()-only lookup.
+        self.f_root = CorpusFolder.objects.create(
+            corpus=self.corpus, name="Filings", creator=self.user
+        )
+        self.f_eight_k_a = CorpusFolder.objects.create(
+            corpus=self.corpus,
+            name="8-K/A",
+            parent=self.f_root,
+            creator=self.user,
+        )
+        self.f_leaf = CorpusFolder.objects.create(
+            corpus=self.corpus,
+            name="2025-06-03",
+            parent=self.f_eight_k_a,
+            creator=self.user,
+        )
+
+        # Create one corpus-isolated Document + DocumentPath per document
+        # so ``_reconstruct_document_paths`` has a row to update.
+        self.doc = Document.objects.create(
+            title="Recon Doc",
+            pdf_file_hash="hash-recon-1",
+            creator=self.user,
+            page_count=1,
+        )
+        self.doc_path = DocumentPath.objects.create(
+            document=self.doc,
+            corpus=self.corpus,
+            folder=None,
+            path="/placeholder.pdf",
+            version_number=1,
+            creator=self.user,
+        )
+
+        self.doc_hash_to_corpus_doc = {"hash-recon-1": self.doc}
+
+        # ``folder_export_id_to_obj`` mirrors what ``import_corpus_folders``
+        # returns: keyed by the export's ``id`` field.
+        self.folder_export_id_to_obj = {
+            "fld-root": self.f_root,
+            "fld-8ka": self.f_eight_k_a,
+            "fld-leaf": self.f_leaf,
+        }
+
+    def _folders_data(self, exporter: str) -> list[dict]:
+        """Build a ``folders_data`` payload with the given exporter style.
+
+        ``"canonical"`` reproduces what ``package_corpus_folders`` writes
+        today (name-joined via ``get_path()``).  ``"slug"`` reproduces what
+        an EDGAR-scraper-style exporter writes (slug-joined paths that do
+        not match ``get_path()``).
+        """
+        if exporter == "canonical":
+            return [
+                {
+                    "id": "fld-root",
+                    "name": "Filings",
+                    "description": "",
+                    "color": "#05313d",
+                    "icon": "folder",
+                    "tags": [],
+                    "is_public": False,
+                    "parent_id": None,
+                    "path": "Filings",
+                },
+                {
+                    "id": "fld-8ka",
+                    "name": "8-K/A",
+                    "description": "",
+                    "color": "#05313d",
+                    "icon": "folder",
+                    "tags": [],
+                    "is_public": False,
+                    "parent_id": "fld-root",
+                    "path": "Filings/8-K/A",
+                },
+                {
+                    "id": "fld-leaf",
+                    "name": "2025-06-03",
+                    "description": "",
+                    "color": "#05313d",
+                    "icon": "folder",
+                    "tags": [],
+                    "is_public": False,
+                    "parent_id": "fld-8ka",
+                    "path": "Filings/8-K/A/2025-06-03",
+                },
+            ]
+        if exporter == "slug":
+            return [
+                {
+                    "id": "fld-root",
+                    "name": "Filings",
+                    "description": "",
+                    "color": "#05313d",
+                    "icon": "folder",
+                    "tags": [],
+                    "is_public": False,
+                    "parent_id": None,
+                    "path": "filings",
+                },
+                {
+                    "id": "fld-8ka",
+                    "name": "8-K/A",
+                    "description": "",
+                    "color": "#05313d",
+                    "icon": "folder",
+                    "tags": [],
+                    "is_public": False,
+                    "parent_id": "fld-root",
+                    "path": "filings/8-k-a",
+                },
+                {
+                    "id": "fld-leaf",
+                    "name": "2025-06-03",
+                    "description": "",
+                    "color": "#05313d",
+                    "icon": "folder",
+                    "tags": [],
+                    "is_public": False,
+                    "parent_id": "fld-8ka",
+                    "path": "filings/8-k-a/2025-06-03",
+                },
+            ]
+        raise ValueError(f"unknown exporter style: {exporter}")
+
+    def _document_paths_data(self, folder_path: str | None) -> list[dict]:
+        return [
+            {
+                "document_ref": "hash-recon-1",
+                "folder_path": folder_path,
+                "path": "/Filings/8-K/A/2025-06-03/doc.pdf",
+                "version_number": 1,
+                "parent_version_number": None,
+                "is_current": True,
+                "is_deleted": False,
+                "created": timezone.now().isoformat(),
+            }
+        ]
+
+    def test_build_lookup_indexes_both_get_path_and_export_path(self):
+        """The helper accepts whichever string the exporter wrote."""
+        folders_data = self._folders_data("slug")
+        lookup = _build_folder_path_lookup(folders_data, self.folder_export_id_to_obj)
+
+        # Slug keys (what document_paths.folder_path will hold in this zip)
+        self.assertIs(lookup["filings"], self.f_root)
+        self.assertIs(lookup["filings/8-k-a"], self.f_eight_k_a)
+        self.assertIs(lookup["filings/8-k-a/2025-06-03"], self.f_leaf)
+
+        # get_path() keys still resolve in case a future export uses
+        # the canonical convention alongside slug paths.
+        self.assertIs(lookup[self.f_root.get_path()], self.f_root)
+        self.assertIs(lookup[self.f_leaf.get_path()], self.f_leaf)
+
+    def test_build_lookup_skips_folders_that_failed_to_import(self):
+        """Folders missing from the id map are silently skipped (already logged)."""
+        folders_data = self._folders_data("slug")
+        # Drop one entry from the map as if import_corpus_folders had logged
+        # an error and returned without that folder.
+        partial_map = dict(self.folder_export_id_to_obj)
+        partial_map.pop("fld-leaf")
+
+        lookup = _build_folder_path_lookup(folders_data, partial_map)
+        self.assertNotIn("filings/8-k-a/2025-06-03", lookup)
+        self.assertIn("filings/8-k-a", lookup)
+
+    def test_canonical_name_joined_folder_path_resolves(self):
+        """Regression guard: canonical ``get_path()``-style exports still work."""
+        _reconstruct_document_paths(
+            document_paths_data=self._document_paths_data(
+                folder_path=self.f_leaf.get_path(),
+            ),
+            corpus_obj=self.corpus,
+            doc_hash_to_corpus_doc=self.doc_hash_to_corpus_doc,
+            folders_data=self._folders_data("canonical"),
+            folder_export_id_to_obj=self.folder_export_id_to_obj,
+        )
+
+        self.doc_path.refresh_from_db()
+        self.assertEqual(self.doc_path.folder, self.f_leaf)
+
+    def test_slug_joined_folder_path_resolves(self):
+        """Primary fix: third-party slug-joined ``folder_path`` resolves.
+
+        Before the fix this DocumentPath would silently stay at
+        ``folder=NULL`` because the importer only indexed by
+        ``get_path()``.
+        """
+        _reconstruct_document_paths(
+            document_paths_data=self._document_paths_data(
+                folder_path="filings/8-k-a/2025-06-03",
+            ),
+            corpus_obj=self.corpus,
+            doc_hash_to_corpus_doc=self.doc_hash_to_corpus_doc,
+            folders_data=self._folders_data("slug"),
+            folder_export_id_to_obj=self.folder_export_id_to_obj,
+        )
+
+        self.doc_path.refresh_from_db()
+        self.assertEqual(self.doc_path.folder, self.f_leaf)
+
+    def test_unresolved_folder_path_logs_warning_and_leaves_root(self):
+        """Operators get a breadcrumb when the conventions don't line up."""
+        with self.assertLogs(
+            "opencontractserver.tasks.import_tasks_v2", level="WARNING"
+        ) as captured:
+            _reconstruct_document_paths(
+                document_paths_data=self._document_paths_data(
+                    folder_path="some/path/the/exporter/invented",
+                ),
+                corpus_obj=self.corpus,
+                doc_hash_to_corpus_doc=self.doc_hash_to_corpus_doc,
+                folders_data=self._folders_data("slug"),
+                folder_export_id_to_obj=self.folder_export_id_to_obj,
+            )
+
+        # Document stays at the corpus root rather than getting silently
+        # mis-attached.
+        self.doc_path.refresh_from_db()
+        self.assertIsNone(self.doc_path.folder)
+
+        joined = "\n".join(captured.output)
+        self.assertIn("some/path/the/exporter/invented", joined)
+        self.assertIn(f"corpus {self.corpus.id}", joined)
 
 
 class TestV2ImportExceptionHandling(TransactionTestCase):
@@ -2190,6 +2444,25 @@ class TestReconstructDocumentPaths(TransactionTestCase):
             creator=self.user,
         )
 
+        # Folder lookup wiring that mirrors what the production caller
+        # gets back from ``import_corpus_folders``. Tests that don't
+        # exercise folder resolution can still pass these through; only
+        # the folder-specific tests vary the contents.
+        self.folders_data = [
+            {
+                "id": "fld-myfolder",
+                "name": "MyFolder",
+                "description": "",
+                "color": "#05313d",
+                "icon": "folder",
+                "tags": [],
+                "is_public": False,
+                "parent_id": None,
+                "path": "MyFolder",
+            }
+        ]
+        self.folder_export_id_to_obj = {"fld-myfolder": self.folder}
+
     def test_updates_path_version_and_folder(self):
         """Test that path, version_number, and folder are updated."""
         from opencontractserver.tasks.import_tasks_v2 import _reconstruct_document_paths
@@ -2207,7 +2480,13 @@ class TestReconstructDocumentPaths(TransactionTestCase):
             }
         ]
 
-        _reconstruct_document_paths(document_paths_data, self.corpus, doc_hash_map)
+        _reconstruct_document_paths(
+            document_paths_data,
+            self.corpus,
+            doc_hash_map,
+            self.folders_data,
+            self.folder_export_id_to_obj,
+        )
 
         # Reload DocumentPath
         updated_path = DocumentPath.objects.filter(
@@ -2234,7 +2513,13 @@ class TestReconstructDocumentPaths(TransactionTestCase):
             }
         ]
 
-        _reconstruct_document_paths(document_paths_data, self.corpus, doc_hash_map)
+        _reconstruct_document_paths(
+            document_paths_data,
+            self.corpus,
+            doc_hash_map,
+            self.folders_data,
+            self.folder_export_id_to_obj,
+        )
 
         # Path should remain unchanged
         self.doc_path.refresh_from_db()
@@ -2256,7 +2541,13 @@ class TestReconstructDocumentPaths(TransactionTestCase):
             }
         ]
 
-        _reconstruct_document_paths(document_paths_data, self.corpus, doc_hash_map)
+        _reconstruct_document_paths(
+            document_paths_data,
+            self.corpus,
+            doc_hash_map,
+            self.folders_data,
+            self.folder_export_id_to_obj,
+        )
 
         self.doc_path.refresh_from_db()
         self.assertEqual(self.doc_path.path, original_path)
@@ -2276,7 +2567,13 @@ class TestReconstructDocumentPaths(TransactionTestCase):
             }
         ]
 
-        _reconstruct_document_paths(document_paths_data, self.corpus, doc_hash_map)
+        _reconstruct_document_paths(
+            document_paths_data,
+            self.corpus,
+            doc_hash_map,
+            self.folders_data,
+            self.folder_export_id_to_obj,
+        )
 
         # No error, path unchanged
         self.doc_path.refresh_from_db()
@@ -2305,7 +2602,13 @@ class TestReconstructDocumentPaths(TransactionTestCase):
         ]
 
         # Should not raise
-        _reconstruct_document_paths(document_paths_data, self.corpus, doc_hash_map)
+        _reconstruct_document_paths(
+            document_paths_data,
+            self.corpus,
+            doc_hash_map,
+            self.folders_data,
+            self.folder_export_id_to_obj,
+        )
 
     def test_no_updates_when_values_match(self):
         """Test that no save is performed when exported values match existing."""
@@ -2324,13 +2627,19 @@ class TestReconstructDocumentPaths(TransactionTestCase):
             }
         ]
 
-        _reconstruct_document_paths(document_paths_data, self.corpus, doc_hash_map)
+        _reconstruct_document_paths(
+            document_paths_data,
+            self.corpus,
+            doc_hash_map,
+            self.folders_data,
+            self.folder_export_id_to_obj,
+        )
 
         # No changes expected
         self.doc_path.refresh_from_db()
 
     def test_folder_path_not_found(self):
-        """Test that unmatched folder_path is silently ignored."""
+        """Test that unmatched folder_path leaves the document at root."""
         from opencontractserver.tasks.import_tasks_v2 import _reconstruct_document_paths
 
         doc_hash_map = {"hash_abc": self.corpus_doc}
@@ -2345,7 +2654,18 @@ class TestReconstructDocumentPaths(TransactionTestCase):
             }
         ]
 
-        _reconstruct_document_paths(document_paths_data, self.corpus, doc_hash_map)
+        # The miss is also logged as a warning now; suppress it so this
+        # test's intent (path applied, folder stays NULL) stays focused.
+        with self.assertLogs(
+            "opencontractserver.tasks.import_tasks_v2", level="WARNING"
+        ):
+            _reconstruct_document_paths(
+                document_paths_data,
+                self.corpus,
+                doc_hash_map,
+                self.folders_data,
+                self.folder_export_id_to_obj,
+            )
 
         updated_path = DocumentPath.objects.filter(
             corpus=self.corpus, document=self.corpus_doc

--- a/opencontractserver/tests/test_corpus_export_import_v2.py
+++ b/opencontractserver/tests/test_corpus_export_import_v2.py
@@ -1273,6 +1273,56 @@ class TestV2FolderPathReconstruction(TransactionTestCase):
         self.assertIn("some/path/the/exporter/invented", joined)
         self.assertIn(f"corpus {self.corpus.id}", joined)
 
+    def test_build_lookup_skips_empty_exported_path(self):
+        """An empty ``folder.path`` string is treated as absent, not registered.
+
+        Indexing ``""`` would silently fuse every empty-path folder onto a
+        single key and let documents land in whichever folder happened to be
+        processed last.  The ``if key:`` guard in ``_register`` prevents that;
+        ``get_path()`` keys still resolve normally.
+        """
+        folders_data = self._folders_data("canonical")
+        # Mutate the root entry's ``path`` to the empty string — mimics a
+        # malformed export.
+        for entry in folders_data:
+            if entry["id"] == "fld-root":
+                entry["path"] = ""
+
+        lookup = _build_folder_path_lookup(folders_data, self.folder_export_id_to_obj)
+        self.assertNotIn("", lookup)
+        # ``get_path()`` for the root folder is still indexed, so resolution
+        # via the canonical key continues to work.
+        self.assertIs(lookup[self.f_root.get_path()], self.f_root)
+
+    def test_build_lookup_warns_on_key_collision(self):
+        """Two folders sharing a lookup key are surfaced loudly.
+
+        Construct a synthetic collision: a sibling's exported ``path`` value
+        is set to the leaf folder's ``get_path()``.  Last writer wins, but
+        the WARNING makes the silent mis-attribution grep-able.
+        """
+        folders_data = self._folders_data("canonical")
+        leaf_canonical = self.f_leaf.get_path()
+        # Force the ``Filings`` root export entry to claim the same lookup key
+        # as the leaf folder's canonical ``get_path()``.
+        for entry in folders_data:
+            if entry["id"] == "fld-root":
+                entry["path"] = leaf_canonical
+
+        with self.assertLogs(
+            "opencontractserver.tasks.import_tasks_v2", level="WARNING"
+        ) as captured:
+            lookup = _build_folder_path_lookup(
+                folders_data, self.folder_export_id_to_obj
+            )
+
+        joined = "\n".join(captured.output)
+        self.assertIn("Folder path key collision", joined)
+        self.assertIn(repr(leaf_canonical), joined)
+        # Last writer wins — whichever folder registered the key second
+        # (iteration order over ``folders_data``) owns the lookup entry.
+        self.assertIn(lookup[leaf_canonical], {self.f_root, self.f_leaf})
+
 
 class TestV2ImportExceptionHandling(TransactionTestCase):
     """Test exception handling in V2 import functions."""

--- a/opencontractserver/tests/test_ingestion_source.py
+++ b/opencontractserver/tests/test_ingestion_source.py
@@ -986,7 +986,9 @@ class TestImportReconstructLineage(TestCase):
                 "ingestion_metadata": {"job_id": "job-789"},
             }
         ]
-        _reconstruct_document_paths(path_data, self.corpus, {"abc123": doc}, source_map)
+        _reconstruct_document_paths(
+            path_data, self.corpus, {"abc123": doc}, [], {}, source_map
+        )
 
         doc_path.refresh_from_db()
         self.assertEqual(doc_path.ingestion_source, source_map["my_crawler"])
@@ -1022,7 +1024,9 @@ class TestImportReconstructLineage(TestCase):
             }
         ]
         # Should not raise even with None source_name_map
-        _reconstruct_document_paths(path_data, self.corpus, {"def456": doc}, None)
+        _reconstruct_document_paths(
+            path_data, self.corpus, {"def456": doc}, [], {}, None
+        )
 
 
 # ------------------------------------------------------------------ #


### PR DESCRIPTION
## Summary
- V2 corpus imports silently lost folder assignments when the exporter wrote slug-joined (or otherwise non-canonical) paths into `document_paths[*].folder_path`. The sidebar showed the full document count but every folder card displayed `0`, because all 53 `DocumentPath` rows ended up at `folder=NULL`.
- `_reconstruct_document_paths` now builds a multi-key lookup (`_build_folder_path_lookup`) keyed by both the imported folder's `get_path()` and the export's own `folder.path` field — so canonical and third-party exporters (e.g. an EDGAR scraper) both resolve, as long as the convention is consistent within a single export.
- Unresolved `folder_path` values now log a structured `WARNING` naming the unresolved path, corpus, doc, and the known folder keys — silent mis-attribution becomes a loud, grep-able failure.

## Root cause
The canonical exporter (`utils/export_v2.py`) writes `folder.get_path()` (name-joined) into both `folder.path` and `document_paths.folder_path`, so it round-tripped through the importer's `get_path()`-only lookup by coincidence. External exporters that build their own zip (the AMD EDGAR scrape ZIP that triggered this report, for instance) wrote slug-joined paths like `advanced-micro-devices-inc/10-k/10-k-2024-01-31-…`, which never matched the importer's `ADVANCED MICRO DEVICES INC/10-K/10-K (2024-01-31)` keys. Without a folder, every document fell to the corpus root in the DB; the UI's folder cards count `DocumentPath(folder__in=descendants, …)` so all of them read `0`.

## Test plan
- [x] `docker compose -f test.yml run --rm django pytest opencontractserver/tests/test_corpus_export_import_v2.py -n 4 --dist loadscope` → 63 passed.
- [x] `docker compose -f test.yml run --rm django pytest opencontractserver/tests/test_corpus_export.py opencontractserver/tests/test_corpus_import.py opencontractserver/tests/test_graphql_import_export_mutations.py -n 4 --dist loadscope` → 10 passed.
- [x] `pre-commit run --files opencontractserver/tasks/import_tasks_v2.py opencontractserver/tests/test_corpus_export_import_v2.py` → black, isort, flake8, mypy all clean.
- [x] Manual repro on the originally-reported AMD zip:
  - Before: `corpus.document_count()=53`, `folder=NULL count=53`, every folder card `0`.
  - After: `corpus.document_count()=53`, `folder=NULL count=0`, root `get_descendant_document_count()=53`, leaf folder counts sum to 53.

## New regression coverage (`TestV2FolderPathReconstruction`)
- `test_build_lookup_indexes_both_get_path_and_export_path` — helper indexes both conventions.
- `test_build_lookup_skips_folders_that_failed_to_import` — partial folder-creation failure is safe.
- `test_canonical_name_joined_folder_path_resolves` — regression guard for the canonical exporter.
- `test_slug_joined_folder_path_resolves` — regression guard for the AMD/EDGAR scraper case.
- `test_unresolved_folder_path_logs_warning_and_leaves_root` — pins the new warning + safe default.

The fixture deliberately uses a folder name containing `/` (`8-K/A`) to also lock down resolution when `get_path()` is ambiguous; the export's `path` field is what resolves it.