### PR TITLE
Fix mobile/desktop layout issues from views audit

### DIFF
--- a/frontend/src/components/corpuses/CorpusListView.tsx
+++ b/frontend/src/components/corpuses/CorpusListView.tsx
@@ -526,7 +526,7 @@ export const CorpusListView: React.FC<CorpusListViewProps> = ({
 
         {/* Stats Grid */}
         <StatsContainer>
-          <StatGrid columns={2}>
+          <StatGrid columns={4}>
             <StatBlock
               value={stats.totalCorpuses.toString()}
               label="Corpuses"

--- a/frontend/src/components/landing/StatsSection.tsx
+++ b/frontend/src/components/landing/StatsSection.tsx
@@ -75,7 +75,7 @@ export const StatsSection: React.FC<StatsSectionProps> = ({
 }) => {
   return (
     <StatsWrapper>
-      <StatGrid columns={2}>
+      <StatGrid columns={4}>
         {statConfigs.map((config) => {
           const value =
             loading || !stats ? "—" : formatNumber(stats[config.key] as number);

--- a/frontend/src/components/layout/DiscoveryViewLayout.ts
+++ b/frontend/src/components/layout/DiscoveryViewLayout.ts
@@ -16,8 +16,10 @@ import {
  * needed.
  */
 
-/** Outer scroll shell with the constrained 1200px (75rem) reading column. */
-export const DiscoveryContainer = styled.div`
+/** Outer scroll shell with the constrained 1200px (75rem) reading column.
+ *  Pass `$fabClearance` on views that render a fixed FAB so trailing
+ *  content can scroll clear of it. */
+export const DiscoveryContainer = styled.div<{ $fabClearance?: boolean }>`
   max-width: 75rem;
   margin: 0 auto;
   padding: 2.5rem 4rem;
@@ -36,6 +38,11 @@ export const DiscoveryContainer = styled.div`
   ${mediaQuery.mobile} {
     padding: 1rem;
   }
+
+  /* Clearance for a fixed FAB (3rem tall, ≤2rem from the bottom edge).
+     Declared after the breakpoint shorthands so it overrides their
+     padding-bottom at every width. */
+  ${({ $fabClearance }) => $fabClearance && "padding-bottom: 7rem;"}
 `;
 
 /** Page header — wraps the title row + filter bar. */

--- a/frontend/src/components/layout/PageLayout.tsx
+++ b/frontend/src/components/layout/PageLayout.tsx
@@ -107,7 +107,6 @@ export const HeroSubtitle = styled.p`
  */
 export const StatsContainer = styled.div`
   margin-bottom: 48px;
-  padding: 32px 0;
 
   /* Override stat value size for list-page prominence. */
   [class*="StatBlock"] > *:first-child,
@@ -116,8 +115,6 @@ export const StatsContainer = styled.div`
   }
 
   @media (max-width: 768px) {
-    padding: 24px 0;
-
     [class*="StatBlock"] > *:first-child,
     [data-testid="stat-value"] {
       font-size: 28px !important;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -33,6 +33,21 @@
   }
 }
 
+/* Global box-sizing reset. Without this, any `width: 100%` element with
+   horizontal padding/border overflows its container by the padding amount
+   (e.g. the site footer extended 32px past the viewport on mobile, and the
+   thread search input ran off-screen). `inherit` lets a subtree opt out if
+   it ever genuinely needs content-box. */
+html {
+  box-sizing: border-box;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: inherit;
+}
+
 body {
   margin: 0;
   overflow-x: hidden;

--- a/frontend/src/views/Annotations.tsx
+++ b/frontend/src/views/Annotations.tsx
@@ -104,12 +104,24 @@ const StatsRow = styled.div`
     grid-template-columns: 1fr 1fr;
     gap: 16px;
   }
+
+  /* On phones a 2-column grid leaves each label only ~110px beside the
+     fixed-width icon, so multi-word labels wrap to 3 cramped lines. Drop
+     to a single column so each stat gets the full row width. */
+  @media (max-width: 480px) {
+    grid-template-columns: 1fr;
+  }
 `;
 
 const StatItem = styled.div`
   display: flex;
   align-items: center;
   gap: 12px;
+  /* Equal share of the row so the four stats fill the card width instead
+     of packing left with dead space; min-width:0 lets long labels wrap
+     rather than force the item wider than its quarter. */
+  flex: 1;
+  min-width: 0;
 
   @media (max-width: 768px) {
     padding: 12px;
@@ -150,6 +162,7 @@ const StatLabel = styled.div`
 const StatDivider = styled.div`
   width: 1px;
   height: 40px;
+  flex-shrink: 0;
   background: ${OS_LEGAL_COLORS.border};
 
   @media (max-width: 768px) {

--- a/frontend/src/views/Documents.styles.ts
+++ b/frontend/src/views/Documents.styles.ts
@@ -16,6 +16,15 @@ export const FilterTabsRow = styled.div`
   display: flex;
   align-items: center;
   gap: 12px;
+  flex-wrap: wrap;
+
+  /* On narrow screens the status tabs wrap to multiple lines; a centered
+     flex row leaves the Filters button floating beside the wrapped block.
+     Stack instead so the button sits cleanly below the tabs. */
+  @media (max-width: 640px) {
+    flex-direction: column;
+    align-items: flex-start;
+  }
 `;
 
 export const FilterButton = styled.button<{

--- a/frontend/src/views/Documents.tsx
+++ b/frontend/src/views/Documents.tsx
@@ -618,7 +618,7 @@ export const Documents = () => {
 
         {/* Stats Grid */}
         <StatsContainer>
-          <StatGrid columns={2}>
+          <StatGrid columns={4}>
             <StatBlock
               value={stats.totalDocs.toString()}
               label="Documents"

--- a/frontend/src/views/Extracts.tsx
+++ b/frontend/src/views/Extracts.tsx
@@ -424,7 +424,7 @@ export const Extracts = () => {
 
         {/* Stats Grid */}
         <StatsContainer>
-          <StatGrid columns={2}>
+          <StatGrid columns={4}>
             <StatBlock
               value={stats.totalExtracts.toString()}
               label="Total Extracts"

--- a/frontend/src/views/GlobalDiscussions.tsx
+++ b/frontend/src/views/GlobalDiscussions.tsx
@@ -289,7 +289,7 @@ export const GlobalDiscussions: React.FC = () => {
   }, [searchParams]);
 
   return (
-    <DiscoveryContainer>
+    <DiscoveryContainer $fabClearance>
       <DiscoveryHeader>
         <TitleRow>
           <DiscoveryTitle>Discussions</DiscoveryTitle>

--- a/frontend/src/views/LabelSets.tsx
+++ b/frontend/src/views/LabelSets.tsx
@@ -402,7 +402,7 @@ export const Labelsets = () => {
 
         {/* Stats Grid */}
         <StatsContainer>
-          <StatGrid columns={2}>
+          <StatGrid columns={4}>
             <StatBlock
               value={stats.totalLabelsets.toString()}
               label="Label Sets"

--- a/frontend/src/views/TermsOfService.tsx
+++ b/frontend/src/views/TermsOfService.tsx
@@ -13,14 +13,14 @@ export class TermsOfService extends Component {
           }}
         >
           <br />
-          <p>
-            <h1>Open Contracts - Terms of Service</h1>
+          <h1>Open Contracts - Terms of Service</h1>
+          <div style={{ marginBottom: "1em" }}>
             <strong>Last Updated: March 20, 2021</strong>
-          </p>
+          </div>
           <br />
         </div>
         <div style={{ maxWidth: "700px", margin: "0 auto", padding: "0 1rem" }}>
-          <p>
+          <div style={{ marginBottom: "1em" }}>
             This Terms of Service ("Agreement") is a legal agreement between you
             (referred to herein as "you" or "your") and Gordium Knot, Inc.
             ("we", "our", or "us") for access to and use of our website (the
@@ -28,8 +28,8 @@ export class TermsOfService extends Component {
             downloads operated by us and that are available through the Website
             (whether accessed directly or through any software Website)
             (collectively, the "Service").
-          </p>
-          <p>
+          </div>
+          <div style={{ marginBottom: "1em" }}>
             BY ACCESSING OR USING THE SERVICE, YOU AGREE TO BE BOUND BY THE
             TERMS AND CONDITIONS OF THIS AGREEMENT, WHETHER OR NOT YOU ARE A
             REGISTERED USER OF OUR SERVICE. IF ANY OF THESE TERMS ARE
@@ -38,9 +38,9 @@ export class TermsOfService extends Component {
             THE SERVICE NOW, OR FOLLOWING THE POSTING OF ANY CHANGES IN THIS
             AGREEMENT, WILL INDICATE ACCEPTANCE AND AGREEMENT BY YOU OF SUCH
             CHANGES.
-          </p>
+          </div>
           <h2>Your Use of the OpenContracts Service</h2>
-          <p>
+          <div style={{ marginBottom: "1em" }}>
             We provide the Service for experimentation purposes only. You may
             not rely on any information, data, contract, label set, markup
             export file, or other materials obtained through the Service for any
@@ -49,8 +49,8 @@ export class TermsOfService extends Component {
             in any respect, or necessarily endorse the content found on
             third­-party Websites or services. You assume sole responsibility
             for your use of third­party links, Websites, products and services.
-          </p>
-          <p>
+          </div>
+          <div style={{ marginBottom: "1em" }}>
             <u>You further agree that:</u>
             <ol style={{ paddingLeft: "1.5rem" }}>
               <li>
@@ -71,8 +71,8 @@ export class TermsOfService extends Component {
                 purpose or any other warranties, express or implied.
               </li>
             </ol>
-          </p>
-          <p>
+          </div>
+          <div style={{ marginBottom: "1em" }}>
             You acknowledge and agree that your use of the Service, including,
             without limitation, the storage of any data, files, information
             and/or other materials on a server owned or under our control or in
@@ -85,8 +85,8 @@ export class TermsOfService extends Component {
             deem, in our sole discretion, such data to be in violation of this
             Agreement and/or any rule or policy of ours and/or any local, state,
             or federal law or regulation
-          </p>
-          <p>
+          </div>
+          <div style={{ marginBottom: "1em" }}>
             We cannot always foresee or anticipate technical or other
             difficulties which may result in failure to obtain data or loss of
             data, personalization settings, or other interruptions. We cannot
@@ -94,8 +94,8 @@ export class TermsOfService extends Component {
             non­delivery or failure to store any user data, communications or
             settings, and you agree we have no obligation to provide you with
             any notice of any downtime, system failures or bugs.
-          </p>
-          <p>
+          </div>
+          <div style={{ marginBottom: "1em" }}>
             <u>You represent, warrant, and agree that you will not:</u>
             <ol style={{ paddingLeft: "1.5rem" }}>
               <li>
@@ -184,8 +184,8 @@ export class TermsOfService extends Component {
                 from the Service by us;
               </li>
             </ol>
-          </p>
-          <p>
+          </div>
+          <div style={{ marginBottom: "1em" }}>
             <h2>Provision of Service by Us</h2>
             You acknowledge and agree that the form and nature of the Service
             which we provide may change from time to time without prior notice
@@ -194,9 +194,9 @@ export class TermsOfService extends Component {
             the Service (or any features or programs or Content within the
             Service) to you or to users generally at our sole discretion,
             without liability or prior notice to you.
-          </p>
+          </div>
 
-          <p>
+          <div style={{ marginBottom: "1em" }}>
             <h2>Content in the Service.</h2>
             You understand that all information and materials (including,
             without limitation, data files, written text, computer software,
@@ -217,8 +217,8 @@ export class TermsOfService extends Component {
             by the owners of that Content, in writing. We reserve the right (but
             shall have no obligation) to pre­screen, review, flag, filter,
             modify, refuse or remove any or all Content.
-          </p>
-          <p>
+          </div>
+          <div style={{ marginBottom: "1em" }}>
             <h2>Intellectual Property</h2>
             You acknowledge and agree that we (or our licensors) own all legal
             right, title and interest in and to the Service, including, without
@@ -232,8 +232,8 @@ export class TermsOfService extends Component {
             logo of any company or organization in a way that is likely or
             intended to cause confusion about the owner or authorized user of
             such marks, names or logos.
-          </p>
-          <p>
+          </div>
+          <div style={{ marginBottom: "1em" }}>
             <h2>Privacy Policy</h2>
             For information about our data protection practices, please read our
             privacy policy available{" "}
@@ -241,8 +241,8 @@ export class TermsOfService extends Component {
             policy explains how we treat your personal information, and how we
             protect your privacy when you use the Service. You agree to the use
             of your data in accordance with our privacy policy.
-          </p>
-          <p>
+          </div>
+          <div style={{ marginBottom: "1em" }}>
             <h2>No Warranties</h2>
             THE SERVICE IS PROVIDED TO YOU ON AN "AS IS" AND "AS AVAILABLE"
             BASIS, WITHOUT WARRANTY OR REPRESENTATION OF ANY KIND. TO THE
@@ -263,8 +263,8 @@ export class TermsOfService extends Component {
             OR PUBLISHING IT, AND YOU AGREE THAT WE ARE ONLY ACTING AS A PASSIVE
             CONDUIT FOR YOUR AND OTHER USERS’ ONLINE DISTRIBUTION AND
             PUBLICATION OF CONTENT PROVIDED BY YOU AND THEM.
-          </p>
-          <p>
+          </div>
+          <div style={{ marginBottom: "1em" }}>
             <h2>Disclaimer of Liability</h2>
             TO THE FULLEST EXTENT PERMITTED BY LAW, IN NO EVENT SHALL WE, OUR
             PARENTS, SUBSIDIARIES, AFFILIATES, OR ANY OF THEIR DIRECTORS,
@@ -296,8 +296,8 @@ export class TermsOfService extends Component {
             administrative or regulatory authority or court, including but not
             limited to those related to export and import of software, technical
             information or services.
-          </p>
-          <p>
+          </div>
+          <div style={{ marginBottom: "1em" }}>
             <h2>Release and Indemnification</h2>
             You agree to release, indemnify and hold harmless us, our parents,
             subsidiaries, affiliates, directors, members, officers, employees,
@@ -323,8 +323,8 @@ export class TermsOfService extends Component {
             that is the subject of your obligations hereunder. For the avoidance
             of doubt, this section shall survive the termination of this
             Agreement.
-          </p>
-          <p>
+          </div>
+          <div style={{ marginBottom: "1em" }}>
             <h2>Term and Termination.</h2>
             This Agreement is effective until terminated by us or you. We shall
             have the right to terminate this Agreement including, without
@@ -336,8 +336,8 @@ export class TermsOfService extends Component {
             your user account on the Service and discontinuing use of any and
             all parts of the Service. Upon termination of this Agreement for any
             reason, you shall immediately cease using the Service.
-          </p>
-          <p>
+          </div>
+          <div style={{ marginBottom: "1em" }}>
             <h2>Governing Law and Venue for Disputes.</h2>
             This Agreement, and your relationship with us under this Agreement,
             shall be governed by the laws of the State of New York without
@@ -351,8 +351,8 @@ export class TermsOfService extends Component {
             arbitration by phone or via document submission to the fullest
             extent allowable by the arbitrator. Each party will bear their own
             costs of arbitration.
-          </p>
-          <p>
+          </div>
+          <div style={{ marginBottom: "1em" }}>
             <h2>No Class Acton.</h2>
             You agree to resolve any disputes related to this Agreement as an
             individual and not as a class or join any class. You understand
@@ -373,24 +373,24 @@ export class TermsOfService extends Component {
                 IN ANY LAWSUIT INVOLVING ANY SUCH DISPUTE.
               </li>
             </ul>
-          </p>
-          <p>
+          </div>
+          <div style={{ marginBottom: "1em" }}>
             <h2>Severability</h2>
             If any provision in this Agreement is invalid or unenforceable or
             contrary to applicable law, such provision shall be construed,
             limited, or altered, as necessary, to eliminate the invalidity or
             unenforceability or the conflict with applicable law, and all other
             provisions of this Agreement shall remain in effect.
-          </p>
-          <p>
+          </div>
+          <div style={{ marginBottom: "1em" }}>
             <h2>Assignment, Sublease and/or Transfer</h2>
             You may not assign, sublicense, or transfer this Agreement or any
             rights or obligations hereunder without our prior written consent.
             Any such attempted assignment, sublicense, or transfer will be null
             and void and we, in our sole discretion, shall have the right to
             immediately terminate this Agreement.
-          </p>
-          <p>
+          </div>
+          <div style={{ marginBottom: "1em" }}>
             <h2>Entire Agreement</h2>
             This Agreement sets forth the entire understanding and agreement
             between the parties relating to its subject matter. All provisions
@@ -402,7 +402,7 @@ export class TermsOfService extends Component {
             no trial by jury. Any waiver of or promise not to enforce any right
             under this Agreement shall not be enforceable unless evidenced by a
             writing signed by the party making said waiver or promise.
-          </p>
+          </div>
         </div>
         <br />
       </div>


### PR DESCRIPTION
## Summary

A visual audit of every high-level view in `frontend/src/views` — driven in real mobile (iPhone 13, 390px) and desktop (1440px) viewports — surfaced overflow, crowding, and layout-density problems. This PR fixes the structural causes (no monkey-patching):

- **Global `box-sizing: border-box` reset** (`index.css`). Without it, any `width:100%` + padding element overflowed: the site footer ran 32px past the viewport on every page, and the thread search input ran 76px off-screen on mobile. One reset fixes both.
- **`FilterTabsRow`** (Documents) now wraps and stacks to a column at ≤640px, so the Filters button no longer floats vertically-centered beside the wrapped status tabs.
- **`DiscoveryContainer`** gains an opt-in `$fabClearance` prop; `GlobalDiscussions` uses it so the fixed FAB no longer overlaps trailing content.
- **Annotations stat cards** drop to a single column at ≤480px instead of forcing a 2-column grid that crammed labels like "Human Annotated (in view)" into 3 lines.
- **`TermsOfService`** invalid `<p>`-wrapping-block-element nesting replaced with `<div>` wrappers — removes React `validateDOMNesting` warnings.
- **Density pass:** `StatGrid` switched from 2 → 4 columns (Documents, Extracts, LabelSets, CorpusListView, landing `StatsSection`) so the four stats fill the row instead of sitting left-packed in a sparse 2×2 grid; removed the redundant 32px `StatsContainer` padding that stacked on `HeroSection`'s margin to make 80px dead gaps; Annotations `StatItem` uses `flex:1` so its stats spread across the card.

The `@os-legal/ui` `SearchBox` mobile bug (icon detaches at ≤480px) is tracked upstream: Open-Source-Legal/OS-Legal-Style#27.

## Test plan

- [x] `yarn tsc --noEmit` passes
- [x] `yarn lint` / prettier pass
- [x] Mobile (390px): no horizontal overflow on any view; FilterTabsRow stacks; threads input fits; Annotations stats single-column
- [x] Desktop (1440px): no overflow; stats fill the row in one line; no dead gaps; no console errors
- [ ] Component tests for affected views (Documents, Annotations, Extracts, LabelSets) — changes are CSS/layout only