### PR TITLE
discovery: rebrand llms.txt / llms-full.txt / .well-known/mcp.json to [cite]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Discovery endpoints rebranded to [cite]** (`opencontractserver/discovery/views.py`). The agent/crawler-facing static surfaces (`/llms.txt`, `/llms-full.txt`, `/.well-known/mcp.json`) now identify as `cite` with the citation-graph framing from the README, instead of describing the platform as "OpenContracts … document analytics platform". `Source code` / `Project home` links repoint from `Open-Source-Legal/OpenContracts` + `contracts.opensource.legal` to `Open-Source-Legal/cite` + `cite.opensource.legal`. In `/.well-known/mcp.json` the global server key is renamed from `opencontracts` to `cite` and scoped entries from `opencontracts-{slug}` to `cite-{slug}` — cosmetic for clients (they pick their own local label) but aligns the discovery document with the new brand. Each text endpoint carries a one-line rebrand note ("Released as OpenContracts since 2019; rebranded as cite for the v3 release line") so crawlers indexing the old name still get a match. `robots.txt`, `sitemap.xml`, `/.well-known/oauth-protected-resource`, and `/api/search/` were already brand-free and untouched. Tests in `opencontractserver/discovery/tests/test_discovery_views.py` updated to pin the new strings.
+
 ### Added
 
 - **v3 surface rebrand: OpenContracts → [cite]** (PR #1781). Ships the public-surface rebrand from OpenContracts to [cite] as part of the v3 milestone. Scope is intentionally narrow: brand assets + landing + /about + chrome (NavMenu, Footer, Login, CookieConsent). The deeper product UI strings, repo name, README references, MCP/agent identity strings, GraphQL types, and the loading splash still use the OpenContracts name and are explicitly out of scope.

--- a/opencontractserver/discovery/tests/test_discovery_views.py
+++ b/opencontractserver/discovery/tests/test_discovery_views.py
@@ -99,10 +99,10 @@ class LlmsTxtTest(TestCase):
         """Verify H1 title, blockquote, and H2 sections per llmstxt.org spec."""
         response = self.client.get("/llms.txt")
         content = response.content.decode()
-        # H1 title
-        self.assertIn("# OpenContracts", content)
-        # Blockquote summary
-        self.assertIn("> OpenContracts is an open-source", content)
+        # H1 title — rebranded from OpenContracts to cite in v3 release line
+        self.assertIn("# cite", content)
+        # Blockquote summary (citation-graph framing)
+        self.assertIn("> cite is the citation layer", content)
         # H2 sections
         self.assertIn("## MCP Server", content)
         self.assertIn("## Available Collections", content)
@@ -333,12 +333,12 @@ class WellKnownMcpTest(TestCase):
         response = self.client.get("/.well-known/mcp.json")
         data = json.loads(response.content)
         self.assertIn("mcpServers", data)
-        self.assertIn("opencontracts", data["mcpServers"])
+        self.assertIn("cite", data["mcpServers"])
 
     def test_global_server_entry(self):
         response = self.client.get("/.well-known/mcp.json")
         data = json.loads(response.content)
-        server = data["mcpServers"]["opencontracts"]
+        server = data["mcpServers"]["cite"]
         self.assertIn("/mcp/", server["url"])
         self.assertEqual(server["transport"], "streamable-http")
         self.assertIsNone(server["authentication"])
@@ -347,14 +347,14 @@ class WellKnownMcpTest(TestCase):
         response = self.client.get("/.well-known/mcp.json")
         data = json.loads(response.content)
         slug = self.corpus.slug
-        key = f"opencontracts-{slug}"
+        key = f"cite-{slug}"
         self.assertIn(key, data["mcpServers"])
         self.assertIn(f"/mcp/corpus/{slug}/", data["mcpServers"][key]["url"])
 
     def test_resolves_hostname(self):
         response = self.client.get("/.well-known/mcp.json")
         data = json.loads(response.content)
-        server = data["mcpServers"]["opencontracts"]
+        server = data["mcpServers"]["cite"]
         self.assertIn("http://testserver", server["url"])
         self.assertNotIn("THIS_HOST", server["url"])
 
@@ -369,7 +369,7 @@ class WellKnownMcpTest(TestCase):
         with override_settings(USE_AUTH0=True, AUTH0_DOMAIN="example.auth0.com"):
             response = self.client.get("/.well-known/mcp.json")
         data = json.loads(response.content)
-        global_server = data["mcpServers"]["opencontracts"]
+        global_server = data["mcpServers"]["cite"]
         self.assertIsNotNone(global_server["authentication"])
         self.assertEqual(global_server["authentication"]["type"], "oauth2")
         self.assertIn(
@@ -379,7 +379,7 @@ class WellKnownMcpTest(TestCase):
         # The same auth block must be attached to corpus-scoped server entries
         # so clients discover auth uniformly whichever endpoint they pick.
         slug = self.corpus.slug
-        scoped_server = data["mcpServers"][f"opencontracts-{slug}"]
+        scoped_server = data["mcpServers"][f"cite-{slug}"]
         self.assertEqual(
             scoped_server["authentication"], global_server["authentication"]
         )
@@ -437,7 +437,7 @@ class DiscoveryNoCorpusesTest(TestCase):
         self.assertEqual(response.status_code, 200)
         content = response.content.decode()
         # Should still have the core sections
-        self.assertIn("# OpenContracts", content)
+        self.assertIn("# cite", content)
         self.assertIn("## MCP Server", content)
         # But no Available Collections section
         self.assertNotIn("## Available Collections", content)
@@ -460,7 +460,7 @@ class DiscoveryNoCorpusesTest(TestCase):
         self.assertEqual(response.status_code, 200)
         data = json.loads(response.content)
         # Should still have global server
-        self.assertIn("opencontracts", data["mcpServers"])
+        self.assertIn("cite", data["mcpServers"])
         # But no corpus-scoped servers beyond the global one
         self.assertEqual(len(data["mcpServers"]), 1)
 

--- a/opencontractserver/discovery/views.py
+++ b/opencontractserver/discovery/views.py
@@ -161,12 +161,16 @@ def llms_txt(request: HttpRequest) -> HttpResponse:
     corpuses = _get_public_corpuses()
 
     lines = [
-        "# OpenContracts",
+        "# cite",
         "",
         (
-            "> OpenContracts is an open-source document analytics platform for "
-            "analyzing, annotating, and querying complex documents. It provides a "
-            "Model Context Protocol (MCP) server for AI agent access."
+            "> cite is the citation layer for agentic workflows: an open citation "
+            "graph that humans and AI agents can read, reason over, and contribute "
+            "back to. Documents are nodes, citations are edges, annotations are how "
+            "humans and agents build the graph together. This instance exposes a "
+            "Model Context Protocol (MCP) endpoint so agents can traverse the graph "
+            "and cite the spans they pulled from. Released as OpenContracts since "
+            "2019; rebranded as cite for the v3 release line."
         ),
         "",
         "## MCP Server",
@@ -190,7 +194,7 @@ def llms_txt(request: HttpRequest) -> HttpResponse:
         "```json",
         "{",
         '  "mcpServers": {',
-        '    "opencontracts": {',
+        '    "cite": {',
         '      "command": "npx",',
         f'      "args": ["mcp-remote", "{base_url}/mcp/"]',
         "    }",
@@ -247,8 +251,8 @@ def llms_txt(request: HttpRequest) -> HttpResponse:
             "## Links",
             "",
             f"- [Full MCP documentation]({base_url}/llms-full.txt)",
-            "- [Source code](https://github.com/Open-Source-Legal/OpenContracts)",
-            "- [Project documentation](https://contracts.opensource.legal)",
+            "- [Source code](https://github.com/Open-Source-Legal/cite)",
+            "- [Project home](https://cite.opensource.legal)",
             "",
         ]
     )
@@ -266,18 +270,20 @@ def llms_full_txt(request: HttpRequest) -> HttpResponse:
     corpuses = _get_public_corpuses()
 
     lines = [
-        "# OpenContracts - Full MCP Documentation",
+        "# cite - Full MCP Documentation",
         "",
         (
-            "> OpenContracts is an open-source document analytics platform for "
-            "analyzing, annotating, and querying complex documents. It provides a "
-            "Model Context Protocol (MCP) server for AI agent access to public data."
+            "> cite is the citation layer for agentic workflows: an open citation "
+            "graph of documents, annotations, and the edges between them. It exposes "
+            "a Model Context Protocol (MCP) server so agents can list corpuses, "
+            "search documents and annotations, and follow citation edges. Released "
+            "as OpenContracts since 2019; rebranded as cite for the v3 release line."
         ),
         "",
         "## MCP Server Overview",
         "",
         (
-            "OpenContracts exposes a read-only MCP server so that AI assistants can "
+            "cite exposes a read-only MCP server so that AI assistants can "
             "access public corpuses, documents, annotations, and discussion threads "
             "without authentication."
         ),
@@ -299,7 +305,7 @@ def llms_full_txt(request: HttpRequest) -> HttpResponse:
         "```json",
         "{",
         '  "mcpServers": {',
-        '    "opencontracts": {',
+        '    "cite": {',
         '      "command": "npx",',
         f'      "args": ["mcp-remote", "{base_url}/mcp/"]',
         "    }",
@@ -581,8 +587,8 @@ def llms_full_txt(request: HttpRequest) -> HttpResponse:
             "",
             "## Links",
             "",
-            "- [Source code](https://github.com/Open-Source-Legal/OpenContracts)",
-            "- [Project site](https://contracts.opensource.legal)",
+            "- [Source code](https://github.com/Open-Source-Legal/cite)",
+            "- [Project home](https://cite.opensource.legal)",
             "- [MCP specification](https://modelcontextprotocol.io)",
             "",
         ]
@@ -690,13 +696,13 @@ def well_known_mcp(request: HttpRequest) -> HttpResponse:
     auth_meta = _build_mcp_auth_metadata(base_url)
 
     servers = {
-        "opencontracts": {
+        "cite": {
             "url": f"{base_url}/mcp/",
             "description": (
-                "Access to OpenContracts corpuses, annotations, and discussion "
-                "threads. Anonymous callers see only public, published resources; "
-                "authenticated callers also see private resources they own or are "
-                "shared on."
+                "Access to the cite citation graph: corpuses, documents, "
+                "annotations, and discussion threads. Anonymous callers see only "
+                "public, published resources; authenticated callers also see "
+                "private resources they own or are shared on."
             ),
             "transport": "streamable-http",
             "authentication": auth_meta,
@@ -708,7 +714,7 @@ def well_known_mcp(request: HttpRequest) -> HttpResponse:
     for c in corpuses:
         slug = c["slug"]
         title = c["title"]
-        servers[f"opencontracts-{slug}"] = {
+        servers[f"cite-{slug}"] = {
             "url": f"{base_url}/mcp/corpus/{slug}/",
             "description": f"Scoped access to: {title}",
             "transport": "streamable-http",


### PR DESCRIPTION
## Summary

The agent/crawler-facing static surfaces in `opencontractserver/discovery/` still introduced the platform as "OpenContracts — document analytics platform". Updated to the README's citation-graph framing under the new [cite] name. Each text endpoint carries a one-line rebrand note ("Released as OpenContracts since 2019; rebranded as cite for the v3 release line") so crawlers indexing the old name still get a match on the new content.

### What changed

- **`/llms.txt`** — H1 → `# cite`; blockquote rewritten to the README's citation-graph pitch; `Source code` link repointed from `Open-Source-Legal/OpenContracts` to `Open-Source-Legal/cite`; `Project home` link from `contracts.opensource.legal` to `cite.opensource.legal`. The Claude Desktop config snippet uses `"cite"` as the local `mcpServers` key.
- **`/llms-full.txt`** — same set of rebrand changes, plus the global "Overview" paragraph rewritten.
- **`/.well-known/mcp.json`** — global server key renamed from `"opencontracts"` to `"cite"`; corpus-scoped keys from `"opencontracts-{slug}"` to `"cite-{slug}"`. Cosmetic for clients (the key is a local label users can rename anyway) but the discovery document itself now matches the brand. `description` rewritten to mention the cite citation graph.
- **`robots.txt`, `sitemap.xml`, `/.well-known/oauth-protected-resource`, `/api/search/`** — already brand-free, untouched.
- **Tests** (`opencontractserver/discovery/tests/test_discovery_views.py`) updated to pin the new strings.
- **`CHANGELOG.md`** — entry under `[Unreleased]` / `Changed`.

### Why GitHub URL is `Open-Source-Legal/cite` and not `…/OpenContracts`

The README narrates "the GitHub repository keeps the `OpenContracts` name through the v3 release line", but the actual git remote is already `Open-Source-Legal/cite`. The new URL is canonical; GitHub auto-redirects the old name, so existing forks and CI keep working either way. The README is the next thing that needs reconciliation but is intentionally out of scope here.

## Test plan

- [ ] `docker compose -f test.yml run django pytest opencontractserver/discovery/tests/test_discovery_views.py -n 4 --dist loadscope` — all assertions updated to the new strings; should pass.
- [ ] Hit `/llms.txt`, `/llms-full.txt`, `/.well-known/mcp.json` on a running instance and eyeball:
  - H1 reads `# cite`, blockquote describes the citation graph
  - Mention of "Released as OpenContracts since 2019" appears once per text endpoint
  - `Source code` link is `https://github.com/Open-Source-Legal/cite`
  - `Project home` link is `https://cite.opensource.legal`
  - `mcp.json` global server key is `cite`, corpus-scoped keys are `cite-{slug}`
- [ ] `/robots.txt`, `/sitemap.xml`, `/.well-known/oauth-protected-resource`, `/api/search/` unchanged in shape (no brand strings to drift).

---
_Generated by [Claude Code](https://claude.ai/code/session_017hWCevDTEYP7WRmSzdJcsT)_