### PR TITLE
Force uuid >= 11.1.1 to close Dependabot alert #106

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -142,7 +142,8 @@
     "postcss": "^8.5.10",
     "rollup": "^4.59.0",
     "immutable": ">=3.8.3",
-    "vite": "^7.3.2"
+    "vite": "^7.3.2",
+    "uuid": "^11.1.1"
   },
   "devDependencies": {
     "@graphql-codegen/cli": "^5.0.2",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -8215,15 +8215,15 @@ util-deprecate@^1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
+uuid@^11.1.1, uuid@^8.3.2:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.1.tgz#f6d81d2e1c65d00762e5e29b16c5d2d995e208ad"
+  integrity sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==
+
 uuid@^14.0.0:
   version "14.0.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-14.0.0.tgz#0af883220163d264ffe0c084f6b8a89b9666966d"
   integrity sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==
-
-uuid@^8.3.2:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 validate.io-array@^1.0.3:
   version "1.0.6"


### PR DESCRIPTION
## Summary
- Adds `"uuid": "^11.1.1"` to `frontend/package.json` `resolutions` so every transitive `uuid` install resolves to the patched 11.1.1 release.
- `yarn install` rewrites the `uuid@^8.3.2` lockfile entry (pulled in via `nyc → istanbul-lib-processinfo`, a dev-only coverage dep) up to 11.1.1.
- Closes the open Dependabot alert: **uuid: Missing buffer bounds check in v3/v5/v6 when buf is provided** (`< 11.1.1`).

## Why this is safe
- Production code already declares `uuid@^14.0.0` directly, so this PR only affects the dev/test dependency tree.
- `istanbul-lib-processinfo` only calls `require('uuid').v4()`. uuid 11.x still ships a CJS build (`./dist/cjs/index.js`) that re-exports `v4`, so the call site keeps working without code changes.
- After the change, every `uuid` install in `yarn.lock` is `>= 11.1.1`:
  ```
  uuid@^11.1.1, uuid@^8.3.2 → 11.1.1
  uuid@^14.0.0              → 14.0.0
  ```

## Test plan
- [x] `yarn install` succeeds and updates `yarn.lock` (no other lockfile churn).
- [x] `yarn run lint` (prettier) clean.
- [ ] CI: frontend builds + Playwright suite stay green.