### PR TITLE
test(e2e): fix flaky Extract pipeline E2E document-processing timeout (#1844)

### DIFF
--- a/frontend/tests/e2e/extract-pdf-workflow.spec.ts
+++ b/frontend/tests/e2e/extract-pdf-workflow.spec.ts
@@ -159,23 +159,36 @@ test.describe("Extract PDF workflow (LLM-gated)", () => {
       // separate concern tracked in the follow-up issue (see
       // docs/superpowers/specs/2026-04-29-followup-issue-no-final-response.md).
       // AG-Grid uses role="cell" for data cells.
+      //
+      // POLL, don't one-shot read (issue #1844): the backend marks the
+      // extract complete — clearing the "Extraction in progress" overlay
+      // that runExtractAndWaitForFinish waits on — a beat before AG-Grid
+      // finishes its per-cell Apollo `data` fetch. A single read therefore
+      // races grid hydration and intermittently sees an empty cell even
+      // though the datacell is populated server-side (the backend logs
+      // "Successfully extracted and saved data for cell N"). Retrying until
+      // the cell hydrates removes the false negative without weakening the
+      // assertion — a genuinely empty extract still fails when the poll
+      // times out.
       for (const docTitle of [DOC_USC_TITLE, DOC_ETON_TITLE]) {
-        const row = page.getByRole("row").filter({ hasText: docTitle });
-        const cells = row.getByRole("cell");
-        const cellCount = await cells.count();
-        expect(cellCount).toBeGreaterThan(0);
-        let nonEmptySeen = false;
-        for (let i = 0; i < cellCount; i++) {
-          const text = (await cells.nth(i).textContent())?.trim() ?? "";
-          if (text.length > 0 && text !== docTitle) {
-            nonEmptySeen = true;
-            break;
+        await expect(async () => {
+          const row = page.getByRole("row").filter({ hasText: docTitle });
+          const cells = row.getByRole("cell");
+          const cellCount = await cells.count();
+          expect(cellCount).toBeGreaterThan(0);
+          let nonEmptySeen = false;
+          for (let i = 0; i < cellCount; i++) {
+            const text = (await cells.nth(i).textContent())?.trim() ?? "";
+            if (text.length > 0 && text !== docTitle) {
+              nonEmptySeen = true;
+              break;
+            }
           }
-        }
-        expect(
-          nonEmptySeen,
-          `Row "${docTitle}" has no non-empty extracted cell — extract may have failed`
-        ).toBe(true);
+          expect(
+            nonEmptySeen,
+            `Row "${docTitle}" has no non-empty extracted cell — extract may have failed`
+          ).toBe(true);
+        }).toPass({ timeout: 120_000, intervals: [1_000, 2_000, 5_000] });
       }
     });
 

--- a/frontend/tests/e2e/extract-pdf-workflow.spec.ts
+++ b/frontend/tests/e2e/extract-pdf-workflow.spec.ts
@@ -18,9 +18,12 @@
  *      to load the cell-level diff and asserts the heatmap renders with
  *      ONLY_IN_A counts equal to the parent's cell count.
  *
- * Gated on `E2E_RUN_LLM_TESTS=true` because step 6 makes a real OpenAI
- * call. CI does not set the gate, so this spec is skipped there until
- * we have a way to mock LLM responses over the wire.
+ * Gated on `E2E_RUN_LLM_TESTS=true` because step 6 exercises the extract
+ * LLM call. Locally that hits a real provider; in CI the
+ * `frontend-e2e-extract.yml` workflow sets the gate and runs the backend
+ * with `OC_LLM_VCR_MODE=replay`, so the LLM call is served from a recorded
+ * cassette (no external traffic). PDF parsing always runs against the
+ * in-stack Docling microservice.
  *
  * INTENTIONAL ASSERTION SCOPE: this spec validates the *pipeline*
  * (upload → parse → embed → extract → export), not LLM commit behavior.
@@ -77,11 +80,15 @@ const COLUMN_QUERY = "What is the title of this document?";
 test.describe("Extract PDF workflow (LLM-gated)", () => {
   test.skip(
     process.env.E2E_RUN_LLM_TESTS !== "true",
-    "Requires E2E_RUN_LLM_TESTS=true and a backend OPENAI_API_KEY. " +
-      "Local-only until LLM responses are mocked in CI."
+    "Requires E2E_RUN_LLM_TESTS=true. CI sets it and replays the LLM call " +
+      "from a VCR cassette; locally it uses a real backend provider key."
   );
 
-  test.setTimeout(20 * 60 * 1000);
+  // 30 min: each document-ready wait now allows up to 14 min for cold-runner
+  // Docling parse + embed (issue #1844); the two waits can serialize in the
+  // worst case, so the overall budget must clear 2x14 min plus the extract +
+  // CSV + fork/diff steps.
+  test.setTimeout(30 * 60 * 1000);
 
   test("uploads two PDFs, runs an extract, exports CSV", async ({ page }) => {
     await test.step("login", async () => {

--- a/frontend/tests/e2e/helpers.ts
+++ b/frontend/tests/e2e/helpers.ts
@@ -1014,13 +1014,23 @@ export async function selectIterationsForCompare(
  *
  * Cards are matched by `data-testid="document-card"` (set in both
  * Documents.tsx and ModernDocumentItem.tsx) and the visible title
- * text. Real-world ingestion can take "up to a few minutes" per PDF;
- * the default 8-minute ceiling leaves headroom for cold workers.
+ * text. Real-world ingestion can take "up to a few minutes" per PDF.
+ *
+ * The default ceiling is 14 minutes. An 8-minute ceiling caused
+ * intermittent CI failures (issue #1844): on a cold GitHub runner the
+ * Docling parse + embedding of a large PDF (e.g. the multi-page US Code
+ * fixture) occasionally exceeds 8 minutes, after which the spec raced an
+ * unprocessed document into the extract step and failed with "row has no
+ * non-empty extracted cell". The spec uploads both PDFs before waiting,
+ * so Celery processes them concurrently — the binding constraint is the
+ * slowest single document, not the sum — which is why one generous
+ * per-document ceiling (rather than two stacked timeouts) is the right
+ * knob. Keep the caller's `test.setTimeout` >= 2x this value as headroom.
  */
 export async function waitForDocumentReady(
   page: Page,
   documentTitle: string,
-  timeoutMs: number = 8 * 60 * 1000
+  timeoutMs: number = 14 * 60 * 1000
 ): Promise<void> {
   await expect(async () => {
     // Re-navigate on every attempt to force a fresh GraphQL fetch and


### PR DESCRIPTION
## Summary
Fixes the intermittently-failing `Extract pipeline (PDF upload → run → CSV)` check (issue #1844). The check is **not** live-LLM gated — `.github/workflows/frontend-e2e-extract.yml` runs the backend with `OC_LLM_VCR_MODE=replay` so the extract LLM call is served from a recorded cassette; only Docling PDF parsing runs live. It is **flaky, not broken** (the workflow has recent `success` runs).

There are **two distinct failure modes**, both fixed here:

### Mode A — document-processing timeout (rarer)
`waitForDocumentReady` waited at most **8 min** for parse + embed. On a cold runner, Docling parsing of the large US Code fixture occasionally exceeds 8 min →
```
Error: Document "USC Title 1 …" still processing (data-processing="true")
  - Timeout 480000ms exceeded
```
**Fix:** ceiling 8 → 14 min (both PDFs upload before either wait, so Celery processes them concurrently — the constraint is the slowest single doc, not the sum); spec `test.setTimeout` 20 → 30 min.

### Mode B — frontend grid-hydration race (dominant / consistent)
This was the real blocker. **The backend extract succeeds** — the failing run's Celery logs show:
```
Raw extraction result: TITLE 1-GENERAL PROVISIONS
✓ Successfully extracted and saved data for cell 6
Linked 33 retrieval citations to datacell 6
Extract 3 marked complete
```
…yet the spec reported `row has no non-empty extracted cell`. The "Extraction in progress" overlay (which `runExtractAndWaitForFinish` waits on) clears when the backend marks the extract complete — a beat **before** AG-Grid finishes its per-cell Apollo `data` fetch. The spec's **one-shot cell read** raced that hydration and saw an empty cell.
**Fix:** wrap the per-row cell check in `expect(...).toPass({ timeout: 120s })` so it retries until the cell hydrates. A genuinely empty extract still fails when the poll times out, so the assertion is **not weakened**.

### Also
Corrected the stale spec docstring/skip-reason that claimed "CI does not set the gate" — CI sets it and replays the LLM via VCR.

## Verification
- Run 26687429414 (before the Mode-B fix) showed exactly the diagnostic signature: 3.5-min attempts, no processing-timeout, all failing on the cell read while the backend logged a successful extract.
- Re-running on this PR after the poll fix.

Closes #1844