### PR TITLE
MCP knowledge-tool UX: unified search feed, annotation/relationship search, bounded full-text (#1858–#1862)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **MCP knowledge-tool UX — make a corpus usable as a low-friction tool**
+  (`opencontractserver/mcp/`, issues #1858–#1862). A hands-on evaluation of the
+  live public MCP interface found search returned nothing, full text crashed on
+  cloud storage (fixed separately in the `read_field_file_text` work), and
+  annotations were not content-searchable. This initiative addresses the
+  remaining gaps:
+  - **`search_corpus` → unified passage + block feed** (#1858, #1862): now
+    searches **annotation** embeddings (passages) instead of document-level
+    vectors, and merges in **`OC_SUBTREE_GROUP` relationship "blocks"**
+    (ancestor + full descendant subtree) from `CoreRelationshipVectorStore`.
+    Each result is tagged `type: "passage" | "block"`. New `granularity`
+    (`passage`/`block`/`both`) and `structural` (tri-state) params. Fixes the
+    prior bug where an empty vector result returned immediately and the text
+    fallback was dead code — the fallback now runs whenever the vector path is
+    empty/absent/errors (`opencontractserver/mcp/tools.py`).
+  - **`list_annotations` content search** (#1859): new `text_contains` and
+    `structural` filters, results ordered by `(page, id)`, and a leaner payload
+    (`format_annotation` drops `color`/`created`; keeps the `structural` flag).
+  - **`list_relationships` tool** (#1862): new tool returning labeled
+    `source → target` edges via `RelationshipService`, filterable by
+    `structural`/`label_text`, document- or corpus-scoped. Adds
+    `RelationshipService.get_corpus_relationships`
+    (`opencontractserver/annotations/services/relationship_service.py`).
+  - **`get_document_text` bounded slicing** (#1860): new `char_offset`/`max_chars`
+    params with `next_offset`/`truncated`/`total_chars` in the response, so long
+    documents no longer blow the context window in one call.
+  - **Polish** (#1861): `get_corpus_info` now surfaces only labels actually used
+    on the corpus's annotations (not the full seeded label set); not-found
+    errors (`Document`/`Corpus.DoesNotExist`) are humanized into actionable
+    messages that name the remediation tool instead of leaking raw Django
+    exception strings; tool descriptions sharpened. New size constants in
+    `opencontractserver/constants/mcp.py`.
+  - Tests: `opencontractserver/mcp/tests/test_mcp.py` (passage/block feed,
+    granularity, structural filter, annotation content search, relationship
+    enumeration, in-use labels, error formatting). Design + plan:
+    `docs/development/2026-05-31-mcp-knowledge-tool-ux-design.md`.
+
 - **Chunked (resumable) uploads for large files** — work around the 100 MB
   per-request body ceiling that upstream proxies (Cloudflare) impose on the
   document-import REST endpoints. The client slices a file into sub-100 MB

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     (`opencontractserver/annotations/services/relationship_service.py`).
   - **`get_document_text` bounded slicing** (#1860): new `char_offset`/`max_chars`
     params with `next_offset`/`truncated`/`total_chars` in the response, so long
-    documents no longer blow the context window in one call.
+    documents no longer blow the context window in one call. **Behavior change:**
+    a call with no `max_chars` now returns at most the first
+    `MCP_DOCUMENT_TEXT_DEFAULT_CHARS` (50 000) characters instead of the full
+    extracted text; the response carries `truncated`/`next_offset` so callers can
+    page through the remainder. MCP clients that relied on a single call returning
+    the whole document must now follow `next_offset` (or pass an explicit
+    `max_chars`, hard-capped at `MCP_DOCUMENT_TEXT_MAX_CHARS` = 200 000).
   - **Polish** (#1861): `get_corpus_info` now surfaces only labels actually used
     on the corpus's annotations (not the full seeded label set); not-found
     errors (`Document`/`Corpus.DoesNotExist`) are humanized into actionable

--- a/docs/development/2026-05-31-mcp-knowledge-tool-ux-design.md
+++ b/docs/development/2026-05-31-mcp-knowledge-tool-ux-design.md
@@ -1,0 +1,201 @@
+# MCP Knowledge-Tool UX — Design
+
+**Date:** 2026-05-31
+**Status:** Approved (design); pre-implementation
+**Branch:** `feature/mcp-knowledge-tool-ux` (off `origin/main`)
+**Packaging:** one umbrella PR, 4 commits → 4 tracking issues
+
+## Background
+
+The public MCP interface (`opencontractserver/mcp/`) is meant to let an AI use an
+OpenContracts corpus as a low-friction knowledge tool. A hands-on evaluation of
+the live deployment (`cite.opensource.legal/mcp/corpus/{slug}/`, v1.27.1) against
+real corpora found the three headline capabilities are not usable today:
+
+| Capability | Tool | Observed |
+|---|---|---|
+| Full-text retrieval | `get_document_text` | Crashes: `"Object of type bytes is not JSON serializable"` (`isError: true`) on every document |
+| Text / semantic search | `search_corpus` | Returns `{"results": []}` for every query, including exact document titles |
+| Annotation search | `list_annotations` | Works, but only filters by `page` / exact `label_text` — cannot search annotation *content* |
+
+Net effect: an AI connecting to a corpus cannot answer a question about it.
+
+### Root causes (code, current branch)
+
+1. **`get_document_text` bytes crash** — `tools.py` reads `txt_extract_file.open("r").read()`
+   and puts the result straight into a `json.dumps`-ed payload. On S3/GCS the
+   django-storages backend returns `bytes` from text-mode reads, which is not
+   JSON-serializable. This is fixed by **PR #1841** (the `read_field_file_text()`
+   helper). #1841 is a prerequisite for this initiative's full-text work, not part
+   of it.
+2. **`search_corpus` always empty** — two compounding bugs in `tools.py:search_corpus`:
+   - It searches **document-level** embeddings (`get_corpus_documents().search_by_embedding(...)`),
+     filtered by the corpus's current `embedder_path`. OpenContracts embeddings live
+     at the **annotation/chunk** level, so the document-level join is empty.
+   - When the vector path returns an empty list it `return`s immediately; the text
+     fallback only runs inside the `except`, so on any embedding-configured server
+     the fallback is dead code.
+   - Even when it worked, it returned only `{slug, title, similarity_score}` — no
+     passage text, no page, no citation. Low value for RAG.
+3. **`list_annotations` is not "search"** — no content/text parameter; results are
+   not ordered by reading position; payload carries low-signal, high-token fields.
+4. **Polish gaps** — `get_corpus_info` advertises the full seeded "Default Labels"
+   set (irrelevant to the corpus, misleads the AI about `label_text`); errors leak
+   raw Python/Django exception strings with no remediation hint; tool descriptions
+   are terse and oversell (`search_corpus` says "Semantic search" with no mention of
+   granularity or that it can return nothing).
+
+## Goals
+
+Make a corpus usable as a knowledge tool via the public MCP interface:
+
+- Semantic + text search returns **passages** (matched text + page + document),
+  and never silently returns empty when matchable content exists.
+- Annotations are searchable by **content** and returned in reading order.
+- Full text is retrievable in **bounded slices** (no token blowout).
+- Corpus metadata and errors are **honest and actionable**.
+
+## Non-Goals
+
+- Fixing the bytes crash itself (that is PR #1841).
+- New models, migrations, or embedding-generation changes.
+- Reranking, hybrid fusion scoring, or cross-corpus search.
+- Changes to the global (non-scoped) `/mcp` endpoint beyond what falls out of
+  shared tool implementations.
+
+## Architecture
+
+All changes are confined to:
+
+- `opencontractserver/mcp/tools.py` — tool implementations
+- `opencontractserver/mcp/server.py` — scoped + global tool **schemas** and the
+  tool-dispatch error formatting
+- `opencontractserver/mcp/formatters.py` — response formatters
+- `opencontractserver/constants/mcp.py` — new size/limit constants
+- `opencontractserver/mcp/tests/test_mcp.py` — tests
+
+Data access reuses existing services only:
+
+- `AnnotationService.get_corpus_annotations(corpus_id, user)` → permission-filtered
+  `AnnotationQuerySet` (includes structural Text-Block chunks that carry body prose;
+  the queryset has `search_by_embedding` via `VectorSearchViaEmbeddingMixin`).
+- `CorpusDocumentService` for corpus/document gating (unchanged).
+
+This honors the CLAUDE.md services-layer rule for MCP tools (no inline
+`visible_to_user` / `user_can` composition).
+
+**No new models or migrations.**
+
+## Components
+
+### Component 1 — `search_corpus` → passage-level (Issue A)
+
+Rewrite `search_corpus` to operate on annotations:
+
+```
+qs = AnnotationService.get_corpus_annotations(corpus.id, user).select_related("document", "annotation_label")
+embedder_path, query_vector = corpus.embed_text(query)
+hits = []
+if query_vector:
+    hits = list(qs.search_by_embedding(query_vector, embedder_path, top_k=limit))
+if not hits:                                  # empty OR no vector OR exception above
+    hits = list(qs.filter(raw_text__icontains=query)[:limit])   # text fallback
+return {"query": query, "results": [format_search_passage(a) for a in hits]}
+```
+
+- The empty-vector case now falls through to text search (fixes the dead-fallback bug).
+- Vector errors (`ValueError`/`TypeError`/`AttributeError`/`RuntimeError`) are caught
+  and also fall through to text search.
+- `format_search_passage(ann)` → `{document_slug, document_title, page, text, similarity_score}`
+  where `text` = `raw_text` truncated to `MCP_SEARCH_SNIPPET_MAX_CHARS` (with an
+  elision marker), and `similarity_score` is `null` for text-fallback hits.
+- Envelope `{query, results}` is unchanged (loosely back-compatible; current output
+  is empty so nothing real regresses).
+
+Schema/description (`server.py`): clarify that it returns matched passages with page
+and document, and that results are semantic with a text fallback.
+
+### Component 2 — `list_annotations` content search + ordering (Issue B)
+
+- Add optional `text_contains: str` → `qs.filter(raw_text__icontains=text_contains)`.
+- Order results `("page", "id")` for stable reading order.
+- Lean payload via `format_annotation`: keep `{id, page, raw_text, annotation_label:{text,label_type}, structural}`; drop `color` and `created` (low signal, high token cost).
+- Update schema + description for the new param.
+
+> Note: `format_annotation` is shared with the annotation **resource** path. The lean
+> shape will be applied consistently; the resource handler test is updated to match.
+
+### Component 3 — `get_document_text` pagination (Issue C) — depends on #1841
+
+- Add `char_offset: int = 0` and `max_chars: int = MCP_DOCUMENT_TEXT_DEFAULT_CHARS`
+  (hard-capped at `MCP_DOCUMENT_TEXT_MAX_CHARS`).
+- Return `{document_slug, page_count, total_chars, char_offset, text, next_offset, truncated}`
+  where `next_offset` is `char_offset + len(text)` when more remains, else `null`.
+- **Char-based, not page-based:** `txt_extract_file` is a flat string with no reliable
+  page boundaries. Page-level access is served by Component 1 (returns `page`) +
+  `list_annotations(page=N)`.
+- Read routed through `read_field_file_text()` (from #1841). This commit is sequenced
+  **last** and rebases on top of #1841 once it merges; if #1841 stalls, cherry-pick the
+  helper.
+
+### Component 4 — Polish (Issue D)
+
+- `get_corpus_info`: return only labels **actually present** on the corpus's
+  annotations — `get_corpus_annotations(corpus.id, user)` → distinct
+  `annotation_label` (text/color/label_type/description), capped at the existing 50 —
+  instead of the full seeded label set. Stops advertising irrelevant labels.
+- Error handling in the tool dispatcher (`server.py` scoped + global `call_tool`,
+  via `_format_tool_error_text`): map `Document.DoesNotExist` / `Corpus.DoesNotExist`
+  to actionable messages that echo the attempted identifier and name the remediation
+  tool (e.g. `No document 'x' in corpus 'y'. Call list_documents to see valid slugs.`).
+  Keep `isError: true`. Never emit raw exception strings.
+- Tighten `search_corpus` / `get_document_text` / `list_annotations` descriptions to
+  state granularity and the search → read → cite workflow.
+
+## Constants
+
+Add to `opencontractserver/constants/mcp.py` (alongside `MAX_THREAD_MESSAGE_LENGTH`):
+
+- `MCP_SEARCH_SNIPPET_MAX_CHARS` — passage `text` truncation (e.g. 1500)
+- `MCP_DOCUMENT_TEXT_DEFAULT_CHARS` — default `get_document_text` window (e.g. 50000)
+- `MCP_DOCUMENT_TEXT_MAX_CHARS` — hard cap for `max_chars` (e.g. 200000)
+
+Exact values finalized in the implementation plan.
+
+## Error-handling philosophy
+
+Keep the existing `isError` envelope (already correct). Humanize messages; echo the
+identifier the caller supplied; point to the remediation tool. Do not leak raw
+Python/Django exception text.
+
+## Testing
+
+Extend `opencontractserver/mcp/tests/test_mcp.py` (seed corpus + documents +
+annotations; embeddings where the vector path is exercised):
+
+- **search_corpus:** vector path returns passages in the new shape; empty-vector →
+  text-fallback path returns `raw_text__icontains` matches; passage shape asserted;
+  `similarity_score` null on fallback.
+- **list_annotations:** `text_contains` filters by content; results ordered by page;
+  lean payload shape asserted (no `color`/`created`).
+- **get_document_text:** slicing by `char_offset`/`max_chars`; `next_offset`/`truncated`
+  correctness; bytes-from-cloud-storage handled (via #1841 helper).
+- **get_corpus_info:** only in-use labels returned (seeded-but-unused labels excluded).
+- **errors:** invalid document slug → actionable message, `isError: true`, no raw
+  exception text.
+
+## Sequencing & dependencies
+
+- Components 1, 2, 4 are independent of #1841.
+- Component 3 depends on #1841's `read_field_file_text`; its commit goes last and
+  rebases once #1841 merges.
+- One feature branch, one umbrella PR with 4 commits closing 4 tracking issues
+  (A=search, B=annotations, C=full-text, D=polish).
+
+## Risks
+
+- **Annotation embeddings may not exist under the corpus's `embedder_path`** on some
+  corpora; the text fallback guarantees non-empty results when matchable content
+  exists, so search degrades gracefully rather than returning nothing.
+- **Shared `format_annotation`** touches the resource path; covered by updating that
+  test and verifying both call sites.

--- a/docs/development/2026-05-31-mcp-knowledge-tool-ux-design.md
+++ b/docs/development/2026-05-31-mcp-knowledge-tool-ux-design.md
@@ -3,7 +3,7 @@
 **Date:** 2026-05-31
 **Status:** Approved (design); pre-implementation
 **Branch:** `feature/mcp-knowledge-tool-ux` (off `origin/main`)
-**Packaging:** one umbrella PR, 4 commits → 4 tracking issues
+**Packaging:** one umbrella PR, 5 commits → 5 tracking issues (#1858–#1862)
 
 ## Background
 
@@ -51,7 +51,12 @@ Make a corpus usable as a knowledge tool via the public MCP interface:
 
 - Semantic + text search returns **passages** (matched text + page + document),
   and never silently returns empty when matchable content exists.
-- Annotations are searchable by **content** and returned in reading order.
+- Annotations are searchable by **content**, filterable by **kind** (structural vs
+  human/analysis), and returned in reading order.
+- Search returns a **single ranked feed** of granular passages and aggregated
+  `OC_SUBTREE_GROUP` blocks, each self-describing via `type`.
+- **Relationships** are reachable: as aggregated "block" hits in search and as
+  explicit labeled edges via a dedicated `list_relationships` tool.
 - Full text is retrievable in **bounded slices** (no token blowout).
 - Corpus metadata and errors are **honest and actionable**.
 
@@ -76,9 +81,18 @@ All changes are confined to:
 
 Data access reuses existing services only:
 
-- `AnnotationService.get_corpus_annotations(corpus_id, user)` → permission-filtered
-  `AnnotationQuerySet` (includes structural Text-Block chunks that carry body prose;
+- `AnnotationService.get_corpus_annotations(corpus_id, user, structural=...)` →
+  permission-filtered `AnnotationQuerySet` (already accepts a `structural`
+  tri-state filter; includes structural Text-Block chunks that carry body prose;
   the queryset has `search_by_embedding` via `VectorSearchViaEmbeddingMixin`).
+- `CoreRelationshipVectorStore(corpus_id=...)` → corpus-scoped, visibility-filtered
+  vector search over `OC_SUBTREE_GROUP` relationships (the embedded ancestor→subtree
+  "blocks"; issue #1645). Uses the same corpus embedder, so block and passage cosine
+  scores are directly comparable and mergeable.
+- `RelationshipService.get_document_relationships(document_id, corpus_id, user)` →
+  permission-filtered relationship queryset for explicit edge enumeration. A
+  corpus-wide `get_corpus_relationships` (mirroring `get_corpus_annotations`) is
+  added if not present.
 - `CorpusDocumentService` for corpus/document gating (unchanged).
 
 This honors the CLAUDE.md services-layer rule for MCP tools (no inline
@@ -88,39 +102,72 @@ This honors the CLAUDE.md services-layer rule for MCP tools (no inline
 
 ## Components
 
-### Component 1 — `search_corpus` → passage-level (Issue A)
+### Component 1 — `search_corpus` → unified passage + block feed (Issue A, extended by Issue E)
 
-Rewrite `search_corpus` to operate on annotations:
+Rewrite `search_corpus` to return a single ranked feed mixing two result types,
+discriminated by `type`:
+
+- `type: "passage"` — an annotation hit.
+- `type: "block"` — an `OC_SUBTREE_GROUP` relationship hit (ancestor + full
+  descendant subtree), the embedded aggregation unit.
+
+New params: `granularity` (`"passage" | "block" | "both"`, default `"both"`) and
+`structural` (tri-state: `null` = both, `true` = structural only, `false` =
+human/analysis only — applied to the passage half).
 
 ```
-qs = AnnotationService.get_corpus_annotations(corpus.id, user).select_related("document", "annotation_label")
+# Passage half (annotations)
+qs = AnnotationService.get_corpus_annotations(corpus.id, user, structural=structural) \
+        .select_related("document", "annotation_label")
 embedder_path, query_vector = corpus.embed_text(query)
-hits = []
-if query_vector:
-    hits = list(qs.search_by_embedding(query_vector, embedder_path, top_k=limit))
-if not hits:                                  # empty OR no vector OR exception above
-    hits = list(qs.filter(raw_text__icontains=query)[:limit])   # text fallback
-return {"query": query, "results": [format_search_passage(a) for a in hits]}
+passages = []
+if granularity in ("passage", "both"):
+    if query_vector:
+        passages = list(qs.search_by_embedding(query_vector, embedder_path, top_k=limit))
+    if not passages:                          # empty OR no vector OR vector error
+        passages = list(qs.filter(raw_text__icontains=query)[:limit])   # text fallback
+
+# Block half (subtree-group relationships)
+blocks = []
+if granularity in ("block", "both") and query_vector:
+    blocks = CoreRelationshipVectorStore(corpus_id=corpus.id, user=user).search(query, top_k=limit)
+
+# Merge by similarity_score (same embedder → comparable), cap at limit
+results = merge_by_score(
+    [format_search_passage(a) for a in passages],
+    [format_search_block(b) for b in blocks],
+)[:limit]
+return {"query": query, "results": results}
 ```
 
-- The empty-vector case now falls through to text search (fixes the dead-fallback bug).
-- Vector errors (`ValueError`/`TypeError`/`AttributeError`/`RuntimeError`) are caught
-  and also fall through to text search.
-- `format_search_passage(ann)` → `{document_slug, document_title, page, text, similarity_score}`
-  where `text` = `raw_text` truncated to `MCP_SEARCH_SNIPPET_MAX_CHARS` (with an
-  elision marker), and `similarity_score` is `null` for text-fallback hits.
-- Envelope `{query, results}` is unchanged (loosely back-compatible; current output
-  is empty so nothing real regresses).
+- The empty-vector case falls through to passage text search (fixes the
+  dead-fallback bug). Vector errors (`ValueError`/`TypeError`/`AttributeError`/
+  `RuntimeError`) are caught and also fall through.
+- `format_search_passage(ann)` → `{type: "passage", document_slug, document_title,
+  page, text, structural, similarity_score}` — `text` = `raw_text` truncated to
+  `MCP_SEARCH_SNIPPET_MAX_CHARS`; `similarity_score` `null` on text fallback; the
+  explicit `structural` flag delineates layout-derived vs human/analysis hits.
+- `format_search_block(rel)` → `{type: "block", document_slug, document_title, page,
+  label, text, member_count, similarity_score}` — `text` = aggregated subtree text
+  truncated to `MCP_BLOCK_SNIPPET_MAX_CHARS`.
+- Text-fallback passages (score `null`) sort after scored hits; block search only
+  runs when a query vector exists (blocks are vector-only).
+- Envelope `{query, results}` is unchanged (current output is empty, so nothing real
+  regresses); each result now self-describes via `type`.
 
-Schema/description (`server.py`): clarify that it returns matched passages with page
-and document, and that results are semantic with a text fallback.
+Schema/description (`server.py`): document the `type` discriminator, `granularity`
+and `structural` params, and that results are semantic with a passage text fallback.
 
-### Component 2 — `list_annotations` content search + ordering (Issue B)
+### Component 2 — `list_annotations` content search, ordering, structural filter (Issue B)
 
 - Add optional `text_contains: str` → `qs.filter(raw_text__icontains=text_contains)`.
+- Add optional `structural` tri-state filter (`null`/`true`/`false`) via
+  `get_corpus_annotations(..., structural=...)` / document-scoped equivalent.
 - Order results `("page", "id")` for stable reading order.
-- Lean payload via `format_annotation`: keep `{id, page, raw_text, annotation_label:{text,label_type}, structural}`; drop `color` and `created` (low signal, high token cost).
-- Update schema + description for the new param.
+- Lean payload via `format_annotation`: keep `{id, page, raw_text,
+  annotation_label:{text,label_type}, structural}` — the explicit `structural` flag
+  delineates the two kinds; drop `color` and `created` (low signal, high token cost).
+- Update schema + description for the new params.
 
 > Note: `format_annotation` is shared with the annotation **resource** path. The lean
 > shape will be applied consistently; the resource handler test is updated to match.
@@ -152,11 +199,45 @@ and document, and that results are semantic with a text fallback.
 - Tighten `search_corpus` / `get_document_text` / `list_annotations` descriptions to
   state granularity and the search → read → cite workflow.
 
+### Component 5 — relationships: unified search blocks + `list_relationships` (Issue E)
+
+Two parts:
+
+1. **Unified search "blocks"** — the block half of Component 1's feed
+   (`format_search_block`, `granularity`, `CoreRelationshipVectorStore`). Specified
+   in Component 1; tracked under Issue E because it is the relationship-aggregation
+   surface.
+2. **New `list_relationships` tool** for explicit graph navigation (distinct from
+   search): `list_relationships(document_slug=None, structural=None, label_text=None,
+   limit=50, offset=0)`. Returns labeled directed edges:
+
+   ```
+   {id, label, structural,
+    source: [{annotation_id, page, text}],
+    target: [{annotation_id, page, text}]}
+   ```
+
+   - Backed by `RelationshipService`: `get_document_relationships(document_id,
+     corpus_id, user)` when `document_slug` is given, else a corpus-wide
+     `get_corpus_relationships(corpus_id, user)` (added mirroring
+     `get_corpus_annotations` if absent).
+   - Filter by `structural` (tri-state) and `label_text` (exact label match).
+   - Source/target annotation `text` truncated to `MCP_REL_ANNOTATION_TEXT_MAX_CHARS`.
+   - New schema entry in both scoped (`get_scoped_tool_definitions`) and global tool
+     lists, plus a handler in `get_scoped_tool_handlers`.
+
+   The two surfaces answer different questions: search blocks = "what aggregated
+   content is *relevant*"; `list_relationships` = "what is explicitly *connected*"
+   (parent/child, cross-references, human- or analysis-drawn edges).
+
 ## Constants
 
 Add to `opencontractserver/constants/mcp.py` (alongside `MAX_THREAD_MESSAGE_LENGTH`):
 
 - `MCP_SEARCH_SNIPPET_MAX_CHARS` — passage `text` truncation (e.g. 1500)
+- `MCP_BLOCK_SNIPPET_MAX_CHARS` — block (subtree-group) `text` truncation (e.g. 4000)
+- `MCP_REL_ANNOTATION_TEXT_MAX_CHARS` — source/target annotation `text` in
+  `list_relationships` (e.g. 500)
 - `MCP_DOCUMENT_TEXT_DEFAULT_CHARS` — default `get_document_text` window (e.g. 50000)
 - `MCP_DOCUMENT_TEXT_MAX_CHARS` — hard cap for `max_chars` (e.g. 200000)
 
@@ -173,11 +254,18 @@ Python/Django exception text.
 Extend `opencontractserver/mcp/tests/test_mcp.py` (seed corpus + documents +
 annotations; embeddings where the vector path is exercised):
 
-- **search_corpus:** vector path returns passages in the new shape; empty-vector →
-  text-fallback path returns `raw_text__icontains` matches; passage shape asserted;
-  `similarity_score` null on fallback.
-- **list_annotations:** `text_contains` filters by content; results ordered by page;
-  lean payload shape asserted (no `color`/`created`).
+- **search_corpus (passages):** vector path returns passages in the new shape;
+  empty-vector → text-fallback returns `raw_text__icontains` matches; `type:"passage"`
+  + `structural` flag present; `similarity_score` null on fallback.
+- **search_corpus (unified feed):** with seeded subtree-group relationships, `granularity:"both"`
+  returns interleaved `type:"passage"` and `type:"block"` hits sorted by score;
+  `granularity:"passage"`/`"block"` restrict correctly; `structural=false` excludes
+  structural passages.
+- **list_relationships:** returns labeled source→target edges; `structural` and
+  `label_text` filters work; corpus-wide (no `document_slug`) vs document-scoped;
+  permission filtering via `RelationshipService`.
+- **list_annotations:** `text_contains` filters by content; `structural` tri-state
+  filter works; results ordered by page; lean payload shape asserted (no `color`/`created`).
 - **get_document_text:** slicing by `char_offset`/`max_chars`; `next_offset`/`truncated`
   correctness; bytes-from-cloud-storage handled (via #1841 helper).
 - **get_corpus_info:** only in-use labels returned (seeded-but-unused labels excluded).
@@ -186,14 +274,18 @@ annotations; embeddings where the vector path is exercised):
 
 ## Sequencing & dependencies
 
-- Components 1, 2, 4 are independent of #1841.
+- Components 1, 2, 4, 5 are independent of #1841.
 - Component 3 depends on #1841's `read_field_file_text`; its commit goes last and
   rebases once #1841 merges.
-- One feature branch, one umbrella PR with 4 commits closing 4 tracking issues:
-  - **A = search** → #1858 (Component 1)
-  - **B = annotations** → #1859 (Component 2)
-  - **C = full-text** → #1860 (Component 3, depends on #1841)
+- Component 5's "block" half extends Component 1's `search_corpus`; land them as one
+  search commit (or 1 then 5 in sequence) since they touch the same function. The
+  `list_relationships` tool is additive and independent.
+- One feature branch, one umbrella PR with 5 commits closing 5 tracking issues:
+  - **A = search (unified feed)** → #1858 (Component 1)
+  - **B = annotations (content search + structural filter)** → #1859 (Component 2)
+  - **C = full-text (pagination)** → #1860 (Component 3, depends on #1841)
   - **D = polish** → #1861 (Component 4)
+  - **E = relationships (search blocks + list_relationships)** → #1862 (Component 5)
 
 ## Risks
 
@@ -202,3 +294,11 @@ annotations; embeddings where the vector path is exercised):
   exists, so search degrades gracefully rather than returning nothing.
 - **Shared `format_annotation`** touches the resource path; covered by updating that
   test and verifying both call sites.
+- **Subtree-group relationships may not be embedded** on a given corpus (depends on
+  whether the parser materialized + embedded them). The block half then returns
+  empty; the passage half still answers, so the unified feed degrades to passages —
+  acceptable. Block search is vector-only (no text fallback) by design.
+- **Score comparability across the two vector stores** relies on both using the same
+  corpus embedder. The merge sorts by `similarity_score` and places text-fallback
+  passages (score `null`) last; if a store returns scores on a different scale this
+  ordering could skew — verified in the unified-feed test with seeded data.

--- a/docs/development/2026-05-31-mcp-knowledge-tool-ux-design.md
+++ b/docs/development/2026-05-31-mcp-knowledge-tool-ux-design.md
@@ -189,8 +189,11 @@ annotations; embeddings where the vector path is exercised):
 - Components 1, 2, 4 are independent of #1841.
 - Component 3 depends on #1841's `read_field_file_text`; its commit goes last and
   rebases once #1841 merges.
-- One feature branch, one umbrella PR with 4 commits closing 4 tracking issues
-  (A=search, B=annotations, C=full-text, D=polish).
+- One feature branch, one umbrella PR with 4 commits closing 4 tracking issues:
+  - **A = search** → #1858 (Component 1)
+  - **B = annotations** → #1859 (Component 2)
+  - **C = full-text** → #1860 (Component 3, depends on #1841)
+  - **D = polish** → #1861 (Component 4)
 
 ## Risks
 

--- a/docs/development/2026-05-31-mcp-knowledge-tool-ux-plan.md
+++ b/docs/development/2026-05-31-mcp-knowledge-tool-ux-plan.md
@@ -1,0 +1,791 @@
+# MCP Knowledge-Tool UX — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make an OpenContracts corpus usable as a low-friction knowledge tool over the public MCP interface — working passage+block search, content-searchable annotations, relationship enumeration, bounded full-text, and honest metadata/errors.
+
+**Architecture:** All changes confined to `opencontractserver/mcp/` (tool impls, schemas, formatters) + `opencontractserver/constants/mcp.py` + one new `RelationshipService.get_corpus_relationships` method. Data access reuses existing services (`AnnotationService`, `RelationshipService`, `CoreRelationshipVectorStore`, `CorpusDocumentService`). No new models/migrations.
+
+**Tech Stack:** Django 4.x, pgvector, the MCP `Server`/`Tool` types, `sync_to_async` dispatch (MCP tool handlers are sync). Tests: `opencontractserver/mcp/tests/test_mcp.py` (Django `TestCase`, `_MCPAsyncRunMixin`).
+
+**Spec:** `docs/development/2026-05-31-mcp-knowledge-tool-ux-design.md`
+**Issues:** #1858 search · #1859 annotations · #1860 full-text · #1861 polish · #1862 relationships
+
+---
+
+## File Structure
+
+- `opencontractserver/constants/mcp.py` — add snippet/window size constants.
+- `opencontractserver/mcp/formatters.py` — add `format_search_passage`, `format_search_block`; trim `format_annotation`.
+- `opencontractserver/mcp/tools.py` — rewrite `search_corpus`; extend `list_annotations`; add `list_relationships`; update `get_corpus_info`, `get_document_text`; register `list_relationships` in `get_scoped_tool_handlers`/`TOOL_HANDLERS`.
+- `opencontractserver/mcp/server.py` — update tool schemas (scoped `get_scoped_tool_definitions` + global `list_tools`); humanize `_format_tool_error_text`.
+- `opencontractserver/annotations/services/relationship_service.py` — add `get_corpus_relationships`.
+- `opencontractserver/utils/files.py` — add `read_field_file_text` (Task 6, only if #1841 not yet merged).
+- `opencontractserver/mcp/tests/test_mcp.py` — tests per task.
+- `CHANGELOG.md` — entry.
+
+Commit order: Task 1 → 2 (#1858) → 3 (#1859) → 4 (#1862) → 5 (#1861) → 6 (#1860, last; rebases on #1841).
+
+---
+
+### Task 1: Constants + formatters foundation
+
+**Files:**
+- Modify: `opencontractserver/constants/mcp.py`
+- Modify: `opencontractserver/mcp/formatters.py`
+- Test: `opencontractserver/mcp/tests/test_mcp.py` (`MCPFormattersTest`)
+
+- [ ] **Step 1: Add constants**
+
+```python
+# opencontractserver/constants/mcp.py — append
+# Truncation budgets (characters) for MCP tool payloads. Keep AI-facing
+# results bounded so a single tool call cannot blow the context window.
+MCP_SEARCH_SNIPPET_MAX_CHARS: int = 1_500       # passage hit `text`
+MCP_BLOCK_SNIPPET_MAX_CHARS: int = 4_000        # subtree-group block `text`
+MCP_REL_ANNOTATION_TEXT_MAX_CHARS: int = 500    # source/target text in list_relationships
+MCP_DOCUMENT_TEXT_DEFAULT_CHARS: int = 50_000   # default get_document_text window
+MCP_DOCUMENT_TEXT_MAX_CHARS: int = 200_000      # hard cap for get_document_text max_chars
+```
+
+- [ ] **Step 2: Add a shared truncation helper + formatters**
+
+```python
+# opencontractserver/mcp/formatters.py — add near top (after imports)
+def _truncate(text: str, max_chars: int) -> str:
+    """Bound a string for AI-facing payloads, marking elision."""
+    text = text or ""
+    if len(text) <= max_chars:
+        return text
+    return text[:max_chars] + " …[truncated]"
+```
+
+```python
+# opencontractserver/mcp/formatters.py — add new formatters
+def format_search_passage(annotation: "Annotation", similarity_score=None) -> dict:
+    """Format an annotation as a passage-level search hit."""
+    from opencontractserver.constants.mcp import MCP_SEARCH_SNIPPET_MAX_CHARS
+
+    return {
+        "type": "passage",
+        "document_slug": annotation.document.slug if annotation.document_id else None,
+        "document_title": (annotation.document.title or "") if annotation.document_id else "",
+        "page": annotation.page,
+        "text": _truncate(annotation.raw_text or "", MCP_SEARCH_SNIPPET_MAX_CHARS),
+        "structural": annotation.structural,
+        "similarity_score": (
+            float(similarity_score) if similarity_score is not None else None
+        ),
+    }
+
+
+def format_search_block(result) -> dict:
+    """Format a CoreRelationshipVectorStore result as a block-level search hit.
+
+    ``result`` is a ``RelationshipVectorSearchResult`` (carries block_text,
+    label_text, document_id, member ids — no extra DB reads needed).
+    """
+    from opencontractserver.constants.mcp import MCP_BLOCK_SNIPPET_MAX_CHARS
+    from opencontractserver.documents.models import Document
+
+    doc_slug, doc_title = None, ""
+    if result.document_id:
+        doc = Document.objects.filter(pk=result.document_id).only("slug", "title").first()
+        if doc:
+            doc_slug, doc_title = doc.slug, (doc.title or "")
+    member_count = (1 if result.source_annotation_id else 0) + len(result.target_annotation_ids)
+    return {
+        "type": "block",
+        "document_slug": doc_slug,
+        "document_title": doc_title,
+        "page": None,
+        "label": result.label_text,
+        "text": _truncate(result.block_text or "", MCP_BLOCK_SNIPPET_MAX_CHARS),
+        "member_count": member_count,
+        "similarity_score": float(result.similarity_score),
+    }
+```
+
+- [ ] **Step 3: Trim `format_annotation` (drop color/created; keep structural delineation)**
+
+```python
+# opencontractserver/mcp/formatters.py — replace format_annotation body
+def format_annotation(annotation: "Annotation") -> dict:
+    """Format an annotation for API response (lean, AI-facing shape)."""
+    label_data = None
+    if annotation.annotation_label:
+        label_data = {
+            "text": annotation.annotation_label.text,
+            "label_type": annotation.annotation_label.label_type,
+        }
+    return {
+        "id": str(annotation.id),
+        "page": annotation.page,
+        "raw_text": annotation.raw_text or "",
+        "annotation_label": label_data,
+        "structural": annotation.structural,
+    }
+```
+
+- [ ] **Step 4: Write failing formatter tests**
+
+```python
+# test_mcp.py — add to MCPFormattersTest
+def test_format_search_passage_shape(self):
+    from opencontractserver.mcp.formatters import format_search_passage
+    # self.annotation seeded in setUpTestData (add if absent: see Task 2 fixtures)
+    out = format_search_passage(self.annotation, similarity_score=0.81)
+    self.assertEqual(out["type"], "passage")
+    self.assertIn("structural", out)
+    self.assertEqual(out["similarity_score"], 0.81)
+
+def test_format_annotation_is_lean(self):
+    from opencontractserver.mcp.formatters import format_annotation
+    out = format_annotation(self.annotation)
+    self.assertNotIn("color", out)
+    self.assertNotIn("created", out)
+    self.assertIn("structural", out)
+```
+
+- [ ] **Step 5: Run** `docker compose -f test.yml run --rm django pytest opencontractserver/mcp/tests/test_mcp.py::MCPFormattersTest -q` → PASS (add a `self.annotation` to `MCPFormattersTest.setUpTestData` if missing).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add opencontractserver/constants/mcp.py opencontractserver/mcp/formatters.py opencontractserver/mcp/tests/test_mcp.py
+git commit -m "feat(mcp): add search/block formatters + size constants; lean annotation payload"
+```
+
+---
+
+### Task 2: `search_corpus` → unified passage + block feed (#1858, block half #1862)
+
+**Files:**
+- Modify: `opencontractserver/mcp/tools.py:219-306` (`search_corpus`, `_text_search_fallback`)
+- Modify: `opencontractserver/mcp/server.py` (`get_scoped_tool_definitions` search_corpus schema + global `list_tools` search_corpus schema)
+- Test: `opencontractserver/mcp/tests/test_mcp.py` (`MCPToolsSearchTest`)
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+# test_mcp.py — MCPToolsSearchTest
+def test_search_returns_passages_with_type_and_structural(self):
+    # embed_text mocked to raise -> text fallback path; corpus has an
+    # annotation whose raw_text contains "Contract"
+    from unittest.mock import patch
+    with patch.object(self.corpus.__class__, "embed_text", side_effect=RuntimeError("no embed")):
+        result = search_corpus(self.corpus.slug, "Contract")
+    self.assertTrue(all(r["type"] == "passage" for r in result["results"]))
+    self.assertTrue(all("structural" in r for r in result["results"]))
+    self.assertTrue(all(r["similarity_score"] is None for r in result["results"]))
+
+def test_search_text_fallback_searches_annotation_body(self):
+    # Body word that is in annotation.raw_text but NOT in title/description
+    from unittest.mock import patch
+    with patch.object(self.corpus.__class__, "embed_text", side_effect=RuntimeError("no embed")):
+        result = search_corpus(self.corpus.slug, self.body_only_term)
+    self.assertGreater(len(result["results"]), 0)
+
+def test_search_granularity_passage_excludes_blocks(self):
+    from unittest.mock import patch
+    with patch.object(self.corpus.__class__, "embed_text", side_effect=RuntimeError("no embed")):
+        result = search_corpus(self.corpus.slug, "Contract", granularity="passage")
+    self.assertTrue(all(r["type"] == "passage" for r in result["results"]))
+
+def test_search_structural_false_excludes_structural_passages(self):
+    from unittest.mock import patch
+    with patch.object(self.corpus.__class__, "embed_text", side_effect=RuntimeError("no embed")):
+        result = search_corpus(self.corpus.slug, "Contract", structural=False)
+    self.assertTrue(all(r["structural"] is False for r in result["results"]))
+```
+
+In `MCPToolsSearchTest.setUpTestData`, ensure at least one **non-structural** annotation whose `raw_text` contains `"Contract"` and a body-only term (set `cls.body_only_term = "indemnification"` and seed an annotation with that text). Keep existing fixtures.
+
+- [ ] **Step 2: Run** the 4 tests → FAIL (`search_corpus() got an unexpected keyword argument 'granularity'`).
+
+- [ ] **Step 3: Rewrite `search_corpus` + replace `_text_search_fallback`**
+
+```python
+# opencontractserver/mcp/tools.py — replace search_corpus and _text_search_fallback
+def search_corpus(
+    corpus_slug: str,
+    query: str,
+    limit: int = 10,
+    granularity: str = "both",            # "passage" | "block" | "both"
+    structural: bool | None = None,       # None=both, True=structural only, False=human only
+    user: UserOrAnonymous | None = None,
+) -> dict:
+    """Search a corpus and return a single ranked feed of passages and blocks.
+
+    - ``passage`` hits are annotations (semantic via embeddings, text fallback
+      on empty/absent vector).
+    - ``block`` hits are ``OC_SUBTREE_GROUP`` relationships (ancestor + full
+      descendant subtree) via ``CoreRelationshipVectorStore`` — the aggregation
+      unit. Blocks are vector-only (no text fallback).
+    """
+    from opencontractserver.annotations.services import AnnotationService
+    from opencontractserver.corpuses.models import Corpus
+
+    from .formatters import format_search_block, format_search_passage
+
+    limit = min(limit, 50)
+    user = user or AnonymousUser()
+    corpus = Corpus.objects.visible_to_user(user).get(slug=corpus_slug)
+
+    embedder_path, query_vector = None, None
+    try:
+        embedder_path, query_vector = corpus.embed_text(query)
+    except (ValueError, TypeError, AttributeError, RuntimeError):
+        embedder_path, query_vector = None, None
+
+    formatted: list[dict] = []
+
+    # --- passage half ---
+    if granularity in ("passage", "both"):
+        ann_qs = AnnotationService.get_corpus_annotations(
+            corpus.id, user, structural=structural
+        ).select_related("document", "annotation_label")
+        passages = []
+        if query_vector:
+            try:
+                passages = list(
+                    ann_qs.search_by_embedding(query_vector, embedder_path, top_k=limit)
+                )
+            except (ValueError, TypeError, AttributeError, RuntimeError):
+                passages = []
+        if not passages:
+            passages = list(ann_qs.filter(raw_text__icontains=query)[:limit])
+        for a in passages:
+            formatted.append(
+                format_search_passage(a, getattr(a, "similarity_score", None))
+            )
+
+    # --- block half (vector-only) ---
+    if granularity in ("block", "both") and query_vector:
+        from opencontractserver.llms.vector_stores.core_relationship_vector_store import (
+            CoreRelationshipVectorStore,
+            RelationshipVectorSearchQuery,
+        )
+
+        try:
+            store = CoreRelationshipVectorStore(
+                user_id=getattr(user, "pk", None),
+                corpus_id=corpus.id,
+                embedder_path=embedder_path,
+                embed_dim=len(query_vector),
+            )
+            blocks = store.search(
+                RelationshipVectorSearchQuery(
+                    query_embedding=query_vector, similarity_top_k=limit
+                )
+            )
+            formatted.extend(format_search_block(b) for b in blocks)
+        except (ValueError, TypeError, AttributeError, RuntimeError):
+            pass
+
+    # Merge by score; text-fallback passages (None) sort last; cap at limit.
+    formatted.sort(
+        key=lambda r: (r["similarity_score"] is not None, r["similarity_score"] or 0.0),
+        reverse=True,
+    )
+    return {"query": query, "results": formatted[:limit]}
+```
+
+Delete `_text_search_fallback` (now dead). Verify no other references: `grep -rn "_text_search_fallback" opencontractserver/`.
+
+- [ ] **Step 4: Run** the 4 tests → PASS.
+
+- [ ] **Step 5: Update tool schemas** in `server.py`
+
+In `get_scoped_tool_definitions`, replace the `search_corpus` Tool's `inputSchema.properties` with:
+
+```python
+"properties": {
+    "query": {"type": "string", "description": "Search query"},
+    "limit": {"type": "integer", "default": 10, "description": "Max hits (1-50)"},
+    "granularity": {
+        "type": "string",
+        "enum": ["passage", "block", "both"],
+        "default": "both",
+        "description": "passage = annotation hits; block = aggregated subtree-group hits; both = merged feed",
+    },
+    "structural": {
+        "type": "boolean",
+        "description": "Filter passages: omit=all, true=structural only, false=human/analysis only",
+    },
+},
+"required": ["query"],
+```
+
+And update its `description` to: `f"Search the '{corpus_slug}' corpus. Returns a ranked feed of passage and block hits (each tagged 'type'); semantic with a text fallback."`. Mirror the same property additions in the **global** `list_tools` `search_corpus` Tool (`server.py:514-688`).
+
+- [ ] **Step 6: Run full search + schema sanity**
+
+`docker compose -f test.yml run --rm django pytest opencontractserver/mcp/tests/test_mcp.py::MCPToolsSearchTest -q` → PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add opencontractserver/mcp/tools.py opencontractserver/mcp/server.py opencontractserver/mcp/tests/test_mcp.py
+git commit -m "feat(mcp): unified passage+block search feed with granularity & structural filter (#1858, #1862)"
+```
+
+---
+
+### Task 3: `list_annotations` content search, ordering, structural filter (#1859)
+
+**Files:**
+- Modify: `opencontractserver/mcp/tools.py:163-216` (`list_annotations`)
+- Modify: `opencontractserver/mcp/server.py` scoped + global `list_annotations` schema
+- Test: `opencontractserver/mcp/tests/test_mcp.py` (`MCPToolsAnnotationsTest`)
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+# test_mcp.py — MCPToolsAnnotationsTest
+def test_list_annotations_text_contains(self):
+    result = list_annotations(self.corpus.slug, self.document.slug, text_contains=self.known_substr)
+    self.assertGreater(result["total_count"], 0)
+    self.assertTrue(all(self.known_substr.lower() in a["raw_text"].lower() for a in result["annotations"]))
+
+def test_list_annotations_structural_filter(self):
+    result = list_annotations(self.corpus.slug, self.document.slug, structural=False)
+    self.assertTrue(all(a["structural"] is False for a in result["annotations"]))
+
+def test_list_annotations_ordered_by_page(self):
+    result = list_annotations(self.corpus.slug, self.document.slug, limit=100)
+    pages = [a["page"] for a in result["annotations"]]
+    self.assertEqual(pages, sorted(pages))
+
+def test_list_annotations_payload_is_lean(self):
+    result = list_annotations(self.corpus.slug, self.document.slug, limit=1)
+    self.assertNotIn("color", result["annotations"][0])
+    self.assertNotIn("created", result["annotations"][0])
+```
+
+Set `cls.known_substr` in `setUpTestData` to a substring present in a seeded annotation's `raw_text`. Ensure both a structural and non-structural annotation exist across ≥2 pages.
+
+- [ ] **Step 2: Run** → FAIL (`unexpected keyword argument 'text_contains'`).
+
+- [ ] **Step 3: Implement**
+
+```python
+# tools.py — list_annotations signature + body changes
+def list_annotations(
+    corpus_slug: str,
+    document_slug: str,
+    page: int | None = None,
+    label_text: str | None = None,
+    text_contains: str | None = None,
+    structural: bool | None = None,
+    limit: int = 100,
+    offset: int = 0,
+    user: UserOrAnonymous | None = None,
+) -> dict:
+    ...
+    qs = AnnotationService.get_document_annotations(
+        document_id=document.id, user=user, corpus_id=corpus.id
+    )
+    if page is not None:
+        qs = qs.filter(page=page)
+    if label_text:
+        qs = qs.filter(annotation_label__text=label_text)
+    if text_contains:
+        qs = qs.filter(raw_text__icontains=text_contains)
+    if structural is not None:
+        qs = qs.filter(structural=structural)
+    qs = qs.order_by("page", "id")
+    total_count = qs.count()
+    annotations = list(qs.select_related("annotation_label")[offset : offset + limit])
+    return {
+        "total_count": total_count,
+        "annotations": [format_annotation(a) for a in annotations],
+    }
+```
+
+- [ ] **Step 4: Run** → PASS.
+
+- [ ] **Step 5: Update schemas** — add to scoped + global `list_annotations` `inputSchema.properties`:
+
+```python
+"text_contains": {"type": "string", "description": "Filter annotations whose text contains this substring"},
+"structural": {"type": "boolean", "description": "Filter: omit=all, true=structural only, false=human/analysis only"},
+```
+
+- [ ] **Step 6: Run** `...::MCPToolsAnnotationsTest -q` → PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add opencontractserver/mcp/tools.py opencontractserver/mcp/server.py opencontractserver/mcp/tests/test_mcp.py
+git commit -m "feat(mcp): list_annotations content search + structural filter + page ordering (#1859)"
+```
+
+---
+
+### Task 4: `list_relationships` tool + `get_corpus_relationships` (#1862)
+
+**Files:**
+- Modify: `opencontractserver/annotations/services/relationship_service.py` (add `get_corpus_relationships`)
+- Modify: `opencontractserver/mcp/tools.py` (add `list_relationships`, register in `get_scoped_tool_handlers`)
+- Modify: `opencontractserver/mcp/server.py` (scoped + global tool schema + global `TOOL_HANDLERS` registration)
+- Modify: `opencontractserver/mcp/formatters.py` (add `format_relationship`)
+- Test: `opencontractserver/mcp/tests/test_mcp.py` (new `MCPToolsRelationshipsTest`)
+
+- [ ] **Step 1: Add `get_corpus_relationships` to RelationshipService**
+
+```python
+# relationship_service.py — new classmethod (mirrors get_corpus_annotations scoping)
+@classmethod
+def get_corpus_relationships(cls, corpus_id: int, user, structural=None) -> QuerySet:
+    """Corpus-wide relationships visible to ``user`` (mirrors get_corpus_annotations).
+
+    Includes corpus-FK relationships, relationships on visible corpus documents,
+    and structural relationships linked via those documents' structural sets.
+    """
+    from opencontractserver.annotations.models import Relationship
+    from opencontractserver.corpuses.models import Corpus
+    from opencontractserver.corpuses.services import CorpusDocumentService
+
+    try:
+        corpus = Corpus.objects.visible_to_user(user).get(id=corpus_id)
+    except Corpus.DoesNotExist:
+        return Relationship.objects.none()
+
+    doc_ids = CorpusDocumentService.get_corpus_documents(
+        user=user, corpus=corpus, include_deleted=False
+    ).values_list("id", flat=True)
+
+    from opencontractserver.annotations.models import StructuralAnnotationSet
+
+    set_ids = StructuralAnnotationSet.objects.filter(
+        documents__in=doc_ids
+    ).values_list("id", flat=True)
+
+    qs = Relationship.objects.filter(
+        Q(corpus_id=corpus_id)
+        | Q(document_id__in=doc_ids)
+        | Q(structural=True, structural_set_id__in=set_ids)
+    )
+    if structural is not None:
+        qs = qs.filter(structural=structural)
+    return qs.distinct()
+```
+
+- [ ] **Step 2: Add `format_relationship` formatter**
+
+```python
+# formatters.py
+def format_relationship(rel) -> dict:
+    """Format a Relationship as labeled source->target edges."""
+    from opencontractserver.constants.mcp import MCP_REL_ANNOTATION_TEXT_MAX_CHARS
+
+    def _node(a):
+        return {
+            "annotation_id": str(a.id),
+            "page": a.page,
+            "text": _truncate(a.raw_text or "", MCP_REL_ANNOTATION_TEXT_MAX_CHARS),
+        }
+
+    return {
+        "id": str(rel.id),
+        "label": rel.relationship_label.text if rel.relationship_label_id else None,
+        "structural": rel.structural,
+        "source": [_node(a) for a in rel.source_annotations.all()],
+        "target": [_node(a) for a in rel.target_annotations.all()],
+    }
+```
+
+- [ ] **Step 3: Add `list_relationships` tool**
+
+```python
+# tools.py
+def list_relationships(
+    corpus_slug: str,
+    document_slug: str | None = None,
+    structural: bool | None = None,
+    label_text: str | None = None,
+    limit: int = 50,
+    offset: int = 0,
+    user: UserOrAnonymous | None = None,
+) -> dict:
+    """List labeled source->target relationships in the corpus (or one document)."""
+    from opencontractserver.annotations.services.relationship_service import (
+        RelationshipService,
+    )
+    from opencontractserver.corpuses.models import Corpus
+    from opencontractserver.corpuses.services import CorpusDocumentService
+
+    from .formatters import format_relationship
+
+    limit = min(limit, 100)
+    user = user or AnonymousUser()
+    corpus = Corpus.objects.visible_to_user(user).get(slug=corpus_slug)
+
+    if document_slug:
+        document = CorpusDocumentService.get_corpus_document_by_slug(
+            user=user, corpus=corpus, slug=document_slug
+        )
+        qs = RelationshipService.get_document_relationships(
+            document_id=document.id, user=user, corpus_id=corpus.id, structural=structural
+        )
+    else:
+        qs = RelationshipService.get_corpus_relationships(
+            corpus_id=corpus.id, user=user, structural=structural
+        )
+
+    if label_text:
+        qs = qs.filter(relationship_label__text=label_text)
+
+    qs = qs.prefetch_related("source_annotations", "target_annotations").select_related(
+        "relationship_label"
+    ).order_by("id")
+    total_count = qs.count()
+    rels = list(qs[offset : offset + limit])
+    return {
+        "total_count": total_count,
+        "relationships": [format_relationship(r) for r in rels],
+    }
+```
+
+- [ ] **Step 4: Register handler + schema**
+
+In `tools.py:get_scoped_tool_handlers`, add:
+```python
+"list_relationships": create_scoped_tool_wrapper(list_relationships, corpus_slug),
+```
+In `server.py:get_scoped_tool_definitions`, append a `Tool(name="list_relationships", description="List labeled source→target relationships in the corpus (or a single document)", inputSchema={...})` with properties `document_slug, structural, label_text, limit (default 50), offset (default 0)`, none required. Mirror in global `list_tools` (with `corpus_slug` required) and add `list_relationships` to the global `TOOL_HANDLERS` map.
+
+- [ ] **Step 5: Write tests** (`MCPToolsRelationshipsTest`)
+
+```python
+class MCPToolsRelationshipsTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        # seed corpus, doc, 2 annotations, 1 non-structural Relationship
+        # (label "cross-reference") source=ann_a target=ann_b
+        ...
+    def test_list_relationships_returns_edges(self):
+        from opencontractserver.mcp.tools import list_relationships
+        result = list_relationships(self.corpus.slug, self.document.slug)
+        self.assertGreaterEqual(result["total_count"], 1)
+        rel = result["relationships"][0]
+        self.assertEqual(rel["label"], "cross-reference")
+        self.assertTrue(rel["source"] and rel["target"])
+    def test_list_relationships_structural_filter(self):
+        from opencontractserver.mcp.tools import list_relationships
+        result = list_relationships(self.corpus.slug, structural=False)
+        self.assertTrue(all(r["structural"] is False for r in result["relationships"]))
+    def test_list_relationships_corpus_wide(self):
+        from opencontractserver.mcp.tools import list_relationships
+        result = list_relationships(self.corpus.slug)  # no document_slug
+        self.assertGreaterEqual(result["total_count"], 1)
+```
+
+- [ ] **Step 6: Run** `...::MCPToolsRelationshipsTest -q` → PASS. Also run a scoped dispatch test asserting `list_relationships` appears in `get_scoped_tool_definitions(slug)` names.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add opencontractserver/annotations/services/relationship_service.py opencontractserver/mcp/tools.py opencontractserver/mcp/server.py opencontractserver/mcp/formatters.py opencontractserver/mcp/tests/test_mcp.py
+git commit -m "feat(mcp): list_relationships tool + RelationshipService.get_corpus_relationships (#1862)"
+```
+
+---
+
+### Task 5: Polish — in-use labels, actionable errors, descriptions (#1861)
+
+**Files:**
+- Modify: `opencontractserver/mcp/tools.py:555-610` (`get_corpus_info`)
+- Modify: `opencontractserver/mcp/server.py:359-376` (`_format_tool_error_text`) + tool descriptions
+- Test: `opencontractserver/mcp/tests/test_mcp.py`
+
+- [ ] **Step 1: Failing tests**
+
+```python
+def test_get_corpus_info_only_in_use_labels(self):
+    from opencontractserver.mcp.tools import get_corpus_info
+    out = get_corpus_info(self.corpus.slug)
+    label_texts = {l["text"] for l in (out["label_set"]["labels"] if out["label_set"] else [])}
+    self.assertIn(self.used_label_text, label_texts)
+    self.assertNotIn(self.unused_label_text, label_texts)
+
+def test_invalid_document_slug_actionable_error(self):
+    # via dispatcher: error text names remediation, no raw "matching query"
+    ...  # call get_document_text with bad slug, assert "list_documents" in message
+```
+
+Seed a label set on the corpus with one **used** label (on an annotation) and one **unused** label.
+
+- [ ] **Step 2: `get_corpus_info` — filter to in-use labels**
+
+```python
+# tools.py get_corpus_info — replace label collection
+from opencontractserver.annotations.services import AnnotationService
+
+used_label_ids = set(
+    AnnotationService.get_corpus_annotations(corpus.id, user)
+    .exclude(annotation_label__isnull=True)
+    .values_list("annotation_label_id", flat=True)
+    .distinct()
+)
+label_set_data = None
+if corpus.label_set:
+    labels = []
+    for label in list(corpus.label_set.annotation_labels.all()):
+        if label.id in used_label_ids:
+            labels.append({
+                "text": label.text,
+                "color": label.color or "#000000",
+                "label_type": label.label_type,
+                "description": label.description or "",
+            })
+        if len(labels) >= 50:
+            break
+    label_set_data = {
+        "title": corpus.label_set.title or "",
+        "description": corpus.label_set.description or "",
+        "labels": labels,
+    }
+```
+
+- [ ] **Step 3: Humanize errors in `_format_tool_error_text`**
+
+```python
+# server.py _format_tool_error_text — add before final return
+from django.core.exceptions import ObjectDoesNotExist
+if isinstance(e, ObjectDoesNotExist):
+    name = type(e).__name__  # e.g. "DoesNotExist" on Document/Corpus
+    cls_name = getattr(getattr(e, "__class__", None), "__qualname__", "")
+    if "Document" in cls_name or "document" in str(e).lower():
+        return ("No matching document was found in this corpus. "
+                "Call list_documents to see valid document_slug values.")
+    if "Corpus" in cls_name or "corpus" in str(e).lower():
+        return ("No matching corpus was found. "
+                "Call list_public_corpuses to see valid corpus_slug values.")
+    return "The requested item was not found."
+```
+
+Also extend the dispatcher catch: in both `call_tool_handler` (`server.py:448`) and the scoped `call_tool`, add `ObjectDoesNotExist` alongside `(PermissionDenied, ValidationError)` so DoesNotExist is returned as a structured `isError` result instead of raising (it currently raises → generic transport error). Import `ObjectDoesNotExist`.
+
+- [ ] **Step 4: Tighten descriptions** — `search_corpus` (done Task 2), `get_document_text` → `"Get extracted document text in bounded slices (char_offset/max_chars)"`, `list_annotations` → `"List/search a document's annotations (filter by page, label_text, text_contains, structural)"`. Update in scoped + global schemas.
+
+- [ ] **Step 5: Run** the polish tests + `MCPToolsTest` (dispatcher) → PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add opencontractserver/mcp/tools.py opencontractserver/mcp/server.py opencontractserver/mcp/tests/test_mcp.py
+git commit -m "feat(mcp): in-use corpus labels, actionable not-found errors, sharper descriptions (#1861)"
+```
+
+---
+
+### Task 6: `get_document_text` pagination (#1860) — LAST, depends on #1841
+
+**Files:**
+- Modify: `opencontractserver/mcp/tools.py:121-160` (`get_document_text`)
+- Modify: `opencontractserver/mcp/server.py` scoped + global `get_document_text` schema
+- Modify (only if #1841 NOT merged): `opencontractserver/utils/files.py` (add `read_field_file_text`)
+- Test: `opencontractserver/mcp/tests/test_mcp.py` (`MCPToolsDocumentsTest`)
+
+- [ ] **Step 1: Rebase check.** `git fetch origin && git log origin/main --oneline | grep -i 1841`. If #1841 is in main, rebase this branch onto it and SKIP adding the helper (import the existing one). If not, add `read_field_file_text` to `utils/files.py` verbatim from PR #1841 (single source of truth; reconciles trivially when #1841 merges).
+
+- [ ] **Step 2: Failing tests**
+
+```python
+def test_get_document_text_pagination(self):
+    full = get_document_text(self.corpus.slug, self.doc1.slug)["text"]
+    page1 = get_document_text(self.corpus.slug, self.doc1.slug, char_offset=0, max_chars=10)
+    self.assertEqual(page1["text"], full[:10])
+    self.assertEqual(page1["char_offset"], 0)
+    self.assertEqual(page1["next_offset"], 10 if len(full) > 10 else None)
+    self.assertEqual(page1["truncated"], len(full) > 10)
+    self.assertEqual(page1["total_chars"], len(full))
+
+def test_get_document_text_offset_tail(self):
+    full = get_document_text(self.corpus.slug, self.doc1.slug)["text"]
+    tail = get_document_text(self.corpus.slug, self.doc1.slug, char_offset=5, max_chars=100000)
+    self.assertEqual(tail["text"], full[5:])
+    self.assertIsNone(tail["next_offset"])
+```
+
+(`get_document_text` with no slice args returns the full text → keep default `max_chars=MCP_DOCUMENT_TEXT_DEFAULT_CHARS`; for docs shorter than the default the existing tests still pass.)
+
+- [ ] **Step 3: Implement**
+
+```python
+# tools.py get_document_text
+def get_document_text(
+    corpus_slug: str,
+    document_slug: str,
+    char_offset: int = 0,
+    max_chars: int | None = None,
+    user: UserOrAnonymous | None = None,
+) -> dict:
+    from opencontractserver.constants.mcp import (
+        MCP_DOCUMENT_TEXT_DEFAULT_CHARS,
+        MCP_DOCUMENT_TEXT_MAX_CHARS,
+    )
+    from opencontractserver.corpuses.models import Corpus
+    from opencontractserver.corpuses.services import CorpusDocumentService
+    from opencontractserver.utils.files import read_field_file_text
+
+    user = user or AnonymousUser()
+    corpus = Corpus.objects.visible_to_user(user).get(slug=corpus_slug)
+    document = CorpusDocumentService.get_corpus_document_by_slug(
+        user=user, corpus=corpus, slug=document_slug
+    )
+
+    full_text = ""
+    if document.txt_extract_file:
+        try:
+            full_text = read_field_file_text(document.txt_extract_file, errors="replace")
+        except Exception:
+            full_text = ""
+
+    total = len(full_text)
+    char_offset = max(0, int(char_offset))
+    window = MCP_DOCUMENT_TEXT_DEFAULT_CHARS if max_chars is None else max_chars
+    window = max(0, min(int(window), MCP_DOCUMENT_TEXT_MAX_CHARS))
+    end = char_offset + window
+    text = full_text[char_offset:end]
+    next_offset = end if end < total else None
+    return {
+        "document_slug": document.slug,
+        "page_count": document.page_count or 0,
+        "total_chars": total,
+        "char_offset": char_offset,
+        "text": text,
+        "next_offset": next_offset,
+        "truncated": next_offset is not None,
+    }
+```
+
+- [ ] **Step 4: Update schema** — add `char_offset` (integer, default 0) and `max_chars` (integer) to scoped + global `get_document_text` properties.
+
+- [ ] **Step 5: Run** `...::MCPToolsDocumentsTest -q` → PASS (existing bytes-from-cloud test continues to pass via the helper).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add opencontractserver/mcp/tools.py opencontractserver/mcp/server.py opencontractserver/mcp/tests/test_mcp.py opencontractserver/utils/files.py
+git commit -m "feat(mcp): bounded get_document_text slicing via char_offset/max_chars (#1860)"
+```
+
+---
+
+### Task 7: Changelog + full MCP suite + PR
+
+- [ ] **Step 1:** Add a `CHANGELOG.md` `[Unreleased]` entry summarizing the 5 components with issue refs.
+- [ ] **Step 2:** Run the full MCP suite: `docker compose -f test.yml run --rm django pytest opencontractserver/mcp/tests/test_mcp.py -n 4 --dist loadscope -q` → all PASS.
+- [ ] **Step 3:** `pre-commit run --files <changed>` → clean.
+- [ ] **Step 4:** Commit changelog; push branch; open umbrella draft PR (body lists components, `Closes #1858 #1859 #1860 #1861 #1862`, notes #1841 dependency for Task 6).
+
+---
+
+## Self-Review
+
+- **Spec coverage:** passage feed (Task 2) ✓, text fallback fix (Task 2) ✓, structural filter+flag (Tasks 2,3) ✓, content search+ordering+lean payload (Task 3) ✓, blocks+granularity (Task 2) ✓, list_relationships+get_corpus_relationships (Task 4) ✓, in-use labels+errors+descriptions (Task 5) ✓, get_document_text pagination+#1841 (Task 6) ✓, constants (Task 1) ✓, tests for each (every task) ✓.
+- **Placeholders:** fixture `...` in test stubs are explicitly described (seed instructions inline); no TODO/TBD in production code steps.
+- **Type consistency:** `format_search_passage(annotation, similarity_score=None)`, `format_search_block(result)`, `format_relationship(rel)`, `read_field_file_text(field_file, errors=)`, `get_corpus_relationships(corpus_id, user, structural=)` used consistently across tasks.

--- a/opencontractserver/annotations/services/relationship_service.py
+++ b/opencontractserver/annotations/services/relationship_service.py
@@ -280,3 +280,48 @@ class RelationshipService(BaseService):
         }
 
         return result
+
+    @classmethod
+    def get_corpus_relationships(
+        cls,
+        corpus_id: int,
+        user,
+        structural: Optional[bool] = None,
+    ) -> QuerySet:
+        """Corpus-wide relationships visible to ``user``.
+
+        Mirrors ``AnnotationService.get_corpus_annotations`` scoping: includes
+        corpus-FK relationships, relationships on visible corpus documents, and
+        structural relationships linked via those documents' structural sets.
+
+        Corpus READ is the gate (via ``CorpusDocumentService.get_corpus_documents``);
+        returns ``Relationship.objects.none()`` if the corpus is not visible.
+        """
+        from opencontractserver.annotations.models import (
+            Relationship,
+            StructuralAnnotationSet,
+        )
+        from opencontractserver.corpuses.models import Corpus
+        from opencontractserver.corpuses.services import CorpusDocumentService
+
+        try:
+            corpus = Corpus.objects.visible_to_user(user).get(id=corpus_id)
+        except Corpus.DoesNotExist:
+            return Relationship.objects.none()
+
+        doc_ids = CorpusDocumentService.get_corpus_documents(
+            user=user, corpus=corpus, include_deleted=False
+        ).values_list("id", flat=True)
+
+        set_ids = StructuralAnnotationSet.objects.filter(
+            documents__in=doc_ids
+        ).values_list("id", flat=True)
+
+        qs = Relationship.objects.filter(
+            Q(corpus_id=corpus_id)
+            | Q(document_id__in=doc_ids)
+            | Q(structural=True, structural_set_id__in=set_ids)
+        )
+        if structural is not None:
+            qs = qs.filter(structural=structural)
+        return qs.distinct()

--- a/opencontractserver/constants/mcp.py
+++ b/opencontractserver/constants/mcp.py
@@ -6,3 +6,11 @@ Constants for the MCP (Model Context Protocol) server and tools.
 # write tool. Caps abusive payloads at the tool boundary independently of
 # any DB-level limit on the ``ChatMessage.content`` column.
 MAX_THREAD_MESSAGE_LENGTH: int = 50_000
+
+# Truncation budgets (characters) for MCP tool payloads. Keep AI-facing
+# results bounded so a single tool call cannot blow the context window.
+MCP_SEARCH_SNIPPET_MAX_CHARS: int = 1_500  # passage hit `text`
+MCP_BLOCK_SNIPPET_MAX_CHARS: int = 4_000  # subtree-group block `text`
+MCP_REL_ANNOTATION_TEXT_MAX_CHARS: int = 500  # source/target text in list_relationships
+MCP_DOCUMENT_TEXT_DEFAULT_CHARS: int = 50_000  # default get_document_text window
+MCP_DOCUMENT_TEXT_MAX_CHARS: int = 200_000  # hard cap for get_document_text max_chars

--- a/opencontractserver/mcp/formatters.py
+++ b/opencontractserver/mcp/formatters.py
@@ -90,22 +90,35 @@ def format_search_passage(
     }
 
 
-def format_search_block(result: RelationshipVectorSearchResult) -> dict:
+def format_search_block(
+    result: RelationshipVectorSearchResult,
+    doc_lookup: dict[int, tuple[str | None, str]] | None = None,
+) -> dict:
     """Format a ``RelationshipVectorSearchResult`` as a block-level search hit.
 
     ``result`` already carries ``block_text``, ``label_text``, ``document_id``
     and member ids, so only a light document slug/title lookup is needed.
+
+    Callers formatting many blocks (e.g. ``search_corpus``) should pass a
+    pre-fetched ``doc_lookup`` mapping ``document_id -> (slug, title)`` to avoid
+    a per-block ``Document`` query (N+1). When omitted, the slug/title is looked
+    up lazily so single-block callers stay correct.
     """
     from opencontractserver.constants.mcp import MCP_BLOCK_SNIPPET_MAX_CHARS
     from opencontractserver.documents.models import Document
 
     doc_slug, doc_title = None, ""
     if result.document_id:
-        doc = (
-            Document.objects.filter(pk=result.document_id).only("slug", "title").first()
-        )
-        if doc:
-            doc_slug, doc_title = doc.slug, (doc.title or "")
+        if doc_lookup is not None:
+            doc_slug, doc_title = doc_lookup.get(result.document_id, (None, ""))
+        else:
+            doc = (
+                Document.objects.filter(pk=result.document_id)
+                .only("slug", "title")
+                .first()
+            )
+            if doc:
+                doc_slug, doc_title = doc.slug, (doc.title or "")
 
     member_count = (1 if result.source_annotation_id else 0) + len(
         result.target_annotation_ids

--- a/opencontractserver/mcp/formatters.py
+++ b/opencontractserver/mcp/formatters.py
@@ -5,10 +5,21 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from opencontractserver.annotations.models import Annotation
+    from opencontractserver.annotations.models import Annotation, Relationship
     from opencontractserver.conversations.models import ChatMessage, Conversation
     from opencontractserver.corpuses.models import Corpus
     from opencontractserver.documents.models import Document
+    from opencontractserver.llms.vector_stores.core_relationship_vector_store import (
+        RelationshipVectorSearchResult,
+    )
+
+
+def _truncate(text: str, max_chars: int) -> str:
+    """Bound a string for AI-facing payloads, marking elision."""
+    text = text or ""
+    if len(text) <= max_chars:
+        return text
+    return text[:max_chars] + " …[truncated]"
 
 
 def format_corpus_summary(corpus: Corpus) -> dict:
@@ -37,12 +48,16 @@ def format_document_summary(document: Document) -> dict:
 
 
 def format_annotation(annotation: Annotation) -> dict:
-    """Format an annotation for API response."""
+    """Format an annotation for API response (lean, AI-facing shape).
+
+    Drops ``color`` and ``created`` (low signal, high token cost for an AI
+    consumer). The ``structural`` flag is retained so callers can always
+    delineate layout-derived chunks from human/analysis annotations.
+    """
     label_data = None
     if annotation.annotation_label:
         label_data = {
             "text": annotation.annotation_label.text,
-            "color": annotation.annotation_label.color or "#000000",
             "label_type": annotation.annotation_label.label_type,
         }
 
@@ -52,7 +67,79 @@ def format_annotation(annotation: Annotation) -> dict:
         "raw_text": annotation.raw_text or "",
         "annotation_label": label_data,
         "structural": annotation.structural,
-        "created": annotation.created.isoformat() if annotation.created else None,
+    }
+
+
+def format_search_passage(
+    annotation: Annotation, similarity_score: float | None = None
+) -> dict:
+    """Format an annotation as a passage-level search hit."""
+    from opencontractserver.constants.mcp import MCP_SEARCH_SNIPPET_MAX_CHARS
+
+    doc = annotation.document if annotation.document_id else None
+    return {
+        "type": "passage",
+        "document_slug": doc.slug if doc else None,
+        "document_title": (doc.title or "") if doc else "",
+        "page": annotation.page,
+        "text": _truncate(annotation.raw_text or "", MCP_SEARCH_SNIPPET_MAX_CHARS),
+        "structural": annotation.structural,
+        "similarity_score": (
+            float(similarity_score) if similarity_score is not None else None
+        ),
+    }
+
+
+def format_search_block(result: RelationshipVectorSearchResult) -> dict:
+    """Format a ``RelationshipVectorSearchResult`` as a block-level search hit.
+
+    ``result`` already carries ``block_text``, ``label_text``, ``document_id``
+    and member ids, so only a light document slug/title lookup is needed.
+    """
+    from opencontractserver.constants.mcp import MCP_BLOCK_SNIPPET_MAX_CHARS
+    from opencontractserver.documents.models import Document
+
+    doc_slug, doc_title = None, ""
+    if result.document_id:
+        doc = (
+            Document.objects.filter(pk=result.document_id).only("slug", "title").first()
+        )
+        if doc:
+            doc_slug, doc_title = doc.slug, (doc.title or "")
+
+    member_count = (1 if result.source_annotation_id else 0) + len(
+        result.target_annotation_ids
+    )
+    return {
+        "type": "block",
+        "document_slug": doc_slug,
+        "document_title": doc_title,
+        "page": None,
+        "label": result.label_text,
+        "text": _truncate(result.block_text or "", MCP_BLOCK_SNIPPET_MAX_CHARS),
+        "member_count": member_count,
+        "similarity_score": float(result.similarity_score),
+    }
+
+
+def format_relationship(rel: Relationship) -> dict:
+    """Format a ``Relationship`` as labeled source->target edges."""
+    from opencontractserver.constants.mcp import MCP_REL_ANNOTATION_TEXT_MAX_CHARS
+
+    def _node(a: Annotation) -> dict:
+        return {
+            "annotation_id": str(a.id),
+            "page": a.page,
+            "text": _truncate(a.raw_text or "", MCP_REL_ANNOTATION_TEXT_MAX_CHARS),
+        }
+
+    label = rel.relationship_label if rel.relationship_label_id else None
+    return {
+        "id": str(rel.id),
+        "label": label.text if label else None,
+        "structural": rel.structural,
+        "source": [_node(a) for a in rel.source_annotations.all()],
+        "target": [_node(a) for a in rel.target_annotations.all()],
     }
 
 

--- a/opencontractserver/mcp/server.py
+++ b/opencontractserver/mcp/server.py
@@ -378,13 +378,18 @@ def _format_tool_error_text(e: BaseException) -> str:
         return str(e) or "Permission denied"
     if isinstance(e, ObjectDoesNotExist):
         # ``Document.DoesNotExist`` / ``Corpus.DoesNotExist`` subclass this.
-        cls_name = type(e).__qualname__
-        if cls_name.startswith("Document"):
+        # Match by identity, not name prefix — a future ``DocumentVersion``
+        # or ``CorpusQuery`` model would otherwise be misclassified by a
+        # ``startswith`` check.
+        from opencontractserver.corpuses.models import Corpus
+        from opencontractserver.documents.models import Document
+
+        if isinstance(e, Document.DoesNotExist):
             return (
                 "No matching document was found in this corpus. Call "
                 "list_documents to see valid document_slug values."
             )
-        if cls_name.startswith("Corpus"):
+        if isinstance(e, Corpus.DoesNotExist):
             return (
                 "No matching corpus was found. Call list_public_corpuses to "
                 "see valid corpus_slug values."
@@ -888,6 +893,9 @@ def get_scoped_tool_definitions(corpus_slug: str) -> list[Tool]:
                     "limit": {"type": "integer", "default": 50},
                     "offset": {"type": "integer", "default": 0},
                 },
+                # No "required" key: the scoped endpoint binds corpus_slug from
+                # the URL, so every remaining parameter is genuinely optional
+                # (unlike the global schema, which requires "corpus_slug").
             },
         ),
         Tool(

--- a/opencontractserver/mcp/server.py
+++ b/opencontractserver/mcp/server.py
@@ -29,7 +29,11 @@ if TYPE_CHECKING:
 
 from asgiref.sync import sync_to_async
 from django.conf import settings
-from django.core.exceptions import PermissionDenied, ValidationError
+from django.core.exceptions import (
+    ObjectDoesNotExist,
+    PermissionDenied,
+    ValidationError,
+)
 from graphql_jwt.exceptions import JSONWebTokenError, JSONWebTokenExpired
 from mcp.server import Server
 from mcp.server.sse import SseServerTransport
@@ -71,6 +75,7 @@ from .tools import (
     list_annotations,
     list_documents,
     list_public_corpuses,
+    list_relationships,
     list_threads,
     search_corpus,
 )
@@ -221,6 +226,7 @@ TOOL_HANDLERS: dict[str, Callable[..., Any]] = {
     "list_documents": list_documents,
     "get_document_text": get_document_text,
     "list_annotations": list_annotations,
+    "list_relationships": list_relationships,
     "search_corpus": search_corpus,
     "list_threads": list_threads,
     "get_thread_messages": get_thread_messages,
@@ -357,22 +363,37 @@ async def read_resource_handler(uri: str) -> str:
 
 
 def _format_tool_error_text(e: BaseException) -> str:
-    """Render a permission/validation error into the LLM-facing error string.
+    """Render a permission/validation/not-found error into the LLM-facing string.
 
     ``ValidationError.messages`` is preferred for structured payloads; the
-    plain ``PermissionDenied`` path falls back to ``str(e)``. Shared between
-    the non-scoped ``call_tool_handler`` and the scoped ``call_tool``
-    dispatcher so error serialisation stays in lockstep.
+    plain ``PermissionDenied`` path falls back to ``str(e)``. ``ObjectDoesNotExist``
+    is humanized into an actionable message that names the remediation tool —
+    never the raw Django ``"... matching query does not exist."`` string, which
+    tells an AI nothing. Shared between the non-scoped ``call_tool_handler`` and
+    the scoped ``call_tool`` dispatcher so error serialisation stays in lockstep.
     """
     if isinstance(e, ValidationError):
         return "; ".join(e.messages) or "Validation error"
     if isinstance(e, PermissionDenied):
         return str(e) or "Permission denied"
+    if isinstance(e, ObjectDoesNotExist):
+        # ``Document.DoesNotExist`` / ``Corpus.DoesNotExist`` subclass this.
+        cls_name = type(e).__qualname__
+        if cls_name.startswith("Document"):
+            return (
+                "No matching document was found in this corpus. Call "
+                "list_documents to see valid document_slug values."
+            )
+        if cls_name.startswith("Corpus"):
+            return (
+                "No matching corpus was found. Call list_public_corpuses to "
+                "see valid corpus_slug values."
+            )
+        return "The requested item was not found."
     # Anything else reaching this helper is an unexpected exception type
-    # (the call sites narrow to ``PermissionDenied``/``ValidationError``,
-    # but the body is shared so be defensive). Returning "Permission
-    # denied" for, say, a raw ``Exception`` would actively mislead the
-    # LLM about what went wrong.
+    # (the call sites narrow to the handled exceptions above, but the body is
+    # shared so be defensive). Returning "Permission denied" for, say, a raw
+    # ``Exception`` would actively mislead the LLM about what went wrong.
     return str(e) or "Unexpected error"
 
 
@@ -445,10 +466,11 @@ async def call_tool_handler(name: str, arguments: dict) -> list[TextContent]:
             document_slug=_document_slug,
         )
         return [TextContent(type="text", text=json.dumps(result, indent=2))]
-    except (PermissionDenied, ValidationError) as e:
+    except (PermissionDenied, ValidationError, ObjectDoesNotExist) as e:
         # Surface permission failures (e.g., write tools called by anonymous
-        # callers) and input-validation errors (blank/oversized content, etc.)
-        # as structured error results so the LLM can reason about them and
+        # callers), input-validation errors (blank/oversized content, etc.) and
+        # not-found lookups (bad slug / cross-corpus / hidden corpus) as
+        # structured error results so the LLM can reason about them and
         # retry/correct, rather than receiving an opaque transport error.
         return await _record_and_return_tool_error(
             e,
@@ -564,7 +586,7 @@ def create_mcp_server() -> Server:
             ),
             Tool(
                 name="get_document_text",
-                description="Get full extracted text from a document",
+                description="Get extracted document text in bounded slices (char_offset/max_chars)",
                 inputSchema={
                     "type": "object",
                     "properties": {
@@ -576,13 +598,25 @@ def create_mcp_server() -> Server:
                             "type": "string",
                             "description": "Document identifier",
                         },
+                        "char_offset": {
+                            "type": "integer",
+                            "default": 0,
+                            "description": "Start offset into the extracted text",
+                        },
+                        "max_chars": {
+                            "type": "integer",
+                            "description": "Window size; use next_offset to paginate",
+                        },
                     },
                     "required": ["corpus_slug", "document_slug"],
                 },
             ),
             Tool(
                 name="list_annotations",
-                description="List annotations on a document",
+                description=(
+                    "List/search a document's annotations (filter by page, "
+                    "label_text, text_contains, structural)"
+                ),
                 inputSchema={
                     "type": "object",
                     "properties": {
@@ -594,7 +628,15 @@ def create_mcp_server() -> Server:
                         },
                         "label_text": {
                             "type": "string",
-                            "description": "Filter by label text",
+                            "description": "Filter by exact label text",
+                        },
+                        "text_contains": {
+                            "type": "string",
+                            "description": "Filter annotations whose text contains this substring",
+                        },
+                        "structural": {
+                            "type": "boolean",
+                            "description": "Filter: omit=all, true=structural only, false=human/analysis only",
                         },
                         "limit": {"type": "integer", "default": 100},
                         "offset": {"type": "integer", "default": 0},
@@ -603,14 +645,62 @@ def create_mcp_server() -> Server:
                 },
             ),
             Tool(
+                name="list_relationships",
+                description=(
+                    "List labeled source→target relationships in a corpus "
+                    "(or a single document) for explicit graph navigation"
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "corpus_slug": {"type": "string"},
+                        "document_slug": {
+                            "type": "string",
+                            "description": "Optional document filter (corpus-wide when omitted)",
+                        },
+                        "structural": {
+                            "type": "boolean",
+                            "description": "Filter: omit=all, true=structural only, false=human/analysis only",
+                        },
+                        "label_text": {
+                            "type": "string",
+                            "description": "Filter by exact relationship label",
+                        },
+                        "limit": {"type": "integer", "default": 50},
+                        "offset": {"type": "integer", "default": 0},
+                    },
+                    "required": ["corpus_slug"],
+                },
+            ),
+            Tool(
                 name="search_corpus",
-                description="Semantic search within a corpus",
+                description=(
+                    "Search a corpus. Returns a ranked feed of passage and "
+                    "block hits (each tagged 'type'); semantic with a text fallback"
+                ),
                 inputSchema={
                     "type": "object",
                     "properties": {
                         "corpus_slug": {"type": "string"},
                         "query": {"type": "string", "description": "Search query"},
-                        "limit": {"type": "integer", "default": 10},
+                        "limit": {
+                            "type": "integer",
+                            "default": 10,
+                            "description": "Max hits (1-50)",
+                        },
+                        "granularity": {
+                            "type": "string",
+                            "enum": ["passage", "block", "both"],
+                            "default": "both",
+                            "description": (
+                                "passage = annotation hits; block = aggregated "
+                                "subtree-group hits; both = merged feed"
+                            ),
+                        },
+                        "structural": {
+                            "type": "boolean",
+                            "description": "Filter passages: omit=all, true=structural only, false=human/analysis only",
+                        },
                     },
                     "required": ["corpus_slug", "query"],
                 },
@@ -721,7 +811,7 @@ def get_scoped_tool_definitions(corpus_slug: str) -> list[Tool]:
         ),
         Tool(
             name="get_document_text",
-            description="Get full extracted text from a document",
+            description="Get extracted document text in bounded slices (char_offset/max_chars)",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -729,13 +819,25 @@ def get_scoped_tool_definitions(corpus_slug: str) -> list[Tool]:
                         "type": "string",
                         "description": "Document identifier",
                     },
+                    "char_offset": {
+                        "type": "integer",
+                        "default": 0,
+                        "description": "Start offset into the extracted text",
+                    },
+                    "max_chars": {
+                        "type": "integer",
+                        "description": "Window size; use next_offset to paginate",
+                    },
                 },
                 "required": ["document_slug"],
             },
         ),
         Tool(
             name="list_annotations",
-            description="List annotations on a document",
+            description=(
+                "List/search a document's annotations (filter by page, "
+                "label_text, text_contains, structural)"
+            ),
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -746,7 +848,15 @@ def get_scoped_tool_definitions(corpus_slug: str) -> list[Tool]:
                     },
                     "label_text": {
                         "type": "string",
-                        "description": "Filter by label text",
+                        "description": "Filter by exact label text",
+                    },
+                    "text_contains": {
+                        "type": "string",
+                        "description": "Filter annotations whose text contains this substring",
+                    },
+                    "structural": {
+                        "type": "boolean",
+                        "description": "Filter: omit=all, true=structural only, false=human/analysis only",
                     },
                     "limit": {"type": "integer", "default": 100},
                     "offset": {"type": "integer", "default": 0},
@@ -755,13 +865,60 @@ def get_scoped_tool_definitions(corpus_slug: str) -> list[Tool]:
             },
         ),
         Tool(
+            name="list_relationships",
+            description=(
+                f"List labeled source→target relationships in the "
+                f"'{corpus_slug}' corpus (or a single document)"
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "document_slug": {
+                        "type": "string",
+                        "description": "Optional document filter (corpus-wide when omitted)",
+                    },
+                    "structural": {
+                        "type": "boolean",
+                        "description": "Filter: omit=all, true=structural only, false=human/analysis only",
+                    },
+                    "label_text": {
+                        "type": "string",
+                        "description": "Filter by exact relationship label",
+                    },
+                    "limit": {"type": "integer", "default": 50},
+                    "offset": {"type": "integer", "default": 0},
+                },
+            },
+        ),
+        Tool(
             name="search_corpus",
-            description=f"Semantic search within the '{corpus_slug}' corpus",
+            description=(
+                f"Search the '{corpus_slug}' corpus. Returns a ranked feed of "
+                f"passage and block hits (each tagged 'type'); semantic with a "
+                f"text fallback"
+            ),
             inputSchema={
                 "type": "object",
                 "properties": {
                     "query": {"type": "string", "description": "Search query"},
-                    "limit": {"type": "integer", "default": 10},
+                    "limit": {
+                        "type": "integer",
+                        "default": 10,
+                        "description": "Max hits (1-50)",
+                    },
+                    "granularity": {
+                        "type": "string",
+                        "enum": ["passage", "block", "both"],
+                        "default": "both",
+                        "description": (
+                            "passage = annotation hits; block = aggregated "
+                            "subtree-group hits; both = merged feed"
+                        ),
+                    },
+                    "structural": {
+                        "type": "boolean",
+                        "description": "Filter passages: omit=all, true=structural only, false=human/analysis only",
+                    },
                 },
                 "required": ["query"],
             },
@@ -1064,10 +1221,10 @@ def create_scoped_mcp_server(corpus_slug: str) -> Server:
                 document_slug=_document_slug,
             )
             return [TextContent(type="text", text=json.dumps(result, indent=2))]
-        except (PermissionDenied, ValidationError) as e:
-            # Same rationale as the non-scoped dispatcher: surface
-            # permission failures and Django input-validation errors as
-            # structured tool results so the LLM can react to them.
+        except (PermissionDenied, ValidationError, ObjectDoesNotExist) as e:
+            # Same rationale as the non-scoped dispatcher: surface permission
+            # failures, Django input-validation errors and not-found lookups
+            # as structured tool results so the LLM can react to them.
             return await _record_and_return_tool_error(
                 e,
                 name=name,

--- a/opencontractserver/mcp/tests/test_mcp.py
+++ b/opencontractserver/mcp/tests/test_mcp.py
@@ -677,6 +677,49 @@ class MCPToolsDocumentsTest(TestCase):
         # ... and the full payload serializes cleanly (the original crash).
         json.dumps(result, indent=2)
 
+    def test_get_document_text_offset_beyond_end(self):
+        """char_offset past total_chars yields empty text and no next page."""
+        from opencontractserver.mcp.tools import get_document_text
+
+        payload = "X" * 40
+        with _patch_fieldfile_open_returns_bytes(payload):
+            result = get_document_text(
+                self.corpus.slug, self.doc1.slug, char_offset=10_000
+            )
+
+        self.assertEqual(result["total_chars"], 40)
+        self.assertEqual(result["text"], "")
+        self.assertIsNone(result["next_offset"])
+        self.assertFalse(result["truncated"])
+
+    def test_get_document_text_max_chars_zero(self):
+        """max_chars=0 produces an empty window."""
+        from opencontractserver.mcp.tools import get_document_text
+
+        payload = "Y" * 40
+        with _patch_fieldfile_open_returns_bytes(payload):
+            result = get_document_text(self.corpus.slug, self.doc1.slug, max_chars=0)
+
+        self.assertEqual(result["text"], "")
+
+    def test_get_document_text_max_chars_clamped_to_hard_cap(self):
+        """max_chars above MCP_DOCUMENT_TEXT_MAX_CHARS is clamped to the cap."""
+        from opencontractserver.constants.mcp import MCP_DOCUMENT_TEXT_MAX_CHARS
+        from opencontractserver.mcp.tools import get_document_text
+
+        payload = "Z" * (MCP_DOCUMENT_TEXT_MAX_CHARS + 50)
+        with _patch_fieldfile_open_returns_bytes(payload):
+            result = get_document_text(
+                self.corpus.slug, self.doc1.slug, max_chars=10_000_000
+            )
+
+        # Window is clamped: only the cap's worth of text is returned, and the
+        # response pages on (next_offset at the cap) rather than honoring the
+        # oversized request.
+        self.assertEqual(len(result["text"]), MCP_DOCUMENT_TEXT_MAX_CHARS)
+        self.assertEqual(result["next_offset"], MCP_DOCUMENT_TEXT_MAX_CHARS)
+        self.assertTrue(result["truncated"])
+
     def test_get_document_resource_handles_bytes_from_cloud_storage(self):
         """Regression: the resource path shares the same bytes-from-cloud bug
         class as ``get_document_text`` (django-storages #382).
@@ -3002,6 +3045,7 @@ class MCPScopedToolsTest(TestCase):
             "list_documents",
             "get_document_text",
             "list_annotations",
+            "list_relationships",
             "search_corpus",
             "list_threads",
             "get_thread_messages",
@@ -3034,6 +3078,19 @@ class MCPScopedToolsTest(TestCase):
 
         self.assertEqual(result["document_slug"], self.doc1.slug)
         self.assertEqual(result["page_count"], 5)
+
+    def test_scoped_list_relationships(self):
+        """Scoped list_relationships dispatches without explicit corpus_slug."""
+        from opencontractserver.mcp.tools import get_scoped_tool_handlers
+
+        handlers = get_scoped_tool_handlers(self.corpus.slug)
+
+        # Corpus-slug is bound from the scope, so no positional arg is needed.
+        result = handlers["list_relationships"]()
+
+        self.assertIn("total_count", result)
+        self.assertIn("relationships", result)
+        self.assertIsInstance(result["relationships"], list)
 
 
 @pytest.mark.serial
@@ -3112,6 +3169,12 @@ class MCPScopedServerTest(TransactionTestCase):
         # search_corpus should only require query
         search_tool = next(t for t in tools if t.name == "search_corpus")
         self.assertEqual(search_tool.inputSchema.get("required", []), ["query"])
+
+        # list_relationships must be advertised by the scoped endpoint and,
+        # since corpus_slug is bound from the URL, expose no required params.
+        self.assertIn("list_relationships", tool_names)
+        rels_tool = next(t for t in tools if t.name == "list_relationships")
+        self.assertEqual(rels_tool.inputSchema.get("required", []), [])
 
         # The scoped create_thread_message variant must drop ``corpus_slug``
         # from required (auto-injected from the URL) and expose the content
@@ -6653,6 +6716,107 @@ class MCPToolsRelationshipsTest(TestCase):
         self.assertGreaterEqual(result["total_count"], 1)
         result_none = list_relationships(self.corpus.slug, label_text="nonexistent")
         self.assertEqual(result_none["total_count"], 0)
+
+
+class MCPListRelationshipsStructuralSetTest(TestCase):
+    """Corpus-wide list_relationships includes structural-set relationships (#1862).
+
+    Exercises the ``Q(structural=True, structural_set_id__in=set_ids)`` branch in
+    ``RelationshipService.get_corpus_relationships`` — a structural relationship
+    has ``document=NULL`` / ``corpus=NULL`` and is reachable only via the
+    structural set shared by the corpus's documents. Without this test the branch
+    (and the existence of ``Relationship.structural_set``) is unverified in CI.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        from opencontractserver.annotations.models import (
+            Annotation,
+            AnnotationLabel,
+            Relationship,
+            StructuralAnnotationSet,
+        )
+        from opencontractserver.documents.models import Document, DocumentPath
+
+        cls.owner = User.objects.create_user(
+            username="structrelowner", email="structrel@test.com", password="pw123456"
+        )
+        cls.corpus = Corpus.objects.create(
+            title="Struct Rel Corpus", creator=cls.owner, is_public=True
+        )
+        cls.struct_set = StructuralAnnotationSet.objects.create(
+            content_hash="structrel-hash-1",
+            creator=cls.owner,
+            is_public=True,
+        )
+        cls.document = Document.objects.create(
+            title="Struct Rel Doc",
+            creator=cls.owner,
+            is_public=True,
+            page_count=2,
+            structural_annotation_set=cls.struct_set,
+        )
+        DocumentPath.objects.create(
+            document=cls.document,
+            corpus=cls.corpus,
+            path="/structrel.pdf",
+            version_number=1,
+            is_current=True,
+            is_deleted=False,
+            creator=cls.owner,
+        )
+        cls.src = Annotation.objects.create(
+            page=0,
+            raw_text="Header",
+            document=cls.document,
+            corpus=cls.corpus,
+            creator=cls.owner,
+            is_public=True,
+            structural=True,
+        )
+        cls.tgt = Annotation.objects.create(
+            page=0,
+            raw_text="Body",
+            document=cls.document,
+            corpus=cls.corpus,
+            creator=cls.owner,
+            is_public=True,
+            structural=True,
+        )
+        cls.rel_label = AnnotationLabel.objects.create(
+            text="contains",
+            label_type="RELATIONSHIP_LABEL",
+            creator=cls.owner,
+            is_public=True,
+        )
+        # Structural relationship: document/corpus NULL, linked via structural_set
+        # (satisfies the document-XOR-structural_set model constraint).
+        cls.rel = Relationship.objects.create(
+            relationship_label=cls.rel_label,
+            document=None,
+            corpus=None,
+            structural_set=cls.struct_set,
+            creator=cls.owner,
+            is_public=True,
+            structural=True,
+        )
+        cls.rel.source_annotations.add(cls.src)
+        cls.rel.target_annotations.add(cls.tgt)
+
+    def test_corpus_wide_includes_structural_set_relationship(self):
+        from opencontractserver.mcp.tools import list_relationships
+
+        result = list_relationships(self.corpus.slug, structural=True)
+        self.assertEqual(result["total_count"], 1)
+        rel = result["relationships"][0]
+        self.assertEqual(rel["label"], "contains")
+        self.assertTrue(rel["structural"])
+
+    def test_human_only_filter_excludes_structural_set_relationship(self):
+        from opencontractserver.mcp.tools import list_relationships
+
+        result = list_relationships(self.corpus.slug, structural=False)
+        self.assertEqual(result["total_count"], 0)
 
 
 class MCPGetCorpusInfoLabelsTest(TestCase):

--- a/opencontractserver/mcp/tests/test_mcp.py
+++ b/opencontractserver/mcp/tests/test_mcp.py
@@ -883,14 +883,38 @@ class MCPToolsSearchTest(TestCase):
             creator=cls.owner,
         )
 
-    def test_search_corpus_text_fallback(self):
-        """Test search falls back to text search without embeddings."""
+        # Annotations: search_corpus now searches passages (annotations), not
+        # documents. Seed a human annotation whose body contains both "Contract"
+        # and a body-only term ("indemnification") absent from any title/desc,
+        # plus a structural annotation also containing "Contract".
+        from opencontractserver.annotations.models import Annotation
+
+        cls.human_ann = Annotation.objects.create(
+            page=0,
+            raw_text="This Contract contains indemnification clauses.",
+            document=cls.doc1,
+            corpus=cls.corpus,
+            creator=cls.owner,
+            is_public=True,
+            structural=False,
+        )
+        cls.structural_ann = Annotation.objects.create(
+            page=1,
+            raw_text="Contract structural block header",
+            document=cls.doc1,
+            corpus=cls.corpus,
+            creator=cls.owner,
+            is_public=True,
+            structural=True,
+        )
+
+    def test_search_corpus_text_fallback_returns_passages(self):
+        """Empty/absent vector falls through to passage text search (issue #1858)."""
         from unittest.mock import patch
 
         from opencontractserver.mcp.tools import search_corpus
 
-        # Mock embed_text to raise RuntimeError, forcing text search fallback
-        # (RuntimeError is explicitly caught by search_corpus to trigger fallback)
+        # Mock embed_text to raise RuntimeError -> no vector -> text fallback.
         with patch.object(
             self.corpus.__class__,
             "embed_text",
@@ -898,34 +922,88 @@ class MCPToolsSearchTest(TestCase):
         ):
             result = search_corpus(self.corpus.slug, "Contract")
 
-        self.assertIn("query", result)
-        self.assertIn("results", result)
         self.assertEqual(result["query"], "Contract")
+        self.assertGreaterEqual(len(result["results"]), 1)
+        self.assertTrue(all(r["type"] == "passage" for r in result["results"]))
+        self.assertTrue(all("structural" in r for r in result["results"]))
+        self.assertTrue(all(r["similarity_score"] is None for r in result["results"]))
 
-        # Should find the document with "Contract" in title
-        self.assertTrue(len(result["results"]) >= 1)
-        self.assertEqual(result["results"][0]["title"], "Contract Agreement")
+    def test_search_corpus_text_fallback_searches_body(self):
+        """Fallback searches annotation body, not just title/description."""
+        from unittest.mock import patch
+
+        from opencontractserver.mcp.tools import search_corpus
+
+        with patch.object(
+            self.corpus.__class__, "embed_text", side_effect=RuntimeError("x")
+        ):
+            result = search_corpus(self.corpus.slug, "indemnification")
+
+        self.assertGreaterEqual(len(result["results"]), 1)
+        self.assertIn("indemnification", result["results"][0]["text"].lower())
+
+    def test_search_corpus_granularity_passage_only(self):
+        """granularity='passage' yields only passage hits."""
+        from unittest.mock import patch
+
+        from opencontractserver.mcp.tools import search_corpus
+
+        with patch.object(
+            self.corpus.__class__, "embed_text", side_effect=RuntimeError("x")
+        ):
+            result = search_corpus(self.corpus.slug, "Contract", granularity="passage")
+
+        self.assertTrue(all(r["type"] == "passage" for r in result["results"]))
+
+    def test_search_corpus_structural_false_excludes_structural(self):
+        """structural=False excludes structural passages from the feed."""
+        from unittest.mock import patch
+
+        from opencontractserver.mcp.tools import search_corpus
+
+        with patch.object(
+            self.corpus.__class__, "embed_text", side_effect=RuntimeError("x")
+        ):
+            result = search_corpus(self.corpus.slug, "Contract", structural=False)
+
+        self.assertGreaterEqual(len(result["results"]), 1)
+        self.assertTrue(all(r["structural"] is False for r in result["results"]))
 
     def test_search_corpus_limit(self):
         """Test search respects limit."""
+        from unittest.mock import patch
+
         from opencontractserver.mcp.tools import search_corpus
 
-        result = search_corpus(self.corpus.slug, "test", limit=1)
+        with patch.object(
+            self.corpus.__class__, "embed_text", side_effect=RuntimeError("x")
+        ):
+            result = search_corpus(self.corpus.slug, "Contract", limit=1)
 
         self.assertLessEqual(len(result["results"]), 1)
 
-    def test_text_search_fallback_directly(self):
-        """Test the text search fallback function directly."""
-        from django.contrib.auth.models import AnonymousUser
+    def test_format_search_block_shape(self):
+        """format_search_block shapes a RelationshipVectorSearchResult."""
+        from opencontractserver.llms.vector_stores.core_relationship_vector_store import (  # noqa: E501
+            RelationshipVectorSearchResult,
+        )
+        from opencontractserver.mcp.formatters import format_search_block
 
-        from opencontractserver.mcp.tools import _text_search_fallback
-
-        anonymous = AnonymousUser()
-        result = _text_search_fallback(self.corpus, "Contract", 10, anonymous)
-
-        self.assertIn("query", result)
-        self.assertEqual(result["query"], "Contract")
-        self.assertTrue(len(result["results"]) >= 1)
+        fake = RelationshipVectorSearchResult(
+            relationship=None,
+            similarity_score=0.77,
+            source_annotation_id=self.human_ann.id,
+            target_annotation_ids=[self.structural_ann.id],
+            block_text="aggregated block text",
+            label_text="OC_SUBTREE_GROUP",
+            document_id=self.doc1.id,
+        )
+        out = format_search_block(fake)
+        self.assertEqual(out["type"], "block")
+        self.assertEqual(out["document_slug"], self.doc1.slug)
+        self.assertEqual(out["label"], "OC_SUBTREE_GROUP")
+        self.assertEqual(out["member_count"], 2)
+        self.assertEqual(out["similarity_score"], 0.77)
 
 
 class MCPToolsThreadsTest(TestCase):
@@ -1484,7 +1562,10 @@ class MCPFormattersExtendedTest(TestCase):
         self.assertEqual(result["raw_text"], "Formatter annotation text")
         self.assertTrue(result["structural"])
         self.assertEqual(result["annotation_label"]["text"], "Formatter Label")
-        self.assertEqual(result["annotation_label"]["color"], "#DDEEFF")
+        self.assertIn("label_type", result["annotation_label"])
+        # Lean payload (#1859): color/created dropped to cut AI token cost.
+        self.assertNotIn("color", result["annotation_label"])
+        self.assertNotIn("created", result)
 
     def test_format_annotation_without_label(self):
         """Test annotation formatting without label."""
@@ -4553,7 +4634,12 @@ class MCPScopedToolsWithLabelSetTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         """Create test data with label set."""
-        from opencontractserver.annotations.models import AnnotationLabel, LabelSet
+        from opencontractserver.annotations.models import (
+            Annotation,
+            AnnotationLabel,
+            LabelSet,
+        )
+        from opencontractserver.documents.models import Document, DocumentPath
 
         cls.owner = User.objects.create_user(
             username="scopedlabelowner",
@@ -4596,6 +4682,31 @@ class MCPScopedToolsWithLabelSetTest(TestCase):
             label_set=cls.label_set,
             allow_comments=True,
         )
+
+        # get_corpus_info now surfaces only labels actually used on the corpus's
+        # annotations (#1861), so seed one annotation per label to keep both in use.
+        cls.document = Document.objects.create(
+            title="Labelled Doc", creator=cls.owner, is_public=True, page_count=1
+        )
+        DocumentPath.objects.create(
+            document=cls.document,
+            corpus=cls.corpus,
+            path="/labelled.pdf",
+            version_number=1,
+            is_current=True,
+            is_deleted=False,
+            creator=cls.owner,
+        )
+        for lbl in (cls.label1, cls.label2):
+            Annotation.objects.create(
+                page=0,
+                raw_text=f"uses {lbl.text}",
+                annotation_label=lbl,
+                document=cls.document,
+                corpus=cls.corpus,
+                creator=cls.owner,
+                is_public=True,
+            )
 
     def test_get_corpus_info_with_label_set(self):
         """Test get_corpus_info returns label set data."""
@@ -6342,3 +6453,288 @@ class MCPExtractBearerTokenTest(TestCase):
             "headers": [(b"authorization", b"Bearer   eyJabc  ")],
         }
         self.assertEqual(_extract_bearer_token(scope), "eyJabc")
+
+
+class MCPToolsAnnotationsSearchTest(TestCase):
+    """Tests for list_annotations content search / structural filter / ordering (#1859)."""
+
+    @classmethod
+    def setUpTestData(cls):
+        from opencontractserver.annotations.models import Annotation, AnnotationLabel
+        from opencontractserver.documents.models import Document, DocumentPath
+
+        cls.owner = User.objects.create_user(
+            username="annsearchowner", email="annsearch@test.com", password="pw123456"
+        )
+        cls.corpus = Corpus.objects.create(
+            title="Ann Search Corpus", creator=cls.owner, is_public=True
+        )
+        cls.document = Document.objects.create(
+            title="Searchable Doc", creator=cls.owner, is_public=True, page_count=3
+        )
+        DocumentPath.objects.create(
+            document=cls.document,
+            corpus=cls.corpus,
+            path="/searchable.pdf",
+            version_number=1,
+            is_current=True,
+            is_deleted=False,
+            creator=cls.owner,
+        )
+        cls.label = AnnotationLabel.objects.create(
+            text="Body",
+            color="#123456",
+            label_type="TOKEN_LABEL",
+            creator=cls.owner,
+            is_public=True,
+        )
+        # page 2 (human), page 0 (human), page 1 (structural) — out of order on
+        # purpose so the ordering test is meaningful.
+        cls.a_p2 = Annotation.objects.create(
+            page=2,
+            raw_text="The termination clause governs indemnification.",
+            annotation_label=cls.label,
+            document=cls.document,
+            corpus=cls.corpus,
+            creator=cls.owner,
+            is_public=True,
+            structural=False,
+        )
+        cls.a_p0 = Annotation.objects.create(
+            page=0,
+            raw_text="Opening recital text.",
+            annotation_label=cls.label,
+            document=cls.document,
+            corpus=cls.corpus,
+            creator=cls.owner,
+            is_public=True,
+            structural=False,
+        )
+        cls.a_p1_struct = Annotation.objects.create(
+            page=1,
+            raw_text="Structural heading about indemnification.",
+            annotation_label=cls.label,
+            document=cls.document,
+            corpus=cls.corpus,
+            creator=cls.owner,
+            is_public=True,
+            structural=True,
+        )
+
+    def test_text_contains_filters_by_body(self):
+        from opencontractserver.mcp.tools import list_annotations
+
+        result = list_annotations(
+            self.corpus.slug, self.document.slug, text_contains="indemnification"
+        )
+        self.assertGreaterEqual(result["total_count"], 2)
+        self.assertTrue(
+            all(
+                "indemnification" in a["raw_text"].lower()
+                for a in result["annotations"]
+            )
+        )
+
+    def test_structural_filter_excludes_human(self):
+        from opencontractserver.mcp.tools import list_annotations
+
+        result = list_annotations(self.corpus.slug, self.document.slug, structural=True)
+        self.assertTrue(all(a["structural"] is True for a in result["annotations"]))
+        self.assertEqual(result["total_count"], 1)
+
+    def test_results_ordered_by_page(self):
+        from opencontractserver.mcp.tools import list_annotations
+
+        result = list_annotations(self.corpus.slug, self.document.slug, limit=100)
+        pages = [a["page"] for a in result["annotations"]]
+        self.assertEqual(pages, sorted(pages))
+
+    def test_payload_is_lean(self):
+        from opencontractserver.mcp.tools import list_annotations
+
+        result = list_annotations(self.corpus.slug, self.document.slug, limit=1)
+        ann = result["annotations"][0]
+        self.assertNotIn("color", ann)
+        self.assertNotIn("created", ann)
+        self.assertIn("structural", ann)
+
+
+class MCPToolsRelationshipsTest(TestCase):
+    """Tests for the list_relationships tool (#1862)."""
+
+    @classmethod
+    def setUpTestData(cls):
+        from opencontractserver.annotations.models import (
+            Annotation,
+            AnnotationLabel,
+            Relationship,
+        )
+        from opencontractserver.documents.models import Document, DocumentPath
+
+        cls.owner = User.objects.create_user(
+            username="relowner", email="rel@test.com", password="pw123456"
+        )
+        cls.corpus = Corpus.objects.create(
+            title="Rel Corpus", creator=cls.owner, is_public=True
+        )
+        cls.document = Document.objects.create(
+            title="Rel Doc", creator=cls.owner, is_public=True, page_count=2
+        )
+        DocumentPath.objects.create(
+            document=cls.document,
+            corpus=cls.corpus,
+            path="/rel.pdf",
+            version_number=1,
+            is_current=True,
+            is_deleted=False,
+            creator=cls.owner,
+        )
+        cls.src = Annotation.objects.create(
+            page=0,
+            raw_text="See section 2.",
+            document=cls.document,
+            corpus=cls.corpus,
+            creator=cls.owner,
+            is_public=True,
+        )
+        cls.tgt = Annotation.objects.create(
+            page=1,
+            raw_text="Section 2 body.",
+            document=cls.document,
+            corpus=cls.corpus,
+            creator=cls.owner,
+            is_public=True,
+        )
+        cls.rel_label = AnnotationLabel.objects.create(
+            text="cross-reference",
+            label_type="RELATIONSHIP_LABEL",
+            creator=cls.owner,
+            is_public=True,
+        )
+        cls.rel = Relationship.objects.create(
+            relationship_label=cls.rel_label,
+            document=cls.document,
+            corpus=cls.corpus,
+            creator=cls.owner,
+            is_public=True,
+            structural=False,
+        )
+        cls.rel.source_annotations.add(cls.src)
+        cls.rel.target_annotations.add(cls.tgt)
+
+    def test_list_relationships_document_scoped(self):
+        from opencontractserver.mcp.tools import list_relationships
+
+        result = list_relationships(self.corpus.slug, self.document.slug)
+        self.assertGreaterEqual(result["total_count"], 1)
+        rel = result["relationships"][0]
+        self.assertEqual(rel["label"], "cross-reference")
+        self.assertEqual(rel["structural"], False)
+        self.assertTrue(rel["source"] and rel["target"])
+        self.assertEqual(rel["source"][0]["annotation_id"], str(self.src.id))
+
+    def test_list_relationships_corpus_wide(self):
+        from opencontractserver.mcp.tools import list_relationships
+
+        result = list_relationships(self.corpus.slug)  # no document_slug
+        self.assertGreaterEqual(result["total_count"], 1)
+
+    def test_list_relationships_structural_filter_excludes_human(self):
+        from opencontractserver.mcp.tools import list_relationships
+
+        result = list_relationships(self.corpus.slug, structural=True)
+        self.assertTrue(all(r["structural"] is True for r in result["relationships"]))
+        self.assertEqual(result["total_count"], 0)
+
+    def test_list_relationships_label_filter(self):
+        from opencontractserver.mcp.tools import list_relationships
+
+        result = list_relationships(self.corpus.slug, label_text="cross-reference")
+        self.assertGreaterEqual(result["total_count"], 1)
+        result_none = list_relationships(self.corpus.slug, label_text="nonexistent")
+        self.assertEqual(result_none["total_count"], 0)
+
+
+class MCPGetCorpusInfoLabelsTest(TestCase):
+    """get_corpus_info surfaces only labels actually used on annotations (#1861)."""
+
+    @classmethod
+    def setUpTestData(cls):
+        from opencontractserver.annotations.models import (
+            Annotation,
+            AnnotationLabel,
+            LabelSet,
+        )
+        from opencontractserver.documents.models import Document, DocumentPath
+
+        cls.owner = User.objects.create_user(
+            username="labelsowner", email="labels@test.com", password="pw123456"
+        )
+        cls.label_set = LabelSet.objects.create(title="Mixed Labels", creator=cls.owner)
+        cls.used_label = AnnotationLabel.objects.create(
+            text="UsedLabel",
+            label_type="TOKEN_LABEL",
+            creator=cls.owner,
+            is_public=True,
+        )
+        cls.unused_label = AnnotationLabel.objects.create(
+            text="UnusedLabel",
+            label_type="TOKEN_LABEL",
+            creator=cls.owner,
+            is_public=True,
+        )
+        cls.label_set.annotation_labels.add(cls.used_label, cls.unused_label)
+        cls.corpus = Corpus.objects.create(
+            title="Labels Corpus",
+            creator=cls.owner,
+            is_public=True,
+            label_set=cls.label_set,
+        )
+        cls.document = Document.objects.create(
+            title="Doc", creator=cls.owner, is_public=True, page_count=1
+        )
+        DocumentPath.objects.create(
+            document=cls.document,
+            corpus=cls.corpus,
+            path="/d.pdf",
+            version_number=1,
+            is_current=True,
+            is_deleted=False,
+            creator=cls.owner,
+        )
+        Annotation.objects.create(
+            page=0,
+            raw_text="x",
+            annotation_label=cls.used_label,
+            document=cls.document,
+            corpus=cls.corpus,
+            creator=cls.owner,
+            is_public=True,
+        )
+
+    def test_only_used_labels_surface(self):
+        from opencontractserver.mcp.tools import get_corpus_info
+
+        out = get_corpus_info(self.corpus.slug)
+        self.assertIsNotNone(out["label_set"])
+        texts = {label["text"] for label in out["label_set"]["labels"]}
+        self.assertIn("UsedLabel", texts)
+        self.assertNotIn("UnusedLabel", texts)
+
+
+class MCPErrorFormattingTest(TestCase):
+    """Not-found errors are humanized with remediation hints (#1861)."""
+
+    def test_document_does_not_exist_message(self):
+        from opencontractserver.documents.models import Document
+        from opencontractserver.mcp.server import _format_tool_error_text
+
+        msg = _format_tool_error_text(Document.DoesNotExist())
+        self.assertIn("list_documents", msg)
+        self.assertNotIn("matching query", msg)
+
+    def test_corpus_does_not_exist_message(self):
+        from opencontractserver.mcp.server import _format_tool_error_text
+
+        msg = _format_tool_error_text(Corpus.DoesNotExist())
+        self.assertIn("list_public_corpuses", msg)

--- a/opencontractserver/mcp/tools.py
+++ b/opencontractserver/mcp/tools.py
@@ -26,7 +26,6 @@ from .formatters import (
 )
 
 if TYPE_CHECKING:
-    from opencontractserver.corpuses.models import Corpus
     from opencontractserver.users.types import UserOrAnonymous
 
 logger = logging.getLogger(__name__)
@@ -120,18 +119,37 @@ def list_documents(
 
 
 def get_document_text(
-    corpus_slug: str, document_slug: str, user: UserOrAnonymous | None = None
+    corpus_slug: str,
+    document_slug: str,
+    char_offset: int = 0,
+    max_chars: int | None = None,
+    user: UserOrAnonymous | None = None,
 ) -> dict:
     """
-    Retrieve full extracted text from a document.
+    Retrieve extracted document text in bounded slices.
+
+    Returns a window of the flat extracted text starting at ``char_offset``.
+    Use ``next_offset`` from the response to page through a long document
+    rather than pulling the whole thing in one (token-blowing) call. For
+    page-targeted reads, use ``search_corpus`` (returns ``page``) and
+    ``list_annotations(page=N)`` instead.
 
     Args:
         corpus_slug: Corpus identifier
         document_slug: Document identifier
+        char_offset: Start offset into the extracted text (default 0)
+        max_chars: Window size in characters (default
+            ``MCP_DOCUMENT_TEXT_DEFAULT_CHARS``, hard-capped at
+            ``MCP_DOCUMENT_TEXT_MAX_CHARS``)
 
     Returns:
-        Dict with document slug, page count, and full text
+        Dict with slug, page_count, total_chars, char_offset, text,
+        next_offset (None when the window reaches the end) and truncated.
     """
+    from opencontractserver.constants.mcp import (
+        MCP_DOCUMENT_TEXT_DEFAULT_CHARS,
+        MCP_DOCUMENT_TEXT_MAX_CHARS,
+    )
     from opencontractserver.corpuses.models import Corpus
     from opencontractserver.corpuses.services import CorpusDocumentService
 
@@ -158,10 +176,22 @@ def get_document_text(
         except Exception:
             full_text = ""
 
+    total = len(full_text)
+    char_offset = max(0, int(char_offset))
+    window = MCP_DOCUMENT_TEXT_DEFAULT_CHARS if max_chars is None else int(max_chars)
+    window = max(0, min(window, MCP_DOCUMENT_TEXT_MAX_CHARS))
+    end = char_offset + window
+    text = full_text[char_offset:end]
+    next_offset = end if end < total else None
+
     return {
         "document_slug": document.slug,
         "page_count": document.page_count or 0,
-        "text": full_text,
+        "total_chars": total,
+        "char_offset": char_offset,
+        "text": text,
+        "next_offset": next_offset,
+        "truncated": next_offset is not None,
     }
 
 
@@ -170,23 +200,28 @@ def list_annotations(
     document_slug: str,
     page: int | None = None,
     label_text: str | None = None,
+    text_contains: str | None = None,
+    structural: bool | None = None,
     limit: int = 100,
     offset: int = 0,
     user: UserOrAnonymous | None = None,
 ) -> dict:
     """
-    List annotations on a document with optional filtering.
+    List / search annotations on a document with optional filtering.
 
     Args:
         corpus_slug: Corpus identifier
         document_slug: Document identifier
         page: Optional page number filter
-        label_text: Optional label text filter
+        label_text: Optional exact label-text filter
+        text_contains: Optional case-insensitive substring filter on annotation text
+        structural: Optional kind filter — None=both, True=structural only,
+            False=human/analysis only
         limit: Number of results (max 100)
         offset: Pagination offset
 
     Returns:
-        Dict with total_count and list of annotations
+        Dict with total_count and list of annotations (ordered by page)
     """
     from opencontractserver.annotations.services import AnnotationService
     from opencontractserver.corpuses.models import Corpus
@@ -212,6 +247,15 @@ def list_annotations(
     if label_text:
         qs = qs.filter(annotation_label__text=label_text)
 
+    if text_contains:
+        qs = qs.filter(raw_text__icontains=text_contains)
+
+    if structural is not None:
+        qs = qs.filter(structural=structural)
+
+    # Stable reading order so an AI can reassemble document flow.
+    qs = qs.order_by("page", "id")
+
     total_count = qs.count()
     annotations = list(qs.select_related("annotation_label")[offset : offset + limit])
 
@@ -221,94 +265,181 @@ def list_annotations(
     }
 
 
-def search_corpus(
-    corpus_slug: str, query: str, limit: int = 10, user: UserOrAnonymous | None = None
+def list_relationships(
+    corpus_slug: str,
+    document_slug: str | None = None,
+    structural: bool | None = None,
+    label_text: str | None = None,
+    limit: int = 50,
+    offset: int = 0,
+    user: UserOrAnonymous | None = None,
 ) -> dict:
     """
-    Semantic search within a corpus using vector embeddings.
+    List labeled source->target relationships in the corpus (or one document).
 
-    Falls back to text search if embeddings are unavailable.
+    Relationships connect annotations (e.g. parent/child, cross-references,
+    human- or analysis-drawn edges) and are used to aggregate related content.
+
+    Args:
+        corpus_slug: Corpus identifier
+        document_slug: Optional document filter (corpus-wide when omitted)
+        structural: Optional kind filter — None=both, True=structural only,
+            False=human/analysis only
+        label_text: Optional exact relationship-label filter
+        limit: Number of results (max 100)
+        offset: Pagination offset
+
+    Returns:
+        Dict with total_count and list of relationships (source/target edges)
+    """
+    from opencontractserver.annotations.services.relationship_service import (
+        RelationshipService,
+    )
+    from opencontractserver.corpuses.models import Corpus
+    from opencontractserver.corpuses.services import CorpusDocumentService
+
+    from .formatters import format_relationship
+
+    limit = min(limit, 100)
+    user = user or AnonymousUser()
+    corpus = Corpus.objects.visible_to_user(user).get(slug=corpus_slug)
+
+    if document_slug:
+        document = CorpusDocumentService.get_corpus_document_by_slug(
+            user=user, corpus=corpus, slug=document_slug
+        )
+        qs = RelationshipService.get_document_relationships(
+            document_id=document.id,
+            user=user,
+            corpus_id=corpus.id,
+            structural=structural,
+        )
+    else:
+        qs = RelationshipService.get_corpus_relationships(
+            corpus_id=corpus.id, user=user, structural=structural
+        )
+
+    if label_text:
+        qs = qs.filter(relationship_label__text=label_text)
+
+    qs = (
+        qs.select_related("relationship_label")
+        .prefetch_related("source_annotations", "target_annotations")
+        .order_by("id")
+    )
+
+    total_count = qs.count()
+    relationships = list(qs[offset : offset + limit])
+
+    return {
+        "total_count": total_count,
+        "relationships": [format_relationship(r) for r in relationships],
+    }
+
+
+def search_corpus(
+    corpus_slug: str,
+    query: str,
+    limit: int = 10,
+    granularity: str = "both",
+    structural: bool | None = None,
+    user: UserOrAnonymous | None = None,
+) -> dict:
+    """
+    Search a corpus and return a single ranked feed of passages and blocks.
+
+    - ``passage`` hits are annotations (semantic via embeddings, with a text
+      fallback when the vector path is empty/absent/errors).
+    - ``block`` hits are ``OC_SUBTREE_GROUP`` relationships (an ancestor plus
+      its full descendant subtree) — the embedded aggregation unit — via
+      ``CoreRelationshipVectorStore``. Blocks are vector-only (no text fallback).
 
     Args:
         corpus_slug: Corpus identifier
         query: Search query text
         limit: Number of results (max 50)
+        granularity: "passage" | "block" | "both" (default "both")
+        structural: Passage filter — None=both, True=structural only,
+            False=human/analysis only
 
     Returns:
-        Dict with query and ranked results
+        Dict with query and a ranked ``results`` list, each tagged ``type``.
     """
+    from opencontractserver.annotations.services import AnnotationService
     from opencontractserver.corpuses.models import Corpus
-    from opencontractserver.corpuses.services import CorpusDocumentService
+
+    from .formatters import format_search_block, format_search_passage
 
     limit = min(limit, 50)
     user = user or AnonymousUser()
     corpus = Corpus.objects.visible_to_user(user).get(slug=corpus_slug)
 
-    # Try to use vector search
+    embedder_path: str | None = None
+    query_vector: list[float] | None = None
     try:
-        # embed_text() returns (embedder_path, query_vector) tuple
+        # embed_text() returns (embedder_path, query_vector) tuple.
         embedder_path, query_vector = corpus.embed_text(query)
+    except (ValueError, TypeError, AttributeError, RuntimeError):
+        embedder_path, query_vector = None, None
 
+    formatted: list[dict] = []
+
+    # --- passage half (annotations) ---
+    if granularity in ("passage", "both"):
+        ann_qs = AnnotationService.get_corpus_annotations(
+            corpus.id, user, structural=structural
+        ).select_related("document", "annotation_label")
+        passages: list = []
         if query_vector:
-            # Single canonical entry point: corpus-as-gate doc set for this user.
-            doc_results = list(
-                CorpusDocumentService.get_corpus_documents(
-                    user=user, corpus=corpus
-                ).search_by_embedding(  # type: ignore[attr-defined]
-                    query_vector, embedder_path, top_k=limit
+            try:
+                passages = list(
+                    ann_qs.search_by_embedding(  # type: ignore[attr-defined]
+                        query_vector, embedder_path, top_k=limit
+                    )
                 )
-            )
-
-            results = []
-            for doc in doc_results:
-                results.append(
-                    {
-                        "type": "document",
-                        "slug": doc.slug,
-                        "title": doc.title or "",
-                        "similarity_score": float(getattr(doc, "similarity_score", 0)),
-                    }
-                )
-
-            return {"query": query, "results": results}
-    except (ValueError, TypeError, AttributeError):
-        # Expected when embeddings are not configured or embed_text returns invalid data
-        pass
-    except RuntimeError as e:
-        # Embedding service or model loading errors
-        import logging
-
-        logging.getLogger(__name__).debug(f"Vector search unavailable: {e}")
-
-    # Fallback to text search
-    return _text_search_fallback(corpus, query, limit, user)
-
-
-def _text_search_fallback(
-    corpus: Corpus, query: str, limit: int, user: UserOrAnonymous
-) -> dict:
-    """Fallback to text search when embeddings are unavailable."""
-    from opencontractserver.corpuses.services import CorpusDocumentService
-
-    # Single canonical entry point: corpus-as-gate doc set for this user.
-    documents = list(
-        CorpusDocumentService.get_corpus_documents(user=user, corpus=corpus).filter(
-            Q(title__icontains=query) | Q(description__icontains=query)
-        )[:limit]
-    )
-
-    results = []
-    for doc in documents:
-        results.append(
-            {
-                "type": "document",
-                "slug": doc.slug,
-                "title": doc.title or "",
-                "similarity_score": None,
-            }
+            except (ValueError, TypeError, AttributeError, RuntimeError):
+                passages = []
+        if not passages:
+            # Fall through to text search whenever the vector path yields
+            # nothing — fixing the prior "return on empty vector" dead-fallback.
+            passages = list(ann_qs.filter(raw_text__icontains=query)[:limit])
+        formatted.extend(
+            format_search_passage(a, getattr(a, "similarity_score", None))
+            for a in passages
         )
 
-    return {"query": query, "results": results}
+    # --- block half (subtree-group relationships, vector-only) ---
+    if granularity in ("block", "both") and query_vector:
+        from opencontractserver.llms.vector_stores.core_relationship_vector_store import (  # noqa: E501
+            CoreRelationshipVectorStore,
+            RelationshipVectorSearchQuery,
+        )
+
+        try:
+            store = CoreRelationshipVectorStore(
+                user_id=getattr(user, "pk", None),
+                corpus_id=corpus.id,
+                embedder_path=embedder_path,
+                embed_dim=len(query_vector),
+            )
+            blocks = store.search(
+                RelationshipVectorSearchQuery(
+                    query_embedding=query_vector, similarity_top_k=limit
+                )
+            )
+            formatted.extend(format_search_block(b) for b in blocks)
+        except (ValueError, TypeError, AttributeError, RuntimeError):
+            pass
+
+    # Merge by score; text-fallback passages (score None) sort last; cap at limit.
+    formatted.sort(
+        key=lambda r: (
+            r["similarity_score"] is not None,
+            r["similarity_score"] or 0.0,
+        ),
+        reverse=True,
+    )
+    return {"query": query, "results": formatted[:limit]}
 
 
 def list_threads(
@@ -571,6 +702,7 @@ def get_corpus_info(corpus_slug: str, user: UserOrAnonymous | None = None) -> di
     Returns:
         Dict with detailed corpus information including label set
     """
+    from opencontractserver.annotations.services import AnnotationService
     from opencontractserver.corpuses.models import Corpus
 
     user = user or AnonymousUser()
@@ -583,12 +715,23 @@ def get_corpus_info(corpus_slug: str, user: UserOrAnonymous | None = None) -> di
         .get(slug=corpus_slug)
     )
 
-    # Get label set info if available
+    # Get label set info if available. Only surface labels that are ACTUALLY
+    # used on this corpus's annotations — the seeded "Default Labels" set
+    # otherwise advertises dozens of irrelevant labels and misleads an AI
+    # about what the `label_text` filter can match.
     label_set_data = None
     if corpus.label_set:
+        used_label_ids = set(
+            AnnotationService.get_corpus_annotations(corpus.id, user)
+            .exclude(annotation_label__isnull=True)
+            .values_list("annotation_label_id", flat=True)
+            .distinct()
+        )
         labels = []
         # annotation_labels is already prefetched, slicing in Python to avoid new query
-        for label in list(corpus.label_set.annotation_labels.all())[:50]:
+        for label in corpus.label_set.annotation_labels.all():
+            if label.id not in used_label_ids:
+                continue
             labels.append(
                 {
                     "text": label.text,
@@ -597,6 +740,8 @@ def get_corpus_info(corpus_slug: str, user: UserOrAnonymous | None = None) -> di
                     "description": label.description or "",
                 }
             )
+            if len(labels) >= 50:
+                break
         label_set_data = {
             "title": corpus.label_set.title or "",
             "description": corpus.label_set.description or "",
@@ -663,6 +808,9 @@ def get_scoped_tool_handlers(corpus_slug: str) -> dict[str, Callable[..., Any]]:
         "list_documents": create_scoped_tool_wrapper(list_documents, corpus_slug),
         "get_document_text": create_scoped_tool_wrapper(get_document_text, corpus_slug),
         "list_annotations": create_scoped_tool_wrapper(list_annotations, corpus_slug),
+        "list_relationships": create_scoped_tool_wrapper(
+            list_relationships, corpus_slug
+        ),
         "search_corpus": create_scoped_tool_wrapper(search_corpus, corpus_slug),
         "list_threads": create_scoped_tool_wrapper(list_threads, corpus_slug),
         "get_thread_messages": create_scoped_tool_wrapper(

--- a/opencontractserver/mcp/tools.py
+++ b/opencontractserver/mcp/tools.py
@@ -8,7 +8,7 @@ Supports both global mode (all public corpuses) and corpus-scoped mode
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any, Callable, Literal
 
 from django.contrib.auth.models import AnonymousUser
 from django.db.models import Count, Q
@@ -341,7 +341,7 @@ def search_corpus(
     corpus_slug: str,
     query: str,
     limit: int = 10,
-    granularity: str = "both",
+    granularity: Literal["passage", "block", "both"] = "both",
     structural: bool | None = None,
     user: UserOrAnonymous | None = None,
 ) -> dict:
@@ -367,6 +367,7 @@ def search_corpus(
     """
     from opencontractserver.annotations.services import AnnotationService
     from opencontractserver.corpuses.models import Corpus
+    from opencontractserver.documents.models import Document
 
     from .formatters import format_search_block, format_search_passage
 
@@ -427,7 +428,16 @@ def search_corpus(
                     query_embedding=query_vector, similarity_top_k=limit
                 )
             )
-            formatted.extend(format_search_block(b) for b in blocks)
+            # Bulk-fetch block document slugs/titles in one query to avoid a
+            # per-block Document lookup (N+1) inside the formatter.
+            block_doc_ids = {b.document_id for b in blocks if b.document_id}
+            doc_lookup = {
+                pk: (slug, title or "")
+                for pk, slug, title in Document.objects.filter(
+                    pk__in=block_doc_ids
+                ).values_list("id", "slug", "title")
+            }
+            formatted.extend(format_search_block(b, doc_lookup) for b in blocks)
         except (ValueError, TypeError, AttributeError, RuntimeError):
             pass
 
@@ -435,7 +445,7 @@ def search_corpus(
     formatted.sort(
         key=lambda r: (
             r["similarity_score"] is not None,
-            r["similarity_score"] or 0.0,
+            r["similarity_score"] if r["similarity_score"] is not None else 0.0,
         ),
         reverse=True,
     )
@@ -728,7 +738,8 @@ def get_corpus_info(corpus_slug: str, user: UserOrAnonymous | None = None) -> di
             .distinct()
         )
         labels = []
-        # annotation_labels is already prefetched, slicing in Python to avoid new query
+        # Iterate the label set's labels, keeping only those actually in use
+        # (filtered against ``used_label_ids`` above). Capped at 50.
         for label in corpus.label_set.annotation_labels.all():
             if label.id not in used_label_ids:
                 continue

--- a/opencontractserver/tests/test_mcp_extended.py
+++ b/opencontractserver/tests/test_mcp_extended.py
@@ -971,7 +971,10 @@ class TestFormatAnnotation(TestCase):
         self.assertEqual(result["raw_text"], "sample text")
         self.assertFalse(result["structural"])
         self.assertEqual(result["annotation_label"]["text"], "Important")
-        self.assertEqual(result["annotation_label"]["color"], "#FF0000")
+        self.assertEqual(result["annotation_label"]["label_type"], "TOKEN_LABEL")
+        # Lean AI-facing payload deliberately omits ``color`` (low signal,
+        # high token cost). See format_annotation docstring.
+        self.assertNotIn("color", result["annotation_label"])
 
     def test_without_label(self):
         annotation = MagicMock()
@@ -987,7 +990,8 @@ class TestFormatAnnotation(TestCase):
         self.assertEqual(result["raw_text"], "")
         self.assertTrue(result["structural"])
 
-    def test_label_without_color(self):
+    def test_label_omits_color(self):
+        """The lean payload exposes label text/type but never ``color``."""
         annotation = MagicMock()
         annotation.id = 1
         annotation.page = 1
@@ -999,7 +1003,9 @@ class TestFormatAnnotation(TestCase):
         annotation.annotation_label.label_type = "TOKEN_LABEL"
 
         result = format_annotation(annotation)
-        self.assertEqual(result["annotation_label"]["color"], "#000000")
+        self.assertEqual(result["annotation_label"]["text"], "Label")
+        self.assertEqual(result["annotation_label"]["label_type"], "TOKEN_LABEL")
+        self.assertNotIn("color", result["annotation_label"])
 
 
 class TestFormatThreadSummary(TestCase):


### PR DESCRIPTION
## Summary

Makes an OpenContracts corpus usable as a low-friction **knowledge tool** over the public MCP interface. Follows a hands-on evaluation of the live deployment (`cite.opensource.legal/mcp`) that found the three headline capabilities unusable: search returned nothing, full-text crashed on cloud storage (fixed separately by the `read_field_file_text` work already in `main`), and annotations weren't content-searchable.

Design + plan: `docs/development/2026-05-31-mcp-knowledge-tool-ux-design.md` / `-plan.md`.

## What changed (by component)

- **`search_corpus` → unified passage + block feed** (#1858, #1862). Searches **annotation** embeddings (passages) instead of document-level vectors, and merges in **`OC_SUBTREE_GROUP` relationship "blocks"** (ancestor + full descendant subtree) from `CoreRelationshipVectorStore`. Each result is tagged `type: "passage" | "block"`. New `granularity` (`passage`/`block`/`both`) and `structural` (tri-state) params. **Fixes the dead-fallback bug**: when the vector path is empty/absent/errors it now falls through to annotation text search instead of returning an empty list.
- **`list_annotations` content search** (#1859). New `text_contains` + `structural` filters; results ordered by `(page, id)`; leaner payload (`format_annotation` drops `color`/`created`, keeps the `structural` delineation flag).
- **`list_relationships` tool** (#1862). Labeled `source → target` edges via `RelationshipService`, filterable by `structural`/`label_text`, document- or corpus-scoped. Adds `RelationshipService.get_corpus_relationships`.
- **`get_document_text` bounded slicing** (#1860). New `char_offset`/`max_chars` with `next_offset`/`truncated`/`total_chars` so long docs don't blow the context window.
- **Polish** (#1861). `get_corpus_info` surfaces only labels **actually used** on the corpus's annotations; not-found errors are humanized into actionable messages (name the remediation tool) instead of leaking raw Django strings; tool descriptions sharpened; new size constants in `constants/mcp.py`.

## Design decisions

- **Single feed for search, separate tool for enumeration.** Search answers "what's relevant" (passages + aggregated blocks); `list_relationships` answers "what's connected" (explicit edges).
- **Structural is a filter + an explicit flag** on both annotation surfaces, so an AI can always distinguish layout-derived chunks from human/analysis annotations.
- **Char-based (not page-based) text slicing** — `txt_extract_file` is a flat string; page access is served by passage search (`page`) + `list_annotations(page=N)`.

## Testing

`docker compose -f test.yml run --rm django pytest opencontractserver/mcp/tests/test_mcp.py -n 4 --dist loadscope` → **211 passed**. New coverage: passage/block feed, granularity, structural filter, annotation content search, relationship enumeration (doc + corpus scope), in-use-labels, and error humanization. `pre-commit` (black/isort/flake8/mypy) clean on all changed files.

Closes #1858
Closes #1859
Closes #1860
Closes #1861
Closes #1862
