### PR TITLE
fix(migrations): decode cloud-storage bytes in canonical-CAML backfill (0054)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Canonical-CAML backfill migration `0054` crashed on cloud storage
+  (`AttributeError: 'bytes' object has no attribute 'encode'`).** Production
+  `manage.py migrate` aborted at
+  `corpuses/migrations/0054_canonical_caml_backfill.py:184`
+  (`ContentFile(body.encode("utf-8"))`). Root cause: S3Boto3Storage /
+  GoogleCloudStorage (django-storages #382) silently return `bytes` from a
+  text-mode (`"r"`) `FieldFile.read()` **without raising**, so the readers'
+  `except`-guarded binary fallbacks never fired and `bytes` flowed into the
+  `str`-only `body.encode(...)`. Invisible locally because `FileSystemStorage`
+  honors text mode and returns `str`.
+  - **Migration readers normalise to `str`** (`_read_md_description`,
+    `_read_caml_doc_body`) via a new module-local `_coerce_to_text` helper,
+    inlined to keep the historical migration self-contained. The migration is
+    atomic (rolled back cleanly on the crash) and idempotent, so a re-run after
+    this fix completes the backfill.
+  - **`description_cache.read_caml_body` had the identical latent bug** and now
+    delegates to the canonical `opencontractserver.utils.files.read_field_file_text`
+    (errors=`ignore`), removing the duplicated hand-rolled fallback. This also
+    fixes the live cache-refresh signal handler and the GraphQL
+    `descriptionRevisions` facade, which read CAML bodies on cloud deployments.
+  - Regression tests in
+    `opencontractserver/tests/test_corpus_canonical_caml_migration.py` exercise
+    both the bytes and str paths for the migration readers and `read_caml_body`.
+
 - **Research report `finalize()` now writes content and provenance atomically**
   (`opencontractserver/research/services/research_reports.py`,
   `ResearchReportService.finalize`). The terminal content/status `save()` and the

--- a/opencontractserver/corpuses/migrations/0054_canonical_caml_backfill.py
+++ b/opencontractserver/corpuses/migrations/0054_canonical_caml_backfill.py
@@ -97,6 +97,28 @@ def _compute_cache_from_caml_body(body) -> tuple[str, str]:
     return plain, _summarize_for_preview(plain)
 
 
+def _coerce_to_text(data) -> str:
+    """Normalise a ``FieldFile.read()`` result to ``str``.
+
+    Cloud storage backends (S3Boto3Storage / GoogleCloudStorage via
+    django-storages #382) silently return ``bytes`` from a text-mode
+    (``"r"``) read *without raising*, so the ``except``-guarded binary
+    fallbacks in the readers below never fire — the ``bytes`` flow
+    downstream into ``str``-only call sites such as ``body.encode("utf-8")``
+    in :func:`_create_caml_doc`, crashing the backfill on cloud deployments
+    (``AttributeError: 'bytes' object has no attribute 'encode'``). Local
+    ``FileSystemStorage`` returns ``str``, which is why this never surfaced
+    in tests.
+
+    Inlined rather than imported from
+    ``opencontractserver.utils.files.read_field_file_text`` to keep this
+    historical migration self-contained (see module docstring).
+    """
+    if isinstance(data, bytes):
+        return data.decode("utf-8", errors="ignore")
+    return data
+
+
 def _read_md_description(corpus) -> str:
     """Mirror Corpus._read_md_description_content for historical model use."""
     field = corpus.md_description
@@ -105,7 +127,7 @@ def _read_md_description(corpus) -> str:
     try:
         field.open("r")
         try:
-            return field.read()
+            return _coerce_to_text(field.read())
         finally:
             field.close()
     except Exception:
@@ -135,7 +157,7 @@ def _read_caml_doc_body(doc) -> str:
     try:
         field.open("r")
         try:
-            return field.read()
+            return _coerce_to_text(field.read())
         finally:
             field.close()
     except Exception:

--- a/opencontractserver/corpuses/services/description_cache.py
+++ b/opencontractserver/corpuses/services/description_cache.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING
 from opencontractserver.constants.truncation import (
     MAX_CORPUS_DESCRIPTION_PREVIEW_LENGTH,
 )
+from opencontractserver.utils.files import read_field_file_text
 
 if TYPE_CHECKING:
     from opencontractserver.documents.models import Document
@@ -76,9 +77,16 @@ def summarize_for_preview(plain_text: str) -> str:
 def read_caml_body(doc: Document) -> str:
     """Return the Readme.CAML body as text.
 
-    Tolerant of binary-mode storage: opens the field in text mode first,
-    then falls back to binary + utf-8 decode on any error. Returns the
-    empty string when the document has no ``txt_extract_file``.
+    Delegates to :func:`opencontractserver.utils.files.read_field_file_text`,
+    which normalises cloud storage backends (S3Boto3Storage /
+    GoogleCloudStorage via django-storages #382) that silently return
+    ``bytes`` from a text-mode read. The previous hand-rolled
+    ``except``-guarded binary fallback never fired for that path because the
+    bytes read did not raise — it only caught backends that *raise* on text
+    mode — so cloud deployments leaked ``bytes`` into
+    ``markdown_to_plain_text`` (``re`` on a bytes-like object) and the
+    GraphQL revisions facade. Returns the empty string when the document has
+    no ``txt_extract_file``.
 
     Promoted from a private helper in ``corpuses/signals.py`` so the
     GraphQL ``descriptionRevisions`` facade (which reads the
@@ -88,23 +96,12 @@ def read_caml_body(doc: Document) -> str:
     if not (doc.txt_extract_file and doc.txt_extract_file.name):
         return ""
     try:
-        doc.txt_extract_file.open("r")
-        try:
-            return doc.txt_extract_file.read()
-        finally:
-            doc.txt_extract_file.close()
-    except Exception:
-        # Binary fallback for storage that rejects text-mode reads. Guarded
-        # so a corrupted blob returns the empty string rather than
+        # ``errors="ignore"`` preserves the prior best-effort decode for a
+        # corrupted blob; the outer guard keeps a hard I/O failure from
         # propagating into the signal handler / GraphQL resolver.
-        try:
-            doc.txt_extract_file.open("rb")
-            try:
-                return doc.txt_extract_file.read().decode("utf-8", errors="ignore")
-            finally:
-                doc.txt_extract_file.close()
-        except Exception:
-            return ""
+        return read_field_file_text(doc.txt_extract_file, errors="ignore")
+    except Exception:
+        return ""
 
 
 def compute_cache_from_caml_body(

--- a/opencontractserver/tests/test_corpus_canonical_caml_migration.py
+++ b/opencontractserver/tests/test_corpus_canonical_caml_migration.py
@@ -21,10 +21,128 @@ Spec: docs/superpowers/specs/2026-05-27-canonical-caml-description-refactor-desi
 
 from __future__ import annotations
 
+import types
+from importlib import import_module
+from io import BytesIO
+from unittest.mock import patch
+
 from django.contrib.auth import get_user_model
-from django.test import TestCase
+from django.core.files.base import ContentFile
+from django.test import SimpleTestCase, TestCase
 
 from opencontractserver.corpuses.models import Corpus
+
+# The backfill migration module name starts with a digit, so it cannot be a
+# normal ``import``; ``import_module`` with the dotted string works.
+_BACKFILL_MIGRATION = import_module(
+    "opencontractserver.corpuses.migrations.0054_canonical_caml_backfill"
+)
+
+
+class _BytesOrStrBackedField:
+    """Minimal stand-in for a ``FieldFile`` whose text-mode read returns the
+    configured payload.
+
+    Cloud storage backends (S3Boto3Storage / GoogleCloudStorage via
+    django-storages #382) return ``bytes`` from a ``"r"``-mode read without
+    raising; local ``FileSystemStorage`` returns ``str``. This fake lets the
+    suite exercise both on machines that only have local storage.
+    """
+
+    def __init__(self, payload, name: str = "Readme.CAML.md"):
+        self._payload = payload
+        self.name = name
+
+    def __bool__(self) -> bool:
+        return True
+
+    def open(self, mode: str = "r"):
+        return self
+
+    def read(self):
+        return self._payload
+
+    def close(self) -> None:
+        pass
+
+
+class CanonicalCamlBackfillBytesReadTest(SimpleTestCase):
+    """Regression for the production ``migrate`` crash at 0054.
+
+    On cloud storage the backfill's readers received ``bytes`` (text mode is
+    silently ignored, no exception, so the ``except``-guarded binary fallback
+    never fired). The ``bytes`` then reached ``body.encode("utf-8")`` in
+    ``_create_caml_doc`` →
+    ``AttributeError: 'bytes' object has no attribute 'encode'``. The readers
+    must normalise to ``str``.
+    """
+
+    def test_coerce_to_text_decodes_bytes(self):
+        self.assertEqual(_BACKFILL_MIGRATION._coerce_to_text(b"caf\xc3\xa9"), "café")
+
+    def test_coerce_to_text_passes_str_through(self):
+        self.assertEqual(_BACKFILL_MIGRATION._coerce_to_text("café"), "café")
+
+    def test_read_md_description_normalises_bytes_to_str(self):
+        corpus = types.SimpleNamespace(
+            md_description=_BytesOrStrBackedField("café ✓".encode())
+        )
+        body = _BACKFILL_MIGRATION._read_md_description(corpus)
+        self.assertIsInstance(body, str)
+        self.assertEqual(body, "café ✓")
+        # The exact downstream operation that crashed in production.
+        body.encode("utf-8")
+
+    def test_read_md_description_str_backend_unaffected(self):
+        corpus = types.SimpleNamespace(
+            md_description=_BytesOrStrBackedField("plain body")
+        )
+        self.assertEqual(_BACKFILL_MIGRATION._read_md_description(corpus), "plain body")
+
+    def test_read_caml_doc_body_normalises_bytes_to_str(self):
+        doc = types.SimpleNamespace(
+            txt_extract_file=_BytesOrStrBackedField(b"# Readme")
+        )
+        body = _BACKFILL_MIGRATION._read_caml_doc_body(doc)
+        self.assertIsInstance(body, str)
+        self.assertEqual(body, "# Readme")
+
+
+class ReadCamlBodyBytesTest(TestCase):
+    """``read_caml_body`` must decode bytes from cloud storage to ``str``.
+
+    Same django-storages #382 root cause as the backfill crash: the live
+    cache-refresh signal handler and GraphQL ``descriptionRevisions`` facade
+    both read CAML bodies through this helper, and a ``bytes`` leak there
+    breaks ``markdown_to_plain_text`` (``re`` on a bytes-like object).
+    """
+
+    def test_read_caml_body_decodes_bytes_from_storage(self):
+        from opencontractserver.corpuses.services.description_cache import (
+            read_caml_body,
+        )
+        from opencontractserver.documents.models import Document
+
+        User = get_user_model()
+        user = User.objects.create_user(username="caml-bytes", password="x")
+        doc = Document.objects.create(
+            title="Readme.CAML", file_type="text/markdown", creator=user
+        )
+        doc.txt_extract_file.save(
+            "Readme.CAML.md", ContentFile(b"placeholder"), save=True
+        )
+
+        payload = "# Heading café ✓"
+        raw = payload.encode()
+        # Patch ``open`` on the FieldFile *class* (resolved on the class, not
+        # the instance ``__dict__``) to mimic a cloud backend yielding bytes.
+        with patch.object(type(doc.txt_extract_file), "open") as mock_open:
+            mock_open.return_value.__enter__ = lambda s: BytesIO(raw)
+            mock_open.return_value.__exit__ = lambda s, *a: None
+            body = read_caml_body(doc)
+
+        self.assertIsInstance(body, str)
+        self.assertEqual(body, payload)
 
 
 class LegacyStorageDroppedTest(TestCase):


### PR DESCRIPTION
## Hotfix

Production \`manage.py migrate\` aborts on cloud storage at \`corpuses/migrations/0054_canonical_caml_backfill.py:184\`:

\`\`\`
File ".../0054_canonical_caml_backfill.py", line 184, in _create_caml_doc
    ContentFile(body.encode("utf-8")),
AttributeError: 'bytes' object has no attribute 'encode'
\`\`\`

### Root cause
S3Boto3Storage / GoogleCloudStorage (django-storages [#382](https://github.com/jschneier/django-storages/issues/382)) **silently return \`bytes\` from a text-mode (\`"r"\`) \`FieldFile.read()\` without raising**. The migration's readers used an \`except\`-guarded binary fallback that only fires when text mode *raises*, so the \`bytes\` slipped through and reached the \`str\`-only \`body.encode("utf-8")\`. Invisible locally because \`FileSystemStorage\` honors text mode and returns \`str\`.

### Fix
- **Migration readers** (\`_read_md_description\`, \`_read_caml_doc_body\`) normalise to \`str\` via a new inlined \`_coerce_to_text\` helper — inlined (not imported) to keep the historical migration self-contained, consistent with the file's existing frozen-snapshot philosophy. The RunPython migration is atomic (the crash rolled back cleanly) and idempotent, so a re-run after this fix completes the backfill.
- **\`description_cache.read_caml_body\`** had the identical latent bug (same root cause, live code path) and now delegates to the canonical \`opencontractserver.utils.files.read_field_file_text\`, removing the duplicated hand-rolled fallback. This also repairs the live cache-refresh signal handler and the GraphQL \`descriptionRevisions\` facade on cloud deployments.
- **Regression tests** in \`test_corpus_canonical_caml_migration.py\` exercise both the bytes and str paths for the migration readers and \`read_caml_body\`.

### Testing
\`\`\`
docker compose -f test.yml run --rm django python manage.py test \
  opencontractserver.tests.test_corpus_canonical_caml_migration \
  opencontractserver.tests.test_corpus_description \
  opencontractserver.tests.test_markdown_parser --keepdb
\`\`\`
All pass (23 tests). pre-commit clean (black/isort/flake8/mypy/pyupgrade).