### PR TITLE
Fix corpus chat duplicate-response loop on WebSocket reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Corpus chat duplicate-response loop on reconnect**
+  (`frontend/src/components/corpuses/CorpusChat.tsx`). Submitting a query from
+  the corpus home search bar navigated into the chat view and auto-sent the
+  `initialQuery` once the WebSocket opened. The auto-send effect had no
+  "already sent" guard, so every `wsReady` false→true transition — i.e. every
+  WebSocket reconnect (the brief "reconnecting" flash) — re-injected the user's
+  message and triggered another assistant response, repeating indefinitely. The
+  initial query is now tracked by a ref (`sentInitialQueryRef`) and sent exactly
+  once; the ref is only stamped after a successful `wsSend`, so a socket that
+  drops before the first send still delivers the query once the connection is
+  stable. Regression test added in `frontend/tests/CorpusChat.ct.tsx`
+  ("initialQuery is NOT re-sent when the WebSocket reconnects").
+
 ### Added
 
 - **MCP knowledge-tool UX — make a corpus usable as a low-friction tool**

--- a/frontend/src/components/corpuses/CorpusChat.tsx
+++ b/frontend/src/components/corpuses/CorpusChat.tsx
@@ -621,18 +621,29 @@ export const CorpusChat: React.FC<CorpusChatProps> = ({
     }
   }, [forceNewChat]);
 
+  // Guards the auto-send of `initialQuery` so it fires exactly once per query.
+  // Without this, the effect below re-runs on every `wsReady` false→true
+  // transition — i.e. every WebSocket reconnect — re-injecting the user's
+  // message and triggering an endless duplicate-response loop. We only stamp
+  // the ref AFTER a successful `wsSend`, so a reconnect that happens before the
+  // first send still delivers the query once the socket is stable.
+  const sentInitialQueryRef = useRef<string | null>(null);
+
   // Send the initial query once the WebSocket is ready
   useEffect(() => {
+    const trimmed = initialQuery?.trim();
     if (
-      initialQuery &&
-      initialQuery.trim().length > 0 &&
+      trimmed &&
+      trimmed.length > 0 &&
       wsReady &&
-      isNewChat
+      isNewChat &&
+      sentInitialQueryRef.current !== trimmed
     ) {
       const timer = setTimeout(() => {
-        const trimmed = initialQuery.trim();
         const ok = wsSend(JSON.stringify({ query: trimmed }));
         if (ok) {
+          // Mark as sent only on success so a dropped socket re-arms the send.
+          sentInitialQueryRef.current = trimmed;
           setChat((prev) => [
             ...prev,
             {

--- a/frontend/src/components/corpuses/CorpusChat.tsx
+++ b/frontend/src/components/corpuses/CorpusChat.tsx
@@ -621,12 +621,8 @@ export const CorpusChat: React.FC<CorpusChatProps> = ({
     }
   }, [forceNewChat]);
 
-  // Guards the auto-send of `initialQuery` so it fires exactly once per query.
-  // Without this, the effect below re-runs on every `wsReady` false→true
-  // transition — i.e. every WebSocket reconnect — re-injecting the user's
-  // message and triggering an endless duplicate-response loop. We only stamp
-  // the ref AFTER a successful `wsSend`, so a reconnect that happens before the
-  // first send still delivers the query once the socket is stable.
+  // Tracks the sent query so the auto-send effect fires exactly once per query —
+  // even across WS reconnects (which re-flip `wsReady` and would otherwise re-send).
   const sentInitialQueryRef = useRef<string | null>(null);
 
   // Send the initial query once the WebSocket is ready
@@ -634,7 +630,6 @@ export const CorpusChat: React.FC<CorpusChatProps> = ({
     const trimmed = initialQuery?.trim();
     if (
       trimmed &&
-      trimmed.length > 0 &&
       wsReady &&
       isNewChat &&
       sentInitialQueryRef.current !== trimmed

--- a/frontend/tests/CorpusChat.ct.tsx
+++ b/frontend/tests/CorpusChat.ct.tsx
@@ -1646,6 +1646,71 @@ test.describe("CorpusChat", () => {
     await component.unmount();
   });
 
+  test("initialQuery is NOT re-sent when the WebSocket reconnects", async ({
+    mount,
+    page,
+  }) => {
+    // Regression guard for the corpus-chat duplication loop: the initial-query
+    // effect used to re-fire on every `wsReady` false→true transition. When the
+    // agent-chat socket dropped and reconnected, the user's message was
+    // re-injected and a second response streamed in — repeating forever. The
+    // send must now happen exactly once per query, tracked by a ref.
+    const component = await mount(
+      <CorpusChatTestWrapper
+        mocks={[emptyConversationsMock, emptyConversationsMock]}
+        corpusId={TEST_CORPUS_ID}
+        forceNewChat
+        initialQuery="auto sent question"
+      />
+    );
+
+    // First (and only) auto-send + echo.
+    await expect(
+      page.getByText("auto sent question", { exact: true })
+    ).toBeVisible({ timeout: 15000 });
+    await expect(
+      page.getByText("Echo: auto sent question", { exact: true })
+    ).toBeVisible({ timeout: 10000 });
+
+    // Force the active socket closed with no close code, which routes through
+    // useWebSocketAuth's reconnect branch (not the clean-close / auth-failure
+    // branches) and schedules a fresh socket. Record the pre-reconnect instance
+    // count so we can wait for the new socket to actually open.
+    const beforeCount = await page.evaluate(() => {
+      const set = (window as any).WebSocketInstances as Set<any>;
+      const sockets = Array.from(set);
+      const sock = sockets[sockets.length - 1];
+      if (sock) {
+        sock.readyState = 3;
+        sock.onclose && sock.onclose({});
+      }
+      return set.size;
+    });
+
+    // Wait for the reconnect (default 3s backoff) to produce a new socket that
+    // opens and flips wsReady back to true — the exact condition that used to
+    // re-trigger the auto-send.
+    await page.waitForFunction(
+      (prev) => ((window as any).WebSocketInstances as Set<any>).size > prev,
+      beforeCount,
+      { timeout: 15000 }
+    );
+
+    // Give the (now-guarded) 500ms send timer and any re-render ample time to
+    // fire. If the bug regressed, a second "auto sent question" bubble and a
+    // second echo would appear here.
+    await page.waitForTimeout(2000);
+
+    await expect(
+      page.getByText("auto sent question", { exact: true })
+    ).toHaveCount(1);
+    await expect(
+      page.getByText("Echo: auto sent question", { exact: true })
+    ).toHaveCount(1);
+
+    await component.unmount();
+  });
+
   test("tool-call events render timeline entries on the assistant message", async ({
     mount,
     page,


### PR DESCRIPTION
## Problem

Submitting a query from the corpus-home search bar navigates into the corpus chat view and auto-sends the query. Users reported that after the brief "reconnecting" flash, their message gets dropped in, an answer streams back, then **the same message is dropped in again with another answer — repeating forever.**

## Root cause

`CorpusChat` auto-sends `initialQuery` once the agent-chat WebSocket is ready, via an effect keyed on `wsReady`:

```ts
useEffect(() => {
  if (initialQuery && ... && wsReady && isNewChat) {
    // send initialQuery, append user bubble
  }
}, [initialQuery, wsReady, isNewChat, user_obj?.email, wsSend]);
```

The effect had **no "already sent" guard**. `wsSend` is stable (`useCallback([])`), so the only volatile dependency is `wsReady`. Every time the socket dropped and reconnected, `wsReady` flipped `false → true` and the effect **re-fired**, re-injecting the user message and triggering a fresh assistant response — an infinite loop, one cycle per reconnect (matching the observed "reconnecting" flash each round).

This only affected the corpus-home auto-send path; manual sends already guard against duplicates via `sendingLockRef`.

## Fix

`frontend/src/components/corpuses/CorpusChat.tsx` — track the sent query in a ref (`sentInitialQueryRef`) and send it **exactly once**. The ref is stamped only **after a successful `wsSend`**, so a socket that drops *before* the first send still delivers the query once the connection stabilizes (no message gets silently lost).

## Test

`frontend/tests/CorpusChat.ct.tsx` — new regression test "initialQuery is NOT re-sent when the WebSocket reconnects": it mounts with an `initialQuery`, waits for the first auto-send + echo, force-closes the active stub socket (routing through `useWebSocketAuth`'s reconnect branch), waits for a fresh socket to open, then asserts the user message and its echo each appear **exactly once**.

Verified the test fails against the pre-fix code (`locator resolved to 2 elements`) and passes with the fix. Full `CorpusChat.ct.tsx` suite (37 tests) passes; `tsc` and prettier are clean.
