### PR TITLE
Location Tagger review follow-up: harden geocoding hints + test/docs polish (#1871)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Location Tagger: non-string geocoding hints crashed the tool (#1871,
+  follow-up to #1822).** `add_annotations_from_exact_strings`
+  (`opencontractserver/llms/tools/core_tools/annotations.py`) forwarded the
+  LLM-supplied `hints` mapping straight to the geocoder. The values come from
+  raw model output, so a model emitting `{"country": 123}` (a non-string)
+  reached `resolve_place` → `_normalise`, where `str.strip().lower()` raised
+  `AttributeError` deep in the geocoding service instead of failing gracefully
+  at the tool boundary. Hint keys/values are now coerced to `str` and `None`
+  values dropped (so `{"country": null}` reads as "no hint", not the literal
+  `"None"`), making the declared `dict[str, str]` contract true at runtime.
+  Part of the #1822 code-review follow-up, which also: moved a per-annotation
+  assertion inside its loop in `test_location_tagger_agent.py` (the post-loop
+  check only validated the last, order-non-deterministic row); decoupled
+  `test_city_without_hints_*` from the geocoder's population tie-break (already
+  pinned by `test_geocoding_service.ResolvePlaceCityTests`); narrowed
+  `LABEL_TEXT_TO_GEOCODE_LABEL_TYPE` to a `Literal` value type; and documented
+  the no-superuser migration-skip recovery path in
+  `docs/agents/location_tagger.md`.
+
 - **Corpus chat duplicate-response loop on reconnect**
   (`frontend/src/components/corpuses/CorpusChat.tsx`). Submitting a query from
   the corpus home search bar navigated into the chat view and auto-sent the

--- a/docs/agents/location_tagger.md
+++ b/docs/agents/location_tagger.md
@@ -49,6 +49,17 @@ them, so existing callers of the tool keep working unchanged.
    > prompt** — update the `Location Tagger` agent record via the Django admin
    > (or a follow-up data migration) to pick up the revision.
 
+   > **Note — a superuser must exist when the migration runs.** The agent is
+   > created with a `creator`, so the migration looks for an existing superuser.
+   > In environments where migrations run **before** any superuser is seeded
+   > (e.g. an ephemeral CI database, or a containerised first boot where
+   > migrations precede fixtures), it logs a warning and skips creation rather
+   > than failing the migration — which means **the agent is never created**. If
+   > the **Location Tagger** is absent from the agent picker after deploying,
+   > seed a superuser and then either re-run the data migration
+   > (`python manage.py migrate agents 0014 && python manage.py migrate agents 0015`)
+   > or create the agent record from the Django admin.
+
 2. **Add a corpus action.** On the corpus you want tagged, create a
    `CorpusAction` that points at the **Location Tagger** agent and choose a
    trigger:

--- a/opencontractserver/agents/migrations/0015_create_location_tagger_agent.py
+++ b/opencontractserver/agents/migrations/0015_create_location_tagger_agent.py
@@ -87,6 +87,10 @@ def create_location_tagger_agent(apps, schema_editor):
         ),
         system_instructions=instructions,
         available_tools=["add_annotations_from_exact_strings"],
+        # Intentionally empty: this agent runs unattended as a corpus action and
+        # its only tool writes annotations the user can review/delete afterwards
+        # — there is no destructive or irreversible call to gate behind an
+        # approval prompt.
         permission_required_tools=[],
         badge_config={
             "icon": "globe",

--- a/opencontractserver/annotations/services/geographic_service.py
+++ b/opencontractserver/annotations/services/geographic_service.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Literal, cast
 
 from django.db.models import Q, QuerySet
 
@@ -35,6 +35,11 @@ from opencontractserver.shared.services.base import BaseService
 
 logger = logging.getLogger(__name__)
 
+
+# The closed set of ``resolve_place`` label-type literals. Naming it once lets
+# the inverse map (and any downstream caller) advertise the exact three values
+# instead of a bare ``str``, so call sites get exhaustiveness checking.
+GeocodeLabelType = Literal["country", "state", "city"]
 
 # Map a frontend ``labelType`` filter value to the backend label text used
 # to mark the annotation. Single source of truth so callers don't sprinkle
@@ -51,9 +56,13 @@ _ALL_GEO_LABELS = frozenset(GEOCODE_LABEL_TYPE_TO_LABEL_TEXT.values())
 # back to the ``resolve_place`` label-type literal. Lets annotation-creation
 # callers that work in terms of label *text* (e.g. the
 # ``add_annotations_from_exact_strings`` agent tool) reuse the same geocoding
-# path the GraphQL mutations use without re-deriving the mapping.
-LABEL_TEXT_TO_GEOCODE_LABEL_TYPE: dict[str, str] = {
-    text: label_type for label_type, text in GEOCODE_LABEL_TYPE_TO_LABEL_TEXT.items()
+# path the GraphQL mutations use without re-deriving the mapping. The ``cast``
+# narrows each value from ``str`` (the forward map's value type) to the
+# ``GeocodeLabelType`` literal — exhaustively true here, but not provable to the
+# type checker through the comprehension.
+LABEL_TEXT_TO_GEOCODE_LABEL_TYPE: dict[str, GeocodeLabelType] = {
+    text: cast(GeocodeLabelType, label_type)
+    for label_type, text in GEOCODE_LABEL_TYPE_TO_LABEL_TEXT.items()
 }
 
 
@@ -86,8 +95,10 @@ def build_geocoded_annotation_data(
             holding a label text should map it via
             :data:`LABEL_TEXT_TO_GEOCODE_LABEL_TYPE` first.
         text: The span text to geocode.
-        country_hint / state_hint: Optional disambiguation hints forwarded to
-            ``resolve_place``.
+        country_hint: Optional disambiguation hint forwarded to ``resolve_place``
+            — narrows ``state`` / ``city`` candidates to the given country.
+        state_hint: Optional disambiguation hint forwarded to ``resolve_place``
+            — narrows ``city`` candidates to the given (US) state.
     """
     from opencontractserver.utils.geocoding import resolve_place
 

--- a/opencontractserver/llms/tools/core_tools/annotations.py
+++ b/opencontractserver/llms/tools/core_tools/annotations.py
@@ -217,14 +217,10 @@ def add_annotations_from_exact_strings(
     from opencontractserver.documents.models import Document
 
     # Collect (label_text, exact_string, hints) tuples for the single
-    # doc/corpus. ``hints`` is only consulted for OC_* geographic labels.
-    # The third element is the item's ``hints`` (AnnotationItem.hints is typed
-    # ``dict[str, str]``), narrowed to None by the isinstance guard below.
+    # doc/corpus. ``hints`` is only consulted for OC_* geographic labels;
+    # the third element is the item's normalised ``hints`` mapping (or None).
     parsed_items: list[tuple[str, str, dict[str, str] | None]] = []
     for item in items:
-        # ``item`` is an AnnotationItem TypedDict (always a dict at runtime);
-        # the inner isinstance still guards against the LLM sending a non-dict
-        # ``hints`` value.
         exact_str = str(item["exact_string"])
         # Skip blank/whitespace-only spans. Besides wasting a geocoder call for
         # OC_* labels, ``doc_text.find("")`` returns the search start so the
@@ -232,14 +228,21 @@ def add_annotations_from_exact_strings(
         # blank-``raw_text`` guard in ``_create_geographic_annotation``.
         if not exact_str.strip():
             continue
+        # Normalise the optional ``hints`` mapping. ``item`` is an AnnotationItem
+        # TypedDict (always a dict at runtime), but the hint *values* come from
+        # raw LLM output, so the declared ``dict[str, str]`` shape is unenforced:
+        # a model can emit ``{"country": 123}`` or ``{"country": null}``. The
+        # geocoder normalises every hint with ``str.strip().lower()``, so a
+        # non-string value would raise ``AttributeError`` deep inside
+        # ``resolve_place`` rather than at this boundary. Coerce keys/values to
+        # ``str`` and drop ``None`` values (so ``{"country": null}`` reads as
+        # "no hint", not the literal string "None"); a non-dict ``hints`` is
+        # discarded outright.
         raw_hints = item.get("hints")
-        parsed_items.append(
-            (
-                str(item["label_text"]),
-                exact_str,
-                raw_hints if isinstance(raw_hints, dict) else None,
-            )
-        )
+        hints: dict[str, str] | None = None
+        if isinstance(raw_hints, dict):
+            hints = {str(k): str(v) for k, v in raw_hints.items() if v is not None}
+        parsed_items.append((str(item["label_text"]), exact_str, hints))
 
     created_ids: list[int] = []
 

--- a/opencontractserver/tests/test_location_tagger_agent.py
+++ b/opencontractserver/tests/test_location_tagger_agent.py
@@ -160,16 +160,18 @@ class LocationTaggerGeocodingTests(_GeoToolFixture):
         # Paris, TX sits at a negative (western) longitude, unlike Paris, FR.
         self.assertLess(ann.data["lng"], 0)
 
-    def test_city_without_hints_resolves_to_france(self):
-        # Assumption: an unhinted "Paris" resolves to the highest-population
-        # match (Paris, FR over Paris, TX). This ties to the geocoder's current
-        # tie-break dataset; if that ranking changes, relax this to assert only
-        # ``ann.data["geocoded"] is True`` and leave the country to the
-        # geocoding service's own tests.
+    def test_city_without_hints_still_geocodes(self):
+        # An unhinted geographic span still flows through the tool and gets a
+        # geocoded payload. Which *specific* place an ambiguous name resolves to
+        # (unhinted "Paris" → Paris, FR by population) is the geocoder's
+        # responsibility and is pinned in
+        # ``test_geocoding_service.test_ambiguous_picks_largest_by_population``;
+        # re-asserting the country here would couple this tool-integration test
+        # to the geocoder's dataset internals.
         ids = self._annotate([{"label_text": OC_CITY_LABEL, "exact_string": "Paris"}])
         ann = Annotation.objects.get(pk=ids[0])
+        self.assertIsNotNone(ann.data)
         self.assertTrue(ann.data["geocoded"])
-        self.assertEqual(ann.data["admin_codes"]["iso_alpha2"], "FR")
 
     def test_ungeocodable_geo_span_marks_not_geocoded(self):
         # A geo label on text that is not a known place still creates the
@@ -233,9 +235,12 @@ class LocationTaggerGeocodingTests(_GeoToolFixture):
             self.assertIsNotNone(ann.data)
             self.assertTrue(ann.data["geocoded"])
             self.assertEqual(ann.data["admin_codes"]["iso_alpha2"], "FR")
+            # Assert per-annotation inside the loop: queryset order is
+            # non-deterministic without an ``order_by``, so a check after the
+            # loop would only validate whichever row happened to come last.
+            self.assertEqual(ann.annotation_type, SPAN_LABEL)
         # Resolver invoked exactly once for the single item, not per occurrence.
         self.assertEqual(spy.call_count, 1)
-        self.assertEqual(ann.annotation_type, SPAN_LABEL)
 
     def test_hints_ignored_for_non_geographic_label(self):
         # Hints on a non-geo label are silently ignored (no crash, no data).
@@ -250,3 +255,22 @@ class LocationTaggerGeocodingTests(_GeoToolFixture):
         )
         ann = Annotation.objects.get(pk=ids[0])
         self.assertIsNone(ann.data)
+
+    def test_non_string_hint_values_are_coerced_not_crashed(self):
+        # LLM output can violate the declared ``dict[str, str]`` hint shape —
+        # e.g. an int country code or a null state. Such values must be coerced
+        # (and ``None`` dropped) at the tool boundary; before the fix they
+        # reached the geocoder's ``str.strip().lower()`` and raised
+        # ``AttributeError``. The span is still created and geocoded.
+        ids = self._annotate(
+            [
+                {
+                    "label_text": OC_CITY_LABEL,
+                    "exact_string": "Paris",
+                    "hints": {"country": 123, "state": None},
+                }
+            ]
+        )
+        ann = Annotation.objects.get(pk=ids[0])
+        self.assertIsNotNone(ann.data)
+        self.assertTrue(ann.data["geocoded"])


### PR DESCRIPTION
Closes #1871.

Addresses the code-review follow-up on the Location Tagger / geocoding work (#1822). Each reported item was assessed against the **current** code (line numbers in the review referenced the PR diff and had drifted) before fixing.

## Findings & resolutions

| # | Review item | Verdict | Resolution |
|---|-------------|---------|------------|
| 1 | **Medium** — loop assertion only checks the last row | ✅ Valid | Moved `assertEqual(ann.annotation_type, SPAN_LABEL)` inside the loop in `test_geocoding_resolved_once_and_reused_for_each_occurrence` (queryset order is non-deterministic without `order_by`, so the post-loop check validated only one of the two annotations). |
| 2 | **Minor** — `hints` values not validated as `str` | ✅ Valid (confirmed crash) | A non-string hint (e.g. `{"country": 123}`) reached the geocoder's `_normalise` → `str.strip().lower()` and raised `AttributeError` deep in `resolve_place`. Hint keys/values are now coerced to `str` at the tool boundary and `None` dropped (`{"country": null}` reads as "no hint", not `"None"`), making the declared `dict[str, str]` contract true. **Regression test added.** |
| 3 | **Minor** — combined `country_hint / state_hint` docstring entry | ✅ Valid | Split into two per-parameter `Args:` lines in `build_geocoded_annotation_data` (Google/Sphinx-parseable). |
| 4 | **Minor** — no-superuser migration skip has no documented recovery | ✅ Valid | Added a note to `docs/agents/location_tagger.md` (the migration already *logs* the recovery hint; the docs now cover it: seed a superuser, then re-run `migrate agents 0014 && migrate agents 0015` or create via Django admin). |
| 5 | **Note** — `test_city_without_hints_*` couples to geocoder dataset | ✅ Valid | The population tie-break ("unhinted Paris → Paris, FR") is already pinned by `test_geocoding_service.ResolvePlaceCityTests.test_ambiguous_picks_largest_by_population`, so the duplicate `iso_alpha2 == "FR"` assertion was redundant coupling. Relaxed to assert `geocoded is True` only and renamed to `test_city_without_hints_still_geocodes`. |
| 6 | **Nit** — `LABEL_TEXT_TO_GEOCODE_LABEL_TYPE` value type | ✅ Valid | Introduced `GeocodeLabelType = Literal["country", "state", "city"]` and narrowed the map's value type, keeping the DRY inverse-map derivation via a (non-redundant) `cast`. |
| 7 | **Nit** — `permission_required_tools=[]` intent | ✅ Valid | Added a comment in migration `0015` explaining the empty list is deliberate (unattended corpus action; its only tool writes reviewable/deletable annotations — nothing to gate). |

## Verification

- `black --check` and `flake8` pass on all changed files.
- The two typing changes (Literal/`cast` comprehension; hint-coercion comprehension) were validated mypy-clean in isolation with the project's strictness flags (`--warn-redundant-casts --warn-unused-ignores --check-untyped-defs`). The Django-plugin mypy and the backend test suite run in CI (no Docker in this environment).
- The new regression test passes a malformed `{"country": 123, "state": null}` hint; the input flows through the untyped `_annotate` fixture helper, so it adds no type-checker friction.

No production behaviour changes for valid inputs — the hint fix only hardens the boundary against malformed LLM output.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UbZvyuD1dukPCVSXZHjX8W)_