### PR TITLE
Fix AnnotationFilterMode str/enum mismatch in export label filtering (#1868)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   referenced labels. `test_filter_modes_change_annotation_count`'s
   `build_label_lookups` assertions were updated to verify the per-mode label
   *membership* (which the fix corrects) rather than brittle raw counts; the
-  `build_document_export` counts are unchanged.
+  `build_document_export` counts are unchanged. Both ETL functions also now
+  normalize their `annotation_filter_mode` argument to an
+  `AnnotationFilterMode` member at the boundary, so an invalid mode string
+  raises a clear `ValueError` instead of silently falling through to
+  `CORPUS_LABELSET_ONLY`; covered by
+  `BuildLabelLookupsStringEnumEquivalenceTestCase.test_invalid_mode_raises_valueerror`.
 
 - **Location Tagger: non-string geocoding hints crashed the tool (#1871,
   follow-up to #1822).** `add_annotations_from_exact_strings`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`AnnotationFilterMode` export filtering silently ignored the requested mode
+  (#1868).** `AnnotationFilterMode` (`opencontractserver/types/enums.py`) was a
+  plain `Enum`, not a `str`-mixin enum like every sibling in the file, so a
+  member never compared equal to its string value. `build_label_lookups`
+  (`opencontractserver/utils/etl.py`) compounded this by mixing comparison
+  styles: bare string literals at the mode-selection branches
+  (`== "ANALYSES_ONLY"`, `== "CORPUS_LABELSET_PLUS_ANALYSES"`) but enum-member
+  membership at the corpus-labelset augmentation branch
+  (`in (AnnotationFilterMode.CORPUS_LABELSET_ONLY, …)`). As a result **no single
+  argument type was handled correctly**:
+  - A **string** argument (what the GraphQL export mutation and Celery tasks
+    deliver — `config/graphql/document_mutations.py:644,672`) satisfied the
+    selection branches but silently **skipped the corpus-labelset augmentation**,
+    so labels defined in a corpus's label set but not referenced by any
+    annotation were dropped from the export's label lookups, breaking
+    roundtrip-safety (fork ≡ export+import).
+  - An **enum-member** argument failed the string selection branches and fell
+    through to `CORPUS_LABELSET_ONLY` for `ANALYSES_ONLY` /
+    `CORPUS_LABELSET_PLUS_ANALYSES`.
+
+  Separately, `build_document_export` compared only against enum members and
+  hit its `else: raise ValueError` for a **string** argument; that exception is
+  caught by the function's own `except`, returning `("", "", None, {}, {})`, so
+  the **V2 export path** (`package_corpus_export_v2` →`build_corpus_v2_zip`,
+  which forwards the GraphQL string unchanged) silently **dropped every
+  document** from the archive — for all modes, including the default.
+
+  Fix: `AnnotationFilterMode` is now `class AnnotationFilterMode(str, enum.Enum)`,
+  and `build_label_lookups`'s string-literal comparisons are normalized to enum
+  members so both ETL functions compare consistently. Members and their string
+  values are now interchangeable, so both the in-process (enum) and
+  GraphQL/Celery (string) call paths hit the same branches. Both ETL function
+  signatures now accept `AnnotationFilterMode | str` to match runtime reality,
+  retiring the `# type: ignore[arg-type]` / `cast(AnnotationFilterMode, …)`
+  workarounds that prior callers had used. Regression coverage added in
+  `opencontractserver/tests/test_corpus_export_with_analysis_filters.py`
+  (`BuildLabelLookupsStringEnumEquivalenceTestCase`) and
+  `opencontractserver/tests/test_types.py`
+  (`TestAnnotationFilterMode.test_is_string_enum`). Observable effect: the
+  string-driven export paths now include the corpus's full label set in their
+  label lookups (matching the enum-driven fork path) instead of only the
+  referenced labels. `test_filter_modes_change_annotation_count`'s
+  `build_label_lookups` assertions were updated to verify the per-mode label
+  *membership* (which the fix corrects) rather than brittle raw counts; the
+  `build_document_export` counts are unchanged.
+
 - **Corpus chat duplicate-response loop on reconnect**
   (`frontend/src/components/corpuses/CorpusChat.tsx`). Submitting a query from
   the corpus home search bar navigated into the chat view and auto-sent the

--- a/opencontractserver/tests/test_corpus_export_import_v2.py
+++ b/opencontractserver/tests/test_corpus_export_import_v2.py
@@ -2807,11 +2807,7 @@ class TestBuildLabelLookupsEdgeCases(TestCase):
         result = build_label_lookups(
             corpus_id=self.corpus.id,
             analysis_ids=None,
-            # ``build_label_lookups`` compares this against the raw string
-            # ("ANALYSES_ONLY") in its body, so the test deliberately passes
-            # a str; cast keeps that runtime value while satisfying the
-            # AnnotationFilterMode-typed parameter.
-            annotation_filter_mode=cast(AnnotationFilterMode, "ANALYSES_ONLY"),
+            annotation_filter_mode=AnnotationFilterMode.ANALYSES_ONLY,
         )
 
         # Should return empty lookups since no analyses specified
@@ -2840,11 +2836,7 @@ class TestBuildLabelLookupsEdgeCases(TestCase):
         result = build_label_lookups(
             corpus_id=self.corpus.id,
             analysis_ids=None,
-            # See note above: the helper string-compares this value, so the
-            # test passes a str and casts to the declared enum type.
-            annotation_filter_mode=cast(
-                AnnotationFilterMode, "CORPUS_LABELSET_PLUS_ANALYSES"
-            ),
+            annotation_filter_mode=AnnotationFilterMode.CORPUS_LABELSET_PLUS_ANALYSES,
         )
 
         # Should include corpus labels only (no analyses to add)

--- a/opencontractserver/tests/test_corpus_export_with_analysis_filters.py
+++ b/opencontractserver/tests/test_corpus_export_with_analysis_filters.py
@@ -473,7 +473,19 @@ class BuildLabelLookupsStringEnumEquivalenceTestCase(TestCase):
             self.assertIn(str(self.analysis_label.pk), lookups["text_labels"])
 
     def test_build_document_export_accepts_string_mode(self):
-        """build_document_export must not error on the string the V2 path passes."""
+        """build_document_export must not error on the string the V2 path passes.
+
+        The fixture document deliberately has no file on disk. That is *not* a
+        confound for this assertion: build_document_export synthesizes a stable
+        ``document_<id>.placeholder`` name for fileless docs and treats the
+        missing PAWLs/text reads as non-fatal, so a correct run always returns a
+        non-empty ``doc_name`` and a populated ``doc_json``. Before the #1868
+        fix, the string mode hit ``else: raise ValueError`` (caught by the
+        function's own except), so the function returned ``("", "", None, {},
+        {})`` — a silently dropped document. Asserting the exact placeholder name
+        and the round-tripped title pins the success path rather than merely
+        ``doc_name != ""``.
+        """
         lookups = build_label_lookups(
             corpus_id=self.corpus.id,
             analysis_ids=None,
@@ -487,5 +499,23 @@ class BuildLabelLookupsStringEnumEquivalenceTestCase(TestCase):
             annotation_filter_mode="CORPUS_LABELSET_ONLY",
         )
         # Before the fix this returned ("", "", None, {}, {}) — a dropped doc.
-        self.assertNotEqual(doc_name, "")
-        self.assertIsNotNone(doc_json)
+        self.assertEqual(doc_name, f"document_{self.document.id}.placeholder")
+        assert doc_json is not None  # narrow for type-checkers + guard the next line
+        self.assertEqual(doc_json["title"], self.document.title)
+
+    def test_invalid_mode_raises_valueerror(self):
+        """A bogus mode string is rejected at the boundary, not silently defaulted."""
+        with self.assertRaises(ValueError):
+            build_label_lookups(
+                corpus_id=self.corpus.id,
+                analysis_ids=None,
+                annotation_filter_mode="BOGUS_MODE",
+            )
+        with self.assertRaises(ValueError):
+            build_document_export(
+                label_lookups={"text_labels": {}, "doc_labels": {}},
+                doc_id=self.document.id,
+                corpus_id=self.corpus.id,
+                analysis_ids=None,
+                annotation_filter_mode="BOGUS_MODE",
+            )

--- a/opencontractserver/tests/test_corpus_export_with_analysis_filters.py
+++ b/opencontractserver/tests/test_corpus_export_with_analysis_filters.py
@@ -9,7 +9,12 @@ from django.test import TestCase
 from django.utils import timezone
 
 from opencontractserver.analyzer.models import Analysis, Analyzer
-from opencontractserver.annotations.models import Annotation, AnnotationLabel
+from opencontractserver.annotations.models import (
+    TOKEN_LABEL,
+    Annotation,
+    AnnotationLabel,
+    LabelSet,
+)
 from opencontractserver.corpuses.models import Corpus, TemporaryFileHandle
 from opencontractserver.documents.models import Document, DocumentPath
 from opencontractserver.tasks.import_tasks import import_corpus
@@ -243,37 +248,51 @@ class ExportCorpusWithAnalysesTestCase(TestCase):
 
         # 1) Build label lookups for the entire corpus, ignoring or including analyses as needed
         #    For CORPUS_LABELSET_ONLY, we should see only "corpus_label" in the lookup
-        # NOTE: build_label_lookups is annotated to take an AnnotationFilterMode enum,
-        # but its body compares the argument against raw string literals (== "ANALYSES_ONLY"
-        # etc.), so callers must pass the string value, not the enum member. The string
-        # form is the contract this test deliberately exercises; the arg-type ignores below
-        # reflect that production annotation/runtime mismatch (see final report).
+        # ``annotation_filter_mode`` accepts an AnnotationFilterMode member or its
+        # string value interchangeably (the GraphQL/Celery boundaries deliver the
+        # string); this test exercises the string form.
         lookups_corpus_only = build_label_lookups(
             corpus_id=self.original_corpus_obj.id,
             analysis_ids=None,
-            annotation_filter_mode="CORPUS_LABELSET_ONLY",  # type: ignore[arg-type]
+            annotation_filter_mode="CORPUS_LABELSET_ONLY",
         )
-        self.assertEqual(
-            len(lookups_corpus_only["text_labels"]), 4
-        )  # just "Corpus Label"
+        # CORPUS_LABELSET_ONLY surfaces the corpus label plus the rest of the
+        # corpus's label set via the augmentation block. #1868 makes that block
+        # fire for the string form too (not just the enum form), so the lookup
+        # now spans the whole imported label set; assert the mode *semantics* by
+        # label identity rather than a raw count, which depends on the fixture's
+        # label-set size. The analysis-only labels must never appear here.
+        corpus_only_pks = set(lookups_corpus_only["text_labels"].keys())
+        self.assertIn(str(self.original_corpus_obj_label.id), corpus_only_pks)
+        self.assertNotIn(str(self.analysis_a_label.id), corpus_only_pks)
+        self.assertNotIn(str(self.analysis_b_label.id), corpus_only_pks)
 
         # 2) Now check CORPUS_LABELSET_PLUS_ANALYSES for both A and B
         lookups_plus_analyses = build_label_lookups(
             corpus_id=self.original_corpus_obj.id,
             analysis_ids=[self.analysis_a.id, self.analysis_b.id],
-            annotation_filter_mode="CORPUS_LABELSET_PLUS_ANALYSES",  # type: ignore[arg-type]
+            annotation_filter_mode="CORPUS_LABELSET_PLUS_ANALYSES",
         )
-        # We expect 3 total labels: corpus_label + analysis_a_label + analysis_b_label
-        self.assertEqual(len(lookups_plus_analyses["text_labels"]), 6)
+        # PLUS_ANALYSES is exactly the corpus-labelset set unioned with the two
+        # analysis labels.
+        analysis_pks = {
+            str(self.analysis_a_label.id),
+            str(self.analysis_b_label.id),
+        }
+        self.assertEqual(
+            set(lookups_plus_analyses["text_labels"].keys()),
+            corpus_only_pks | analysis_pks,
+        )
 
         # 3) ANALYSES_ONLY
         lookups_analyses_only = build_label_lookups(
             corpus_id=self.original_corpus_obj.id,
             analysis_ids=[self.analysis_a.id, self.analysis_b.id],
-            annotation_filter_mode="ANALYSES_ONLY",  # type: ignore[arg-type]
+            annotation_filter_mode="ANALYSES_ONLY",
         )
-        # We expect 2 total labels: analysis_a_label + analysis_b_label
-        self.assertEqual(len(lookups_analyses_only["text_labels"]), 2)
+        # ANALYSES_ONLY keeps its narrow contract: only the analysis labels, with
+        # no corpus-labelset augmentation.
+        self.assertEqual(set(lookups_analyses_only["text_labels"].keys()), analysis_pks)
 
         # Next, let's see how many annotations we get from build_document_export itself:
 
@@ -329,3 +348,144 @@ class ExportCorpusWithAnalysesTestCase(TestCase):
         )
         assert doc_export_data is not None
         self.assertEqual(len(doc_export_data["labelled_text"]), 2)
+
+
+@pytest.mark.django_db
+class BuildLabelLookupsStringEnumEquivalenceTestCase(TestCase):
+    """Regression for #1868.
+
+    ``AnnotationFilterMode`` is a str-mixin enum, so a member and its string
+    value must drive identical behaviour. Before the fix, build_label_lookups
+    compared the mode against bare string literals in some branches but against
+    enum members in the corpus-labelset augmentation branch, so a *string*
+    argument (what GraphQL/Celery deliver) silently skipped that augmentation;
+    build_document_export compared only against enum members and raised
+    ValueError (caught -> empty export) for a string argument, which is exactly
+    what the V2 export path passes.
+    """
+
+    user: User
+    corpus: Corpus
+    referenced_label: AnnotationLabel
+    orphan_label: AnnotationLabel
+    analysis: Analysis
+    analysis_label: AnnotationLabel
+    document: Document
+
+    def setUp(self):
+        self.user = User.objects.create_user(username="eq", password="12345678")
+        labelset = LabelSet.objects.create(title="LS", creator=self.user)
+        self.corpus = Corpus.objects.create(
+            title="Equivalence Corpus", label_set=labelset, creator=self.user
+        )
+
+        # A label referenced by a corpus annotation ...
+        self.referenced_label = AnnotationLabel.objects.create(
+            text="Referenced", label_type=TOKEN_LABEL, creator=self.user
+        )
+        # ... and one that lives in the labelset but has NO annotation. The
+        # corpus-labelset augmentation block is the branch that used to be
+        # skipped for string input, so this orphan label is the canary.
+        self.orphan_label = AnnotationLabel.objects.create(
+            text="Orphan", label_type=TOKEN_LABEL, creator=self.user
+        )
+        labelset.annotation_labels.add(self.referenced_label, self.orphan_label)
+
+        analyzer = Analyzer.objects.create(
+            id="EQ_ANALYZER",
+            description="x",
+            disabled=False,
+            is_public=True,
+            creator=self.user,
+            task_name="fake.task.eq",
+        )
+        self.analysis = Analysis.objects.create(
+            analyzer=analyzer,
+            analyzed_corpus=self.corpus,
+            creator=self.user,
+            analysis_started=timezone.now(),
+            analysis_completed=timezone.now(),
+        )
+        self.analysis_label = AnnotationLabel.objects.create(
+            text="AnalysisLbl", label_type=TOKEN_LABEL, creator=self.user
+        )
+
+        self.document = Document.objects.create(
+            title="Doc", creator=self.user, page_count=1
+        )
+        # Corpus annotation (no analysis) referencing referenced_label.
+        Annotation.objects.create(
+            document=self.document,
+            corpus=self.corpus,
+            annotation_label=self.referenced_label,
+            raw_text="ref",
+            creator=self.user,
+        )
+        # Analysis annotation referencing analysis_label.
+        Annotation.objects.create(
+            document=self.document,
+            corpus=self.corpus,
+            annotation_label=self.analysis_label,
+            analysis=self.analysis,
+            raw_text="an",
+            creator=self.user,
+        )
+
+    def test_string_and_enum_inputs_are_equivalent(self):
+        """A string mode and its enum member produce identical label lookups."""
+        for mode in AnnotationFilterMode:
+            from_enum = build_label_lookups(
+                corpus_id=self.corpus.id,
+                analysis_ids=[self.analysis.id],
+                annotation_filter_mode=mode,
+            )
+            from_string = build_label_lookups(
+                corpus_id=self.corpus.id,
+                analysis_ids=[self.analysis.id],
+                annotation_filter_mode=mode.value,
+            )
+            self.assertEqual(
+                from_enum,
+                from_string,
+                msg=f"string vs enum diverged for {mode.value}",
+            )
+
+    def test_corpus_labelset_augmentation_fires_for_string_input(self):
+        """Orphan labelset label is included for string input (the #1868 bug)."""
+        for mode in ("CORPUS_LABELSET_ONLY", "CORPUS_LABELSET_PLUS_ANALYSES"):
+            lookups = build_label_lookups(
+                corpus_id=self.corpus.id,
+                analysis_ids=None,
+                annotation_filter_mode=mode,
+            )
+            self.assertIn(str(self.orphan_label.pk), lookups["text_labels"], mode)
+            self.assertIn(str(self.referenced_label.pk), lookups["text_labels"], mode)
+
+    def test_analyses_only_does_not_augment_with_corpus_labelset(self):
+        """ANALYSES_ONLY keeps its narrow contract for both input forms."""
+        for mode in ("ANALYSES_ONLY", AnnotationFilterMode.ANALYSES_ONLY):
+            lookups = build_label_lookups(
+                corpus_id=self.corpus.id,
+                analysis_ids=[self.analysis.id],
+                annotation_filter_mode=mode,
+            )
+            self.assertNotIn(str(self.orphan_label.pk), lookups["text_labels"])
+            self.assertIn(str(self.analysis_label.pk), lookups["text_labels"])
+
+    def test_build_document_export_accepts_string_mode(self):
+        """build_document_export must not error on the string the V2 path passes."""
+        lookups = build_label_lookups(
+            corpus_id=self.corpus.id,
+            analysis_ids=None,
+            annotation_filter_mode="CORPUS_LABELSET_ONLY",
+        )
+        doc_name, _b64, doc_json, _text, _doc = build_document_export(
+            label_lookups=lookups,
+            doc_id=self.document.id,
+            corpus_id=self.corpus.id,
+            analysis_ids=None,
+            annotation_filter_mode="CORPUS_LABELSET_ONLY",
+        )
+        # Before the fix this returned ("", "", None, {}, {}) — a dropped doc.
+        self.assertNotEqual(doc_name, "")
+        self.assertIsNotNone(doc_json)

--- a/opencontractserver/tests/test_types.py
+++ b/opencontractserver/tests/test_types.py
@@ -144,6 +144,18 @@ class TestAnnotationFilterMode(TestCase):
     def test_member_count(self):
         self.assertEqual(len(AnnotationFilterMode), 3)
 
+    def test_is_string_enum(self):
+        # AnnotationFilterMode must be a str-mixin enum so a member and its
+        # string value compare equal — build_label_lookups / build_document_export
+        # rely on this for the string values delivered by GraphQL/Celery (#1868).
+        self.assertIsInstance(AnnotationFilterMode.CORPUS_LABELSET_ONLY, str)
+        self.assertEqual(
+            AnnotationFilterMode.CORPUS_LABELSET_ONLY, "CORPUS_LABELSET_ONLY"
+        )
+        self.assertEqual(
+            AnnotationFilterMode("ANALYSES_ONLY"), AnnotationFilterMode.ANALYSES_ONLY
+        )
+
 
 class TestContentModality(TestCase):
     """Tests for ContentModality enum and its conversion methods."""

--- a/opencontractserver/types/enums.py
+++ b/opencontractserver/types/enums.py
@@ -1,5 +1,4 @@
 import enum
-from enum import Enum
 
 
 class OpenContractsEnum(str, enum.Enum):
@@ -48,7 +47,11 @@ class PermissionTypes(str, enum.Enum):
     ALL = "ALL"
 
 
-class AnnotationFilterMode(Enum):
+# str-mixin (like every sibling enum here) so a member and its string value
+# compare equal: the GraphQL/Celery boundaries deliver the value as a plain
+# string while in-process callers pass the member, and both must hit the same
+# branches in build_label_lookups / build_document_export (issue #1868).
+class AnnotationFilterMode(str, enum.Enum):
     CORPUS_LABELSET_ONLY = "CORPUS_LABELSET_ONLY"
     CORPUS_LABELSET_PLUS_ANALYSES = "CORPUS_LABELSET_PLUS_ANALYSES"
     ANALYSES_ONLY = "ANALYSES_ONLY"

--- a/opencontractserver/utils/etl.py
+++ b/opencontractserver/utils/etl.py
@@ -73,6 +73,12 @@ def build_label_lookups(
     """
     logger.info(f"build_label_lookups for corpus id #{corpus_id}")
 
+    # Normalize the boundary input to an enum member. The GraphQL/Celery
+    # callers deliver a plain string; coercing here gives an invalid mode a
+    # clear ValueError instead of a silent fallback to CORPUS_LABELSET_ONLY,
+    # and lets every comparison below stay enum-to-enum.
+    annotation_filter_mode = AnnotationFilterMode(annotation_filter_mode)
+
     # Base first: only labels within the corpus
     corpus_label_ids = (
         Annotation.objects.filter(corpus_id=corpus_id, analysis__isnull=True)
@@ -261,6 +267,13 @@ def build_document_export(
 
     logger.info(f"burn_doc_annotations - label_lookups: {label_lookups}")
 
+    # Normalize the boundary input to an enum member before the broad
+    # try/except below. The GraphQL/Celery callers deliver a plain string;
+    # coercing here surfaces an invalid mode as a clear ValueError to the
+    # caller instead of being swallowed into a silent empty-export tuple, and
+    # lets every comparison below stay enum-to-enum.
+    annotation_filter_mode = AnnotationFilterMode(annotation_filter_mode)
+
     try:
 
         text_labels = label_lookups["text_labels"]
@@ -337,9 +350,7 @@ def build_document_export(
                     annotation_label_id__in=corpus_label_ids
                 )
 
-        elif (
-            annotation_filter_mode == AnnotationFilterMode.CORPUS_LABELSET_ONLY
-        ):  # "CORPUS_LABELSET_ONLY"
+        elif annotation_filter_mode == AnnotationFilterMode.CORPUS_LABELSET_ONLY:
             corpus_label_pks = (
                 label_lookups.get("doc_labels", {}).keys()
                 | label_lookups.get("text_labels", {}).keys()
@@ -350,8 +361,12 @@ def build_document_export(
             )
 
         else:
+            # Unreachable for a valid mode (the input is coerced to an
+            # AnnotationFilterMode member above). Retained as a guard so a
+            # newly-added enum member without a branch here fails loudly
+            # rather than silently exporting an unfiltered annotation set.
             raise ValueError(
-                f"Invalid annotation_filter_mode: {annotation_filter_mode}"
+                f"Unhandled annotation_filter_mode: {annotation_filter_mode}"
             )
 
         # Initialize document annotation JSON structure (used for both PDF and non-PDF)

--- a/opencontractserver/utils/etl.py
+++ b/opencontractserver/utils/etl.py
@@ -48,7 +48,9 @@ User = get_user_model()
 def build_label_lookups(
     corpus_id: int,
     analysis_ids: list[int] | None = None,
-    annotation_filter_mode: AnnotationFilterMode = AnnotationFilterMode.CORPUS_LABELSET_ONLY,
+    annotation_filter_mode: (
+        AnnotationFilterMode | str
+    ) = AnnotationFilterMode.CORPUS_LABELSET_ONLY,
 ) -> LabelLookupPythonType:
     """
     Build a label lookup dictionary for the specified corpus. Optionally filter
@@ -57,7 +59,9 @@ def build_label_lookups(
     Args:
         corpus_id (int): The primary key of the corpus.
         analysis_ids (list[int] | None): Optional list of Analysis PKs.
-        annotation_filter_mode (str): One of:
+        annotation_filter_mode (AnnotationFilterMode | str): An
+            ``AnnotationFilterMode`` member or its equivalent string value
+            (the two compare equal). One of:
           - "CORPUS_LABELSET_ONLY"
           - "CORPUS_LABELSET_PLUS_ANALYSES"
           - "ANALYSES_ONLY"
@@ -76,7 +80,7 @@ def build_label_lookups(
         .distinct()
     )
 
-    if annotation_filter_mode == "ANALYSES_ONLY":
+    if annotation_filter_mode == AnnotationFilterMode.ANALYSES_ONLY:
         logger.info("Using ANALYSES_ONLY mode for label filtering")
         # If analyses are specified, gather only labels used by those analyses
         if analysis_ids:
@@ -89,7 +93,7 @@ def build_label_lookups(
         else:
             # If user wants only analyses but there are none, no labels
             label_ids = []
-    elif annotation_filter_mode == "CORPUS_LABELSET_PLUS_ANALYSES":
+    elif annotation_filter_mode == AnnotationFilterMode.CORPUS_LABELSET_PLUS_ANALYSES:
         logger.info("Using CORPUS_LABELSET_PLUS_ANALYSES mode for label filtering")
         # Combine corpus' label set with any from the analyses
         if analysis_ids:
@@ -107,7 +111,7 @@ def build_label_lookups(
 
     # Also gather labels used on Relationship objects (RELATIONSHIP_LABEL type)
     # These are not captured by Annotation queries since they live on Relationship
-    if annotation_filter_mode == "ANALYSES_ONLY":
+    if annotation_filter_mode == AnnotationFilterMode.ANALYSES_ONLY:
         if analysis_ids:
             relationship_label_ids = (
                 Relationship.objects.filter(
@@ -120,7 +124,7 @@ def build_label_lookups(
             relationship_label_ids = Relationship.objects.none().values_list(
                 "relationship_label", flat=True
             )
-    elif annotation_filter_mode == "CORPUS_LABELSET_PLUS_ANALYSES":
+    elif annotation_filter_mode == AnnotationFilterMode.CORPUS_LABELSET_PLUS_ANALYSES:
         corpus_rel_label_ids = (
             Relationship.objects.filter(corpus_id=corpus_id, analysis__isnull=True)
             .values_list("relationship_label", flat=True)
@@ -228,7 +232,9 @@ def build_document_export(
     doc_id: int,
     corpus_id: int,
     analysis_ids: list[int] | None = None,
-    annotation_filter_mode: AnnotationFilterMode = AnnotationFilterMode.CORPUS_LABELSET_ONLY,
+    annotation_filter_mode: (
+        AnnotationFilterMode | str
+    ) = AnnotationFilterMode.CORPUS_LABELSET_ONLY,
 ) -> tuple[
     str,
     str,


### PR DESCRIPTION
## Summary

Resolves the deferred `etl.py` production bug tracked in #1868 (originally surfaced in the review of #1866).

`AnnotationFilterMode` (`opencontractserver/types/enums.py`) was a plain `Enum`, **not** a `str`-mixin enum like every sibling in that file (`ExportType`, `LabelType`, `JobStatus`, `PermissionTypes`, `ContentModality`). So a member never compared equal to its string value, and the two ETL functions that branch on it disagreed about which form they accept.

## The bug (verified)

**`build_label_lookups`** mixed comparison styles against the same parameter:
- mode-selection branches compared against **bare string literals** (`== "ANALYSES_ONLY"`, `== "CORPUS_LABELSET_PLUS_ANALYSES"`)
- the corpus-labelset **augmentation** branch compared against **enum members** (`in (AnnotationFilterMode.CORPUS_LABELSET_ONLY, …)`)

Because a plain-enum member `!=` its string, **no single argument type worked end-to-end**:
- A **string** (what the GraphQL export mutation and Celery tasks deliver — `config/graphql/document_mutations.py:644,672`) satisfied the selection branches but **silently skipped the labelset augmentation**, dropping labels defined in a corpus's label set but unreferenced by annotations — breaking roundtrip-safety (fork ≡ export+import).
- An **enum member** failed the selection branches and fell through to `CORPUS_LABELSET_ONLY` for the analyses modes.

**Broader consequence not noted in the issue:** `build_document_export` compares **only** against enum members and ends in `else: raise ValueError`. That exception is caught by the function's own `except`, which returns `("", "", None, {}, {})`. The **V2 export path** (`package_corpus_export_v2` → `build_corpus_v2_zip`) forwards the GraphQL **string** straight through, so every document hit the `ValueError` → empty-tuple path and was **silently dropped from the archive — for all modes, including the default.** No existing test caught this because every V2 test calls the helpers with the enum **default** (a Python call), never the string the GraphQL layer sends.

The V1 (`burn_doc_annotations`, via `AnnotationFilterMode(...)`) and FUNSD (`convert_doc_to_funsd`, via `.value`) paths already coerced/compared correctly and were unaffected.

## Fix

- `AnnotationFilterMode` is now `class AnnotationFilterMode(str, enum.Enum)` — members and string values are interchangeable, so the in-process (enum) and GraphQL/Celery (string) paths hit the same branches. (Removed the now-unused `from enum import Enum`.)
- Normalized `build_label_lookups`'s string-literal comparisons to enum members so both ETL functions compare consistently and no magic strings remain.
- Broadened both ETL signatures to `AnnotationFilterMode | str` to match runtime reality, retiring the `# type: ignore[arg-type]` / `cast(AnnotationFilterMode, …)` workarounds that callers/tests had needed.

**Observable behavior change:** the string-driven export paths now include the corpus's full label set in their label lookups (matching the enum-driven fork path) instead of only the referenced labels. This is the intended roundtrip-safety behavior the augmentation block documents.

## Verification of the three "minor" review items in #1868

- **#1 (multi-line comment style):** cites a CLAUDE.md "one short line max" rule that **does not exist** in this repo — not actioned (per "do not assume reported issues exist").
- **#2 (`cast(zipfile.ZipFile, None)`) / #3 (`label_lookup: dict`):** explicitly "informational"; the `AnnotationFilterMode`-related `cast`/`# type: ignore` workarounds they reference are **removed** as a natural consequence of the real fix.

## Tests

- New `BuildLabelLookupsStringEnumEquivalenceTestCase` (fixture-free): string ≡ enum equivalence across all three modes, the labelset augmentation **firing for string input** (the #1868 canary), `ANALYSES_ONLY` keeping its narrow contract, and `build_document_export` accepting a string mode (the V2 regression).
- `TestAnnotationFilterMode.test_is_string_enum` locks in the str-mixin contract.
- `test_filter_modes_change_annotation_count`: the `build_label_lookups` assertions now verify per-mode label **membership** (correct regardless of the fixture's label-set size) rather than brittle raw counts that the now-correct augmentation shifts; the `build_document_export` counts are unchanged. The `TestBuildLabelLookupsEdgeCases` string casts were switched to enum members.

## Validation performed

- ✅ `AnnotationFilterMode` str-mixin behavior verified directly (equality, `in`, `.value`, construction, JSON serialization, unchanged `str()`/`repr`).
- ✅ `black`, `flake8`, `py_compile` clean on all changed files.
- ⚠️ The backend test suite and the pinned `mypy` could **not** be run in this environment — the network policy blocks building the test Docker image (no PyPI access), and local mypy lacks the django-stubs plugin. The type changes are additive (`| str`) with the now-unused ignores/casts removed, and `mypy.ini` has no `strict_equality`, so the union comparisons are safe. **CI should be relied on for the full backend + mypy gate.**

Closes #1868
