### PR TITLE
Register deep-research and memory Celery tasks on the worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Deep-research and conversation-memory Celery tasks were never registered on the worker (2026-06).**
+  `run_deep_research` (`opencontractserver/tasks/research_tasks.py`) and the
+  memory tasks `check_conversations_for_curation` / `curate_corpus_memory`
+  (`opencontractserver/tasks/memory_tasks.py`) were absent from
+  `opencontractserver/tasks/__init__.py`. The Celery worker registers central
+  tasks only as a side effect of that package's `__init__` running at boot
+  (the `@shared_task` decorator registers a task when its module is imported);
+  these three modules were reachable only through lazy, function-local
+  producer-side imports (`research/services/research_reports.py`) or by
+  name via `CELERY_BEAT_SCHEDULE`. A real worker would therefore reject the
+  queued message with *"Received unregistered task"*, leaving deep-research
+  reports stuck and the conversation-curation beat job non-functional. The
+  defect was masked in the unit suite because `config/settings/test.py` runs
+  Celery in `CELERY_TASK_ALWAYS_EAGER` mode, where `.delay()` executes inline
+  in the process that just lazily imported the module. Fix: import the three
+  tasks in `opencontractserver/tasks/__init__.py` (and add them to `__all__`),
+  matching the registration mechanism every other shipped task relies on.
+  Added a subprocess-based regression test
+  (`opencontractserver/tests/architecture/test_celery_task_registration.py`)
+  that boots a worker in a clean interpreter and asserts these task names are
+  present in `app.tasks`.
+
 ### Changed
 
 - **Scoped admin (superuser) data access — admins are no longer omniscient over user data (2026-06).**

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -124,9 +124,7 @@ try:
                 # timeout must stay disabled (the historical channels-redis
                 # default that every redis-py < 8.0 provided). Do NOT pin redis
                 # back below 8.0 to "fix" this. See issue #1886.
-                "hosts": [
-                    {"host": host, "port": int(port), "socket_timeout": None}
-                ],
+                "hosts": [{"host": host, "port": int(port), "socket_timeout": None}],
             },
         },
     }

--- a/opencontractserver/tasks/__init__.py
+++ b/opencontractserver/tasks/__init__.py
@@ -18,9 +18,11 @@ from .import_tasks import (
     process_documents_zip,
 )
 from .lookup_tasks import build_label_lookups_task
+from .memory_tasks import check_conversations_for_curation, curate_corpus_memory
 
 # Materialized view tasks removed - using direct queries instead
 from .permissioning_tasks import make_analysis_public_task, make_corpus_public_task
+from .research_tasks import run_deep_research
 from .telemetry_tasks import send_usage_heartbeat
 
 # Great, quick guidance on how to restructure tasks into multiple modules:
@@ -48,4 +50,7 @@ __all__ = [
     "generate_agent_response",
     "trigger_agent_responses_for_message",
     "send_usage_heartbeat",
+    "run_deep_research",
+    "check_conversations_for_curation",
+    "curate_corpus_memory",
 ]

--- a/opencontractserver/tests/architecture/test_celery_task_registration.py
+++ b/opencontractserver/tests/architecture/test_celery_task_registration.py
@@ -31,6 +31,7 @@ boot-time registration.
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import sys
@@ -41,8 +42,10 @@ import pytest
 # Canonical task names that MUST be registered on a freshly-booted worker.
 # These are tasks reachable only through lazy/beat dispatch (no module-level
 # import on the boot path), which is exactly the class of task that silently
-# fails to register. Add new entries here when a task is dispatched by name
-# (beat schedule) or via a lazy ``.delay()`` import.
+# fails to register. Add an entry here whenever a task is dispatched by name
+# (beat schedule) or via a lazy, function-local ``.delay()`` import -- i.e.
+# any task whose defining module is NOT transitively imported from
+# ``opencontractserver/tasks/__init__.py`` at worker boot.
 REQUIRED_TASK_NAMES = [
     "opencontractserver.tasks.research_tasks.run_deep_research",
     "opencontractserver.tasks.memory_tasks.check_conversations_for_curation",
@@ -93,7 +96,9 @@ def test_required_tasks_register_on_fresh_worker_boot() -> None:
         capture_output=True,
         text=True,
         env=env,
-        timeout=300,
+        # Django setup in a fresh interpreter is ~5-15s; 90s is generous but
+        # fails fast if the subprocess genuinely hangs.
+        timeout=90,
     )
 
     assert result.returncode == 0, (
@@ -103,8 +108,6 @@ def test_required_tasks_register_on_fresh_worker_boot() -> None:
 
     # The boot script prints a single JSON object on its final stdout line.
     last_line = result.stdout.strip().splitlines()[-1]
-    import json
-
     present = json.loads(last_line)
 
     missing = [name for name, ok in present.items() if not ok]

--- a/opencontractserver/tests/architecture/test_celery_task_registration.py
+++ b/opencontractserver/tests/architecture/test_celery_task_registration.py
@@ -1,0 +1,117 @@
+"""Architecture invariant: every shipped Celery task must register on a
+freshly-booted worker.
+
+Background (investigation 2026-06-01): the Celery worker does **not**
+discover the central ``opencontractserver/tasks/`` package directly —
+``autodiscover_tasks()`` only finds per-app ``tasks.py`` modules, and the
+only one that exists is ``opencontractserver/users/tasks.py``. The central
+package is imported as a *side effect* of Django boot (admin/signal/service
+imports eventually trigger ``opencontractserver/tasks/__init__.py``), and
+that ``__init__`` eagerly imports a curated list of submodules. The
+``@shared_task`` decorator only registers a task when its module is
+imported, so any task module missing from that boot chain is silently
+absent from the worker's registry.
+
+``run_deep_research`` (research) and the ``memory_tasks`` beat tasks were
+only reachable via lazy, function-local producer-side imports, so they
+queued fine from the web process but were *unregistered on the worker* —
+a real worker would reject the message with "Received unregistered task".
+The defect hides from the unit suite because ``config.settings.test`` runs
+Celery in ``CELERY_TASK_ALWAYS_EAGER`` mode, where ``.delay()`` runs inline
+in the same process that just lazily imported the module.
+
+This test boots a worker the way the worker boots — in a clean subprocess,
+running only ``django.setup()`` + ``autodiscover_tasks()`` +
+``import_default_modules()`` and **never** importing the producer
+services — then asserts the canonical task names are present in
+``app.tasks``. Running in a subprocess is essential: the in-process pytest
+interpreter has already imported many modules, which would mask a missing
+boot-time registration.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+# Canonical task names that MUST be registered on a freshly-booted worker.
+# These are tasks reachable only through lazy/beat dispatch (no module-level
+# import on the boot path), which is exactly the class of task that silently
+# fails to register. Add new entries here when a task is dispatched by name
+# (beat schedule) or via a lazy ``.delay()`` import.
+REQUIRED_TASK_NAMES = [
+    "opencontractserver.tasks.research_tasks.run_deep_research",
+    "opencontractserver.tasks.memory_tasks.check_conversations_for_curation",
+    "opencontractserver.tasks.memory_tasks.curate_corpus_memory",
+]
+
+# Replicates the Celery worker boot path (``celery -A config.celery_app
+# worker``) in a clean interpreter and reports which of the required task
+# names made it into the registry. It must NOT import any producer service
+# (e.g. ``research.services.research_reports``) — doing so would import the
+# task module directly and mask the very defect this test guards against.
+_BOOT_SCRIPT = textwrap.dedent("""
+    import json
+    import django
+
+    django.setup()
+
+    from config.celery_app import app
+
+    # The worker calls autodiscover at startup and finalizes task discovery
+    # via import_default_modules during bootstrap. Mirror both here.
+    app.autodiscover_tasks()
+    app.loader.import_default_modules()
+
+    required = {required!r}
+    present = {{name: name in app.tasks for name in required}}
+    print(json.dumps(present))
+    """).format(required=REQUIRED_TASK_NAMES)
+
+
+@pytest.mark.serial
+def test_required_tasks_register_on_fresh_worker_boot() -> None:
+    """Tasks dispatched by name/lazy import must register at worker boot.
+
+    Boots a worker in a clean subprocess and asserts every name in
+    ``REQUIRED_TASK_NAMES`` is in ``app.tasks``. A missing name means the
+    task module is absent from the boot import chain (most commonly: not
+    imported in ``opencontractserver/tasks/__init__.py``), so the real
+    worker would reject the queued message as an unregistered task.
+    """
+    env = dict(os.environ)
+    # Settings module choice is irrelevant to registration (it is about
+    # import wiring, not eager mode); fall back to the test settings.
+    env.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.test")
+
+    result = subprocess.run(
+        [sys.executable, "-c", _BOOT_SCRIPT],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=300,
+    )
+
+    assert result.returncode == 0, (
+        "Worker boot subprocess failed.\n"
+        f"stdout:\n{result.stdout}\n\nstderr:\n{result.stderr}"
+    )
+
+    # The boot script prints a single JSON object on its final stdout line.
+    last_line = result.stdout.strip().splitlines()[-1]
+    import json
+
+    present = json.loads(last_line)
+
+    missing = [name for name, ok in present.items() if not ok]
+    assert not missing, (
+        "These Celery tasks did NOT register on a fresh worker boot: "
+        f"{missing}. Add the defining module to "
+        "opencontractserver/tasks/__init__.py (and __all__) so the "
+        "@shared_task decorator runs during worker startup. A worker would "
+        "otherwise reject these as 'Received unregistered task'."
+    )


### PR DESCRIPTION
## Problem

`run_deep_research` (`opencontractserver/tasks/research_tasks.py`) and the conversation-memory tasks `check_conversations_for_curation` / `curate_corpus_memory` (`opencontractserver/tasks/memory_tasks.py`) were **not registered on the Celery worker**.

The worker doesn't discover the central `opencontractserver/tasks/` package directly — `autodiscover_tasks()` only finds per-app `tasks.py` modules (only `users/tasks.py` exists). The central package's tasks get registered solely as a **side effect** of `opencontractserver/tasks/__init__.py` running at boot (the `@shared_task` decorator registers a task when its module is imported). These three modules were missing from that `__init__`, and were reachable only via:

- a lazy, function-local import in `research/services/research_reports.py` (producer/web process), and
- by-name dispatch via `CELERY_BEAT_SCHEDULE` (memory curation).

So `.delay()` enqueued fine from the web process, but a **real worker** — never having imported the module — would reject the message with *"Received unregistered task"*. Result: deep-research reports stuck in a non-terminal state, and the conversation-curation beat job silently non-functional.

### Why it wasn't caught

`config/settings/test.py` sets `CELERY_TASK_ALWAYS_EAGER = True`. In eager mode `.delay()` runs inline in the same process that just lazily imported the task module, so registration is irrelevant and the unit suite passes regardless.

## Fix

Import the three tasks in `opencontractserver/tasks/__init__.py` (and add to `__all__`) — the same registration mechanism every other shipped task relies on.

## Regression test

`opencontractserver/tests/architecture/test_celery_task_registration.py` boots a worker in a **clean subprocess** (`django.setup()` + `autodiscover_tasks()` + `import_default_modules()`, no producer-service imports) and asserts the canonical task names are present in `app.tasks`. Subprocess isolation is required — the in-process pytest interpreter has already imported much of the codebase, which would mask a missing boot-time registration. `REQUIRED_TASK_NAMES` is the documented place to add any future by-name/lazy-dispatched task.

## Verification (TDD)

- **RED:** test failed reporting all three names missing from a fresh worker boot.
- **GREEN:** after the `__init__.py` change, `1 passed`.
- pre-commit (black/isort/flake8/mypy) clean; CHANGELOG updated under `### Fixed`.