### PR TITLE
Gracefully handle mobile reconnect without alarming network toasts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Alarming "Reconnecting…" / network-error toast pile-up on mobile screen-unlock (2026-06).**
+  On mobile, locking the screen suspends the page and drops in-flight queries
+  and WebSockets; on unlock a burst of failures fired before connectivity
+  re-established, stacking a column of red toasts ("Network error.",
+  repeated "ERROR Unable to fetch corpuses.", "Failed to refresh data. Please
+  reload the page."). Two root causes: (1) the per-query error toasts in the
+  corpus views (`frontend/src/views/Corpuses.tsx`,
+  `frontend/src/components/{documents,extracts,annotations,analyses,research}/*Cards.tsx`)
+  were fired from the component render body **without a `toastId`**, so each
+  re-render while `error` stayed truthy stacked a brand-new toast; (2)
+  `frontend/src/graphql/errorLink.ts` and
+  `frontend/src/components/network/NetworkStatusHandler.tsx` showed network/refetch
+  error toasts unconditionally, even during the brief, expected reconnect window.
+  Fix: a shared "reconnecting" grace window (`isReconnectingVar` in
+  `frontend/src/graphql/cache.ts`, helpers in
+  `frontend/src/utils/networkNotifications.ts`). `NetworkStatusHandler` arms the
+  window around its reconnect refetch (and a 10s safety auto-disarm); while armed
+  — or while `navigator.onLine` is false — `notifyTransientNetworkError` suppresses
+  the alarming toasts in favour of the single calm "Reconnecting…" indicator. All
+  transient network toasts now carry a stable `toastId` so they de-duplicate
+  instead of stacking; genuine persistent failures still surface once (after the
+  window closes). The red "Failed to refresh data. Please reload the page." toast
+  on a reconnect refetch failure was removed. Tests:
+  `frontend/src/utils/__tests__/networkNotifications.test.ts` and updated
+  `frontend/src/components/network/__tests__/NetworkStatusHandler.test.tsx`.
+
 - **Deep-research and conversation-memory Celery tasks were never registered on the worker (2026-06).**
   `run_deep_research` (`opencontractserver/tasks/research_tasks.py`) and the
   memory tasks `check_conversations_for_curation` / `curate_corpus_memory`

--- a/frontend/src/components/analyses/CorpusAnalysesCards.tsx
+++ b/frontend/src/components/analyses/CorpusAnalysesCards.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo } from "react";
 import _ from "lodash";
-import { toast } from "react-toastify";
+import { notifyTransientNetworkError } from "../../utils/networkNotifications";
 import { useQuery, useReactiveVar } from "@apollo/client";
 import { useLocation } from "react-router-dom";
 
@@ -66,7 +66,9 @@ export const CorpusAnalysesCards = () => {
   });
   if (analyses_load_error) {
     console.error("Corpus analysis fetch error", analyses_load_error);
-    toast.error("ERROR\nCould not fetch analyses for corpus.");
+    notifyTransientNetworkError("ERROR\nCould not fetch analyses for corpus.", {
+      toastId: "fetch-analyses-error",
+    });
   }
 
   ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/frontend/src/components/annotations/CorpusAnnotationCards.tsx
+++ b/frontend/src/components/annotations/CorpusAnnotationCards.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import _ from "lodash";
 
 import { toast } from "react-toastify";
+import { notifyTransientNetworkError } from "../../utils/networkNotifications";
 import { useQuery, useLazyQuery, useReactiveVar } from "@apollo/client";
 import { useLocation, useNavigate } from "react-router-dom";
 
@@ -185,7 +186,10 @@ export const CorpusAnnotationCards = ({
   );
 
   if (annotation_error) {
-    toast.error("ERROR\nCould not fetch annotations for corpus.");
+    notifyTransientNetworkError(
+      "ERROR\nCould not fetch annotations for corpus.",
+      { toastId: "fetch-annotations-error" }
+    );
   }
 
   // Determine if we're in semantic search mode

--- a/frontend/src/components/documents/CorpusDocumentCards.tsx
+++ b/frontend/src/components/documents/CorpusDocumentCards.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo } from "react";
 import { toast } from "react-toastify";
+import { notifyTransientNetworkError } from "../../utils/networkNotifications";
 import { useMutation, useQuery, useReactiveVar } from "@apollo/client";
 import { useNavigate } from "react-router-dom";
 
@@ -143,7 +144,12 @@ export const CorpusDocumentCards = ({
     notifyOnNetworkStatusChange: true, // necessary in order to trigger loading signal on fetchMore
   });
   if (documents_error) {
-    toast.error("ERROR\nCould not fetch documents for corpus.");
+    notifyTransientNetworkError(
+      "ERROR\nCould not fetch documents for corpus.",
+      {
+        toastId: "fetch-documents-error",
+      }
+    );
   }
 
   // Fetch folders for current directory
@@ -161,7 +167,9 @@ export const CorpusDocumentCards = ({
   );
 
   if (folders_error) {
-    toast.error("ERROR\nCould not fetch folders for corpus.");
+    notifyTransientNetworkError("ERROR\nCould not fetch folders for corpus.", {
+      toastId: "fetch-folders-error",
+    });
   }
 
   // Filter folders to show only direct children of current folder

--- a/frontend/src/components/extracts/CorpusExtractCards.tsx
+++ b/frontend/src/components/extracts/CorpusExtractCards.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo } from "react";
-import { toast } from "react-toastify";
+import { notifyTransientNetworkError } from "../../utils/networkNotifications";
 import { useQuery, useReactiveVar } from "@apollo/client";
 import { useLocation } from "react-router-dom";
 import { ExtractCards } from "./ExtractCards";
@@ -60,7 +60,9 @@ export const CorpusExtractCards: React.FC<CorpusExtractCardsProps> = ({
   });
 
   if (extracts_load_error) {
-    toast.error("ERROR\nCould not fetch extracts for corpus.");
+    notifyTransientNetworkError("ERROR\nCould not fetch extracts for corpus.", {
+      toastId: "fetch-extracts-error",
+    });
   }
 
   useEffect(() => {

--- a/frontend/src/components/network/NetworkStatusHandler.tsx
+++ b/frontend/src/components/network/NetworkStatusHandler.tsx
@@ -15,6 +15,7 @@ import { useCallback, useRef } from "react";
 import { useApolloClient } from "@apollo/client";
 import { toast } from "react-toastify";
 import { useNetworkStatus } from "../../hooks/useNetworkStatus";
+import { setReconnecting } from "../../utils/networkNotifications";
 
 // ============================================================================
 // Constants
@@ -25,8 +26,18 @@ const TOAST_IDS = {
   RECONNECTING: "network-reconnecting",
   ONLINE: "network-online",
   OFFLINE: "network-offline",
-  REFETCH_ERROR: "network-refetch-error",
 } as const;
+
+/**
+ * Delay (ms) after a reconnect refetch settles before the "reconnecting" grace
+ * window is disarmed.
+ *
+ * Queries that failed-then-(maybe)-succeeded during the reconnect emit a
+ * trailing error render as their state settles; keeping the window armed a
+ * little longer lets {@link notifyTransientNetworkError} swallow that final
+ * flicker instead of flashing a red toast right as we recover.
+ */
+const RECONNECT_TRAILING_DELAY = 1500;
 
 /**
  * Delay (ms) before refetching after network comes online.
@@ -98,6 +109,12 @@ export function NetworkStatusHandler({
       }
       lastRefetchRef.current = now;
 
+      // Arm the reconnect grace window: while a reconnect refetch is in flight,
+      // the queries it re-runs may briefly fail and trigger component-level
+      // error toasts. Suppress those (and errorLink's network-error toast) in
+      // favour of the single calm "Reconnecting…" indicator below.
+      setReconnecting(true);
+
       try {
         console.debug(
           `[NetworkStatusHandler] Refetching active queries: ${reason}`
@@ -111,22 +128,23 @@ export function NetworkStatusHandler({
 
         console.debug("[NetworkStatusHandler] Refetch completed successfully");
       } catch (error) {
+        // Deliberately quiet: a refetch failure here means the connection is
+        // still flaky right after resuming/coming online. We do NOT throw a
+        // red "reload the page" toast at the user mid-reconnect — the calm
+        // "Reconnecting…" indicator already conveys state, and any genuinely
+        // persistent failure surfaces (once) via the normal per-query error
+        // toasts after the grace window closes.
         console.error(
           "[NetworkStatusHandler] Error refetching queries:",
           error
         );
-
-        // Notify user that data may be stale
-        if (showToasts) {
-          toast.error("Failed to refresh data. Please reload the page.", {
-            toastId: TOAST_IDS.REFETCH_ERROR,
-            position: "bottom-right",
-            autoClose: 5000,
-          });
-        }
+      } finally {
+        // Keep the window armed briefly so the trailing error render from
+        // queries that just settled stays suppressed, then disarm.
+        setTimeout(() => setReconnecting(false), RECONNECT_TRAILING_DELAY);
       }
     },
-    [client, refetchDebounceMs, showToasts]
+    [client, refetchDebounceMs]
   );
 
   /**

--- a/frontend/src/components/network/NetworkStatusHandler.tsx
+++ b/frontend/src/components/network/NetworkStatusHandler.tsx
@@ -113,6 +113,13 @@ export function NetworkStatusHandler({
       // the queries it re-runs may briefly fail and trigger component-level
       // error toasts. Suppress those (and errorLink's network-error toast) in
       // favour of the single calm "Reconnecting…" indicator below.
+      //
+      // Intentionally NOT gated on `showToasts`: the window only suppresses
+      // *other* surfaces' toasts (errorLink, per-query card errors), which are
+      // global and exist regardless of this handler's `showToasts` prop. A
+      // consumer passing `showToasts={false}` only silences this handler's own
+      // status toasts, not those independent error surfaces, so the grace
+      // window must still arm to keep them quiet during reconnect.
       setReconnecting(true);
 
       try {

--- a/frontend/src/components/network/__tests__/NetworkStatusHandler.test.tsx
+++ b/frontend/src/components/network/__tests__/NetworkStatusHandler.test.tsx
@@ -355,39 +355,18 @@ describe("NetworkStatusHandler", () => {
       consoleErrorSpy.mockRestore();
     });
 
-    it("should show error toast when refetch fails and showToasts is true", async () => {
+    // Behavior change (issue #697 follow-up): a reconnect refetch failing right
+    // after screen-unlock is expected flakiness, not a user-actionable error.
+    // We intentionally NO LONGER throw a red "reload the page" toast here — the
+    // calm "Reconnecting…" indicator covers it and the reconnect grace window
+    // suppresses the per-query error toasts that would otherwise pile up.
+    it("should NOT show an alarming error toast when reconnect refetch fails", async () => {
       const consoleErrorSpy = vi
         .spyOn(console, "error")
         .mockImplementation(() => {});
       mockRefetchQueries.mockRejectedValueOnce(new Error("Network error"));
 
       renderComponent({ showToasts: true });
-
-      await act(async () => {
-        mockOnResume();
-        // Wait a tick for the async rejection to be handled
-        await Promise.resolve();
-      });
-
-      expect(toast.error).toHaveBeenCalledWith(
-        "Failed to refresh data. Please reload the page.",
-        {
-          toastId: "network-refetch-error",
-          position: "bottom-right",
-          autoClose: 5000,
-        }
-      );
-
-      consoleErrorSpy.mockRestore();
-    });
-
-    it("should NOT show error toast when refetch fails and showToasts is false", async () => {
-      const consoleErrorSpy = vi
-        .spyOn(console, "error")
-        .mockImplementation(() => {});
-      mockRefetchQueries.mockRejectedValueOnce(new Error("Network error"));
-
-      renderComponent({ showToasts: false });
 
       await act(async () => {
         mockOnResume();

--- a/frontend/src/components/research/CorpusResearchReportCards.tsx
+++ b/frontend/src/components/research/CorpusResearchReportCards.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef } from "react";
-import { toast } from "react-toastify";
+import { notifyTransientNetworkError } from "../../utils/networkNotifications";
 import { useQuery, useReactiveVar } from "@apollo/client";
 import styled from "styled-components";
 import { Button, EmptyState } from "@os-legal/ui";
@@ -119,7 +119,10 @@ export const CorpusResearchReportCards: React.FC<
   // call re-fires on every re-render while ``error`` stays truthy.
   useEffect(() => {
     if (error) {
-      toast.error("ERROR\nCould not fetch research reports for this corpus.");
+      notifyTransientNetworkError(
+        "ERROR\nCould not fetch research reports for this corpus.",
+        { toastId: "fetch-research-reports-error" }
+      );
     }
   }, [error]);
 

--- a/frontend/src/graphql/cache.ts
+++ b/frontend/src/graphql/cache.ts
@@ -788,6 +788,19 @@ export type AuthStatus = "LOADING" | "AUTHENTICATED" | "ANONYMOUS";
 export const authStatusVar = makeVar<AuthStatus>("LOADING");
 
 /**
+ * Network reconnection state.
+ *
+ * True while the app is knowingly re-establishing connectivity — e.g. the page
+ * just resumed from background after a mobile screen-unlock, or a reconnect
+ * refetch is in flight. While true, transient network-error toasts are
+ * suppressed in favour of a single calm "Reconnecting…" indicator so users
+ * don't see an alarming pile of red errors during the brief reconnect window
+ * (issue #697 follow-up). Driven by NetworkStatusHandler; read by the network
+ * notification helpers in utils/networkNotifications.ts.
+ */
+export const isReconnectingVar = makeVar<boolean>(false);
+
+/**
  * Tracks whether auth initialization is fully complete, including any cache operations.
  *
  * This is separate from authStatusVar because:

--- a/frontend/src/graphql/errorLink.ts
+++ b/frontend/src/graphql/errorLink.ts
@@ -1,6 +1,7 @@
 import { onError } from "@apollo/client/link/error";
 import { toast } from "react-toastify";
 import { authToken, authStatusVar, userObj } from "./cache";
+import { notifyTransientNetworkError } from "../utils/networkNotifications";
 
 /**
  * Apollo error link that handles authentication errors and network errors.
@@ -123,13 +124,14 @@ export const errorLink = onError(
       // Log other network errors
       console.error(`[Network Error]: ${networkError}`, networkError);
 
-      // Show user-friendly network error message
-      toast.error(
+      // Show a user-friendly network error message — but stay quiet while we
+      // are knowingly reconnecting (e.g. mobile screen-unlock) or offline, so a
+      // transient blip doesn't spam alarming toasts. The single calm
+      // "Reconnecting…"/offline indicator covers that window; a genuine
+      // persistent failure still surfaces (once) afterwards.
+      notifyTransientNetworkError(
         "Network error. Please check your connection and try again.",
-        {
-          toastId: "network-error",
-          autoClose: 5000,
-        }
+        { toastId: "network-error" }
       );
     }
   }

--- a/frontend/src/utils/__tests__/networkNotifications.test.ts
+++ b/frontend/src/utils/__tests__/networkNotifications.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Tests for the reconnection-aware network notification helpers.
+ *
+ * Verifies that transient network-error toasts are suppressed while the app is
+ * knowingly reconnecting (mobile screen-unlock) or offline, and that repeated
+ * render-time calls de-duplicate via a stable toast id.
+ *
+ * Related to Issue #697 - Error on screen unlock
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { toast } from "react-toastify";
+import {
+  notifyTransientNetworkError,
+  setReconnecting,
+  shouldSuppressNetworkError,
+} from "../networkNotifications";
+import { isReconnectingVar } from "../../graphql/cache";
+
+vi.mock("react-toastify", () => ({
+  toast: {
+    error: vi.fn(),
+  },
+}));
+
+describe("networkNotifications", () => {
+  let originalOnLine: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    // Ensure a clean grace-window state between tests.
+    isReconnectingVar(false);
+
+    originalOnLine = Object.getOwnPropertyDescriptor(navigator, "onLine");
+    Object.defineProperty(navigator, "onLine", {
+      value: true,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    setReconnecting(false);
+    vi.useRealTimers();
+    if (originalOnLine) {
+      Object.defineProperty(navigator, "onLine", originalOnLine);
+    }
+  });
+
+  const setOnLine = (value: boolean) =>
+    Object.defineProperty(navigator, "onLine", {
+      value,
+      writable: true,
+      configurable: true,
+    });
+
+  describe("notifyTransientNetworkError", () => {
+    it("shows a toast when online and not reconnecting", () => {
+      notifyTransientNetworkError("Boom", { toastId: "boom" });
+
+      expect(toast.error).toHaveBeenCalledWith("Boom", {
+        toastId: "boom",
+        autoClose: 5000,
+      });
+    });
+
+    it("defaults the toastId to the message so repeats de-duplicate", () => {
+      notifyTransientNetworkError("Same message");
+
+      expect(toast.error).toHaveBeenCalledWith("Same message", {
+        toastId: "Same message",
+        autoClose: 5000,
+      });
+    });
+
+    it("suppresses the toast while reconnecting", () => {
+      setReconnecting(true);
+
+      notifyTransientNetworkError("Boom", { toastId: "boom" });
+
+      expect(toast.error).not.toHaveBeenCalled();
+    });
+
+    it("suppresses the toast while offline", () => {
+      setOnLine(false);
+
+      notifyTransientNetworkError("Boom", { toastId: "boom" });
+
+      expect(toast.error).not.toHaveBeenCalled();
+    });
+
+    it("resumes showing toasts once the grace window is disarmed", () => {
+      setReconnecting(true);
+      notifyTransientNetworkError("Boom", { toastId: "boom" });
+      expect(toast.error).not.toHaveBeenCalled();
+
+      setReconnecting(false);
+      notifyTransientNetworkError("Boom", { toastId: "boom" });
+      expect(toast.error).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("setReconnecting", () => {
+    it("toggles the shared reconnecting reactive var", () => {
+      expect(isReconnectingVar()).toBe(false);
+
+      setReconnecting(true);
+      expect(isReconnectingVar()).toBe(true);
+      expect(shouldSuppressNetworkError()).toBe(true);
+
+      setReconnecting(false);
+      expect(isReconnectingVar()).toBe(false);
+    });
+
+    it("auto-disarms after the safety window so errors are never suppressed forever", () => {
+      setReconnecting(true);
+      expect(isReconnectingVar()).toBe(true);
+
+      // Advance past the 10s safety window.
+      vi.advanceTimersByTime(10000);
+
+      expect(isReconnectingVar()).toBe(false);
+    });
+  });
+});

--- a/frontend/src/utils/__tests__/networkNotifications.test.ts
+++ b/frontend/src/utils/__tests__/networkNotifications.test.ts
@@ -29,8 +29,10 @@ describe("networkNotifications", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.clearAllMocks();
-    // Ensure a clean grace-window state between tests.
-    isReconnectingVar(false);
+    // Ensure a clean grace-window state between tests. Go through
+    // setReconnecting (not isReconnectingVar directly) so any pending safety
+    // timeout left armed by a prior test is force-cleared too.
+    setReconnecting(false);
 
     originalOnLine = Object.getOwnPropertyDescriptor(navigator, "onLine");
     Object.defineProperty(navigator, "onLine", {
@@ -72,6 +74,22 @@ describe("networkNotifications", () => {
         toastId: "Same message",
         autoClose: 5000,
       });
+    });
+
+    it("emits a stable toast id on every repeat so the toasts de-duplicate", () => {
+      // Simulates the same component re-rendering while `error` stays truthy.
+      // react-toastify is mocked here, so the actual collapse-into-one happens
+      // in the real lib via `toastId`; what we assert is the contract that makes
+      // it possible — every call carries the SAME stable id (not a fresh one).
+      notifyTransientNetworkError("Unable to fetch corpuses.");
+      notifyTransientNetworkError("Unable to fetch corpuses.");
+      notifyTransientNetworkError("Unable to fetch corpuses.");
+
+      expect(toast.error).toHaveBeenCalledTimes(3);
+      const ids = (toast.error as ReturnType<typeof vi.fn>).mock.calls.map(
+        ([, opts]) => (opts as { toastId?: string }).toastId
+      );
+      expect(new Set(ids)).toEqual(new Set(["Unable to fetch corpuses."]));
     });
 
     it("suppresses the toast while reconnecting", () => {

--- a/frontend/src/utils/networkNotifications.ts
+++ b/frontend/src/utils/networkNotifications.ts
@@ -1,0 +1,110 @@
+/**
+ * networkNotifications - Centralized, reconnection-aware network toasts.
+ *
+ * Mobile devices suspend the page while the screen is locked. On unlock a burst
+ * of in-flight queries can fail before connectivity re-establishes, producing a
+ * stack of alarming red error toasts (see the screen-unlock issue #697 and its
+ * follow-up). The helpers here gate transient network-error toasts behind a
+ * shared "reconnecting" grace window:
+ *
+ * - While the app is knowingly reconnecting (page just resumed from background)
+ *   or the browser reports being offline, scary error toasts are suppressed in
+ *   favour of the single calm "Reconnecting…" indicator shown by
+ *   NetworkStatusHandler.
+ * - Genuine, persistent failures still surface once the window closes — but
+ *   only ONCE, because every toast is given a stable id and therefore
+ *   de-duplicates instead of stacking on each re-render.
+ *
+ * Related to Issue #697 - Error on screen unlock
+ */
+
+import { toast } from "react-toastify";
+import { isReconnectingVar } from "../graphql/cache";
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** Auto-close (ms) for a transient network-error toast shown outside the grace window. */
+const TRANSIENT_ERROR_AUTOCLOSE_MS = 5000;
+
+/**
+ * Max time (ms) the reconnecting grace window stays armed before force-clearing.
+ *
+ * Safety net: a reconnect refetch that never settles must not be able to
+ * suppress error toasts forever, so the window auto-disarms after this window
+ * even if nothing explicitly clears it.
+ */
+const RECONNECT_MAX_WINDOW_MS = 10000;
+
+// ============================================================================
+// Reconnect grace window
+// ============================================================================
+
+let forceClearTimeout: ReturnType<typeof setTimeout> | null = null;
+
+/**
+ * Arm or disarm the reconnecting grace window.
+ *
+ * While armed, {@link notifyTransientNetworkError} suppresses alarming toasts.
+ * Arming (re)starts a safety timeout that force-disarms the window after
+ * {@link RECONNECT_MAX_WINDOW_MS}.
+ */
+export function setReconnecting(active: boolean): void {
+  isReconnectingVar(active);
+
+  if (forceClearTimeout) {
+    clearTimeout(forceClearTimeout);
+    forceClearTimeout = null;
+  }
+
+  if (active) {
+    forceClearTimeout = setTimeout(() => {
+      isReconnectingVar(false);
+      forceClearTimeout = null;
+    }, RECONNECT_MAX_WINDOW_MS);
+  }
+}
+
+/**
+ * Whether transient network errors should currently be suppressed.
+ *
+ * True when we're mid-reconnect, or when the browser reports being offline
+ * (the offline state already shows its own single, dedicated toast).
+ */
+export function shouldSuppressNetworkError(): boolean {
+  const offline =
+    typeof navigator !== "undefined" && navigator.onLine === false;
+  return isReconnectingVar() || offline;
+}
+
+// ============================================================================
+// Notifications
+// ============================================================================
+
+/**
+ * Show a network-error toast UNLESS we're mid-reconnect (or offline), in which
+ * case the calm "Reconnecting…" / offline indicators already cover the
+ * situation and a red error would just be alarming noise.
+ *
+ * A stable `toastId` (defaulting to the message text) is always set so repeated
+ * render-time calls — e.g. `if (error) toast.error(...)` in a component body,
+ * which re-fires on every re-render while `error` stays truthy — collapse into
+ * a single toast instead of stacking.
+ *
+ * @param message - User-facing error text.
+ * @param options.toastId - Stable de-dupe id. Defaults to `message`.
+ */
+export function notifyTransientNetworkError(
+  message: string,
+  options: { toastId?: string } = {}
+): void {
+  if (shouldSuppressNetworkError()) {
+    return;
+  }
+
+  toast.error(message, {
+    toastId: options.toastId ?? message,
+    autoClose: TRANSIENT_ERROR_AUTOCLOSE_MS,
+  });
+}

--- a/frontend/src/utils/networkNotifications.ts
+++ b/frontend/src/utils/networkNotifications.ts
@@ -18,7 +18,7 @@
  * Related to Issue #697 - Error on screen unlock
  */
 
-import { toast } from "react-toastify";
+import { toast, type ToastOptions } from "react-toastify";
 import { isReconnectingVar } from "../graphql/cache";
 
 // ============================================================================
@@ -93,18 +93,23 @@ export function shouldSuppressNetworkError(): boolean {
  * a single toast instead of stacking.
  *
  * @param message - User-facing error text.
- * @param options.toastId - Stable de-dupe id. Defaults to `message`.
+ * @param options - Standard react-toastify options. `toastId` is a stable
+ *   de-dupe id that defaults to `message`; `autoClose` defaults to
+ *   {@link TRANSIENT_ERROR_AUTOCLOSE_MS} but, like any other option, may be
+ *   overridden by the caller.
  */
 export function notifyTransientNetworkError(
   message: string,
-  options: { toastId?: string } = {}
+  options: Omit<ToastOptions, "toastId"> & { toastId?: string } = {}
 ): void {
   if (shouldSuppressNetworkError()) {
     return;
   }
 
+  const { toastId, ...rest } = options;
   toast.error(message, {
-    toastId: options.toastId ?? message,
     autoClose: TRANSIENT_ERROR_AUTOCLOSE_MS,
+    ...rest,
+    toastId: toastId ?? message,
   });
 }

--- a/frontend/src/views/Corpuses.tsx
+++ b/frontend/src/views/Corpuses.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect, useMemo, useCallback } from "react";
 import _ from "lodash";
 import { toast } from "react-toastify";
+import { notifyTransientNetworkError } from "../utils/networkNotifications";
 import {
   useLazyQuery,
   useMutation,
@@ -544,7 +545,9 @@ export const Corpuses = () => {
    * -------------------------------------------------------------------------------------------------- */
 
   if (corpus_load_error) {
-    toast.error("ERROR\nUnable to fetch corpuses.");
+    notifyTransientNetworkError("ERROR\nUnable to fetch corpuses.", {
+      toastId: "fetch-corpuses-error",
+    });
   }
 
   ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -590,7 +593,12 @@ export const Corpuses = () => {
     }
   );
   if (documents_error) {
-    toast.error("ERROR\nCould not fetch documents for corpus.");
+    notifyTransientNetworkError(
+      "ERROR\nCould not fetch documents for corpus.",
+      {
+        toastId: "fetch-documents-error",
+      }
+    );
   }
 
   useEffect(() => {


### PR DESCRIPTION
## Problem

On mobile, locking the screen suspends the page and drops in-flight queries and WebSockets. On unlock, a burst of failures fires before connectivity re-establishes, stacking a column of alarming red toasts:

- "Network error. Please check your connection and try again."
- repeated "ERROR Unable to fetch corpuses." (5×+)
- "Failed to refresh data. Please reload the page."

<img width="260" alt="before" src="https://github.com/user-attachments/assets/placeholder" />

Two root causes:

1. **Stacking duplicates** — the per-query error toasts in the corpus views were fired from the **component render body without a `toastId`**, so every re-render while `error` stayed truthy stacked a brand-new toast (that's the 5× "Unable to fetch corpuses" pile).
2. **No reconnect awareness** — `errorLink.ts` and `NetworkStatusHandler` showed network/refetch error toasts unconditionally, even during the brief, *expected* reconnect window right after unlock.

The reconnect/refetch machinery from issue #697 (`NetworkStatusHandler`, `useNetworkStatus`) already existed — the alarming toasts were simply bypassing it.

## Fix

A shared **"reconnecting" grace window**:

- `isReconnectingVar` reactive var (`frontend/src/graphql/cache.ts`) + helpers in `frontend/src/utils/networkNotifications.ts` (`setReconnecting`, `notifyTransientNetworkError`, `shouldSuppressNetworkError`), with a 10s safety auto-disarm so errors can never be suppressed forever.
- `NetworkStatusHandler` **arms** the window around its reconnect refetch and no longer shows the red "Failed to refresh data. Please reload the page." toast on a reconnect-refetch failure.
- `errorLink` and the corpus per-query error toasts (`Corpuses`, `Corpus{Document,Extract,Annotation,Analyses,ResearchReport}Cards`) now route through `notifyTransientNetworkError`, which:
  - **suppresses** the alarming toast while the window is armed **or** the device is offline (the single calm "Reconnecting…" / offline indicator covers it), and
  - always sets a **stable `toastId`** so render-time calls de-duplicate instead of stacking.

Genuine, persistent failures still surface — but only **once**, after the grace window closes. Desktop benefits too (no more duplicate-toast pile-ups).

## Tests

- New `frontend/src/utils/__tests__/networkNotifications.test.ts` — suppression while reconnecting/offline, stable-id de-dup, safety auto-disarm.
- Updated `frontend/src/components/network/__tests__/NetworkStatusHandler.test.tsx` — asserts the graceful (no-alarming-toast) reconnect-failure behavior in place of the old "Failed to refresh data" assertion.
- `tsc --noEmit` clean; `errorLink.test.ts` and the touched component helper tests pass.

https://claude.ai/code/session_01CyzMzwuzbqMaTFc6wijGZL

---
_Generated by [Claude Code](https://claude.ai/code/session_01CyzMzwuzbqMaTFc6wijGZL)_