### PR TITLE
Fix Discover search box icon/input stacking on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Discover landing search box stacked its icon on a separate line from the input on mobile (2026-06).**
+  The `@os-legal/ui` `SearchBox` ships a `@media (max-width: 480px)` rule that
+  sets `.oc-search-box__input { flex: 1 1 100% }`, forcing the input onto its
+  own full-width row and stranding the magnifying-glass icon alone on the line
+  above the placeholder. Added a higher-specificity override in the
+  `SearchContainer` styled-component
+  (`frontend/src/components/landing/NewHeroSection.tsx`) that restores
+  `flex: 1 1 auto` on the input below `SMALL_MOBILE_BREAKPOINT` (480px), so the
+  icon and input share one row again while the submit button still wraps to its
+  own full-width row.
+
 - **Deep-research and conversation-memory Celery tasks were never registered on the worker (2026-06).**
   `run_deep_research` (`opencontractserver/tasks/research_tasks.py`) and the
   memory tasks `check_conversations_for_curation` / `curate_corpus_memory`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`frontend/src/components/landing/NewHeroSection.tsx`) that restores
   `flex: 1 1 auto` on the input below `SMALL_MOBILE_BREAKPOINT` (480px), so the
   icon and input share one row again while the submit button still wraps to its
-  own full-width row.
+  own full-width row. Note: the upstream `SearchBox` mobile rule is unchanged
+  through the latest `@os-legal/ui` 0.1.19, so this consumer-side override is
+  version-independent and is retained after the bump noted under Changed.
 
 - **Deep-research and conversation-memory Celery tasks were never registered on the worker (2026-06).**
   `run_deep_research` (`opencontractserver/tasks/research_tasks.py`) and the
@@ -43,6 +45,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   present in `app.tasks`.
 
 ### Changed
+
+- **Bumped `@os-legal/ui` 0.1.16 → 0.1.19** (`frontend/package.json`,
+  `frontend/yarn.lock`). The upstream `SearchBox` mobile layout is unchanged in
+  0.1.19, so the consumer-side icon/input override above is still required.
 
 - **Scoped admin (superuser) data access — admins are no longer omniscient over user data (2026-06).**
   Previously a `is_superuser` account received a blanket bypass throughout the

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
     "@hello-pangea/dnd": "^18.0.1",
     "@os-legal/caml": "^0.1.2",
     "@os-legal/caml-react": "^0.1.2",
-    "@os-legal/ui": "0.1.16",
+    "@os-legal/ui": "0.1.19",
     "@rjsf/core": "^5.24.12",
     "@rjsf/utils": "^5.24.1",
     "@rjsf/validator-ajv8": "^5.24.12",

--- a/frontend/src/components/landing/NewHeroSection.tsx
+++ b/frontend/src/components/landing/NewHeroSection.tsx
@@ -7,6 +7,7 @@ import {
   OS_LEGAL_TYPOGRAPHY,
 } from "../../assets/configurations/osLegalStyles";
 import {
+  SMALL_MOBILE_BREAKPOINT,
   TABLET_BREAKPOINT,
   TABLET_LANDSCAPE_BREAKPOINT,
 } from "../../assets/configurations/constants";
@@ -100,6 +101,19 @@ const HeroSubtitle = styled.p`
 
 const SearchContainer = styled.div`
   margin-bottom: 16px;
+
+  /* The @os-legal/ui SearchBox ships a mobile rule that sets the input to
+     "flex: 1 1 100%", which forces it onto its own full-width row. That wraps
+     the magnifying-glass icon onto a line by itself, above the placeholder
+     (and pushes the submit button to a third row). Keep the icon and input on
+     the same row on small screens; the full-width button can still wrap below.
+     The two-class selector here out-specifies the library's single-class media
+     rule, so it wins regardless of stylesheet injection order. */
+  @media (max-width: ${SMALL_MOBILE_BREAKPOINT}px) {
+    .oc-search-box__input {
+      flex: 1 1 auto;
+    }
+  }
 `;
 
 const FilterContainer = styled.div`

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1550,10 +1550,10 @@
   resolved "https://registry.yarnpkg.com/@os-legal/caml/-/caml-0.1.2.tgz#403fcd236c5206abd9ed3d5657e95a898a67bda2"
   integrity sha512-7Kdhu5ziXMepoDg+ONC041vag4kHAQfam98R0pvmPST7xbfZCu+oY3jDdVtPuNjcVgbKZWh223VfStJCAKExQQ==
 
-"@os-legal/ui@0.1.16":
-  version "0.1.16"
-  resolved "https://registry.yarnpkg.com/@os-legal/ui/-/ui-0.1.16.tgz#e417df07eb08a7ed793987e4a62d08167d95bc68"
-  integrity sha512-2ltI5voRHCsXUBK/OqEErc9u5n6Ks0xz8arOpzpUe31hahdwnGbS6aeVVN/qHpYp3txUx39544eCpFLF+rbtww==
+"@os-legal/ui@0.1.19":
+  version "0.1.19"
+  resolved "https://registry.yarnpkg.com/@os-legal/ui/-/ui-0.1.19.tgz#d3511090cc41a8b8e0f499bcab23bd010e99e237"
+  integrity sha512-+bu/s0hJc5pS92Rd/iKggb7Luutwc6Gs76+ErT4uMTnzoIwxI6PA0HQS2FJFbcnvuNBNy+qRxy32AKhFuAzkAA==
 
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"


### PR DESCRIPTION
## Problem

On mobile, the Discover landing page search box renders the magnifying-glass icon on a separate line **above** the input placeholder, with the submit button stacked below as a third row:

[reported issue: icon stranded on its own line above "Search the citation graph…"]

## Root cause

The search box is the `SearchBox` component from the external `@os-legal/ui` package (`NewHeroSection.tsx`). That package ships a responsive rule:

```css
@media (max-width: 480px) {
  .oc-search-box { flex-wrap: wrap; }
  .oc-search-box__input { flex: 1 1 100%; order: 1; }   /* <- forces input onto its own full-width row */
  .oc-search-box__icon  { order: 0; }
  .oc-search-box__button { order: 2; width: 100%; margin-top: 8px; }
}
```

Because the input is given `flex: 1 1 100%`, it wraps to its own line, leaving the small icon stranded alone on the row above it. The styles are real (injected via `allStyles` in `index.tsx`) — this is the library's intended mobile layout, but it strands the icon.

## Fix

Added a higher-specificity override in the `SearchContainer` styled-component (`frontend/src/components/landing/NewHeroSection.tsx`) that restores `flex: 1 1 auto` on the input below `SMALL_MOBILE_BREAKPOINT` (480px). The two-class selector out-specifies the library's single-class media rule, so it wins regardless of stylesheet injection order. Result: the icon and input share one row again; the full-width submit button still wraps to its own row below.

## Notes

- Reused the existing `SMALL_MOBILE_BREAKPOINT = 480` constant (matches the library's media query exactly) — no magic numbers.
- `tsc --noEmit` passes; Prettier clean.
- CHANGELOG updated.

https://claude.ai/code/session_0197t5czQr6t7dCEXZe1tqRu

---
_Generated by [Claude Code](https://claude.ai/code/session_0197t5czQr6t7dCEXZe1tqRu)_