### PR TITLE
Eliminate CHANGELOG.md merge conflicts with per-PR changelog fragments

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,3 +9,13 @@ frontend/src/assets/** linguist-vendored
 #   with merge=ours).
 # Requires one-time local setup: git config merge.ours.driver true
 docs/assets/images/screenshots/auto/** merge=ours -diff -text
+
+# CHANGELOG.md is append-heavy: every PR adds entries to the top of the
+# "## [Unreleased]" section, so concurrent PRs constantly collide on the same
+# lines. `merge=union` is a *built-in* git driver (no `git config` needed,
+# unlike merge=ours above) that resolves such conflicts by keeping the added
+# lines from BOTH sides instead of raising a conflict. Going forward, prefer
+# adding a fragment under changelog.d/ (see changelog.d/README.md) so PRs never
+# touch this file at all; the union driver is a safety net for direct edits and
+# for the existing in-flight PRs.
+CHANGELOG.md merge=union

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,18 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
 
+  - repo: local
+    hooks:
+      # Validate changelog fragments (changelog.d/<slug>.<type>.md). PRs add a
+      # fragment instead of editing CHANGELOG.md directly, so concurrent PRs
+      # never collide on the changelog. See changelog.d/README.md.
+      - id: changelog-fragments
+        name: validate changelog fragments
+        entry: python scripts/collate_changelog.py --check
+        language: system
+        files: ^changelog\.d/
+        pass_filenames: false
+
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.20.0
     hooks:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -502,27 +502,40 @@ This project follows **trunk-based development**:
 
 ## Changelog Maintenance
 
-**IMPORTANT**: Always update `CHANGELOG.md` when making significant changes to the codebase.
+**IMPORTANT**: Always record significant changes — but **do NOT edit `CHANGELOG.md`
+directly in a PR.** Add a *changelog fragment* under `changelog.d/` instead.
 
-The changelog follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format:
+**Why:** every PR used to insert its entry at the top of `CHANGELOG.md`'s single
+`## [Unreleased]` section, so concurrent PRs collided on the same lines and
+produced perpetual merge conflicts (the file changed in ~hundreds of commits per
+month). Each PR now adds its own uniquely-named file, so two PRs can never touch
+the same lines — changelog merge conflicts become structurally impossible. The
+fragments are collated into `CHANGELOG.md` at release time. (A `merge=union`
+driver in `.gitattributes` is a safety net for any direct edit that slips
+through; it auto-keeps both sides instead of conflicting.)
 
-```markdown
-## [Unreleased] - YYYY-MM-DD
+**How to add an entry** — create one file per change:
 
-### Added
-- New features
-
-### Fixed
-- Bug fixes with file locations and line numbers
-
-### Changed
-- Changes to existing functionality
-
-### Technical Details
-- Implementation specifics, architectural notes
+```
+changelog.d/<slug>.<type>.md
 ```
 
-**When to update**:
+- `<slug>` — anything unique; the PR number (`1901`) is ideal, or a short
+  kebab-case description.
+- `<type>` — one of `added`, `changed`, `deprecated`, `removed`, `fixed`,
+  `security` (Keep a Changelog groups).
+- **Body** = the markdown bullet(s) you'd have written under the section header,
+  *without* the `### Fixed` header itself (the type comes from the filename).
+- Keep the same quality bar: file paths, line numbers, issue/impact, rationale.
+- Multiple categories in one PR → multiple fragments
+  (`1908-search.added.md` + `1908-search.fixed.md`).
+
+Tooling (`scripts/collate_changelog.py`): `--check` validates fragments (CI /
+pre-commit), `--preview` prints the collated markdown, `--apply` folds fragments
+into `CHANGELOG.md`'s `[Unreleased]` section and deletes them (release step).
+See `changelog.d/README.md` for full details.
+
+**When to add a fragment**:
 - New features or models added
 - Production code bugs fixed (document file location, line numbers, and impact)
 - Breaking changes to APIs or data models

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -1,0 +1,59 @@
+# Changelog fragments (`changelog.d/`)
+
+**Do not edit `CHANGELOG.md` directly in a PR.** Add a *fragment* here instead.
+
+Every PR that touches `CHANGELOG.md`'s `## [Unreleased]` section edits the same
+lines, so concurrent PRs collide constantly. Fragments fix this at the root:
+each PR adds its **own uniquely-named file**, so two PRs can never touch the
+same lines — merge conflicts on the changelog become structurally impossible.
+At release time the fragments are collated into `CHANGELOG.md` and deleted.
+
+## How to add an entry
+
+Create one file per change, named:
+
+```
+changelog.d/<slug>.<type>.md
+```
+
+- `<slug>` — anything unique. The PR number is ideal (`1901`), or a short
+  kebab-case description (`pdf-white-line`). Uniqueness is all that matters.
+- `<type>` — one of the [Keep a Changelog](https://keepachangelog.com/) groups
+  (case-insensitive): `added`, `changed`, `deprecated`, `removed`, `fixed`,
+  `security`.
+
+The file body is the markdown bullet(s) — **the same prose you'd have written
+under the section header**, just without the `### Fixed` line itself.
+
+### Example
+
+`changelog.d/1901-pdf-white-line.fixed.md`:
+
+```markdown
+- **Fixed white-line artifact in PDF annotation highlights.** When a bounding
+  box was hidden, `SelectionLayer` (`frontend/src/components/.../Selection.tsx`)
+  still rendered a 1px border, leaving a white seam across the token. ...
+```
+
+That's it. No `### Fixed` header inside the file — the type comes from the
+filename, and the collation script adds the header.
+
+## Multiple categories in one PR
+
+Add multiple fragments — e.g. `1908-search.added.md` and `1908-search.fixed.md`.
+
+## Previewing / releasing
+
+```bash
+# See what the next release section will look like:
+python scripts/collate_changelog.py --preview
+
+# Validate fragment names/contents (used by CI / pre-commit):
+python scripts/collate_changelog.py --check
+
+# At release time: fold all fragments into CHANGELOG.md's [Unreleased]
+# section (grouped by category) and delete the fragment files:
+python scripts/collate_changelog.py --apply
+```
+
+See `scripts/collate_changelog.py --help` for details.

--- a/changelog.d/changelog-fragments.changed.md
+++ b/changelog.d/changelog-fragments.changed.md
@@ -1,0 +1,11 @@
+- **Changelog now uses per-PR fragments to eliminate `CHANGELOG.md` merge
+  conflicts.** Every PR previously inserted its entry at the top of the single
+  `## [Unreleased]` section, so concurrent PRs collided on the same lines
+  (the file changed in hundreds of commits per month, perpetually conflicting).
+  PRs now add a uniquely-named fragment under `changelog.d/<slug>.<type>.md`
+  instead — unique filenames mean two PRs can never touch the same lines, so
+  changelog conflicts are structurally impossible. `scripts/collate_changelog.py`
+  collates fragments into `CHANGELOG.md` at release time (`--check` / `--preview`
+  / `--apply`), a `repo: local` pre-commit hook validates fragment names, and
+  `CHANGELOG.md merge=union` in `.gitattributes` is a safety net for direct
+  edits. See `changelog.d/README.md`.

--- a/scripts/collate_changelog.py
+++ b/scripts/collate_changelog.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Collate per-PR changelog fragments into CHANGELOG.md.
+
+Background
+----------
+Every PR used to edit the top of ``CHANGELOG.md``'s ``## [Unreleased]`` section,
+so concurrent PRs collided on the same lines and produced perpetual merge
+conflicts. Instead, each PR now drops a uniquely-named *fragment* in
+``changelog.d/`` (see ``changelog.d/README.md``). Unique filenames mean PRs
+never touch the same lines, so changelog conflicts become impossible.
+
+This script turns those fragments into changelog prose:
+
+    python scripts/collate_changelog.py --check     # validate fragments (CI)
+    python scripts/collate_changelog.py --preview    # print collated markdown
+    python scripts/collate_changelog.py --apply      # fold into CHANGELOG.md
+                                                      # and delete fragments
+
+``--apply`` merges the fragments into the existing ``## [Unreleased]`` section,
+grouping everything by category in Keep-a-Changelog order. It does NOT cut a
+version — renaming ``[Unreleased]`` to ``[X.Y.Z]`` and opening a fresh empty
+``[Unreleased]`` stays a deliberate manual release step.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# Keep a Changelog category order. Filenames use the lowercase key; the rendered
+# section header uses the title-cased value.
+CATEGORIES: dict[str, str] = {
+    "added": "Added",
+    "changed": "Changed",
+    "deprecated": "Deprecated",
+    "removed": "Removed",
+    "fixed": "Fixed",
+    "security": "Security",
+}
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+FRAGMENT_DIR = REPO_ROOT / "changelog.d"
+CHANGELOG = REPO_ROOT / "CHANGELOG.md"
+
+# Fragment filenames look like "<slug>.<type>.md"; README.md is ignored.
+FRAGMENT_RE = re.compile(r"^(?P<slug>.+)\.(?P<type>[a-zA-Z]+)\.md$")
+
+
+class FragmentError(Exception):
+    """A fragment file is malformed (bad type suffix or empty body)."""
+
+
+def discover_fragments() -> list[Path]:
+    """Return fragment files in changelog.d/, excluding README.md."""
+    if not FRAGMENT_DIR.is_dir():
+        return []
+    return sorted(
+        p
+        for p in FRAGMENT_DIR.iterdir()
+        if p.is_file() and p.name.lower() != "readme.md"
+    )
+
+
+def parse_fragment(path: Path) -> tuple[str, str]:
+    """Return (category_key, body_text) for one fragment, validating it.
+
+    Raises FragmentError if the filename has no valid ``.<type>.md`` suffix or
+    the body is empty.
+    """
+    match = FRAGMENT_RE.match(path.name)
+    if not match:
+        raise FragmentError(
+            f"{path.name}: name must be '<slug>.<type>.md' where <type> is one "
+            f"of {', '.join(CATEGORIES)}"
+        )
+    category = match.group("type").lower()
+    if category not in CATEGORIES:
+        raise FragmentError(
+            f"{path.name}: unknown type '{match.group('type')}'. "
+            f"Use one of: {', '.join(CATEGORIES)}"
+        )
+    body = path.read_text(encoding="utf-8").strip()
+    if not body:
+        raise FragmentError(f"{path.name}: fragment body is empty")
+    return category, body
+
+
+def collect(fragments: list[Path]) -> dict[str, list[str]]:
+    """Group fragment bodies by category, preserving filename sort order."""
+    grouped: dict[str, list[str]] = {key: [] for key in CATEGORIES}
+    errors: list[str] = []
+    for path in fragments:
+        try:
+            category, body = parse_fragment(path)
+        except FragmentError as exc:
+            errors.append(str(exc))
+            continue
+        grouped[category].append(body)
+    if errors:
+        raise FragmentError("\n".join(errors))
+    return grouped
+
+
+def render(grouped: dict[str, list[str]]) -> str:
+    """Render grouped fragment bodies as Keep-a-Changelog markdown."""
+    blocks: list[str] = []
+    for key, header in CATEGORIES.items():
+        entries = grouped.get(key) or []
+        if not entries:
+            continue
+        blocks.append(f"### {header}\n\n" + "\n".join(entries))
+    return "\n\n".join(blocks)
+
+
+def _split_unreleased(text: str) -> tuple[str, str, str]:
+    """Split CHANGELOG into (before, unreleased_body, after).
+
+    ``unreleased_body`` is everything between the ``## [Unreleased]`` header and
+    the next ``## [`` header. Raises ValueError if no Unreleased header exists.
+    """
+    header_re = re.compile(r"^## \[Unreleased\][^\n]*$", re.MULTILINE)
+    header = header_re.search(text)
+    if not header:
+        raise ValueError("No '## [Unreleased]' header found in CHANGELOG.md")
+    body_start = header.end()
+    next_section = re.compile(r"^## \[", re.MULTILINE).search(text, body_start)
+    body_end = next_section.start() if next_section else len(text)
+    return text[:body_start], text[body_start:body_end], text[body_end:]
+
+
+def apply_to_changelog(grouped: dict[str, list[str]]) -> int:
+    """Insert fragments into CHANGELOG.md's Unreleased section. Returns count.
+
+    Surgical and lossless: existing Unreleased prose is never reparsed or
+    re-rendered. For each category with fragments we either insert the new
+    entries directly beneath the existing ``### <Header>`` line (top of that
+    group) or, if no such header exists yet, prepend a fresh group at the top of
+    the Unreleased body. Every other byte of the file is left exactly as-is.
+    """
+    text = CHANGELOG.read_text(encoding="utf-8")
+    before, body, after = _split_unreleased(text)
+
+    # Insert new-group blocks (for categories with no existing header) at the
+    # very top of the Unreleased body, in canonical order.
+    new_groups: list[str] = []
+    for key, header in CATEGORIES.items():
+        entries = grouped.get(key) or []
+        if not entries:
+            continue
+        joined = "\n".join(entries)
+        # Match an existing "### Header" line that is exactly this category
+        # (avoid matching "### Technical Details" etc.).
+        header_re = re.compile(rf"^### {re.escape(header)}\s*$", re.MULTILINE)
+        existing_header = header_re.search(body)
+        if existing_header:
+            insert_at = existing_header.end()
+            body = body[:insert_at] + "\n\n" + joined + body[insert_at:]
+        else:
+            new_groups.append(f"### {header}\n\n{joined}")
+
+    if new_groups:
+        body = "\n\n" + "\n\n".join(new_groups) + "\n" + body
+
+    CHANGELOG.write_text(before + body + after, encoding="utf-8")
+    return sum(len(v) for v in grouped.values())
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--check",
+        action="store_true",
+        help="Validate fragment names/contents; exit nonzero on any problem.",
+    )
+    group.add_argument(
+        "--preview",
+        action="store_true",
+        help="Print the collated markdown to stdout without modifying anything.",
+    )
+    group.add_argument(
+        "--apply",
+        action="store_true",
+        help="Fold fragments into CHANGELOG.md's [Unreleased] section and "
+        "delete the fragment files.",
+    )
+    args = parser.parse_args(argv)
+
+    fragments = discover_fragments()
+
+    if args.check:
+        try:
+            collect(fragments)
+        except FragmentError as exc:
+            print("Invalid changelog fragment(s):\n" + str(exc), file=sys.stderr)
+            return 1
+        print(f"OK: {len(fragments)} changelog fragment(s) valid.")
+        return 0
+
+    if not fragments:
+        print("No changelog fragments in changelog.d/.", file=sys.stderr)
+        return 0
+
+    try:
+        grouped = collect(fragments)
+    except FragmentError as exc:
+        print("Invalid changelog fragment(s):\n" + str(exc), file=sys.stderr)
+        return 1
+
+    if args.preview:
+        print(render(grouped))
+        return 0
+
+    # --apply
+    count = apply_to_changelog(grouped)
+    for path in fragments:
+        path.unlink()
+    print(f"Folded {count} fragment(s) into {CHANGELOG.name} and removed them.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/collate_changelog.py
+++ b/scripts/collate_changelog.py
@@ -21,6 +21,7 @@ grouping everything by category in Keep-a-Changelog order. It does NOT cut a
 version — renaming ``[Unreleased]`` to ``[X.Y.Z]`` and opening a fresh empty
 ``[Unreleased]`` stays a deliberate manual release step.
 """
+
 from __future__ import annotations
 
 import argparse


### PR DESCRIPTION
## Problem

Every PR inserts its entry at the top of `CHANGELOG.md`'s single `## [Unreleased]` section, so concurrent PRs collide on the same lines. The file changed in **786 commits over the last 60 days**, and multiple in-flight PRs (#1901–#1904) are currently blocked solely on `CHANGELOG.md` conflicts — a constant, recurring source of delay.

## Fix: per-PR changelog fragments

PRs stop editing `CHANGELOG.md` directly. Instead each PR adds a uniquely-named fragment:

```
changelog.d/<slug>.<type>.md      e.g. 1901-pdf-white-line.fixed.md
```

Unique filename per PR ⇒ two PRs can **never** touch the same lines ⇒ changelog merge conflicts become structurally impossible. Fragments are collated into `CHANGELOG.md` at release time.

## What's included

| File | Purpose |
|------|---------|
| `changelog.d/` + `README.md` | Fragment directory + contributor guide |
| `scripts/collate_changelog.py` | `--check` (validate, used by pre-commit), `--preview` (render), `--apply` (fold fragments into `[Unreleased]` at release, then delete). `--apply` is **lossless** — surgical insertion into existing category groups, verified as *5 insertions / 0 deletions* against the real changelog. |
| `.pre-commit-config.yaml` | `repo: local` hook failing on malformed fragments |
| `.gitattributes` | `CHANGELOG.md merge=union` — safety net for any direct edit; **scoped to that one path only**, all other files keep the default 3-way merge. `union` is a built-in driver needing no local `git config`. |
| `CLAUDE.md` | Updated convention: add a fragment, don't edit `CHANGELOG.md` |

## Notes

- The currently-conflicting PRs (#1901–#1904) are being separately merged with `main` to clear their conflicts via the union driver.
- This PR dogfoods the system: its own changelog entry is the fragment `changelog.d/changelog-fragments.changed.md`.