### PR TITLE
LLM credential review follow-ups: clear_cache() API + test hardening (#1917)

### DIFF
--- a/changelog.d/1917-llm-singleton-followup.changed.md
+++ b/changelog.d/1917-llm-singleton-followup.changed.md
@@ -1,0 +1,24 @@
+- **LLM provider credential follow-ups (PR #1897 review, issue #1917).** Code-quality
+  hardening for the DB-configurable LLM credential feature:
+  - Added a public, documented `PipelineSettings.clear_cache()` classmethod
+    (`opencontractserver/documents/models.py`) as the canonical way to drop the
+    cached singleton; the existing `_invalidate_cache()` is now a thin
+    backwards-compatible alias that delegates to it. Tests and admin/CLI tooling
+    that write the singleton out-of-band no longer have to reach for the private
+    underscore method.
+  - `opencontractserver/tests/test_llm_model_factory.py`: assert the credentialed
+    model against pydantic-ai's exported abstract base `pydantic_ai.models.Model`
+    (`assertIsInstance`) instead of the fragile `type(result).__name__.endswith("Model")`
+    class-name string, which would have silently broken on an upstream rename of
+    `OpenAIChatModel`; switched cache resets to the new `clear_cache()` (dropping a
+    redundant `cache.delete()` + `_invalidate_cache()` double call); and added
+    `self.addCleanup(reset_registry)` to every `setUp` so the pipeline-component
+    registry is restored symmetrically after each test rather than only reset
+    before it.
+  - The correctness/security items from the same review — narrowing the
+    `except Exception` fallbacks to explicit recoverable-error tuples, the
+    `base_url`-without-`api_key` warning, `urlparse` scheme validation of a
+    DB-configured `base_url`, and the `test_colonless_spec_returned_unchanged`
+    comment — were already addressed in `opencontractserver/llms/model_factory.py`
+    / the test before #1897 merged. The aiohttp `<3.14` cap (#1920) and the
+    per-call credential-read cost (#1921) are tracked as separate follow-up issues.

--- a/opencontractserver/documents/models.py
+++ b/opencontractserver/documents/models.py
@@ -1298,10 +1298,10 @@ class PipelineSettings(django.db.models.Model):
         super().save(*args, **kwargs)
         # Eagerly invalidate cache after save for immediate consistency
         # (required in autocommit mode and Django TestCase which never commits).
-        self._invalidate_cache()
+        self.clear_cache()
         # Also invalidate on commit in case save() runs inside a larger
         # transaction that might roll back and be retried.
-        transaction.on_commit(lambda: self._invalidate_cache())
+        transaction.on_commit(lambda: self.clear_cache())
 
     def delete(self, *args: Any, **kwargs: Any) -> NoReturn:
         """Prevent deletion of the singleton instance."""
@@ -1323,7 +1323,11 @@ class PipelineSettings(django.db.models.Model):
 
     @classmethod
     def _invalidate_cache(cls) -> None:
-        """Backwards-compatible internal alias for :meth:`clear_cache`."""
+        """Backwards-compatible alias for :meth:`clear_cache`.
+
+        Retained for the existing test call sites that predate
+        :meth:`clear_cache`; new code should use the public method.
+        """
         cls.clear_cache()
 
     @classmethod

--- a/opencontractserver/documents/models.py
+++ b/opencontractserver/documents/models.py
@@ -1308,11 +1308,23 @@ class PipelineSettings(django.db.models.Model):
         raise ValidationError("PipelineSettings singleton cannot be deleted.")
 
     @classmethod
-    def _invalidate_cache(cls) -> None:
-        """Invalidate the cached instance."""
+    def clear_cache(cls) -> None:
+        """Drop the cached singleton so the next ``get_instance()`` re-reads the DB.
+
+        The public, documented entry point for forcing cache invalidation.
+        ``save()`` already invalidates automatically, so application code
+        rarely needs this; it exists for tests and admin/CLI tooling that
+        write the singleton row out-of-band (e.g. a direct ``QuerySet.update``
+        or a fixture load) and then need the change visible immediately.
+        """
         from django.core.cache import cache
 
         cache.delete(cls.CACHE_KEY)
+
+    @classmethod
+    def _invalidate_cache(cls) -> None:
+        """Backwards-compatible internal alias for :meth:`clear_cache`."""
+        cls.clear_cache()
 
     @classmethod
     def get_instance(cls, use_cache: bool = True) -> PipelineSettings:

--- a/opencontractserver/documents/models.py
+++ b/opencontractserver/documents/models.py
@@ -1327,8 +1327,9 @@ class PipelineSettings(django.db.models.Model):
     def _invalidate_cache(cls) -> None:
         """Backwards-compatible alias for :meth:`clear_cache`.
 
-        Retained for the existing test call sites that predate
-        :meth:`clear_cache`; new code should use the public method.
+        Retained for existing callers (the test suite and ``conftest.py``)
+        that predate :meth:`clear_cache`; new code should use the public
+        method.
         """
         cls.clear_cache()
 

--- a/opencontractserver/documents/models.py
+++ b/opencontractserver/documents/models.py
@@ -1300,8 +1300,10 @@ class PipelineSettings(django.db.models.Model):
         # (required in autocommit mode and Django TestCase which never commits).
         self.clear_cache()
         # Also invalidate on commit in case save() runs inside a larger
-        # transaction that might roll back and be retried.
-        transaction.on_commit(lambda: self.clear_cache())
+        # transaction that might roll back and be retried. clear_cache is a
+        # classmethod, so register it directly rather than capturing self in a
+        # lambda.
+        transaction.on_commit(PipelineSettings.clear_cache)
 
     def delete(self, *args: Any, **kwargs: Any) -> NoReturn:
         """Prevent deletion of the singleton instance."""

--- a/opencontractserver/tests/test_llm_model_factory.py
+++ b/opencontractserver/tests/test_llm_model_factory.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 from unittest import mock
 
 from asgiref.sync import async_to_sync
-from django.core.cache import cache
 from django.test import TestCase
 
 from opencontractserver.documents.models import PipelineSettings
@@ -46,6 +45,7 @@ class TestProviderSettingsSchema(TestCase):
 
     def setUp(self):
         reset_registry()
+        self.addCleanup(reset_registry)
 
     def test_anthropic_declares_secret_api_key_and_optional_base_url(self):
         schema = get_settings_schema(AnthropicProvider)
@@ -87,8 +87,8 @@ class TestBuildAgentModelEnvFallback(TestCase):
 
     def setUp(self):
         reset_registry()
-        cache.delete(PipelineSettings.CACHE_KEY)
-        PipelineSettings._invalidate_cache()
+        self.addCleanup(reset_registry)
+        PipelineSettings.clear_cache()
 
     def test_no_db_creds_returns_bare_spec_string(self):
         # A fresh singleton has no provider creds → env fallback (string).
@@ -122,8 +122,8 @@ class TestBuildAgentModelDbWins(TestCase):
 
     def setUp(self):
         reset_registry()
-        cache.delete(PipelineSettings.CACHE_KEY)
-        PipelineSettings._invalidate_cache()
+        self.addCleanup(reset_registry)
+        PipelineSettings.clear_cache()
         openai_defn = get_llm_provider_by_key_cached("openai")
         assert openai_defn is not None
         self.openai_path = openai_defn.class_name
@@ -134,7 +134,7 @@ class TestBuildAgentModelDbWins(TestCase):
         if base_url is not None:
             instance.component_settings = {self.openai_path: {"base_url": base_url}}
         instance.save()
-        PipelineSettings._invalidate_cache()
+        PipelineSettings.clear_cache()
 
     def test_db_creds_route_through_construct_model(self):
         """When DB creds exist, _construct_model is invoked with them."""
@@ -166,12 +166,16 @@ class TestBuildAgentModelDbWins(TestCase):
 
     def test_db_creds_build_real_pydantic_ai_model(self):
         """End-to-end: a non-string credentialed pydantic-ai model is returned."""
+        from pydantic_ai.models import Model
+
         self._configure_openai_creds(
             api_key="sk-db-key", base_url="http://gateway.local/v1"
         )
         result = build_agent_model("openai:gpt-4o")
         self.assertNotIsInstance(result, str)
-        self.assertTrue(type(result).__name__.endswith("Model"))
+        # Assert against pydantic-ai's exported abstract base class, not a
+        # class-name string: robust to a future rename of OpenAIChatModel.
+        self.assertIsInstance(result, Model)
 
     def test_abuild_agent_model_async_wrapper(self):
         self._configure_openai_creds(api_key="sk-db-key")
@@ -184,8 +188,8 @@ class TestProviderSecretStatusSurface(TestCase):
 
     def setUp(self):
         reset_registry()
-        cache.delete(PipelineSettings.CACHE_KEY)
-        PipelineSettings._invalidate_cache()
+        self.addCleanup(reset_registry)
+        PipelineSettings.clear_cache()
         anthropic_defn = get_llm_provider_by_key_cached("anthropic")
         assert anthropic_defn is not None
         self.anthropic_path = anthropic_defn.class_name

--- a/opencontractserver/tests/test_llm_model_factory.py
+++ b/opencontractserver/tests/test_llm_model_factory.py
@@ -133,8 +133,9 @@ class TestBuildAgentModelDbWins(TestCase):
         instance.set_secrets({self.openai_path: {"api_key": api_key}})
         if base_url is not None:
             instance.component_settings = {self.openai_path: {"base_url": base_url}}
+        # save() eagerly invalidates the singleton cache, so the subsequent
+        # get_instance() in build_agent_model() re-reads these creds from the DB.
         instance.save()
-        PipelineSettings.clear_cache()
 
     def test_db_creds_route_through_construct_model(self):
         """When DB creds exist, _construct_model is invoked with them."""

--- a/opencontractserver/tests/test_llm_model_factory.py
+++ b/opencontractserver/tests/test_llm_model_factory.py
@@ -18,6 +18,7 @@ from unittest import mock
 
 from asgiref.sync import async_to_sync
 from django.test import TestCase
+from pydantic_ai.models import Model
 
 from opencontractserver.documents.models import PipelineSettings
 from opencontractserver.llms.model_factory import (
@@ -89,6 +90,7 @@ class TestBuildAgentModelEnvFallback(TestCase):
         reset_registry()
         self.addCleanup(reset_registry)
         PipelineSettings.clear_cache()
+        self.addCleanup(PipelineSettings.clear_cache)
 
     def test_no_db_creds_returns_bare_spec_string(self):
         # A fresh singleton has no provider creds → env fallback (string).
@@ -124,6 +126,7 @@ class TestBuildAgentModelDbWins(TestCase):
         reset_registry()
         self.addCleanup(reset_registry)
         PipelineSettings.clear_cache()
+        self.addCleanup(PipelineSettings.clear_cache)
         openai_defn = get_llm_provider_by_key_cached("openai")
         assert openai_defn is not None
         self.openai_path = openai_defn.class_name
@@ -167,8 +170,6 @@ class TestBuildAgentModelDbWins(TestCase):
 
     def test_db_creds_build_real_pydantic_ai_model(self):
         """End-to-end: a non-string credentialed pydantic-ai model is returned."""
-        from pydantic_ai.models import Model
-
         self._configure_openai_creds(
             api_key="sk-db-key", base_url="http://gateway.local/v1"
         )
@@ -191,6 +192,7 @@ class TestProviderSecretStatusSurface(TestCase):
         reset_registry()
         self.addCleanup(reset_registry)
         PipelineSettings.clear_cache()
+        self.addCleanup(PipelineSettings.clear_cache)
         anthropic_defn = get_llm_provider_by_key_cached("anthropic")
         assert anthropic_defn is not None
         self.anthropic_path = anthropic_defn.class_name

--- a/opencontractserver/tests/test_llm_model_factory.py
+++ b/opencontractserver/tests/test_llm_model_factory.py
@@ -136,8 +136,8 @@ class TestBuildAgentModelDbWins(TestCase):
         instance.set_secrets({self.openai_path: {"api_key": api_key}})
         if base_url is not None:
             instance.component_settings = {self.openai_path: {"base_url": base_url}}
-        # save() eagerly invalidates the singleton cache, so the subsequent
-        # get_instance() in build_agent_model() re-reads these creds from the DB.
+        # save() auto-invalidates the PipelineSettings cache, so no explicit
+        # clear_cache() is needed here.
         instance.save()
 
     def test_db_creds_route_through_construct_model(self):
@@ -174,9 +174,9 @@ class TestBuildAgentModelDbWins(TestCase):
             api_key="sk-db-key", base_url="http://gateway.local/v1"
         )
         result = build_agent_model("openai:gpt-4o")
-        self.assertNotIsInstance(result, str)
         # Assert against pydantic-ai's exported abstract base class, not a
         # class-name string: robust to a future rename of OpenAIChatModel.
+        # (A Model instance is necessarily not the bare spec string.)
         self.assertIsInstance(result, Model)
 
     def test_abuild_agent_model_async_wrapper(self):


### PR DESCRIPTION
Closes #1917.

Resolves the outstanding follow-up items from the PR #1897 code review (issue #1917 — *LLM Singleton Follow Up*).

## Status of all 10 review items

| # | Item | Resolution |
|---|------|-----------|
| 1 | Misleading `test_colonless_spec_returned_unchanged` comment | ✅ Already corrected before #1897 merged (`test_llm_model_factory.py`) |
| 2 | Warning when `base_url` set but `api_key` blank | ✅ Already in merged code (`model_factory.py` — `logger.warning` for `api_key is None and provider_key != "ollama"`) |
| 3 | All 5 call sites covered | ✅ Confirmation only |
| 4 | `except Exception` too broad (×2) | ✅ Already in merged code — narrowed to `_DB_READ_RECOVERABLE_ERRORS` / `_MODEL_BUILD_RECOVERABLE_ERRORS` tuples |
| **5** | Tests use private `_invalidate_cache()` | **✅ This PR** |
| **6** | Fragile `endswith("Model")` assertion | **✅ This PR** |
| **7** | `reset_registry()` without symmetric teardown | **✅ This PR** |
| 8 | Per-call DB credential read | 📋 Tracked in #1921 |
| 9 | `base_url` not validated | ✅ Already in merged code — `urlparse(base_url).scheme in ("http","https")` check |
| 10 | aiohttp `<3.14` cap tracking | 📋 Tracked in #1920 |

Items 1, 2, 4, and 9 were already addressed during #1897's review cycle (before merge), so this PR is scoped to the remaining "minor quality items suitable for a follow-up PR" (5, 6, 7) plus the two tracking issues the review asked for (8 → #1921, 10 → #1920).

## Changes

**Item 5 — drop the private-API reach.** Added a public, documented `PipelineSettings.clear_cache()` classmethod (`opencontractserver/documents/models.py`) as the canonical way to drop the cached singleton. The existing `_invalidate_cache()` becomes a thin backwards-compatible alias that delegates to it — `save()` and the other call sites across the test suite keep working unchanged (no churn). `save()` itself now calls `clear_cache()` directly (registered on `transaction.on_commit` without a `self`-capturing lambda). `test_llm_model_factory.py` now calls `clear_cache()`, which also let me delete a redundant `cache.delete(CACHE_KEY)` + `_invalidate_cache()` double-call in each `setUp` and remove the now-unused `cache` import.

**Item 6 — robust model-type assertion.** `test_db_creds_build_real_pydantic_ai_model` now asserts `assertIsInstance(result, pydantic_ai.models.Model)` (the exported abstract base) instead of `type(result).__name__.endswith("Model")`, which would have silently broken on an upstream rename of `OpenAIChatModel`.

**Item 7 — symmetric registry teardown.** Every `setUp` now registers `self.addCleanup(reset_registry)` (and, where it clears the singleton cache, `self.addCleanup(PipelineSettings.clear_cache)`) so the pipeline-component registry and cache are restored after each test, not just reset before it.

## Follow-up refinements (review)

Subsequent commits applied review nits: route `save()` invalidation through `clear_cache()` directly; drop the now-redundant post-save `clear_cache()` in the test helper; register the `on_commit` callback without a closure; move the `pydantic_ai.models.Model` import to module level; add symmetric cache teardown; drop a redundant `assertNotIsInstance(result, str)` (implied by the `Model` assertion); and small docstring/comment accuracy tweaks. Migrating the remaining `_invalidate_cache()` callers and deleting the alias is tracked in #1928.

## Verification

- `python -m py_compile` ✅, `black --check` ✅, `flake8` ✅ on both changed files.
- `python scripts/collate_changelog.py --check` ✅ (changelog fragment valid).
- Verified the item-6 assertion against the pinned pydantic-ai (`>=1.105.0,<2`): `from pydantic_ai.models import Model` imports, `OpenAIChatModel` is a subclass, and a real credentialed model built exactly as `_construct_model` does passes `isinstance(model, Model)`.

A `changelog.d/1917-llm-singleton-followup.changed.md` fragment is included.