### PR TITLE
Harden mobile annotation deep-link loader (PR #1903 follow-up)

### DIFF
--- a/changelog.d/1918-mobile-annotation-loader-followup.fixed.md
+++ b/changelog.d/1918-mobile-annotation-loader-followup.fixed.md
@@ -1,0 +1,21 @@
+- **Mobile annotation deep-link loader: closed a one-frame not-found flash for structural deep-links and made the loader screen-reader-announced (PR #1903 follow-up, #1918).**
+  Two refinements to the mobile `?ann=<id>` loader added in #1903:
+  - **One-frame flash for structural deep-links.** `useStructuralAnnotations`
+    (`frontend/src/components/knowledge_base/document/document_kb/useStructuralAnnotations.ts`)
+    dispatches the targeted lazy fetch from an effect that runs *after* the
+    render that needs it, so for one frame its result is
+    `{ called: false, loading: false }` — long enough for
+    `MobileAnnotationDetail` to flash "This annotation is no longer available."
+    before the spinner appeared. The returned `loading` now also reports the
+    pre-dispatch window (mirroring the effect's own guard, gated on
+    `!called` so it self-heals once the fetch fires and never sticks — the
+    targeted path deliberately leaves `structuralAnnotationsLoaded` false).
+    The loader is now continuous from the first render until the fetch settles.
+  - **Accessibility.** The mobile loader (`LoadingState` in
+    `frontend/src/components/knowledge_base/document/layouts/mobile/MobileAnnotationDetail.tsx`)
+    is now a `role="status"` live region, so assistive technology announces
+    "Loading annotation…" when a deep-link opens the sheet. The spinner icon
+    stays `aria-hidden`.
+  - **Defensive API.** `MobileAnnotationDetail`'s `loading` prop is now optional
+    (defaults to `false`), so a future callsite that forgets to thread it
+    degrades safely to the not-found state instead of breaking the build.

--- a/frontend/src/components/knowledge_base/document/document_kb/__tests__/useStructuralAnnotations.test.tsx
+++ b/frontend/src/components/knowledge_base/document/document_kb/__tests__/useStructuralAnnotations.test.tsx
@@ -190,6 +190,50 @@ describe("useStructuralAnnotations", () => {
     expect(utils.getByTestId("rels").textContent).toBe("rel-99");
   });
 
+  it("reports loading on the very first render of a pending deep-link, before the targeted fetch is dispatched", async () => {
+    // Cold-cache structural deep-link: an id is selected before anything has
+    // loaded. The targeted fetch is dispatched by an effect that runs *after*
+    // the first render, so on that first render Apollo's lazy-query result is
+    // still `{ called: false, loading: false }`. The hook must nonetheless
+    // report loading immediately, otherwise the consuming not-found guard
+    // (MobileAnnotationDetail) flashes "no longer available" for one frame.
+    selectedAnnotationIds(["ann-77"]);
+
+    const mocks = [
+      makeMock(
+        "doc-C",
+        ["ann-77"],
+        [annotation("ann-77")],
+        [relationship("rel-77")]
+      ),
+    ];
+
+    const loadingByRender: boolean[] = [];
+    const LoadingProbe: React.FC<{ documentId: string }> = ({ documentId }) => {
+      const { loading } = useStructuralAnnotations(documentId);
+      loadingByRender.push(loading);
+      return <span data-testid="loading">{loading ? "1" : "0"}</span>;
+    };
+
+    const utils = render(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <Provider>
+          <LoadingProbe documentId="doc-C" />
+        </Provider>
+      </MockedProvider>
+    );
+
+    // The discriminating assertion: the first render — captured before any
+    // effect runs — must already report loading.
+    expect(loadingByRender[0]).toBe(true);
+
+    // Once the targeted fetch settles, loading drops back to false so a
+    // genuinely-missing annotation can still surface the not-found state.
+    await waitFor(() =>
+      expect(utils.getByTestId("loading").textContent).toBe("0")
+    );
+  });
+
   it("clears all three atoms when the documentId changes", async () => {
     showStructuralAnnotations(true);
 

--- a/frontend/src/components/knowledge_base/document/document_kb/useStructuralAnnotations.ts
+++ b/frontend/src/components/knowledge_base/document/document_kb/useStructuralAnnotations.ts
@@ -46,6 +46,14 @@ import { relationToGroup } from "./helpers";
  * The all-structural toggle fetch is deliberately excluded: it only runs when
  * the user turns structural visibility on, and folding it into a shared loading
  * flag would make unrelated surfaces flash loading on that toggle.
+ *
+ * The flag also covers the window *before* the targeted query is dispatched:
+ * its effect runs only after the render that needs it, so for one frame
+ * `targetedStructuralResult` reads `{ called: false, loading: false }`.
+ * Reporting that pending window as loading (by mirroring the effect's own
+ * guard) keeps the loader continuous from the first render until the fetch
+ * settles, closing the one-frame not-found flash entirely rather than merely
+ * shortening it.
  */
 export function useStructuralAnnotations(documentId: string): {
   loading: boolean;
@@ -189,5 +197,23 @@ export function useStructuralAnnotations(documentId: string): {
     setStructuralRelationships,
   ]);
 
-  return { loading: targetedStructuralResult.loading };
+  // The targeted lazy query is dispatched by the effect above, which runs only
+  // *after* this render commits. Until then `targetedStructuralResult` reads
+  // `{ called: false, loading: false }`, so returning its raw `loading` would
+  // leave a one-frame gap where a structural `?ann=<id>` deep-link flashes the
+  // not-found message. Mirror the dispatch effect's own guard to treat that
+  // pending window as loading; once the fetch is dispatched (`called` latches
+  // true) we defer to the query's real `loading`. This can't get stuck: the
+  // targeted path deliberately leaves `structuralAnnotationsLoaded` false, but
+  // `called` stays true, so a genuinely-missing annotation still settles to
+  // `loading: false` and surfaces the not-found state.
+  const targetedFetchPending =
+    deepLinkedAnnotationIds.length > 0 &&
+    !!documentId &&
+    !structuralAnnotationsLoaded &&
+    !targetedStructuralResult.called;
+
+  return {
+    loading: targetedFetchPending || targetedStructuralResult.loading,
+  };
 }

--- a/frontend/src/components/knowledge_base/document/layouts/mobile/MobileAnnotationDetail.tsx
+++ b/frontend/src/components/knowledge_base/document/layouts/mobile/MobileAnnotationDetail.tsx
@@ -34,8 +34,13 @@ const spin = keyframes`
  * annotations) are still being fetched — e.g. a deep-link straight to an
  * annotation before anything is cached. A quietly spinning icon over the
  * sheet's white surface, never a heavy full-bleed spinner.
+ *
+ * `role="status"` (implicit `aria-live="polite"`) makes the state audible to
+ * assistive technology: a screen-reader user arriving via deep-link hears
+ * "Loading annotation…" announced when the sheet opens. The spinner icon stays
+ * `aria-hidden` so only the label is read.
  */
-const LoadingState = styled(EmptyState)`
+const LoadingState = styled(EmptyState).attrs({ role: "status" })`
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -98,8 +103,12 @@ interface MobileAnnotationDetailProps {
    * Threaded from the document loader so a deep-link straight to an annotation
    * — before anything is cached — shows a loader instead of prematurely
    * claiming the annotation is gone.
+   *
+   * Optional; defaults to `false` (fall through to the not-found state) so a
+   * future callsite that forgets to thread it degrades safely rather than
+   * breaking at compile time.
    */
-  loading: boolean;
+  loading?: boolean;
 }
 
 /**
@@ -119,7 +128,7 @@ interface MobileAnnotationDetailProps {
  */
 export const MobileAnnotationDetail: React.FC<MobileAnnotationDetailProps> = ({
   readOnly,
-  loading,
+  loading = false,
 }) => {
   const { selectedAnnotations } = useAnnotationSelection();
   const allAnnotations = useAllAnnotations();

--- a/frontend/tests/MobileAnnotationDetail.ct.tsx
+++ b/frontend/tests/MobileAnnotationDetail.ct.tsx
@@ -28,6 +28,10 @@ test.describe("MobileAnnotationDetail", () => {
       page.getByText("This annotation is no longer available.")
     ).not.toBeVisible();
 
+    // The loader is exposed as an ARIA live region (role="status" →
+    // aria-live="polite") so screen readers announce it on a deep-link.
+    await expect(page.getByRole("status")).toBeVisible();
+
     await docScreenshot(page, "annotations--mobile-annotation-detail--loading");
 
     await component.unmount();


### PR DESCRIPTION
## Summary

Resolves the three actionable items from the PR #1903 code review captured in #1918. Surgical, frontend-only follow-up to the mobile `?ann=<id>` deep-link loader.

### 1. Close the one-frame not-found flash for structural deep-links (review item #1)
`useStructuralAnnotations` dispatches its targeted lazy fetch from an effect that runs *after* the render that needs it. For one frame the lazy-query result is `{ called: false, loading: false }` — long enough for `MobileAnnotationDetail` to flash *"This annotation is no longer available."* before the spinner appears.

The returned `loading` now also reports that **pre-dispatch window** by mirroring the dispatch effect's own guard:

```ts
const targetedFetchPending =
  deepLinkedAnnotationIds.length > 0 &&
  !!documentId &&
  !structuralAnnotationsLoaded &&
  !targetedStructuralResult.called;

return { loading: targetedFetchPending || targetedStructuralResult.loading };
```

Gating on `!called` means it **self-heals** once the fetch fires and **never sticks**: the targeted path deliberately leaves `structuralAnnotationsLoaded` false, but `called` latches true, so a genuinely-missing annotation still settles to `loading: false` and surfaces the not-found state. (This is why the review's literal "loading=true whenever ids non-empty and not loaded" suggestion was not used directly — it would spin forever.)

### 2. Make `loading` optional with a safe default (review item #2)
`MobileAnnotationDetailProps.loading` is now `loading?: boolean`, destructured as `loading = false`, so a future callsite that forgets to thread it degrades safely to the not-found state instead of breaking at compile time.

### 3. Announce the loader to screen readers (review item #3)
`LoadingState` is now a `role="status"` (implicit `aria-live="polite"`) live region, so assistive technology announces *"Loading annotation…"* when a deep-link opens the sheet. The spinner icon stays `aria-hidden`.

> Non-blocking "Observations" in the issue (hook naming collision, `Card` hardcoded px, happy-path test) were explicitly out of scope per the review and are left as follow-ups.

## Tests
- **Hook regression test** (`useStructuralAnnotations.test.tsx`): asserts `loading` is `true` on the *very first render* of a pending deep-link, before the targeted fetch is dispatched. Verified it **fails against the old raw-loading return** (`expected false to be true`) and passes with the fix. All 5 hook tests green.
- **Component test** (`MobileAnnotationDetail.ct.tsx`): added a `getByRole("status")` assertion to the loading case. Both CT tests pass.
- `tsc --noEmit` clean; prettier clean.

## Changelog
`changelog.d/1918-mobile-annotation-loader-followup.fixed.md`

Closes #1918

https://claude.ai/code/session_018oR2i1kw2G1vbkrim1tUzF

---
_Generated by [Claude Code](https://claude.ai/code/session_018oR2i1kw2G1vbkrim1tUzF)_