### PR TITLE
Corpus Chat view review follow-up: reset conversation-expanded flag on ASK→VIEW entry

### DIFF
--- a/changelog.d/1911-corpus-chat-view-followup.fixed.md
+++ b/changelog.d/1911-corpus-chat-view-followup.fixed.md
@@ -1,0 +1,17 @@
+- **Corpus Chat (Home tab) — reset the conversation-expanded flag on ASK -> VIEW
+  entry.** `CorpusQueryView` suppresses its outer "Conversation History" header
+  while a single conversation is open by reading `chatExpandedInConversation`
+  (`frontend/src/views/CorpusQueryView.tsx`). `backToAskFromView` already cleared
+  that flag on the VIEW -> ASK exit, but the symmetric ASK -> VIEW entry
+  (`openHistoryView`) did not, so a `true` left by an ASK-flow conversation could
+  carry into VIEW and momentarily hide the outer header before `CorpusChat`
+  mounts and re-reports list mode via `onViewModeChange`. `openHistoryView` now
+  clears the flag on entry, mirroring `backToAskFromView`. Follow-up to the
+  PR #1890 review (#1911); the existing VIEW header-suppression regression test
+  (`frontend/src/views/__tests__/CorpusQueryView.handlers.test.tsx`) continues to
+  pin the clean-entry contract.
+- **Corpus Chat — scroll-mode comments.** Clarified the scroll-to-bottom effect
+  in `frontend/src/components/corpuses/CorpusChat.tsx`: documented that a first
+  mount with a pre-loaded transcript resolves to an instant `"auto"` jump (never
+  smooth), and dropped a redundant comment over `scrollToBottom` whose default is
+  self-evident from the `behavior: ScrollBehavior = "auto"` signature.

--- a/frontend/src/components/corpuses/CorpusChat.tsx
+++ b/frontend/src/components/corpuses/CorpusChat.tsx
@@ -381,8 +381,6 @@ export const CorpusChat: React.FC<CorpusChatProps> = ({
     lastCombinedMessage.isComplete !== true;
   const showWarmupTicker = isProcessing && !inFlightAssistantPresent;
 
-  // Scroll to bottom helper. Defaults to an instant jump; callers opt into a
-  // smooth scroll for incremental appends only.
   const scrollToBottom = useCallback((behavior: ScrollBehavior = "auto") => {
     if (messagesContainerRef.current) {
       const container = messagesContainerRef.current;
@@ -399,6 +397,12 @@ export const CorpusChat: React.FC<CorpusChatProps> = ({
   // mutate the last entry without changing the count) both instant-jump. This
   // removes the long, janky smooth animation that previously played every time
   // a populated conversation opened.
+  //
+  // First mount with a pre-loaded transcript also instant-jumps: the refs start
+  // at undefined/0, so a directly-selected conversation reads as a switch
+  // ("auto"), and server-loaded messages with no selected id read as neither a
+  // switch nor a single +1 append once there are 2+ messages ("auto"). Smooth is
+  // never used for the initial paint.
   const prevConversationKeyRef = useRef<string | undefined>(undefined);
   const prevMessageCountRef = useRef<number>(0);
   useEffect(() => {

--- a/frontend/src/views/CorpusQueryView.tsx
+++ b/frontend/src/views/CorpusQueryView.tsx
@@ -266,7 +266,13 @@ export const CorpusQueryView = ({
     // cleanup, so a second source could fire against an unmounted input.
   };
 
+  // ASK -> VIEW entry. Clear the conversation-expanded flag on the way in so a
+  // stale `true` (left by an ASK-flow conversation that was still open when VIEW
+  // is entered) can't suppress the outer "Conversation History" header before
+  // CorpusChat mounts in VIEW and re-reports list mode via onViewModeChange.
+  // Symmetric with backToAskFromView, which clears it on the VIEW -> ASK exit.
   const openHistoryView = () => {
+    setChatExpandedInConversation(false);
     showQueryViewState("VIEW");
   };
 


### PR DESCRIPTION
## Summary

Addresses the PR #1890 code-review follow-up tracked in #1911. The review raised
one substantive item (a potential stale flag on the ASK→VIEW transition) plus
minor polish. Changes here are deliberately small and surgical.

Closes #1911.

## Concern-by-concern

**#1 — Stale `chatExpandedInConversation` on ASK→VIEW (the main item). Fixed.**
`CorpusQueryView` suppresses its outer *Conversation History* header while a
single conversation is open by reading `chatExpandedInConversation`. The exit
path (`backToAskFromView`, VIEW→ASK) already cleared that flag, but the
symmetric entry path (`openHistoryView`, ASK→VIEW) did not — so a `true` left by
an ASK‑flow conversation could carry into VIEW and momentarily hide the outer
header before `CorpusChat` mounts and re‑reports list mode via
`onViewModeChange`. `openHistoryView` now clears the flag on entry, mirroring
`backToAskFromView`.
- File: `frontend/src/views/CorpusQueryView.tsx`
- `openHistoryView` is the only production entry to the VIEW state, so this
  covers every current ASK→VIEW path. Note: the stale state is not reachable
  through today's UI (the History affordance is suppressed *exactly* when the
  flag is set), so this is defensive symmetry that also guards against a future
  VIEW entry point added while a conversation is open. The existing VIEW
  header‑suppression regression test
  (`frontend/src/views/__tests__/CorpusQueryView.handlers.test.tsx`) continues to
  pin the clean‑entry contract.

**#2 — Scroll‑spy install/clear ordering. Already satisfied; no change.**
The merged test already installs the spy *before* `mount` and clears captured
behaviors *after* mount but *before* the action‑under‑test — exactly the
ordering the review recommends (`frontend/tests/CorpusChat.ct.tsx`,
`installScrollSpy` at the top of each test, `clearScrollBehaviors` right before
the click/keypress). The concern appears to have been written against an earlier
revision of the diff. No edit needed.

**#3 — First‑mount‑with‑non‑empty‑messages scroll edge case. Documented.**
Added a comment to the scroll effect in
`frontend/src/components/corpuses/CorpusChat.tsx` making the invariant explicit:
on first mount the refs start at `undefined`/`0`, so a directly‑selected
conversation reads as a switch (`"auto"`) and server‑loaded messages with no
selected id read as neither a switch nor a single `+1` append for 2+ messages
(`"auto"`) — smooth is never used for the initial paint.

**#4 — CHANGELOG italic style. Intentionally not changed.**
`CLAUDE.md` explicitly forbids editing `CHANGELOG.md` directly in a PR (entries
go in `changelog.d/` fragments, and a `merge=union` driver makes cosmetic
line‑level edits to that file actively risky). Honoring that rule rather than
churning a conflict‑prone file for a purely cosmetic `*italic*`↔`_italic_`
normalization. This PR's own entry is added as a fragment
(`changelog.d/1911-corpus-chat-view-followup.fixed.md`).

**#5 — Redundant comment density. Fixed.**
Removed the comment over `scrollToBottom` whose content is self‑evident from the
`behavior: ScrollBehavior = "auto"` signature
(`frontend/src/components/corpuses/CorpusChat.tsx`).

## Test plan
- `tsc --noEmit` — clean
- `vitest run src/views/__tests__/CorpusQueryView.handlers.test.tsx` — 9/9 pass
- `prettier --check` on changed files — clean
- `scripts/collate_changelog.py --check` — fragment valid
- Pre-commit: `frontend/` is excluded from the hooks; the `changelog.d/`
  validation hook passes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SSxUduDjHgJhsSByKLm1Wz)_