### PR TITLE
Resolve PR #1908 follow-up review (issue #1919)

### DIFF
--- a/changelog.d/1919-discover-followup.changed.md
+++ b/changelog.d/1919-discover-followup.changed.md
@@ -1,0 +1,26 @@
+- **Discover search: dedupe the per-query embedding across the five category resolvers (PR #1908 follow-up, issue #1919).**
+  The Discover "All" tab fires all five category resolvers
+  (`config/graphql/discover_queries.py`) as five independent HTTP requests
+  (Apollo uses a non-batching link), each of which previously embedded the
+  *same* query string with the same default embedder — up to 5× the embedding
+  latency/cost for one user search. A new per-process LRU
+  (`_cached_query_vector`, sized by
+  `DISCOVER_QUERY_VECTOR_CACHE_SIZE` in `opencontractserver/constants/search.py`)
+  memoises the deterministic `(query_text, embedder_path)` embedding so those
+  requests share one embedding call. The semantic arm stays best-effort: a
+  transient embedder failure is never cached as a wrong result and the text arm
+  always returns on its own.
+- **Clarity/DRY cleanups in `discover_queries.py`.** `_order_by_ids` now *owns*
+  the `id__in=ids` predicate; the five resolvers no longer pre-filter the
+  visible queryset (removing a redundant double `id__in` clause that only
+  PostgreSQL's optimiser was collapsing). The five identical deferred
+  `get_default_embedder_path` imports inside the resolver bodies are
+  consolidated into a single module-level `_default_embedder_path()` helper.
+  Added inline docs for the `discoverCorpuses` content-match `IN (...)` size
+  bound and for the `5 × READ_LIGHT` per-search rate cost of the "All" tab
+  (`DISCOVER_DEFAULT_LIMIT` comment).
+- **New backend test coverage** in
+  `opencontractserver/tests/test_discover_search_graphql.py`: the `limit`
+  parameter is now exercised end-to-end (`limit=1` clamps the fused result set),
+  and `discoverCorpuses` is asserted not to surface a collection whose content
+  matches the query but which the user cannot read.

--- a/changelog.d/1919-discover-followup.fixed.md
+++ b/changelog.d/1919-discover-followup.fixed.md
@@ -1,0 +1,11 @@
+- **Removed the blanket `mypy.ini` suppression for `test_discover_search_graphql` by fixing the root-cause type error (issue #1919).**
+  PR #1908 added `[mypy-opencontractserver.tests.test_discover_search_graphql]
+  ignore_errors = True` to silence 8 `"Client" has no attribute "execute"`
+  errors. The real cause was a name collision: the test stored its
+  `graphene.test.Client` on `self.client`, which `django-stubs` types as
+  `django.test.Client` (inherited from `TestCase`) — a class with no
+  `.execute()`. Renaming the attribute to `self.graphene_client` (the
+  convention already used by the mypy-clean `test_document_queries.py`) makes
+  the file type-check cleanly, so the per-module suppression is deleted rather
+  than carried forward as a precedent for brand-new code. Verified with a
+  full-project `mypy --config-file=mypy.ini opencontractserver config` run.

--- a/config/graphql/discover_queries.py
+++ b/config/graphql/discover_queries.py
@@ -23,6 +23,7 @@ Design notes:
   the arm simply contributes nothing and the text arm still returns results.
 """
 
+import functools
 import logging
 from typing import Any, Optional
 
@@ -45,6 +46,7 @@ from opencontractserver.constants.search import (
     DISCOVER_CORPUS_CONTENT_OVERSAMPLE,
     DISCOVER_DEFAULT_LIMIT,
     DISCOVER_OVERSAMPLE,
+    DISCOVER_QUERY_VECTOR_CACHE_SIZE,
     FTS_CONFIG,
     RRF_K,
 )
@@ -100,6 +102,19 @@ def _rrf(rankings: list[list[Any]], limit: int) -> list[Any]:
     return ordered[:limit]
 
 
+def _default_embedder_path() -> Optional[str]:
+    """Resolve the install-wide default embedder path.
+
+    The import is deferred to module-call time to avoid a circular import at
+    load (``pipeline.utils`` pulls in models that import this module's
+    siblings). Centralising it here removes the five identical deferred imports
+    that previously lived inside each resolver body.
+    """
+    from opencontractserver.pipeline.utils import get_default_embedder_path
+
+    return get_default_embedder_path()
+
+
 def _query_vector(query_text: str, embedder_path: Optional[str]) -> Optional[list]:
     """Embed ``query_text`` with the default embedder, or ``None`` on failure.
 
@@ -115,6 +130,26 @@ def _query_vector(query_text: str, embedder_path: Optional[str]) -> Optional[lis
         query_text, embedder_path=embedder_path
     )
     return vector
+
+
+@functools.lru_cache(maxsize=DISCOVER_QUERY_VECTOR_CACHE_SIZE)
+def _cached_query_vector(query_text: str, embedder_path: str) -> Optional[list]:
+    """Per-process memoised wrapper around :func:`_query_vector`.
+
+    Discover's "All" tab fires all five category resolvers as five independent
+    HTTP requests (Apollo uses a non-batching link), each of which would embed
+    the *same* query string with the same default embedder. Embedding is
+    deterministic for a given ``(query_text, embedder_path)``, so caching the
+    result lets those requests share one embedding call instead of five.
+
+    Caveats (acceptable for a best-effort arm): there is no TTL, so a vector
+    lives until LRU-evicted — fine, because the same inputs always produce the
+    same vector. A transient embedder failure (``None``) is also cached for the
+    LRU window; the consequence is text-only results for that exact query until
+    eviction, never a wrong result, and the text arm always returns on its own.
+    Tests reset the cache in ``setUp`` (``_cached_query_vector.cache_clear()``).
+    """
+    return _query_vector(query_text, embedder_path)
 
 
 def _text_ids(
@@ -157,7 +192,11 @@ def _semantic_ids(
     ``VectorSearchViaEmbeddingMixin`` (Annotation, Note, Document,
     Conversation). Returns ``[]`` if the query can't be embedded.
     """
-    vector = _query_vector(query_text, embedder_path)
+    if not embedder_path:
+        # No embedder configured → semantic arm is a no-op. Guard here (rather
+        # than relying on the cache) so we never seed the LRU with a null key.
+        return []
+    vector = _cached_query_vector(query_text, embedder_path)
     if not vector:
         return []
     try:
@@ -175,6 +214,11 @@ def _semantic_ids(
 
 def _order_by_ids(qs: QuerySet, ids: list[Any]) -> list[Any]:
     """Fetch ``qs`` rows for ``ids`` and return them in ``ids`` order.
+
+    ``_order_by_ids`` *owns* the ``id__in`` predicate — callers pass the bare
+    visible queryset (already carrying ``select_related`` / ``annotate``) and
+    must NOT pre-filter by ``ids`` themselves, to avoid a redundant double
+    ``id__in`` clause.
 
     Builds the id->object map by iterating ``filter(id__in=...)`` rather than
     ``QuerySet.in_bulk`` because ``visible_to_user`` querysets apply
@@ -244,8 +288,6 @@ class DiscoverSearchQueryMixin:
         fetch_k = limit * DISCOVER_OVERSAMPLE
         user = info.context.user
 
-        from opencontractserver.pipeline.utils import get_default_embedder_path
-
         visible = BaseService.filter_visible(Annotation, user, request=info.context)
         # Substring (label + raw_text) catches prefixes/fragments; search_vector
         # adds stemmed full-text matching. See resolve_search_annotations_for_mention.
@@ -255,12 +297,11 @@ class DiscoverSearchQueryMixin:
             | Q(search_vector=SearchQuery(text, config=FTS_CONFIG))
         )
         text_ids = _text_ids(visible, text_q, "created", fetch_k)
-        semantic_ids = _semantic_ids(
-            visible, text, get_default_embedder_path(), fetch_k
-        )
+        semantic_ids = _semantic_ids(visible, text, _default_embedder_path(), fetch_k)
         ids = _rrf([text_ids, semantic_ids], limit)
 
-        qs = visible.filter(id__in=ids).select_related(
+        # ``_order_by_ids`` applies the ``id__in=ids`` filter itself.
+        qs = visible.select_related(
             "annotation_label",
             "document",
             "document__creator",
@@ -283,17 +324,14 @@ class DiscoverSearchQueryMixin:
         fetch_k = limit * DISCOVER_OVERSAMPLE
         user = info.context.user
 
-        from opencontractserver.pipeline.utils import get_default_embedder_path
-
         visible = BaseService.filter_visible(Document, user, request=info.context)
         text_q = Q(title__icontains=text) | Q(description__icontains=text)
         text_ids = _text_ids(visible, text_q, "modified", fetch_k)
-        semantic_ids = _semantic_ids(
-            visible, text, get_default_embedder_path(), fetch_k
-        )
+        semantic_ids = _semantic_ids(visible, text, _default_embedder_path(), fetch_k)
         ids = _rrf([text_ids, semantic_ids], limit)
 
-        qs = visible.filter(id__in=ids).select_related("creator")
+        # ``_order_by_ids`` applies the ``id__in=ids`` filter itself.
+        qs = visible.select_related("creator")
         return _order_by_ids(qs, ids)
 
     # ------------------------------------------------------------------ #
@@ -310,8 +348,6 @@ class DiscoverSearchQueryMixin:
         fetch_k = limit * DISCOVER_OVERSAMPLE
         user = info.context.user
 
-        from opencontractserver.pipeline.utils import get_default_embedder_path
-
         visible = BaseService.filter_visible(Note, user, request=info.context)
         # Note now has a trigger-maintained search_vector (migration 0076), so
         # full-text (stemmed) matching joins the substring fallback.
@@ -321,16 +357,13 @@ class DiscoverSearchQueryMixin:
             | Q(search_vector=SearchQuery(text, config=FTS_CONFIG))
         )
         text_ids = _text_ids(visible, text_q, "modified", fetch_k)
-        semantic_ids = _semantic_ids(
-            visible, text, get_default_embedder_path(), fetch_k
-        )
+        semantic_ids = _semantic_ids(visible, text, _default_embedder_path(), fetch_k)
         ids = _rrf([text_ids, semantic_ids], limit)
 
-        qs = (
-            visible.filter(id__in=ids)
-            .select_related("document", "document__creator", "corpus", "creator")
-            .annotate(content_preview=Left("content", 400))
-        )
+        # ``_order_by_ids`` applies the ``id__in=ids`` filter itself.
+        qs = visible.select_related(
+            "document", "document__creator", "corpus", "creator"
+        ).annotate(content_preview=Left("content", 400))
         return _order_by_ids(qs, ids)
 
     # ------------------------------------------------------------------ #
@@ -394,6 +427,14 @@ class DiscoverSearchQueryMixin:
                 : fetch_k * DISCOVER_CORPUS_CONTENT_OVERSAMPLE
             ]
         )
+        # Collapse the two content-match id streams to a distinct corpus set.
+        # Size bound: each stream is capped at
+        # ``fetch_k × DISCOVER_CORPUS_CONTENT_OVERSAMPLE`` rows, so this set —
+        # and therefore the ``Q(id__in=...)`` clause below — holds at most
+        # ``2 × fetch_k × DISCOVER_CORPUS_CONTENT_OVERSAMPLE`` ids before the
+        # distinct-corpus collapse (≈800 with today's constants). If
+        # ``DISCOVER_CORPUS_CONTENT_OVERSAMPLE`` is tuned up, this ``IN`` clause
+        # grows linearly — keep it bounded or switch to a subquery join.
         content_corpus_ids = {
             cid
             for cid in list(corpus_ids_from_docs) + list(corpus_ids_from_annots)
@@ -404,7 +445,8 @@ class DiscoverSearchQueryMixin:
         )
 
         ids = _rrf([meta_ids, content_ids], limit)
-        qs = visible.filter(id__in=ids).select_related("creator")
+        # ``_order_by_ids`` applies the ``id__in=ids`` filter itself.
+        qs = visible.select_related("creator")
         return _order_by_ids(qs, ids)
 
     # ------------------------------------------------------------------ #
@@ -420,8 +462,6 @@ class DiscoverSearchQueryMixin:
         limit = _clamp_limit(limit)
         fetch_k = limit * DISCOVER_OVERSAMPLE
         user = info.context.user
-
-        from opencontractserver.pipeline.utils import get_default_embedder_path
 
         # Discover "Discussions" == collaborative THREADs (never personal CHATs).
         # Exclude soft-deleted threads server-side so deleted thread metadata
@@ -439,12 +479,11 @@ class DiscoverSearchQueryMixin:
         # now findable.
         text_q = Q(title__icontains=text) | Q(chat_messages__content__icontains=text)
         text_ids = _text_ids(visible, text_q, "created", fetch_k)
-        semantic_ids = _semantic_ids(
-            visible, text, get_default_embedder_path(), fetch_k
-        )
+        semantic_ids = _semantic_ids(visible, text, _default_embedder_path(), fetch_k)
         ids = _rrf([text_ids, semantic_ids], limit)
 
-        qs = visible.filter(id__in=ids).select_related(
+        # ``_order_by_ids`` applies the ``id__in=ids`` filter itself.
+        qs = visible.select_related(
             "creator",
             "chat_with_corpus",
             "chat_with_corpus__creator",

--- a/mypy.ini
+++ b/mypy.ini
@@ -204,9 +204,6 @@ ignore_errors = True
 [mypy-opencontractserver.tests.test_default_labelset]
 ignore_errors = True
 
-[mypy-opencontractserver.tests.test_discover_search_graphql]
-ignore_errors = True
-
 [mypy-opencontractserver.tests.test_django_annotation_vector_store]
 ignore_errors = True
 

--- a/opencontractserver/constants/search.py
+++ b/opencontractserver/constants/search.py
@@ -41,11 +41,25 @@ HYBRID_SEARCH_OVERSAMPLE_FACTOR = 3
 
 # Default number of results returned per category when the caller does not
 # specify a ``limit``. The frontend caps this per tab (preview vs. entity tab).
+#
+# Rate-cost note: the Discover "All" tab fires all FIVE category resolvers
+# (annotations/documents/notes/collections/discussions) simultaneously, each
+# decorated with the ``READ_LIGHT`` tier. So a single "All" search costs
+# ``5 × READ_LIGHT`` tokens, not one. Account for that multiplier when tuning
+# the READ_LIGHT rate in ``config/graphql/ratelimits.py``.
 DISCOVER_DEFAULT_LIMIT = 25
 
 # How many candidates each arm fetches relative to the requested ``limit``
 # before fusion — a small oversample so RRF has room to reorder.
 DISCOVER_OVERSAMPLE = 4
+
+# Size of the per-process LRU that memoises the embedded query vector across
+# the five Discover resolvers. The "All" tab issues one HTTP request per
+# category (the frontend uses a non-batching Apollo link), so without a cache a
+# single user search would embed the *same* query string up to five times. The
+# embedding is deterministic for a given ``(query_text, embedder_path)``, so a
+# small module-level cache lets those requests share one embedding call.
+DISCOVER_QUERY_VECTOR_CACHE_SIZE = 32
 
 # Extra oversample applied to the corpus "content match" pre-filters
 # (documents/annotations whose text matches), on top of ``fetch_k``. A corpus

--- a/opencontractserver/tests/test_discover_search_graphql.py
+++ b/opencontractserver/tests/test_discover_search_graphql.py
@@ -153,7 +153,14 @@ class DiscoverSearchTextArmTest(TestCase):
             is_public=True,
         )
 
-        self.client = Client(schema, context_value=TestContext(self.user))
+        self.graphene_client = Client(schema, context_value=TestContext(self.user))
+        # The query-vector LRU is process-global; clear it so a vector cached by
+        # a prior test can't bypass the patch below (and so this test's entries
+        # don't leak into the next). See discover_queries._cached_query_vector.
+        from config.graphql.discover_queries import _cached_query_vector
+
+        _cached_query_vector.cache_clear()
+        self.addCleanup(_cached_query_vector.cache_clear)
         # Disable the semantic arm so these assertions are deterministic.
         p = patch("config.graphql.discover_queries._query_vector", return_value=None)
         p.start()
@@ -161,7 +168,7 @@ class DiscoverSearchTextArmTest(TestCase):
 
     # ------------------------------------------------------------------ #
     def _run(self, field, query="indemnification"):
-        result = self.client.execute(
+        result = self.graphene_client.execute(
             """
             query D($t: String!) {
               %s(textSearch: $t) { __typename }
@@ -173,7 +180,7 @@ class DiscoverSearchTextArmTest(TestCase):
         return result["data"][field]
 
     def test_discover_annotations_text_match(self):
-        result = self.client.execute(
+        result = self.graphene_client.execute(
             "query D($t: String!){ discoverAnnotations(textSearch:$t){ id rawText } }",
             variables={"t": "indemnify"},  # FTS stems indemnify==indemnification
         )
@@ -188,7 +195,7 @@ class DiscoverSearchTextArmTest(TestCase):
         self.assertEqual(len(rows), 1)
 
     def test_discover_documents_is_a_new_category(self):
-        result = self.client.execute(
+        result = self.graphene_client.execute(
             "query D($t: String!){ discoverDocuments(textSearch:$t){ id title } }",
             variables={"t": "Indemnification"},
         )
@@ -202,7 +209,7 @@ class DiscoverSearchTextArmTest(TestCase):
         # Note.search_vector path works — a plain icontains substring match
         # would miss it, since "indemnifications" is not a substring of the
         # note's title or content.
-        result = self.client.execute(
+        result = self.graphene_client.execute(
             "query D($t: String!){ discoverNotes(textSearch:$t){ id title } }",
             variables={"t": "indemnifications"},
         )
@@ -211,7 +218,7 @@ class DiscoverSearchTextArmTest(TestCase):
         self.assertIn("Indemnification notes", titles)
 
     def test_discover_corpuses_matches_by_title(self):
-        result = self.client.execute(
+        result = self.graphene_client.execute(
             "query D($t: String!){ discoverCorpuses(textSearch:$t){ id title } }",
             variables={"t": "merger"},
         )
@@ -222,7 +229,7 @@ class DiscoverSearchTextArmTest(TestCase):
     def test_discover_corpuses_matches_by_contained_content(self):
         # The corpus title/description do NOT contain "indemnification"; it is
         # surfaced via its contained document + annotation matching.
-        result = self.client.execute(
+        result = self.graphene_client.execute(
             "query D($t: String!){ discoverCorpuses(textSearch:$t){ id title } }",
             variables={"t": "indemnification"},
         )
@@ -230,8 +237,56 @@ class DiscoverSearchTextArmTest(TestCase):
         titles = [c["title"] for c in result["data"]["discoverCorpuses"]]
         self.assertIn("Merger Agreements", titles)
 
+    def test_discover_corpuses_excludes_unreadable_content_match(self):
+        # "confidential" appears ONLY in ``private_other_ann``, which lives on a
+        # corpus/document ``user`` cannot read. The corpus content-match arm
+        # filters Annotation through ``filter_visible`` before collecting corpus
+        # ids, AND the final fetch re-filters Corpus through ``filter_visible``,
+        # so the unreadable collection must never surface — even though its
+        # contained text matches the query. (Mirrors the annotation-arm leak
+        # assertion in ``test_discover_annotations_text_match``.)
+        result = self.graphene_client.execute(
+            "query D($t: String!){ discoverCorpuses(textSearch:$t){ id title } }",
+            variables={"t": "confidential"},
+        )
+        self.assertIsNone(result.get("errors"), result.get("errors"))
+        titles = [c["title"] for c in result["data"]["discoverCorpuses"]]
+        self.assertNotIn("Other private corpus", titles)
+
+    def test_discover_limit_caps_results(self):
+        # A second visible annotation that also matches "indemnify", so without
+        # a cap the fused result set would hold more than one row.
+        Annotation.objects.create(
+            document=self.document,
+            corpus=self.corpus,
+            creator=self.user,
+            raw_text="Buyer agrees to indemnify the seller as well",
+            page=1,
+            is_public=True,
+        )
+        # The default limit surfaces both matches...
+        unlimited = self.graphene_client.execute(
+            "query D($t: String!){ discoverAnnotations(textSearch:$t){ id } }",
+            variables={"t": "indemnify"},
+        )
+        self.assertIsNone(unlimited.get("errors"), unlimited.get("errors"))
+        self.assertGreaterEqual(
+            len(unlimited["data"]["discoverAnnotations"]),
+            2,
+            "control: >1 visible annotation should match before the cap",
+        )
+        # ...but limit=1 clamps the fused result set to a single row end-to-end
+        # (_clamp_limit -> _rrf(..., limit)).
+        capped = self.graphene_client.execute(
+            "query D($t: String!, $l: Int){"
+            " discoverAnnotations(textSearch:$t, limit:$l){ id } }",
+            variables={"t": "indemnify", "l": 1},
+        )
+        self.assertIsNone(capped.get("errors"), capped.get("errors"))
+        self.assertEqual(len(capped["data"]["discoverAnnotations"]), 1)
+
     def test_discover_discussions_matches_message_body_not_just_title(self):
-        result = self.client.execute(
+        result = self.graphene_client.execute(
             "query D($t: String!){ discoverDiscussions(textSearch:$t){ id title } }",
             variables={"t": "indemnification"},
         )
@@ -294,7 +349,13 @@ class DiscoverSemanticArmTest(TestCase):
         self.vector = [0.5] * 384
         self.annotation.add_embedding(self.embedder_path, self.vector)
 
-        self.client = Client(schema, context_value=TestContext(self.user))
+        self.graphene_client = Client(schema, context_value=TestContext(self.user))
+        # Clear the process-global query-vector LRU so the in-test patch is hit
+        # on a cache miss (and doesn't leak into other suites).
+        from config.graphql.discover_queries import _cached_query_vector
+
+        _cached_query_vector.cache_clear()
+        self.addCleanup(_cached_query_vector.cache_clear)
 
     def test_semantic_only_hit(self):
         # Resolve the default embedder at runtime — calling
@@ -308,7 +369,7 @@ class DiscoverSemanticArmTest(TestCase):
             "config.graphql.discover_queries._query_vector",
             return_value=self.vector,
         ):
-            result = self.client.execute(
+            result = self.graphene_client.execute(
                 "query D($t: String!){ discoverAnnotations(textSearch:$t){ id rawText } }",
                 variables={"t": "semantic concept with no shared words"},
             )


### PR DESCRIPTION
Closes #1919.

Surgically addresses the code-review findings on the hybrid Discover search (PR #1908). Each item below maps to a point raised in the issue.

## Medium

### 1. Five resolvers embedded the same query string independently
The Discover **All** tab fires all five category resolvers, and the frontend uses a **non-batching** Apollo link (`createHttpLink` in `frontend/src/index.tsx`), so each category is a *separate* HTTP request — a per-request cache on `info.context` would not have helped. Added a per-process LRU `_cached_query_vector` (sized by the new `DISCOVER_QUERY_VECTOR_CACHE_SIZE = 32` constant) that memoises the deterministic `(query_text, embedder_path)` embedding so those requests share one embedding call instead of five. The semantic arm stays best-effort: a transient failure is never returned as a wrong result, and the text arm always returns on its own. `_semantic_ids` guards the no-embedder case before touching the cache so a null key never seeds the LRU.

### 2. `_order_by_ids` received a queryset already filtered by `id__in`
Chose the cleaner of the two suggested options: `_order_by_ids` now **owns** the `id__in=ids` predicate (its docstring says so), and the five resolvers pass the bare `visible.select_related(...)` / `.annotate(...)` queryset — dropping the redundant double `id__in` clause.

## Low

- **`content_corpus_ids` IN(...) bound** — added an inline comment documenting the `2 × fetch_k × DISCOVER_CORPUS_CONTENT_OVERSAMPLE` (~800) upper bound and the linear growth if the oversample is tuned up.
- **Rate-limit cost** — documented the `5 × READ_LIGHT` per-search cost of the All tab in the `DISCOVER_DEFAULT_LIMIT` constant comment.
- **`mypy.ini` suppression** — **root-caused and removed** rather than carried forward. The 8 errors were all `"Client" has no attribute "execute"`. Cause: the test stored its `graphene.test.Client` on `self.client`, which django-stubs types as `django.test.Client` (inherited from `TestCase`) — a class with no `.execute()`. The mypy-clean `test_document_queries.py` avoids this by naming it `self.graphene_client`; renamed to match. The blanket `ignore_errors` block is deleted. Verified with a full-project `mypy --config-file=mypy.ini opencontractserver config` run (`Success: no issues found in 1263 source files`).

## Missing test coverage

- **`limit` end-to-end** — `test_discover_limit_caps_results` proves `limit=1` clamps the fused result set to a single row (with a control assertion that >1 would otherwise match).
- **`discoverCorpuses` permission isolation** — `test_discover_corpuses_excludes_unreadable_content_match` asserts a corpus whose content matches the query but which the user cannot read never surfaces (analogous to the annotation-arm leak assertion).

## Nits

- **Repeated deferred import** — consolidated the five identical `from opencontractserver.pipeline.utils import get_default_embedder_path` statements into a single module-level `_default_embedder_path()` helper.
- **Frontend `THREAD_NODE` `slug`** — investigated; **no change warranted**. `ConversationType` (`config/graphql/conversation_types.py`) has no `slug` field and `DISCOVER_DISCUSSIONS` does not request one. The discussion row (`ThreadListItem`) navigates via `chatWithCorpus.slug`, which the fixture already includes. Adding a top-level `slug` would introduce a field that doesn't exist in the schema.

## Verification

- `black` (26.1.0), `isort` (6.0.1), `flake8` (7.2.0), `pyupgrade` (`--py39-plus`) all clean on the changed files.
- Full-project mypy clean with the suppression removed.
- `python manage.py test opencontractserver.tests.test_discover_search_graphql` — **14 tests pass** (the semantic test runs rather than skips, confirming the cache + patch interaction); `test_constants` passes.

A changelog fragment (`changelog.d/1919-discover-followup.{changed,fixed}.md`) is included.

---
_Generated by [Claude Code](https://claude.ai/code/session_019xiJuE7T65HJhUW8nAhHYJ)_