### PR TITLE
Close annotation/relationship gaps in bulk import format

### DIFF
--- a/changelog.d/bulk-import-relationships-metadata.added.md
+++ b/changelog.d/bulk-import-relationships-metadata.added.md
@@ -1,0 +1,44 @@
+- **Bulk import: annotation-to-annotation relationships, richer annotation metadata, and cross-batch document relationships.**
+  Closes long-standing gaps in what the bulk-ZIP / dumb-anchor sidecar format
+  could express. Builds on the deferred-remap pipeline (the producer-id →
+  new-annotation `id_map` it already persisted is now consumed end-to-end).
+  - **Annotation-to-annotation relationships in sidecars.** A dumb-anchor
+    sidecar may now carry a top-level `relationships` list
+    (`relationshipLabel` + `source_annotation_ids` / `target_annotation_ids`
+    referencing the sidecar's own annotation `id`s — e.g. `OC_PARENT_CHILD`,
+    `OC_SUBTREE_GROUP`). `import_zip_with_folder_structure`
+    (`opencontractserver/tasks/import_tasks.py`) persists them verbatim onto the
+    `PendingDocumentAnnotations` payload (and counts them in the new
+    `sidecar_relationships_found` result field) instead of the old
+    drop-and-warn. After ingest, `remap_pending_annotations`
+    (`opencontractserver/tasks/doc_tasks.py`, `_wire_pending_relationships`)
+    wires them in the **same atomic block** as the annotation import, using the
+    `import_annotations` `id_map` to resolve endpoints (int/str-id tolerant) and
+    auto-creating each `RELATIONSHIP_LABEL` via `corpus.ensure_label_and_labelset`
+    (mirroring the `relationships.csv` path). An edge whose endpoints did not
+    survive anchoring is **dropped and reported** on the row (`relationships` /
+    `relationships_dropped` counts), never silently lost.
+  - **`link_url` + `data` survive the re-anchor.** `anchor_annotations`
+    (`opencontractserver/utils/annotation_anchoring.py`) now carries the OC_URL
+    click-through `link_url` and the structured `data` sidecar (e.g. the geocoded
+    `OC_COUNTRY`/`OC_STATE`/`OC_CITY` `{canonical_name, lat, lng, …}` payload)
+    verbatim through PDF, span, and legacy-adapter anchoring; `import_annotations`
+    (`opencontractserver/utils/importing.py`) persists `data` onto
+    `Annotation.data` (it already handled `link_url`). `OpenContractsAnnotationPythonType`
+    gains an optional `data` field.
+  - **Cross-batch document relationships.** A `relationships.csv` endpoint that
+    matches no file in the current ZIP now falls back to a document already in
+    the corpus (`build_existing_corpus_path_map`, gated by
+    `CorpusDocumentService.get_corpus_documents` so only documents the importing
+    user can access are eligible). The phase runs whenever a `relationships.csv`
+    is present — even for a ZIP that contains *only* the CSV — so separately
+    imported batches can be wired together; the in-import map takes precedence
+    over the corpus fallback.
+  - **Validation.** `validate_dumb_anchor_sidecar`
+    (`opencontractserver/utils/validate_export.py`) now validates the
+    `relationships` list (label present; non-empty source/target id lists; every
+    endpoint references an annotation declared in the sidecar) and type-checks
+    optional `link_url` (string) / `data` (object) on annotations.
+  Span annotations still import as `TOKEN_LABEL`-typed labels (the deliberate
+  importer constraint is unchanged), and `structural=true` / exact-geometry
+  pinning remain re-derived by the parser by design.

--- a/docs/architecture/bulk-import.md
+++ b/docs/architecture/bulk-import.md
@@ -80,6 +80,31 @@ if parsed.is_valid:
 
 Relationships are created using `corpus.ensure_label_and_labelset()` for atomic label/labelset creation with `LabelType.RELATIONSHIP_LABEL`.
 
+**Cross-batch resolution**: endpoints first resolve against documents imported
+in the current ZIP (`document_path_map`), then fall back to documents already in
+the corpus via `build_existing_corpus_path_map()` (which is gated by
+`CorpusDocumentService.get_corpus_documents`, so only documents the importing
+user can access are eligible). The two maps are merged with the in-import map on
+top. The phase runs whenever a `relationships.csv` is present — even if the ZIP
+contains no documents — so a relationship-only ZIP can wire existing corpus
+documents.
+
+### Annotation Sidecars (deferred remap)
+
+A document's co-located `.json` sidecar (`{"annotations": [...], "doc_labels":
+[...], "relationships": [...]}`) is persisted verbatim into a
+`PendingDocumentAnnotations` row and applied after ingest by
+`remap_pending_annotations` (`opencontractserver/tasks/doc_tasks.py`):
+
+1. `anchor_annotations()` re-anchors each dumb-anchor annotation onto the
+   freshly-parsed PAWLs/text layer (carrying `link_url` and `data` through).
+2. `import_annotations()` creates the annotations and returns the
+   producer-id → new-pk map (persisted on the row's `id_map`).
+3. `_wire_pending_relationships()` wires the sidecar's annotation-to-annotation
+   `relationships` using that map, auto-creating each `RELATIONSHIP_LABEL`.
+   Edges whose endpoints did not survive anchoring are dropped and recorded on
+   the row's `report`.
+
 ## Task Result Schema
 
 The Celery task returns a detailed result dict:
@@ -103,6 +128,7 @@ The Celery task returns a detailed result dict:
     "folders_reused": 2,
     "metadata_file_found": True,
     "metadata_applied": 12,
+    "sidecar_relationships_found": 3,
     "relationships_file_found": True,
     "relationships_created": 8,
     "relationships_skipped": 1,

--- a/docs/upload_methods/bulk_zip_import.md
+++ b/docs/upload_methods/bulk_zip_import.md
@@ -135,6 +135,89 @@ contracts\agreement.pdf
 
 Path traversal (`..`) is rejected for security.
 
+### Cross-batch Relationships
+
+An endpoint that does not match a file inside the current ZIP is resolved
+against documents **already in the corpus** (matched by their path within the
+corpus, which equals the ZIP-relative path when no target folder is used). This
+lets a `relationships.csv` connect documents that were imported in **separate
+batches** — you can upload a ZIP containing *only* a `relationships.csv` to wire
+together documents already present in the corpus.
+
+Resolution order for each endpoint:
+
+1. A document imported in the current ZIP (same archive), then
+2. A current, non-deleted document already in the corpus that you can access.
+
+Only documents you can already see in the corpus are eligible, so cross-batch
+resolution never exposes a document you lacked access to. An endpoint that
+matches neither is skipped (and reported), exactly as before.
+
+## Annotation Sidecars
+
+A document may ship a co-located JSON **sidecar** (same name, `.json`
+extension — e.g. `agreement.pdf` + `agreement.json`) describing producer
+annotations to attach. Each annotation is a *dumb anchor*: a `label` + the
+`rawText` to find, plus a location hint (PDF `page` + `bbox`, or text
+`start`/`end`). The document is parsed normally and the annotations are
+re-anchored onto the freshly-produced text/PAWLs layer after ingest, so the
+anchors survive re-parsing.
+
+### Sidecar Schema
+
+```json
+{
+  "annotations": [
+    {
+      "id": 1,
+      "label": "OC_SECTION",
+      "rawText": "Article 1 — Definitions",
+      "page": 0,
+      "bbox": {"left": 50, "top": 50, "right": 300, "bottom": 70},
+      "link_url": "https://example.com/ref",
+      "data": {"canonical_name": "France", "lat": 46.0, "lng": 2.0}
+    },
+    {
+      "id": 2,
+      "label": "OC_CLAUSE",
+      "rawText": "indemnification obligations",
+      "start": 1234,
+      "end": 1261
+    }
+  ],
+  "doc_labels": ["Contract"],
+  "relationships": [
+    {
+      "id": "r1",
+      "relationshipLabel": "OC_PARENT_CHILD",
+      "source_annotation_ids": [1],
+      "target_annotation_ids": [2]
+    }
+  ]
+}
+```
+
+| Field | Scope | Description |
+|-------|-------|-------------|
+| `annotations[].label` | required | Resolves against `labels.json`/the corpus label set |
+| `annotations[].rawText` | required | The text to (re-)anchor onto — the source of truth |
+| `annotations[].page` + `bbox` | PDF | Location hint for token-based anchoring |
+| `annotations[].start` + `end` | text | Character-offset hint for span anchoring |
+| `annotations[].link_url` | optional | Click-through target for `OC_URL` hyperlink annotations |
+| `annotations[].data` | optional | Structured sidecar persisted to `Annotation.data` (e.g. geocoded `OC_COUNTRY`/`OC_STATE`/`OC_CITY` payloads) |
+| `relationships[]` | optional | Annotation-to-annotation edges (see below) |
+
+### Annotation-to-annotation Relationships
+
+The optional `relationships` list declares edges **between annotations in the
+same sidecar**. Each entry carries a `relationshipLabel` (auto-created as a
+`RELATIONSHIP_LABEL` if it doesn't exist — e.g. `OC_PARENT_CHILD`,
+`OC_SUBTREE_GROUP`) and `source_annotation_ids` / `target_annotation_ids` that
+reference the sidecar annotations' own `id`s. Relationships are wired after the
+annotations are re-anchored, using the producer-id → new-annotation map. An edge
+whose endpoints did not survive anchoring is dropped and recorded on the import
+report, never silently lost.
+
 ## Security Constraints
 
 | Constraint | Default | Description |

--- a/opencontractserver/documents/models.py
+++ b/opencontractserver/documents/models.py
@@ -2117,7 +2117,8 @@ class PendingDocumentAnnotations(django.db.models.Model):
     creator = django.db.models.ForeignKey(
         get_user_model(), on_delete=django.db.models.CASCADE
     )
-    # {"annotations": [<dumb-anchor dicts>], "doc_labels": [<label names>]}
+    # {"annotations": [<dumb-anchor dicts>], "doc_labels": [<label names>],
+    #  "relationships": [<annotation-to-annotation edge dicts>]}
     payload = django.db.models.JSONField(default=dict)
     status = django.db.models.CharField(
         max_length=16, choices=Status.choices, default=Status.PENDING, db_index=True
@@ -2132,8 +2133,9 @@ class PendingDocumentAnnotations(django.db.models.Model):
     # and gate a run's deferred work without a first-class run model.
     ingestion_run_id = django.db.models.UUIDField(null=True, blank=True, db_index=True)
     # old export-local annotation id -> newly created Annotation pk, recorded by
-    # remap_pending_annotations. Forward-investment so a future relationship-
-    # wiring feature can resolve endpoints without re-deriving the mapping.
+    # remap_pending_annotations. Drives the annotation-to-annotation relationship
+    # wiring in that task (resolving sidecar relationship endpoints) and is
+    # persisted so the mapping survives without re-deriving it.
     id_map = django.db.models.JSONField(default=dict, blank=True)
 
     class Meta:

--- a/opencontractserver/tasks/doc_tasks.py
+++ b/opencontractserver/tasks/doc_tasks.py
@@ -64,9 +64,14 @@ from opencontractserver.types.dicts import (
     LabelLookupPythonType,
     OpenContractDocExport,
     OpenContractsAnnotationPythonType,
+    OpenContractsRelationshipPythonType,
     PawlsTokenPythonType,
 )
-from opencontractserver.types.enums import AnnotationFilterMode, PermissionTypes
+from opencontractserver.types.enums import (
+    AnnotationFilterMode,
+    LabelType,
+    PermissionTypes,
+)
 from opencontractserver.utils.annotation_anchoring import (
     anchor_annotations,
     report_rawtext_preview,
@@ -74,7 +79,7 @@ from opencontractserver.utils.annotation_anchoring import (
 from opencontractserver.utils.compact_pawls import expand_pawls_pages
 from opencontractserver.utils.etl import build_document_export, pawls_bbox_to_funsd_box
 from opencontractserver.utils.files import split_pdf_into_images
-from opencontractserver.utils.importing import import_annotations
+from opencontractserver.utils.importing import import_annotations, import_relationships
 from opencontractserver.utils.permissioning import set_permissions_for_obj_to_user
 from opencontractserver.utils.text import truncate
 
@@ -1201,6 +1206,125 @@ def remap_pending_annotations(
     }
 
 
+def _wire_pending_relationships(
+    rel_specs: list[dict],
+    annot_id_map: dict[Any, int],
+    doc: Document,
+    corpus: Any,
+    user_id: int,
+    report: list[dict],
+) -> tuple[int, int]:
+    """Wire a pending row's annotation-to-annotation relationships.
+
+    ``rel_specs`` are the verbatim sidecar relationship dicts (each carrying a
+    label plus ``source_annotation_ids`` / ``target_annotation_ids`` that
+    reference the sidecar's own annotation ids). ``annot_id_map`` is the
+    export-local-id -> new-Annotation-pk map returned by ``import_annotations``;
+    only annotations that anchored AND whose label resolved appear in it, so an
+    endpoint can legitimately be missing.
+
+    Each relationship's endpoints are resolved against ``annot_id_map`` and the
+    unresolved ones dropped. A relationship that keeps a usable label and at
+    least one resolved source AND one resolved target is imported — its
+    ``RELATIONSHIP_LABEL`` is auto-created in the corpus labelset if absent,
+    mirroring the document-to-document ``relationships.csv`` path. Everything
+    else is dropped with a ``report`` entry so the loss is never silent.
+
+    Returns ``(created, dropped)``.
+    """
+    if not rel_specs:
+        return 0, 0
+
+    if corpus is None:
+        # No corpus -> no labelset to host the RELATIONSHIP_LABEL (and the
+        # annotations themselves all failed for the same reason). Drop every
+        # relationship with a clear reason rather than raising.
+        for spec in rel_specs:
+            report.append(
+                {
+                    "id": spec.get("id"),
+                    "rawText": "",
+                    "dropped": True,
+                    "reason": "relationship skipped — pending row has no corpus",
+                }
+            )
+        return 0, len(rel_specs)
+
+    # ``import_annotations`` keys the map by the raw export-local id (often an
+    # int); a sidecar relationship may reference the same id as a str. Accept
+    # both forms so an int/str mismatch doesn't spuriously drop an endpoint.
+    resolvable: dict[Any, int] = dict(annot_id_map)
+    for old_id, new_pk in annot_id_map.items():
+        resolvable.setdefault(str(old_id), new_pk)
+
+    rel_label_lookup: dict[str, Any] = {}
+    importable: list[dict] = []
+    dropped = 0
+    for spec in rel_specs:
+        label_name = spec.get("relationshipLabel") or spec.get("label")
+        source_ids = spec.get("source_annotation_ids") or []
+        target_ids = spec.get("target_annotation_ids") or []
+        resolved_sources = [i for i in source_ids if i in resolvable]
+        resolved_targets = [i for i in target_ids if i in resolvable]
+
+        if not label_name or not resolved_sources or not resolved_targets:
+            dropped += 1
+            if not label_name:
+                reason = "relationship missing label"
+            elif not resolved_sources and not resolved_targets:
+                reason = (
+                    "relationship endpoints unresolved — neither source nor "
+                    "target annotation survived anchoring"
+                )
+            elif not resolved_sources:
+                reason = "relationship has no resolvable source annotation"
+            else:
+                reason = "relationship has no resolvable target annotation"
+            report.append(
+                {
+                    "id": spec.get("id"),
+                    "rawText": "",
+                    "dropped": True,
+                    "reason": reason,
+                }
+            )
+            continue
+
+        if label_name not in rel_label_lookup:
+            rel_label_lookup[label_name] = corpus.ensure_label_and_labelset(
+                label_text=label_name,
+                creator_id=user_id,
+                label_type=LabelType.RELATIONSHIP_LABEL,
+            )
+
+        importable.append(
+            {
+                "id": spec.get("id"),
+                "relationshipLabel": label_name,
+                "source_annotation_ids": resolved_sources,
+                "target_annotation_ids": resolved_targets,
+                # Producer relationships are never structural — structural
+                # relationships are regenerated by the parser (the same rule the
+                # anchor step applies to structural annotations).
+                "structural": False,
+            }
+        )
+
+    if importable:
+        import_relationships(
+            user_id=user_id,
+            doc_obj=doc,
+            corpus_obj=corpus,
+            relationships_data=cast(
+                list[OpenContractsRelationshipPythonType], importable
+            ),
+            label_lookup=rel_label_lookup,
+            annotation_id_map=resolvable,
+        )
+
+    return len(importable), dropped
+
+
 def _remap_one_pending_row(
     pending: PendingDocumentAnnotations,
     doc: Document,
@@ -1218,6 +1342,7 @@ def _remap_one_pending_row(
     payload = pending.payload or {}
     dumb_anns = payload.get("annotations", []) or []
     doc_label_names = payload.get("doc_labels", []) or []
+    rel_specs = payload.get("relationships", []) or []
 
     is_pdf = (doc.file_type or "").lower() == "application/pdf"
     pawls: list[dict] = []
@@ -1326,10 +1451,9 @@ def _remap_one_pending_row(
 
         # Creates one Annotation per anchored item whose label resolves (and wires
         # parent relationships + dispatches embeddings as a side effect). The
-        # return map (export-local id -> new Annotation pk) is not used for the
-        # success count (see ``created`` below) but IS persisted on the row's
-        # ``id_map`` so a future relationship-wiring feature can resolve endpoints
-        # without a backfill.
+        # return map (export-local id -> new Annotation pk) drives the
+        # annotation-to-annotation relationship wiring below and is persisted on
+        # the row's ``id_map`` so the mapping survives without a backfill.
         annot_id_map = import_annotations(
             user_id=user_id,
             doc_obj=doc,
@@ -1341,6 +1465,16 @@ def _remap_one_pending_row(
         pending.id_map = {
             str(old_id): new_pk for old_id, new_pk in annot_id_map.items()
         }
+
+        # Wire intra-document annotation-to-annotation relationships now that the
+        # annotation id_map exists. Sharing the annotation import's atomic block
+        # means a relationship failure rolls the annotations back too, and the
+        # concurrent-retry guard above prevents a duplicated task from
+        # double-creating. Endpoints that did not survive anchoring are dropped
+        # and recorded on ``report`` (never silently).
+        relationships_created, relationships_dropped = _wire_pending_relationships(
+            rel_specs, annot_id_map, doc, corpus, user_id, report
+        )
 
         # ------------------------------------------------------------------
         # Close the label-resolution silent-failure gap.
@@ -1434,7 +1568,13 @@ def _remap_one_pending_row(
         #     ``anchored and created == 0`` guard short-circuited to DONE here
         #     and mis-reported a total anchor failure as success.
         # An empty payload (nothing requested, nothing dropped) stays DONE.
-        nothing_landed = created == 0 and doc_labels_created == 0
+        # ``relationships_created`` is folded in so a sidecar that landed only
+        # relationships (no new annotations — e.g. all endpoints already
+        # existed) is not mis-marked FAILED. In practice relationships need
+        # freshly-anchored annotations, so this is belt-and-suspenders.
+        nothing_landed = (
+            created == 0 and doc_labels_created == 0 and relationships_created == 0
+        )
         any_dropped = any(r.get("dropped") for r in report)
         if nothing_landed and any_dropped:
             pending.status = PendingDocumentAnnotations.Status.FAILED
@@ -1450,4 +1590,6 @@ def _remap_one_pending_row(
         "label_unresolved": label_unresolved,
         "doc_labels": doc_labels_created,
         "doc_labels_unresolved": doc_labels_unresolved,
+        "relationships": relationships_created,
+        "relationships_dropped": relationships_dropped,
     }

--- a/opencontractserver/tasks/import_tasks.py
+++ b/opencontractserver/tasks/import_tasks.py
@@ -460,7 +460,9 @@ def create_relationships_from_parsed(
     Args:
         corpus: The Corpus object to create relationships in
         user: The User creating the relationships
-        document_path_map: Mapping of normalized paths to Document objects
+        document_path_map: Mapping of normalized paths to Document objects. May
+            include documents already in the corpus (not just this import's), so
+            endpoints can resolve across separately-imported batches.
         parsed_relationships: List of ParsedRelationship objects from the parser
         logger: Logger instance for logging
 
@@ -550,6 +552,46 @@ def create_relationships_from_parsed(
     )
 
     return results
+
+
+def build_existing_corpus_path_map(
+    user: UserModel,
+    corpus: Corpus,
+) -> dict[str, Document]:
+    """Map current corpus document paths -> Document for cross-batch relationships.
+
+    A ``relationships.csv`` endpoint that does not match a file in *this* ZIP is
+    resolved against documents already in the corpus, so a relationship can span
+    separately-imported batches (the cross-batch edges a single ZIP otherwise
+    can't express). Only current, non-deleted paths whose document the importing
+    user can access — via ``CorpusDocumentService.get_corpus_documents``, the
+    canonical corpus-scoped accessor — are included, so the map can never resolve
+    an endpoint to a document the user could not already see in the corpus.
+
+    Keys are the document's path within the corpus (``DocumentPath.path``, e.g.
+    ``/contracts/master.pdf``), which equals the ZIP-relative path when no target
+    folder is used, so the common case "Just Works".
+    """
+    from opencontractserver.corpuses.services import CorpusDocumentService
+    from opencontractserver.documents.models import DocumentPath
+
+    accessible_doc_ids = set(
+        CorpusDocumentService.get_corpus_documents(user, corpus).values_list(
+            "id", flat=True
+        )
+    )
+    if not accessible_doc_ids:
+        return {}
+
+    path_map: dict[str, Document] = {}
+    for doc_path in DocumentPath.objects.filter(
+        corpus=corpus,
+        is_current=True,
+        is_deleted=False,
+        document_id__in=accessible_doc_ids,
+    ).select_related("document"):
+        path_map[doc_path.path] = doc_path.document
+    return path_map
 
 
 def _read_sidecar(
@@ -688,6 +730,11 @@ def import_zip_with_folder_structure(
         "annotations_imported": 0,
         "pipeline_skipped": 0,
         "pending_annotation_docs": 0,
+        # Count of intra-document annotation-to-annotation relationships found
+        # across all sidecars and persisted for deferred wiring. The relationships
+        # themselves are created later by ``remap_pending_annotations`` (once the
+        # annotation id_map exists), so this is a "captured", not "created", count.
+        "sidecar_relationships_found": 0,
         # Relationship statistics
         "relationships_file_found": False,
         "relationships_created": 0,
@@ -1017,6 +1064,12 @@ def import_zip_with_folder_structure(
                     sidecar_data: dict | None = None
                     has_pending_annotations = False
                     pending_annotations_list: list | None = None
+                    # Intra-document annotation-to-annotation relationships
+                    # (source/target annotation ids referencing the sidecar's
+                    # own annotations). Carried verbatim into the pending row so
+                    # the deferred remap can wire them once the annotation
+                    # id_map exists.
+                    pending_relationships_list: list | None = None
                     # True only for the dumb-anchor format (top-level
                     # ``"annotations"``); the legacy ``"labelled_text"`` format
                     # has no pre-flight schema and is re-anchored leniently.
@@ -1059,33 +1112,21 @@ def import_zip_with_folder_structure(
                             has_pending_annotations = (
                                 pending_annotations_list is not None
                             )
-                            # Intra-document annotation relationships are not yet
-                            # wired by the deferred remap pipeline (forward
-                            # investment — see PR description). The old sidecar
-                            # format carried a ``"relationships"`` list; never
-                            # drop it silently. Warn so producers know their
-                            # relationships were ignored on import.
-                            # TODO(deferred-remap): wire relationship import into
-                            # remap_pending_annotations once the dumb-anchor
-                            # id_map is consumed end-to-end, then remove this
-                            # drop-and-warn path.
+                            # Intra-document annotation-to-annotation
+                            # relationships ride alongside the annotations in a
+                            # top-level ``"relationships"`` list. They reference
+                            # the sidecar's own annotation ids, so they cannot be
+                            # wired until those annotations have been anchored and
+                            # assigned real pks. We capture them here and persist
+                            # them on the pending row; ``remap_pending_annotations``
+                            # wires them after ``import_annotations`` builds the
+                            # export-id -> new-pk map.
                             sidecar_rels = sidecar_data.get("relationships")
                             if isinstance(sidecar_rels, list) and sidecar_rels:
-                                rel_msg = (
-                                    f"Sidecar {sidecar_path} declares "
-                                    f"{len(sidecar_rels)} intra-document "
-                                    "relationship(s) which the deferred remap "
-                                    "pipeline does not yet import; they were "
-                                    "ignored."
+                                pending_relationships_list = sidecar_rels
+                                results["sidecar_relationships_found"] += len(
+                                    sidecar_rels
                                 )
-                                logger.warning(
-                                    "import_zip_with_folder_structure() - %s",
-                                    rel_msg,
-                                )
-                                # Surface to the caller, not just the Celery log
-                                # (review finding #3): an import that drops
-                                # relationships must not look like a clean success.
-                                results["errors"].append(rel_msg)
                         except Exception as e:
                             logger.error(
                                 f"import_zip_with_folder_structure() - "
@@ -1207,6 +1248,9 @@ def import_zip_with_folder_structure(
                                             "doc_labels": sidecar_data.get(
                                                 "doc_labels", []
                                             ),
+                                            "relationships": (
+                                                pending_relationships_list or []
+                                            ),
                                         },
                                         status=pending_status,
                                         report=pending_report,
@@ -1260,8 +1304,11 @@ def import_zip_with_folder_structure(
                         f"Error processing {entry.sanitized_path}: {str(e)}"
                     )
 
-            # Phase 5: Process relationships file if present
-            if manifest.relationship_file and document_path_map:
+            # Phase 5: Process relationships file if present.
+            # The gate no longer requires ``document_path_map`` to be non-empty:
+            # a relationship-only ZIP (just a relationships.csv wiring documents
+            # already in the corpus) is a valid cross-batch use case.
+            if manifest.relationship_file:
                 from opencontractserver.utils.relationship_file_parser import (
                     parse_relationship_file,
                 )
@@ -1270,6 +1317,16 @@ def import_zip_with_folder_structure(
                     f"import_zip_with_folder_structure() - Processing relationships "
                     f"file: {manifest.relationship_file}"
                 )
+
+                # Resolve endpoints against documents imported in THIS ZIP first,
+                # falling back to documents already in the corpus so a
+                # relationship can span separately-imported batches. The
+                # in-import map is layered on TOP so a path imported now wins over
+                # the same path's prior version.
+                resolution_path_map = {
+                    **build_existing_corpus_path_map(user_obj, corpus_obj),
+                    **document_path_map,
+                }
 
                 # Parse the relationships file
                 parse_result = parse_relationship_file(
@@ -1296,7 +1353,7 @@ def import_zip_with_folder_structure(
                         rel_results = create_relationships_from_parsed(
                             corpus=corpus_obj,
                             user=user_obj,
-                            document_path_map=document_path_map,
+                            document_path_map=resolution_path_map,
                             parsed_relationships=parse_result.relationships,
                             logger=logger,
                         )
@@ -1349,6 +1406,8 @@ def import_zip_with_folder_structure(
             f"pending annotation docs: {results['pending_annotation_docs']}, "
             f"pipeline skipped: {results['pipeline_skipped']}, "
             f"annotations imported: {results['annotations_imported']}, "
+            f"sidecar relationships captured: "
+            f"{results['sidecar_relationships_found']}, "
             f"relationships created: {results['relationships_created']}"
         )
 

--- a/opencontractserver/tests/test_annotation_anchoring.py
+++ b/opencontractserver/tests/test_annotation_anchoring.py
@@ -311,3 +311,85 @@ class LegacyFormatAdapterTests(SimpleTestCase):
         self.assertTrue(report[0]["dropped"])
         # Direct adapter call also returns None for structural.
         self.assertIsNone(legacy_annotation_to_dumb_anchor(legacy[0], is_pdf=True))
+
+
+class MetadataPassthroughTests(SimpleTestCase):
+    """``link_url`` (OC_URL target) and ``data`` (e.g. geocoded payload) are
+    not part of the anchor geometry, so the re-anchor must carry them verbatim
+    onto the anchored dict — otherwise bulk import silently strips them."""
+
+    def setUp(self):
+        self.pawls = [_page([_tok(10, "CHAPTER"), _tok(90, "1")])]
+
+    def test_pdf_carries_link_url_and_data(self):
+        geo = {"canonical_name": "France", "lat": 46.0, "lng": 2.0, "geocoded": True}
+        anns = [
+            {
+                "id": "u1",
+                "label": "OC_URL",
+                "rawText": "CHAPTER 1",
+                "page": 0,
+                "bbox": {"left": 8, "top": 8, "right": 130, "bottom": 24},
+                "link_url": "https://example.com/ref",
+                "data": geo,
+                "parent_id": None,
+            }
+        ]
+        out, _ = anchor_annotations(anns, is_pdf=True, pawls=self.pawls, content="")
+        self.assertEqual(out[0]["link_url"], "https://example.com/ref")
+        self.assertEqual(out[0]["data"], geo)
+
+    def test_text_carries_link_url_and_data(self):
+        content = "Intro. PARIS is here. Tail."
+        geo = {"canonical_name": "Paris", "lat": 48.85, "lng": 2.35, "geocoded": True}
+        anns = [
+            {
+                "id": "c1",
+                "label": "OC_CITY",
+                "rawText": "PARIS",
+                "start": 0,
+                "end": 5,
+                "data": geo,
+                "parent_id": None,
+            }
+        ]
+        out, _ = anchor_annotations(anns, is_pdf=False, pawls=[], content=content)
+        self.assertEqual(out[0]["data"], geo)
+        # No link_url supplied -> key is absent (column stays NULL), not None.
+        self.assertNotIn("link_url", out[0])
+
+    def test_absent_metadata_keys_stay_absent(self):
+        anns = [
+            {
+                "id": "a1",
+                "label": "OC_SECTION",
+                "rawText": "CHAPTER 1",
+                "page": 0,
+                "bbox": {"left": 8, "top": 8, "right": 130, "bottom": 24},
+                "parent_id": None,
+            }
+        ]
+        out, _ = anchor_annotations(anns, is_pdf=True, pawls=self.pawls, content="")
+        self.assertNotIn("link_url", out[0])
+        self.assertNotIn("data", out[0])
+
+    def test_legacy_adapter_carries_link_url(self):
+        legacy = [
+            {
+                "id": 7,
+                "annotationLabel": "OC_URL",
+                "rawText": "CHAPTER 1",
+                "page": 0,
+                "parent_id": None,
+                "link_url": "https://example.com/legacy",
+                "annotation_json": {
+                    "0": {
+                        "bounds": {"left": 8, "top": 8, "right": 130, "bottom": 24},
+                        "tokensJsons": [{"pageIndex": 0, "tokenIndex": 99}],
+                        "rawText": "CHAPTER 1",
+                    }
+                },
+            }
+        ]
+        out, _ = anchor_annotations(legacy, is_pdf=True, pawls=self.pawls, content="")
+        self.assertEqual(out[0]["link_url"], "https://example.com/legacy")

--- a/opencontractserver/tests/test_remap_pending_annotations.py
+++ b/opencontractserver/tests/test_remap_pending_annotations.py
@@ -19,6 +19,7 @@ from opencontractserver.annotations.models import (
     Annotation,
     AnnotationLabel,
     LabelSet,
+    Relationship,
 )
 from opencontractserver.corpuses.models import Corpus
 from opencontractserver.documents.models import Document, PendingDocumentAnnotations
@@ -291,14 +292,138 @@ class TestRemapPendingAnnotations(TestCase):
         )
 
     def test_id_map_persisted_after_remap(self):
-        """remap stores the old_id -> new_annotation_pk map on the row, so a
-        future relationship-wiring feature has the mapping without a backfill."""
+        """remap stores the old_id -> new_annotation_pk map on the row; the
+        relationship-wiring step (and any later consumer) reads it without a
+        backfill."""
         result = remap_pending_annotations(doc_id=self.doc.id)
         self.assertNotIn("skipped", result)
         self.pending.refresh_from_db()
         ann = Annotation.objects.get(document=self.doc, annotation_label=self.label)
         # _DUMB_ANN carries id "a1"; JSON object keys are strings.
         self.assertEqual(self.pending.id_map, {"a1": ann.id})
+
+    # -- annotation-to-annotation relationship wiring ------------------------
+
+    def test_relationship_between_annotations_is_created(self):
+        """A sidecar ``relationships`` edge is wired between the two anchored
+        annotations using the import id_map, auto-creating its RELATIONSHIP_LABEL.
+        """
+        ann1 = {**_DUMB_ANN, "id": "a1"}
+        ann2 = {**_DUMB_ANN, "id": "a2"}
+        self.pending.payload = {
+            "annotations": [ann1, ann2],
+            "doc_labels": [],
+            "relationships": [
+                {
+                    "id": "r1",
+                    "relationshipLabel": "REFERENCES",
+                    "source_annotation_ids": ["a1"],
+                    "target_annotation_ids": ["a2"],
+                }
+            ],
+        }
+        self.pending.save(update_fields=["payload"])
+
+        result = remap_pending_annotations(doc_id=self.doc.id)
+
+        self.assertEqual(result["status"], PendingDocumentAnnotations.Status.DONE)
+        self.assertEqual(result["relationships"], 1, msg=f"{result}")
+        self.assertEqual(result["relationships_dropped"], 0, msg=f"{result}")
+
+        rels = Relationship.objects.filter(document=self.doc, corpus=self.corpus)
+        self.assertEqual(rels.count(), 1)
+        rel = rels.first()
+        self.assertEqual(rel.relationship_label.text, "REFERENCES")
+        self.assertEqual(rel.relationship_label.label_type, "RELATIONSHIP_LABEL")
+        # Producer relationships are never structural.
+        self.assertFalse(rel.structural)
+
+        src = list(rel.source_annotations.all())
+        tgt = list(rel.target_annotations.all())
+        self.assertEqual(len(src), 1)
+        self.assertEqual(len(tgt), 1)
+        self.assertNotEqual(src[0].id, tgt[0].id)
+
+        # The id_map carries both annotation endpoints (keys stringified).
+        self.pending.refresh_from_db()
+        self.assertEqual(set(self.pending.id_map.keys()), {"a1", "a2"})
+
+    def test_relationship_endpoint_ids_match_across_int_and_str(self):
+        """An int sidecar annotation id and a str relationship endpoint id (or
+        vice versa) still resolve — the wiring accepts both forms."""
+        ann1 = {**_DUMB_ANN, "id": 1}
+        ann2 = {**_DUMB_ANN, "id": 2}
+        self.pending.payload = {
+            "annotations": [ann1, ann2],
+            "doc_labels": [],
+            "relationships": [
+                {
+                    "relationshipLabel": "REFERENCES",
+                    "source_annotation_ids": ["1"],  # str vs int id above
+                    "target_annotation_ids": [2],
+                }
+            ],
+        }
+        self.pending.save(update_fields=["payload"])
+
+        result = remap_pending_annotations(doc_id=self.doc.id)
+        self.assertEqual(result["relationships"], 1, msg=f"{result}")
+        self.assertEqual(Relationship.objects.filter(document=self.doc).count(), 1)
+
+    def test_link_url_and_data_persisted_on_annotations(self):
+        """``link_url`` (OC_URL) and ``data`` (geocoded payload) survive the
+        deferred remap onto the created Annotation."""
+        geo = {"canonical_name": "France", "lat": 46.0, "lng": 2.0, "geocoded": True}
+        ann = {
+            **_DUMB_ANN,
+            "id": "u1",
+            "link_url": "https://example.com/ref",
+            "data": geo,
+        }
+        self.pending.payload = {"annotations": [ann], "doc_labels": []}
+        self.pending.save(update_fields=["payload"])
+
+        result = remap_pending_annotations(doc_id=self.doc.id)
+        self.assertEqual(result["status"], PendingDocumentAnnotations.Status.DONE)
+
+        ann_obj = Annotation.objects.get(document=self.doc, annotation_label=self.label)
+        self.assertEqual(ann_obj.link_url, "https://example.com/ref")
+        self.assertEqual(ann_obj.data, geo)
+
+    def test_relationship_with_dangling_endpoint_dropped_and_reported(self):
+        """A relationship whose target never anchored is dropped (not silently)
+        and counted, while the resolvable annotation still lands (row DONE)."""
+        ann1 = {**_DUMB_ANN, "id": "a1"}
+        self.pending.payload = {
+            "annotations": [ann1],
+            "doc_labels": [],
+            "relationships": [
+                {
+                    "id": "r1",
+                    "relationshipLabel": "REFERENCES",
+                    "source_annotation_ids": ["a1"],
+                    "target_annotation_ids": ["ghost"],  # never declared/anchored
+                }
+            ],
+        }
+        self.pending.save(update_fields=["payload"])
+
+        result = remap_pending_annotations(doc_id=self.doc.id)
+
+        # The annotation landed, so the row is DONE despite the dropped edge.
+        self.assertEqual(result["status"], PendingDocumentAnnotations.Status.DONE)
+        self.assertEqual(result["relationships"], 0, msg=f"{result}")
+        self.assertEqual(result["relationships_dropped"], 1, msg=f"{result}")
+        self.assertEqual(Relationship.objects.filter(document=self.doc).count(), 0)
+
+        self.pending.refresh_from_db()
+        self.assertTrue(
+            any(
+                r.get("dropped") and "target" in (r.get("reason") or "")
+                for r in self.pending.report
+            ),
+            msg=f"Expected a dropped-target report entry: {self.pending.report}",
+        )
 
     def test_skipped_when_no_pending_row(self):
         """Task returns a 'skipped' dict when the document has no pending row."""

--- a/opencontractserver/tests/test_sidecar_import.py
+++ b/opencontractserver/tests/test_sidecar_import.py
@@ -43,16 +43,19 @@ logger = logging.getLogger(__name__)
 def _build_sidecar_json(
     annotations: list[dict] | None = None,
     doc_labels: list[str] | None = None,
+    relationships: list[dict] | None = None,
 ) -> dict:
     """
     Build a dumb-anchor sidecar dict in the NEW importer format.
 
     The new sidecar is a flat ``{"annotations": [...], "doc_labels": [...]}``
-    document. Each annotation is a label/rawText anchor with either a
+    document (plus an optional ``"relationships": [...]`` list of annotation-to-
+    annotation edges). Each annotation is a label/rawText anchor with either a
     page+bbox (PDF) or start+end (span) locator — there is no PAWLs content,
     no ``content``, no ``skip_pipeline``, and no ``tokensJsons``. The importer
     persists this payload verbatim into a ``PendingDocumentAnnotations`` row
-    for post-ingest re-anchoring by ``remap_pending_annotations``.
+    for post-ingest re-anchoring (and relationship wiring) by
+    ``remap_pending_annotations``.
     """
     if annotations is None:
         annotations = []
@@ -60,10 +63,13 @@ def _build_sidecar_json(
     if doc_labels is None:
         doc_labels = []
 
-    return {
+    sidecar: dict = {
         "annotations": annotations,
         "doc_labels": doc_labels,
     }
+    if relationships is not None:
+        sidecar["relationships"] = relationships
+    return sidecar
 
 
 def _build_labels_json(
@@ -423,6 +429,61 @@ class TestSidecarImportTask(_SidecarImportTestMixin, TestCase):
         # standard chain's remap step (and later relationship wiring) can group
         # and gate it.
         self.assertIsNotNone(row.ingestion_run_id)
+
+    def test_sidecar_relationships_captured_into_pending_payload(self):
+        """A sidecar's ``relationships`` list is persisted verbatim on the
+        pending row (not dropped/errored) for deferred wiring at remap time."""
+        annotations = [
+            _make_annotation(1, "Master Agreement", "Heading", page=0),
+            _make_annotation(2, "Schedule A", "Heading", page=0),
+        ]
+        relationships = [
+            {
+                "id": "r1",
+                "relationshipLabel": "REFERENCES",
+                "source_annotation_ids": [1],
+                "target_annotation_ids": [2],
+            }
+        ]
+        sidecar = _build_sidecar_json(
+            annotations=annotations, relationships=relationships
+        )
+        files = {
+            "agreement.pdf": self.pdf_bytes,
+            "agreement.json": json.dumps(sidecar).encode("utf-8"),
+        }
+
+        result = self._run_import(files, "test-sidecar-rels")
+
+        self.assertTrue(result["success"], f"Errors: {result.get('errors')}")
+        self.assertEqual(result["pending_annotation_docs"], 1)
+        # Relationships are captured, not dropped — the old drop-and-warn that
+        # appended to results["errors"] is gone.
+        self.assertEqual(result["sidecar_relationships_found"], 1)
+        self.assertEqual(
+            result["errors"], [], msg=f"Unexpected errors: {result['errors']}"
+        )
+
+        row = PendingDocumentAnnotations.objects.get()
+        self.assertEqual(row.payload["relationships"], relationships)
+        self.assertEqual(row.status, PendingDocumentAnnotations.Status.PENDING)
+
+    def test_sidecar_without_relationships_persists_empty_list(self):
+        """A sidecar with no ``relationships`` key still persists an empty list
+        so the remap's ``payload.get('relationships')`` is always well-formed."""
+        annotations = [_make_annotation(1, "Heading", "Heading", page=0)]
+        sidecar = _build_sidecar_json(annotations=annotations)
+        files = {
+            "doc.pdf": self.pdf_bytes,
+            "doc.json": json.dumps(sidecar).encode("utf-8"),
+        }
+
+        result = self._run_import(files, "test-sidecar-no-rels")
+
+        self.assertTrue(result["success"], f"Errors: {result.get('errors')}")
+        self.assertEqual(result["sidecar_relationships_found"], 0)
+        row = PendingDocumentAnnotations.objects.get()
+        self.assertEqual(row.payload["relationships"], [])
 
     def test_sidecar_without_doc_labels_persists_empty_list(self):
         """A sidecar with only span annotations persists doc_labels=[]."""

--- a/opencontractserver/tests/test_validate_export.py
+++ b/opencontractserver/tests/test_validate_export.py
@@ -1414,3 +1414,133 @@ class TestDumbAnchorSidecarValidation(unittest.TestCase):
         sidecar = {"annotations": [child, parent]}  # forward reference OK
         result = validate_dumb_anchor_sidecar(sidecar, _labels_json())
         self.assertTrue(result.ok, msg=result.summary())
+
+    # --- link_url / data passthrough validation ---
+
+    def test_valid_link_url_and_data(self):
+        ann = self._pdf_ann(
+            label="OC_URL",
+            link_url="https://example.com",
+            data={"canonical_name": "France", "geocoded": True},
+        )
+        result = validate_dumb_anchor_sidecar(
+            {"annotations": [ann]},
+            _labels_json(section_label_types={"OC_URL": "TOKEN_LABEL"}),
+        )
+        self.assertTrue(result.ok, msg=result.summary())
+
+    def test_non_string_link_url_is_error(self):
+        sidecar = {"annotations": [self._pdf_ann(link_url=123)]}
+        result = validate_dumb_anchor_sidecar(sidecar, _labels_json())
+        self.assertFalse(result.ok)
+        self.assertTrue(any("'link_url' must be a string" in e for e in result.errors))
+
+    def test_non_object_data_is_error(self):
+        sidecar = {"annotations": [self._pdf_ann(data=["not", "a", "dict"])]}
+        result = validate_dumb_anchor_sidecar(sidecar, _labels_json())
+        self.assertFalse(result.ok)
+        self.assertTrue(any("'data' must be a JSON object" in e for e in result.errors))
+
+    # --- annotation-to-annotation relationship validation ---
+
+    def _rel_labels(self) -> dict:
+        return _labels_json(
+            section_label_types={
+                "OC_SECTION": "TOKEN_LABEL",
+                "OC_PARENT_CHILD": "RELATIONSHIP_LABEL",
+            }
+        )
+
+    def test_valid_relationship(self):
+        sidecar = {
+            "annotations": [
+                self._pdf_ann(id="a1"),
+                self._pdf_ann(id="a2"),
+            ],
+            "relationships": [
+                {
+                    "id": "r1",
+                    "relationshipLabel": "OC_PARENT_CHILD",
+                    "source_annotation_ids": ["a1"],
+                    "target_annotation_ids": ["a2"],
+                }
+            ],
+        }
+        result = validate_dumb_anchor_sidecar(sidecar, self._rel_labels())
+        self.assertTrue(result.ok, msg=result.summary())
+
+    def test_relationships_must_be_list(self):
+        sidecar = {"annotations": [self._pdf_ann()], "relationships": {}}
+        result = validate_dumb_anchor_sidecar(sidecar, self._rel_labels())
+        self.assertFalse(result.ok)
+        self.assertTrue(
+            any("'relationships' must be a JSON list" in e for e in result.errors)
+        )
+
+    def test_relationship_missing_label_is_error(self):
+        sidecar = {
+            "annotations": [self._pdf_ann(id="a1"), self._pdf_ann(id="a2")],
+            "relationships": [
+                {"source_annotation_ids": ["a1"], "target_annotation_ids": ["a2"]}
+            ],
+        }
+        result = validate_dumb_anchor_sidecar(sidecar, self._rel_labels())
+        self.assertFalse(result.ok)
+        self.assertTrue(
+            any("'relationshipLabel' must be a non-empty" in e for e in result.errors)
+        )
+
+    def test_relationship_empty_endpoints_is_error(self):
+        sidecar = {
+            "annotations": [self._pdf_ann(id="a1")],
+            "relationships": [
+                {
+                    "relationshipLabel": "OC_PARENT_CHILD",
+                    "source_annotation_ids": ["a1"],
+                    "target_annotation_ids": [],
+                }
+            ],
+        }
+        result = validate_dumb_anchor_sidecar(sidecar, self._rel_labels())
+        self.assertFalse(result.ok)
+        self.assertTrue(
+            any(
+                "'target_annotation_ids' must be a non-empty list" in e
+                for e in result.errors
+            )
+        )
+
+    def test_relationship_dangling_endpoint_is_error(self):
+        sidecar = {
+            "annotations": [self._pdf_ann(id="a1")],
+            "relationships": [
+                {
+                    "relationshipLabel": "OC_PARENT_CHILD",
+                    "source_annotation_ids": ["a1"],
+                    "target_annotation_ids": ["ghost"],
+                }
+            ],
+        }
+        result = validate_dumb_anchor_sidecar(sidecar, self._rel_labels())
+        self.assertFalse(result.ok)
+        self.assertTrue(
+            any(
+                "references annotation id 'ghost' not present" in e
+                for e in result.errors
+            )
+        )
+
+    def test_relationship_label_alias_accepted(self):
+        """``label`` is accepted as an alias for ``relationshipLabel``."""
+        sidecar = {
+            "annotations": [self._pdf_ann(id="a1"), self._pdf_ann(id="a2")],
+            "relationships": [
+                {
+                    "label": "OC_PARENT_CHILD",
+                    "source_annotation_ids": ["a1"],
+                    "target_annotation_ids": ["a2"],
+                }
+            ],
+        }
+        result = validate_dumb_anchor_sidecar(sidecar, self._rel_labels())
+        self.assertTrue(result.ok, msg=result.summary())

--- a/opencontractserver/tests/test_zip_import_integration.py
+++ b/opencontractserver/tests/test_zip_import_integration.py
@@ -1393,6 +1393,109 @@ contracts/legal/agreement.pdf,REFERENCES,contracts/financial/report.pdf,
         rel = DocumentRelationship.objects.get(corpus=self.corpus)
         self.assertEqual(rel.annotation_label.text, "REFERENCES")
 
+    def test_cross_batch_relationship_resolves_existing_corpus_documents(self):
+        """A relationship-only ZIP connects documents imported in an EARLIER
+        batch, resolving both endpoints against existing corpus documents."""
+        from opencontractserver.documents.models import DocumentRelationship
+        from opencontractserver.tasks.import_tasks import (
+            import_zip_with_folder_structure,
+        )
+
+        # --- Batch 1: two documents, no relationships file ---
+        result1 = import_zip_with_folder_structure.apply(
+            kwargs={
+                "temporary_file_handle_id": self._create_temp_file_handle(
+                    self._create_test_zip(
+                        {"alpha.pdf": self.pdf_bytes, "beta.pdf": self.pdf_bytes}
+                    )
+                ).id,
+                "user_id": self.user.id,
+                "job_id": "cross-batch-1",
+                "corpus_id": self.corpus.id,
+            }
+        ).get()
+        self.assertTrue(result1["success"], f"Errors: {result1.get('errors')}")
+        self.assertEqual(result1["files_processed"], 2)
+
+        # --- Batch 2: relationships.csv ONLY, referencing batch-1 docs by their
+        #     corpus path (== zip path when no target folder is used) ---
+        csv_content = b"""source_path,relationship_label,target_path,notes
+alpha.pdf,REFERENCES,beta.pdf,cross-batch edge
+"""
+        result2 = import_zip_with_folder_structure.apply(
+            kwargs={
+                "temporary_file_handle_id": self._create_temp_file_handle(
+                    self._create_test_zip({"relationships.csv": csv_content})
+                ).id,
+                "user_id": self.user.id,
+                "job_id": "cross-batch-2",
+                "corpus_id": self.corpus.id,
+            }
+        ).get()
+
+        self.assertTrue(result2["completed"], f"Errors: {result2.get('errors')}")
+        self.assertTrue(result2["success"], f"Errors: {result2.get('errors')}")
+        self.assertEqual(result2["relationships_created"], 1)
+        self.assertEqual(result2["relationships_skipped"], 0)
+
+        rel = DocumentRelationship.objects.get(corpus=self.corpus)
+        self.assertEqual(rel.annotation_label.text, "REFERENCES")
+        self.assertIsNotNone(rel.source_document)
+        self.assertIsNotNone(rel.target_document)
+        self.assertNotEqual(rel.source_document_id, rel.target_document_id)
+
+    def test_relationship_endpoints_mix_new_and_existing_documents(self):
+        """One endpoint resolves to a same-ZIP document, the other to a document
+        already in the corpus — the in-import and corpus maps are merged."""
+        from opencontractserver.documents.models import DocumentRelationship
+        from opencontractserver.tasks.import_tasks import (
+            import_zip_with_folder_structure,
+        )
+
+        # --- Batch 1: a single existing document ---
+        result1 = import_zip_with_folder_structure.apply(
+            kwargs={
+                "temporary_file_handle_id": self._create_temp_file_handle(
+                    self._create_test_zip({"alpha.pdf": self.pdf_bytes})
+                ).id,
+                "user_id": self.user.id,
+                "job_id": "mix-batch-1",
+                "corpus_id": self.corpus.id,
+            }
+        ).get()
+        self.assertTrue(result1["success"], f"Errors: {result1.get('errors')}")
+
+        # --- Batch 2: a NEW document + relationships.csv referencing both the
+        #     new (gamma) and the existing (alpha) document ---
+        csv_content = b"""source_path,relationship_label,target_path,notes
+gamma.pdf,DERIVES_FROM,alpha.pdf,
+"""
+        result2 = import_zip_with_folder_structure.apply(
+            kwargs={
+                "temporary_file_handle_id": self._create_temp_file_handle(
+                    self._create_test_zip(
+                        {
+                            "gamma.pdf": self.pdf_bytes,
+                            "relationships.csv": csv_content,
+                        }
+                    )
+                ).id,
+                "user_id": self.user.id,
+                "job_id": "mix-batch-2",
+                "corpus_id": self.corpus.id,
+            }
+        ).get()
+
+        self.assertTrue(result2["success"], f"Errors: {result2.get('errors')}")
+        self.assertEqual(result2["files_processed"], 1)
+        self.assertEqual(result2["relationships_created"], 1)
+        self.assertEqual(result2["relationships_skipped"], 0)
+
+        rel = DocumentRelationship.objects.get(
+            corpus=self.corpus, annotation_label__text="DERIVES_FROM"
+        )
+        self.assertNotEqual(rel.source_document_id, rel.target_document_id)
+
 
 class TestMetadataFileImport(TestCase):
     """Tests for importing ZIP files with meta.csv."""
@@ -2476,3 +2579,117 @@ class TestDumbAnchorRemapThroughChain(TransactionTestCase):
         span = ann.json
         self.assertEqual(span["text"], content[span["start"] : span["end"]])
         self.assertEqual(span["text"], DUMB_ANCHOR_SPAN_RAWTEXT)
+
+    def test_pdf_sidecar_relationships_and_metadata_remap_via_chain(self):
+        """End-to-end: a dumb-anchor PDF sidecar carrying an annotation-to-
+        annotation relationship plus ``link_url`` / ``data`` runs the real
+        chain. The relationship is wired between the two anchored annotations
+        (its RELATIONSHIP_LABEL auto-created) and the metadata lands on the
+        heading annotation.
+        """
+        from opencontractserver.annotations.models import Annotation, Relationship
+        from opencontractserver.documents.models import PendingDocumentAnnotations
+        from opencontractserver.tasks.import_tasks import (
+            import_zip_with_folder_structure,
+        )
+
+        self._set_preferred_parser("application/pdf", _DUMB_ANCHOR_PDF_PARSER_PATH)
+
+        geo = {"canonical_name": "France", "lat": 46.0, "lng": 2.0, "geocoded": True}
+        sidecar = {
+            "annotations": [
+                {
+                    "id": 1,
+                    "label": "OC_SECTION",
+                    "rawText": DUMB_ANCHOR_HEADING_TEXT,
+                    "page": 0,
+                    "bbox": DUMB_ANCHOR_HEADING_BBOX,
+                    "link_url": "https://example.com/ref",
+                    "data": geo,
+                    "parent_id": None,
+                },
+                {
+                    "id": 2,
+                    "label": "OC_SECTION",
+                    "rawText": "Body",
+                    "page": 0,
+                    # bbox enclosing the page-0 "Body" token (x=50,y=200).
+                    "bbox": {
+                        "left": 45.0,
+                        "top": 195.0,
+                        "right": 115.0,
+                        "bottom": 217.0,
+                    },
+                    "parent_id": None,
+                },
+            ],
+            "doc_labels": [],
+            "relationships": [
+                {
+                    "id": "r1",
+                    "relationshipLabel": "REFERENCES",
+                    "source_annotation_ids": [1],
+                    "target_annotation_ids": [2],
+                }
+            ],
+        }
+        labels = {
+            "text_labels": {
+                "OC_SECTION": {
+                    "text": "OC_SECTION",
+                    "label_type": "TOKEN_LABEL",
+                    "description": "Section heading",
+                    "color": "#FF0000",
+                    "icon": "tag",
+                }
+            },
+            "doc_labels": {},
+        }
+        files = {
+            "chapter.pdf": self.pdf_bytes,
+            "chapter.json": json.dumps(sidecar).encode("utf-8"),
+            "labels.json": json.dumps(labels).encode("utf-8"),
+        }
+        handle = self._create_temp_file_handle(self._create_test_zip(files))
+
+        result = import_zip_with_folder_structure.apply(
+            kwargs={
+                "temporary_file_handle_id": handle.id,
+                "user_id": self.user.id,
+                "job_id": "dumb-anchor-rels",
+                "corpus_id": self.corpus.id,
+            }
+        ).get()
+
+        self.assertTrue(result["success"], f"Errors: {result.get('errors')}")
+        self.assertEqual(result["sidecar_relationships_found"], 1)
+
+        doc = Document.objects.get(pk=int(result["document_ids"][0]))
+        pending = PendingDocumentAnnotations.objects.get(document=doc)
+        self.assertEqual(pending.status, PendingDocumentAnnotations.Status.DONE)
+
+        # Two producer annotations anchored (structural=False filters out any
+        # parser-generated structural annotations).
+        anns = Annotation.objects.filter(
+            document=doc, annotation_label__text="OC_SECTION", structural=False
+        )
+        self.assertEqual(anns.count(), 2)
+
+        # link_url + data landed on the heading annotation.
+        heading = anns.get(raw_text=DUMB_ANCHOR_HEADING_TEXT)
+        self.assertEqual(heading.link_url, "https://example.com/ref")
+        self.assertEqual(heading.data, geo)
+
+        # The annotation-to-annotation relationship was wired, its
+        # RELATIONSHIP_LABEL auto-created, connecting heading -> body.
+        rel = Relationship.objects.get(
+            document=doc, relationship_label__text="REFERENCES"
+        )
+        self.assertEqual(rel.relationship_label.label_type, "RELATIONSHIP_LABEL")
+        self.assertFalse(rel.structural)
+        self.assertEqual(rel.source_annotations.count(), 1)
+        self.assertEqual(rel.target_annotations.count(), 1)
+        self.assertEqual(
+            rel.source_annotations.first().raw_text, DUMB_ANCHOR_HEADING_TEXT
+        )
+        self.assertEqual(rel.target_annotations.first().raw_text, "Body")

--- a/opencontractserver/types/dicts.py
+++ b/opencontractserver/types/dicts.py
@@ -245,6 +245,13 @@ class OpenContractsAnnotationPythonType(TypedDict):
     # round-trip so a corpus full of link annotations doesn't silently lose
     # all its targets through fork / V2-export / V2-import.
     link_url: NotRequired[Optional[str]]
+    # Free-form structured sidecar persisted to ``Annotation.data``. Carries
+    # label-specific state that lives nowhere else in the annotation shape —
+    # most notably the geocoded ``{canonical_name, lat, lng, admin_codes,
+    # geocoded}`` payload that OC_COUNTRY / OC_STATE / OC_CITY spans write so
+    # the map UI can aggregate pins without re-running the geocoder. Optional;
+    # absent / null leaves the column NULL.
+    data: NotRequired[Optional[dict]]
 
 
 class SpanAnnotation(TypedDict):

--- a/opencontractserver/utils/annotation_anchoring.py
+++ b/opencontractserver/utils/annotation_anchoring.py
@@ -44,6 +44,28 @@ def _norm(s: str) -> str:
     return " ".join((s or "").casefold().split())
 
 
+def _passthrough_annotation_metadata(ann: dict) -> dict:
+    """Optional annotation fields carried verbatim from the dumb-anchor input.
+
+    ``link_url`` (the OC_URL click-through hyperlink target) and ``data`` (a
+    label-specific structured sidecar — most notably the geocoded
+    ``{canonical_name, lat, lng, admin_codes, geocoded}`` payload that
+    OC_COUNTRY / OC_STATE / OC_CITY spans carry) are not part of the anchor
+    geometry, so the re-anchor would otherwise silently strip them. We splice
+    them back onto the anchored dict so ``import_annotations`` can persist them
+    onto ``Annotation.link_url`` / ``Annotation.data``. Only non-None values
+    are emitted, so an absent field stays absent (and the column stays NULL).
+    """
+    out: dict = {}
+    link_url = ann.get("link_url")
+    if link_url is not None:
+        out["link_url"] = link_url
+    data = ann.get("data")
+    if data is not None:
+        out["data"] = data
+    return out
+
+
 def _anchor_pdf_page(
     page_idx: object, bbox: object, raw: str, pawls: list[dict]
 ) -> list[int] | None:
@@ -126,6 +148,7 @@ def _anchor_pdf(ann: dict, pawls: list[dict]) -> dict | None:
         "long_description": ann.get("long_description"),
         "page": first_page,
         "annotation_json": annotation_json,
+        **_passthrough_annotation_metadata(ann),
     }
 
 
@@ -159,6 +182,7 @@ def _anchor_text(ann: dict, content: str) -> dict | None:
         # rather than the misleading 1.
         "page": 0,
         "annotation_json": {"start": chosen, "end": end, "text": content[chosen:end]},
+        **_passthrough_annotation_metadata(ann),
     }
 
 
@@ -190,6 +214,10 @@ def legacy_annotation_to_dumb_anchor(ann: dict, *, is_pdf: bool) -> dict | None:
         "rawText": raw,
         "parent_id": ann.get("parent_id"),
         "long_description": ann.get("long_description"),
+        # Carry the click-through / structured sidecar fields onto the
+        # converted dumb-anchor dict so a legacy export annotation keeps its
+        # OC_URL target and geocoded ``data`` through the re-anchor.
+        **_passthrough_annotation_metadata(ann),
     }
 
     if is_pdf:

--- a/opencontractserver/utils/importing.py
+++ b/opencontractserver/utils/importing.py
@@ -154,6 +154,11 @@ def import_annotations(
                 # must survive round-trip through bulk import. Falsy /
                 # missing values stay NULL on the column.
                 link_url=annotation_data.get("link_url") or None,
+                # Label-specific structured sidecar (e.g. the geocoded
+                # OC_COUNTRY/STATE/CITY payload). Persisted verbatim so map /
+                # other data-driven features survive bulk import; missing /
+                # empty stays NULL.
+                data=annotation_data.get("data") or None,
             )
         )
         parallel_old_ids.append(annotation_data.get("id"))

--- a/opencontractserver/utils/validate_export.py
+++ b/opencontractserver/utils/validate_export.py
@@ -981,6 +981,23 @@ def _check_dumb_anchor_annotation(
         ):
             result.error(f"{prefix}: 'end' must be an integer > 'start'")
 
+    # Optional structured passthrough fields. ``link_url`` (OC_URL target) and
+    # ``data`` (label-specific sidecar, e.g. geocoded OC_COUNTRY/STATE/CITY
+    # payload) are carried verbatim onto the created annotation, so reject an
+    # obviously wrong-typed value here rather than letting it fail at the DB.
+    link_url = ann.get("link_url")
+    if link_url is not None and not isinstance(link_url, str):
+        result.error(
+            f"{prefix}: 'link_url' must be a string when present "
+            f"(got {type(link_url).__name__})"
+        )
+    data = ann.get("data")
+    if data is not None and not isinstance(data, dict):
+        result.error(
+            f"{prefix}: 'data' must be a JSON object when present "
+            f"(got {type(data).__name__})"
+        )
+
     # Label resolution against labels.json
     if label is not None:
         if label not in label_types:
@@ -1003,6 +1020,45 @@ def _check_dumb_anchor_annotation(
                 )
 
 
+def _check_dumb_anchor_relationship(
+    rel: dict,
+    index: int,
+    annotation_ids: set[str],
+    result: ValidationResult,
+) -> None:
+    """Validate one dumb-anchor annotation-to-annotation relationship.
+
+    Each relationship carries a label (``relationshipLabel`` — ``label`` is
+    accepted as an alias for symmetry with annotations) plus
+    ``source_annotation_ids`` / ``target_annotation_ids`` that reference the
+    sidecar's own annotation ``id``s. The relationship *label* is resolved (and
+    auto-created as a ``RELATIONSHIP_LABEL``) at remap time, so it is only
+    checked for presence here. Every endpoint id, however, MUST reference an
+    annotation declared in the same sidecar: a dangling endpoint silently drops
+    the relationship at remap, so it is an error to catch before import.
+    """
+    prefix = f"relationships[{index}]"
+    if not isinstance(rel, dict):
+        result.error(f"{prefix}: must be a JSON object, got {type(rel).__name__}")
+        return
+
+    label = rel.get("relationshipLabel") or rel.get("label")
+    if not isinstance(label, str) or not label.strip():
+        result.error(f"{prefix}: 'relationshipLabel' must be a non-empty string")
+
+    for direction in ("source_annotation_ids", "target_annotation_ids"):
+        ids = rel.get(direction)
+        if not isinstance(ids, list) or not ids:
+            result.error(f"{prefix}: '{direction}' must be a non-empty list")
+            continue
+        for ref in ids:
+            if str(ref) not in annotation_ids:
+                result.error(
+                    f"{prefix}: {direction} references annotation id "
+                    f"'{ref}' not present in this sidecar"
+                )
+
+
 def validate_dumb_anchor_sidecar(
     sidecar: dict, labels_json: dict | None = None
 ) -> ValidationResult:
@@ -1020,7 +1076,14 @@ def validate_dumb_anchor_sidecar(
       present in the same sidecar,
     * span (start/end) annotations whose label is declared ``SPAN_LABEL`` in
       ``labels.json`` are rejected — the importer only accepts
-      ``TOKEN_LABEL`` / ``DOC_TYPE_LABEL`` / ``RELATIONSHIP_LABEL``.
+      ``TOKEN_LABEL`` / ``DOC_TYPE_LABEL`` / ``RELATIONSHIP_LABEL``,
+    * optional ``"link_url"`` (string) and ``"data"`` (object) are type-checked
+      when present.
+
+    An optional top-level ``"relationships"`` list declares annotation-to-
+    annotation edges. Each relationship must have a non-empty label and
+    non-empty ``source_annotation_ids`` / ``target_annotation_ids`` that
+    reference annotation ``"id"``s present in the same sidecar.
 
     Args:
         sidecar: The parsed sidecar JSON (must contain ``"annotations"``).
@@ -1038,8 +1101,8 @@ def validate_dumb_anchor_sidecar(
 
     label_types = _collect_sidecar_label_types(labels_json or {})
 
-    # Collect all annotation ids first so parent_id references can be checked
-    # regardless of declaration order.
+    # Collect all annotation ids first so parent_id and relationship endpoint
+    # references can be checked regardless of declaration order.
     annotation_ids: set[str] = set()
     for ann in annotations:
         if isinstance(ann, dict) and ann.get("id") is not None:
@@ -1055,6 +1118,14 @@ def validate_dumb_anchor_sidecar(
                     f"annotations[{i}]: parent_id '{parent_id}' does not "
                     f"reference any annotation 'id' in this sidecar"
                 )
+
+    relationships = sidecar.get("relationships")
+    if relationships is not None:
+        if not isinstance(relationships, list):
+            result.error("sidecar 'relationships' must be a JSON list")
+        else:
+            for i, rel in enumerate(relationships):
+                _check_dumb_anchor_relationship(rel, i, annotation_ids, result)
 
     return result
 


### PR DESCRIPTION
## Summary

Bulk-ZIP / dumb-anchor sidecar imports previously couldn't express several kinds of annotations and relationships. This closes the three most impactful gaps by consuming the deferred-remap pipeline's already-persisted producer-id → new-pk `id_map` **end to end** (it shipped unused, with a `# TODO(deferred-remap)` drop-and-warn marking the intended work).

### 1. Annotation-to-annotation relationships in sidecars *(the keystone)*
- A sidecar may now carry a top-level `relationships` list (`relationshipLabel` + `source_annotation_ids` / `target_annotation_ids` referencing the sidecar's own annotation `id`s — e.g. `OC_PARENT_CHILD`, `OC_SUBTREE_GROUP`).
- `import_zip_with_folder_structure` persists them onto the `PendingDocumentAnnotations` payload (counted in the new `sidecar_relationships_found` result field) **instead of the prior drop-and-warn**.
- `remap_pending_annotations._wire_pending_relationships` wires them in the **same atomic block** as the annotation import, resolving endpoints against the `id_map` (int/str-id tolerant) and auto-creating each `RELATIONSHIP_LABEL` via `corpus.ensure_label_and_labelset` (mirroring the `relationships.csv` path). Edges whose endpoints didn't survive anchoring are **dropped and reported** (`relationships` / `relationships_dropped` counts), never silent.

### 2. `link_url` + structured `data` survive the re-anchor
- `anchor_annotations` carries the OC_URL `link_url` and the structured `data` sidecar (e.g. geocoded `OC_COUNTRY`/`OC_STATE`/`OC_CITY` `{canonical_name, lat, lng, …}` payloads) verbatim through PDF, span, and legacy-adapter anchoring (`_passthrough_annotation_metadata`).
- `import_annotations` persists `data` onto `Annotation.data` (it already handled `link_url`). `OpenContractsAnnotationPythonType` gains an optional `data`.

### 3. Cross-batch document relationships
- `relationships.csv` endpoints that match no file in the current ZIP now resolve against documents **already in the corpus** (`build_existing_corpus_path_map`, gated by `CorpusDocumentService.get_corpus_documents` so only documents the importing user can access are eligible).
- The phase now runs whenever a `relationships.csv` is present — even for a ZIP containing *only* the CSV — so separately-imported batches can be wired together. The in-import map takes precedence over the corpus fallback.

`validate_dumb_anchor_sidecar` gains relationship validation (label present; non-empty endpoint lists; every endpoint references a sidecar annotation) and type checks for optional `link_url`/`data`.

### Deliberately out of scope
Per the agreed scope, these remain unchanged **by design**: span annotations still import as `TOKEN_LABEL`-typed labels (the importer's `SPAN_LABEL` constraint), and `structural=true` / exact-geometry / token-index pinning stay parser-regenerated (the whole point of `rawText`-based re-anchoring is robustness to re-parsing).

## Testing
- **Backend (targeted): 111 passed, no regressions.**
  - `test_annotation_anchoring.py` — `link_url`/`data` passthrough (PDF, span, legacy adapter)
  - `test_validate_export.py::TestDumbAnchorSidecarValidation` — relationship + `link_url`/`data` validation
  - `test_remap_pending_annotations.py` — relationship wiring, int/str id matching, metadata persistence, dangling-endpoint drop+report
  - `test_sidecar_import.py` — relationships captured into the pending payload
  - `test_zip_import_integration.py` — cross-batch + relationship-only ZIP resolution, and end-to-end relationship+metadata through the real ingest→remap chain
- `black` / `isort` / `flake8` clean on all changed files; changelog fragment validates.

## Docs / changelog
- `docs/upload_methods/bulk_zip_import.md` (sidecar schema, annotation-to-annotation relationships, cross-batch resolution) and `docs/architecture/bulk-import.md` (deferred-remap + cross-batch internals) updated.
- `changelog.d/bulk-import-relationships-metadata.added.md` added.

https://claude.ai/code/session_01M2YEStYrDK25rCsiTHbUBb

---
_Generated by [Claude Code](https://claude.ai/code/session_01M2YEStYrDK25rCsiTHbUBb)_