### PR TITLE
Fix env-configurable zip-import limits frozen to defaults at import time

### DIFF
--- a/changelog.d/zip-import-limits-import-freeze.fixed.md
+++ b/changelog.d/zip-import-limits-import-freeze.fixed.md
@@ -1,0 +1,24 @@
+- **Fixed env-configurable zip-import limits being silently frozen to their
+  defaults in production.** `opencontractserver/constants/zip_import.py` read
+  every limit (`ZIP_MAX_FILE_COUNT`, `ZIP_MAX_TOTAL_SIZE_BYTES`,
+  `ZIP_MAX_SINGLE_FILE_SIZE_BYTES`, `ZIP_MAX_FOLDER_COUNT`,
+  `ZIP_MAX_SIDECAR_SIZE_BYTES`, `ZIP_DOCUMENT_BATCH_SIZE`,
+  `BULK_UPLOAD_OWNER_CACHE_TTL_SECONDS`, …) via a *module-level*
+  `getattr(settings, …)`. Because `config/settings/base.py` imports from
+  `opencontractserver.constants.*` at the top of the settings module, the
+  constants package `__init__` — which eagerly `import *`-ed `zip_import` —
+  executed *while settings was still mid-load*, so each limit bound to its
+  hard-coded default before `base.py` defined the env-driven value and froze
+  there for the life of the process. ConfigMap/`env` overrides of any `ZIP_*`
+  limit were therefore permanently inert (these are the zip-bomb / resource-
+  exhaustion / path-length security limits, so an operator tightening them got
+  the shipped defaults instead). The limits are now read lazily at call time
+  through `get_*()` accessors (mirroring the sibling
+  `opencontractserver/constants/zip_export.py`), `DEFAULT_*` constants hold the
+  fallbacks, and `zip_import` is no longer barrel-imported by
+  `opencontractserver/constants/__init__.py` — so settings/`env` overrides are
+  honoured at runtime. Consumers updated to call the accessors:
+  `opencontractserver/utils/zip_security.py`,
+  `opencontractserver/tasks/import_tasks.py`,
+  `opencontractserver/document_imports/services.py`. Regression test:
+  `opencontractserver/tests/test_constants.py::TestZipImportConstants::test_accessors_reflect_settings_overrides`.

--- a/opencontractserver/constants/__init__.py
+++ b/opencontractserver/constants/__init__.py
@@ -16,4 +16,12 @@ from opencontractserver.constants.document_processing import *  # noqa: F401, F4
 from opencontractserver.constants.extracts import *  # noqa: F401, F403
 from opencontractserver.constants.moderation import *  # noqa: F401, F403
 from opencontractserver.constants.truncation import *  # noqa: F401, F403
-from opencontractserver.constants.zip_import import *  # noqa: F401, F403
+
+# NOTE: ``zip_import`` and ``zip_export`` are deliberately NOT barrel-imported
+# here. ``config/settings/base.py`` imports from this package at the top of the
+# settings module, so anything pulled in by this ``__init__`` runs *while
+# settings is still building*. Both modules expose settings-derived limits; an
+# eager import here previously froze ``zip_import``'s limits to their defaults
+# (the env/ConfigMap overrides became permanently inert). Import their ``get_*``
+# accessors from the submodule (``opencontractserver.constants.zip_import``) at
+# call sites instead.

--- a/opencontractserver/constants/zip_import.py
+++ b/opencontractserver/constants/zip_import.py
@@ -7,55 +7,67 @@ These limits protect against:
 - Resource exhaustion
 - Denial of service
 
-All limits can be overridden via Django settings with the same name and via
-the matching environment variable consumed in `config/settings/base.py`.
-Example: settings.ZIP_MAX_FILE_COUNT = 2000  (or `ZIP_MAX_FILE_COUNT=2000`
+All limits are overridable via a Django setting of the same name (and the
+matching environment variable consumed in ``config/settings/base.py``).
+Example: ``settings.ZIP_MAX_FILE_COUNT = 2000`` (or ``ZIP_MAX_FILE_COUNT=2000``
 in the environment).
+
+WHY THE ``get_*`` ACCESSORS — DO NOT re-introduce module-level
+``getattr(settings, …)`` here:
+``config/settings/base.py`` imports from ``opencontractserver.constants.*`` at
+the very top of the file. Importing any ``constants`` submodule first executes
+``constants/__init__.py``. If that import chain reaches *this* module while the
+settings module is still mid-load, every ``getattr(settings, "ZIP_MAX_…", …)``
+evaluated at import time would read a half-built settings object, silently fall
+back to the default, and freeze there for the life of the process — so any
+ConfigMap/env override would become permanently inert (the feature would be
+dead in production no matter what the operator configured). Reading inside the
+accessors defers the lookup until call time, after settings is fully
+initialised, so ``@override_settings`` and env/deployment overrides are honoured
+at runtime. This mirrors the sibling ``zip_export.py`` module, which is kept out
+of the ``constants`` barrel for the same reason.
 """
 
 from django.conf import settings
 
-# Maximum number of files allowed in a single zip
-ZIP_MAX_FILE_COUNT = getattr(settings, "ZIP_MAX_FILE_COUNT", 1000)
+# --- Default limits ---------------------------------------------------------
+# These ``DEFAULT_*`` values are the *only* hard-coded numbers. They are plain
+# constants (no settings read) and are used as the fallback by the matching
+# ``get_*`` accessor when the setting is unset.
 
-# Maximum total uncompressed size in bytes (500MB default)
-ZIP_MAX_TOTAL_SIZE_BYTES = getattr(
-    settings, "ZIP_MAX_TOTAL_SIZE_BYTES", 500 * 1024 * 1024
-)
+# Maximum number of files allowed in a single zip.
+DEFAULT_ZIP_MAX_FILE_COUNT = 1000
 
-# Maximum size of a single file in bytes (100MB default)
-# Files exceeding this limit are skipped with an error message
-ZIP_MAX_SINGLE_FILE_SIZE_BYTES = getattr(
-    settings, "ZIP_MAX_SINGLE_FILE_SIZE_BYTES", 100 * 1024 * 1024
-)
+# Maximum total uncompressed size in bytes (500MB default).
+DEFAULT_ZIP_MAX_TOTAL_SIZE_BYTES = 500 * 1024 * 1024
 
-# Maximum compression ratio (uncompressed/compressed) before flagging as suspicious
-# Files exceeding this ratio trigger additional validation
-ZIP_MAX_COMPRESSION_RATIO = getattr(settings, "ZIP_MAX_COMPRESSION_RATIO", 100)
+# Maximum size of a single file in bytes (100MB default).
+# Files exceeding this limit are skipped with an error message.
+DEFAULT_ZIP_MAX_SINGLE_FILE_SIZE_BYTES = 100 * 1024 * 1024
 
-# Maximum folder depth (number of nested folders)
-ZIP_MAX_FOLDER_DEPTH = getattr(settings, "ZIP_MAX_FOLDER_DEPTH", 20)
+# Maximum compression ratio (uncompressed/compressed) before flagging as
+# suspicious. Files exceeding this ratio trigger additional validation.
+DEFAULT_ZIP_MAX_COMPRESSION_RATIO = 100
 
-# Maximum number of folders that can be created from a single zip
-ZIP_MAX_FOLDER_COUNT = getattr(settings, "ZIP_MAX_FOLDER_COUNT", 500)
+# Maximum folder depth (number of nested folders).
+DEFAULT_ZIP_MAX_FOLDER_DEPTH = 20
 
-# Maximum length of a single path component (folder or file name) in characters
-ZIP_MAX_PATH_COMPONENT_LENGTH = getattr(settings, "ZIP_MAX_PATH_COMPONENT_LENGTH", 255)
+# Maximum number of folders that can be created from a single zip.
+DEFAULT_ZIP_MAX_FOLDER_COUNT = 500
 
-# Maximum total path length in characters
-ZIP_MAX_PATH_LENGTH = getattr(settings, "ZIP_MAX_PATH_LENGTH", 1024)
+# Maximum length of a single path component (folder or file name) in characters.
+DEFAULT_ZIP_MAX_PATH_COMPONENT_LENGTH = 255
+
+# Maximum total path length in characters.
+DEFAULT_ZIP_MAX_PATH_LENGTH = 1024
 
 # Maximum size of a single annotation sidecar JSON in bytes (50MB default).
 # Sidecars are fully loaded into memory for JSON parsing; this limit
 # prevents a single oversized sidecar from causing excessive memory usage.
-# Override via Django settings (ZIP_MAX_SIDECAR_SIZE_BYTES) or the
-# matching environment variable consumed in config/settings/base.py.
-ZIP_MAX_SIDECAR_SIZE_BYTES = getattr(
-    settings, "ZIP_MAX_SIDECAR_SIZE_BYTES", 50 * 1024 * 1024
-)
+DEFAULT_ZIP_MAX_SIDECAR_SIZE_BYTES = 50 * 1024 * 1024
 
-# Batch size for document processing (commit after N documents)
-ZIP_DOCUMENT_BATCH_SIZE = getattr(settings, "ZIP_DOCUMENT_BATCH_SIZE", 50)
+# Batch size for document processing (log progress after N documents).
+DEFAULT_ZIP_DOCUMENT_BATCH_SIZE = 50
 
 # IDOR protection: bulk-upload job-id ↔ owner mapping in cache.
 # At enqueue time we cache the (job_id → user_id) pair; the status
@@ -65,7 +77,85 @@ ZIP_DOCUMENT_BATCH_SIZE = getattr(settings, "ZIP_DOCUMENT_BATCH_SIZE", 50)
 # to poll progress for the full lifetime of the job. Shortening this
 # would silently turn legitimate "still processing" polls into
 # opaque "not found" responses once the cache entry expired.
+DEFAULT_BULK_UPLOAD_OWNER_CACHE_TTL_SECONDS = 24 * 60 * 60
+
+# Cache key prefix for the IDOR owner mapping. Not settings-derived, so it is a
+# plain constant — safe to bind at import.
 BULK_UPLOAD_OWNER_CACHE_PREFIX = "bulk_upload_owner:"
-BULK_UPLOAD_OWNER_CACHE_TTL_SECONDS = getattr(
-    settings, "BULK_UPLOAD_OWNER_CACHE_TTL_SECONDS", 24 * 60 * 60
-)
+
+
+# --- Lazy accessors ---------------------------------------------------------
+# Call these at use time; never copy their result into a module-level constant.
+
+
+def get_zip_max_file_count() -> int:
+    """Maximum number of files allowed in a single import zip."""
+    return getattr(settings, "ZIP_MAX_FILE_COUNT", DEFAULT_ZIP_MAX_FILE_COUNT)
+
+
+def get_zip_max_total_size_bytes() -> int:
+    """Maximum total uncompressed size (bytes) of a single import zip."""
+    return getattr(
+        settings, "ZIP_MAX_TOTAL_SIZE_BYTES", DEFAULT_ZIP_MAX_TOTAL_SIZE_BYTES
+    )
+
+
+def get_zip_max_single_file_size_bytes() -> int:
+    """Maximum size (bytes) of any single file inside an import zip."""
+    return getattr(
+        settings,
+        "ZIP_MAX_SINGLE_FILE_SIZE_BYTES",
+        DEFAULT_ZIP_MAX_SINGLE_FILE_SIZE_BYTES,
+    )
+
+
+def get_zip_max_compression_ratio() -> int:
+    """Compression ratio above which a zip entry is flagged as suspicious."""
+    return getattr(
+        settings, "ZIP_MAX_COMPRESSION_RATIO", DEFAULT_ZIP_MAX_COMPRESSION_RATIO
+    )
+
+
+def get_zip_max_folder_depth() -> int:
+    """Maximum folder depth (nested folders) inside an import zip."""
+    return getattr(settings, "ZIP_MAX_FOLDER_DEPTH", DEFAULT_ZIP_MAX_FOLDER_DEPTH)
+
+
+def get_zip_max_folder_count() -> int:
+    """Maximum number of folders created from a single import zip."""
+    return getattr(settings, "ZIP_MAX_FOLDER_COUNT", DEFAULT_ZIP_MAX_FOLDER_COUNT)
+
+
+def get_zip_max_path_component_length() -> int:
+    """Maximum length (chars) of a single path component inside an import zip."""
+    return getattr(
+        settings,
+        "ZIP_MAX_PATH_COMPONENT_LENGTH",
+        DEFAULT_ZIP_MAX_PATH_COMPONENT_LENGTH,
+    )
+
+
+def get_zip_max_path_length() -> int:
+    """Maximum total path length (chars) for any entry in an import zip."""
+    return getattr(settings, "ZIP_MAX_PATH_LENGTH", DEFAULT_ZIP_MAX_PATH_LENGTH)
+
+
+def get_zip_max_sidecar_size_bytes() -> int:
+    """Maximum size (bytes) of a single annotation sidecar JSON."""
+    return getattr(
+        settings, "ZIP_MAX_SIDECAR_SIZE_BYTES", DEFAULT_ZIP_MAX_SIDECAR_SIZE_BYTES
+    )
+
+
+def get_zip_document_batch_size() -> int:
+    """Number of documents to process per batch when draining a zip import."""
+    return getattr(settings, "ZIP_DOCUMENT_BATCH_SIZE", DEFAULT_ZIP_DOCUMENT_BATCH_SIZE)
+
+
+def get_bulk_upload_owner_cache_ttl_seconds() -> int:
+    """TTL (seconds) for the bulk-upload job-id ↔ owner IDOR cache entry."""
+    return getattr(
+        settings,
+        "BULK_UPLOAD_OWNER_CACHE_TTL_SECONDS",
+        DEFAULT_BULK_UPLOAD_OWNER_CACHE_TTL_SECONDS,
+    )

--- a/opencontractserver/document_imports/services.py
+++ b/opencontractserver/document_imports/services.py
@@ -39,7 +39,7 @@ from graphql_relay import from_global_id
 
 from opencontractserver.constants.zip_import import (
     BULK_UPLOAD_OWNER_CACHE_PREFIX,
-    BULK_UPLOAD_OWNER_CACHE_TTL_SECONDS,
+    get_bulk_upload_owner_cache_ttl_seconds,
 )
 from opencontractserver.corpuses.models import Corpus, CorpusFolder, TemporaryFileHandle
 from opencontractserver.document_imports.models import (
@@ -447,7 +447,7 @@ def import_documents_zip_for_user(
     cache.set(
         f"{BULK_UPLOAD_OWNER_CACHE_PREFIX}{job_id}",
         user.id,
-        BULK_UPLOAD_OWNER_CACHE_TTL_SECONDS,
+        get_bulk_upload_owner_cache_ttl_seconds(),
     )
 
     storage_filename = f"documents_zip_import_{job_id}.zip"
@@ -552,7 +552,7 @@ def import_zip_to_corpus_for_user(
     cache.set(
         f"{BULK_UPLOAD_OWNER_CACHE_PREFIX}{job_id}",
         user.id,
-        BULK_UPLOAD_OWNER_CACHE_TTL_SECONDS,
+        get_bulk_upload_owner_cache_ttl_seconds(),
     )
 
     storage_filename = f"zip_import_{job_id}.zip"

--- a/opencontractserver/tasks/import_tasks.py
+++ b/opencontractserver/tasks/import_tasks.py
@@ -32,7 +32,7 @@ from opencontractserver.constants.document_processing import (
     DEFAULT_DOCUMENT_PATH_PREFIX,
     MAX_FILENAME_LENGTH,
 )
-from opencontractserver.constants.zip_import import ZIP_MAX_SIDECAR_SIZE_BYTES
+from opencontractserver.constants.zip_import import get_zip_max_sidecar_size_bytes
 from opencontractserver.corpuses.models import Corpus, TemporaryFileHandle
 from opencontractserver.documents.models import (
     Document,
@@ -634,22 +634,26 @@ def _read_sidecar(
     # name lookup against the zip's central directory — it does NOT touch the
     # filesystem and cannot be used for path-traversal.
 
+    # Read the configurable limit at call time (never frozen at import — see
+    # opencontractserver/constants/zip_import.py).
+    max_sidecar_size_bytes = get_zip_max_sidecar_size_bytes()
+
     # Pre-read size check using the central directory's declared size.
     # This avoids allocating memory for oversized sidecars.  A malicious zip
     # could forge this value, so we keep a post-read assertion as well.
     info = import_zip.getinfo(sidecar_path)
-    if info.file_size > ZIP_MAX_SIDECAR_SIZE_BYTES:
+    if info.file_size > max_sidecar_size_bytes:
         raise ValueError(
             f"Sidecar {sidecar_path} declares {info.file_size} bytes, "
-            f"exceeds limit of {ZIP_MAX_SIDECAR_SIZE_BYTES} bytes"
+            f"exceeds limit of {max_sidecar_size_bytes} bytes"
         )
 
     with import_zip.open(sidecar_path) as sidecar_handle:
         raw = sidecar_handle.read()
-        if len(raw) > ZIP_MAX_SIDECAR_SIZE_BYTES:
+        if len(raw) > max_sidecar_size_bytes:
             raise ValueError(
                 f"Sidecar {sidecar_path} is {len(raw)} bytes, "
-                f"exceeds limit of {ZIP_MAX_SIDECAR_SIZE_BYTES} bytes"
+                f"exceeds limit of {max_sidecar_size_bytes} bytes"
             )
         return json.loads(raw.decode("UTF-8"))
 
@@ -711,10 +715,14 @@ def import_zip_with_folder_structure(
         - Relationship statistics (created, skipped, errors)
         - Document IDs and error messages
     """
-    from opencontractserver.constants.zip_import import ZIP_DOCUMENT_BATCH_SIZE
+    from opencontractserver.constants.zip_import import get_zip_document_batch_size
     from opencontractserver.corpuses.models import Corpus, CorpusFolder
     from opencontractserver.corpuses.services import FolderCRUDService
     from opencontractserver.utils.zip_security import validate_zip_for_import
+
+    # Read the configurable batch size once for this run (never frozen at
+    # import — see opencontractserver/constants/zip_import.py).
+    zip_document_batch_size = get_zip_document_batch_size()
 
     results: dict[str, Any] = {
         "job_id": job_id,
@@ -1304,7 +1312,7 @@ def import_zip_with_folder_structure(
                             results["upversioned_paths"].append(doc_path_str)
 
                         batch_count += 1
-                        if batch_count % ZIP_DOCUMENT_BATCH_SIZE == 0:
+                        if batch_count % zip_document_batch_size == 0:
                             logger.info(
                                 f"import_zip_with_folder_structure() - "
                                 f"Processed {batch_count} documents..."

--- a/opencontractserver/tests/test_bulk_document_upload.py
+++ b/opencontractserver/tests/test_bulk_document_upload.py
@@ -17,7 +17,7 @@ from graphql_relay import to_global_id
 from config.graphql.schema import schema
 from opencontractserver.constants.zip_import import (
     BULK_UPLOAD_OWNER_CACHE_PREFIX,
-    BULK_UPLOAD_OWNER_CACHE_TTL_SECONDS,
+    get_bulk_upload_owner_cache_ttl_seconds,
 )
 from opencontractserver.corpuses.models import Corpus
 from opencontractserver.documents.models import Document
@@ -222,7 +222,7 @@ class BulkDocumentUploadTests(TestCase):
         cache.set(
             f"{BULK_UPLOAD_OWNER_CACHE_PREFIX}{test_task_id}",
             self.user.id,
-            BULK_UPLOAD_OWNER_CACHE_TTL_SECONDS,
+            get_bulk_upload_owner_cache_ttl_seconds(),
         )
 
         # Use our known task ID to perform the status query
@@ -600,7 +600,7 @@ class BulkDocumentUploadStatusIDORTests(TestCase):
         cache.set(
             f"{BULK_UPLOAD_OWNER_CACHE_PREFIX}{job_id}",
             self.owner.id,
-            BULK_UPLOAD_OWNER_CACHE_TTL_SECONDS,
+            get_bulk_upload_owner_cache_ttl_seconds(),
         )
         AsyncResult(job_id).backend.store_result(
             job_id,

--- a/opencontractserver/tests/test_constants.py
+++ b/opencontractserver/tests/test_constants.py
@@ -5,7 +5,7 @@ Validates that all constants have the expected types, values, and that
 Django-settings-configurable constants respect overrides.
 """
 
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from opencontractserver.constants.auth import (
     ADMIN_CLAIMS_CACHE_TTL,
@@ -273,34 +273,77 @@ class TestZipImportConstants(TestCase):
 
     def test_all_positive(self):
         from opencontractserver.constants.zip_import import (
-            ZIP_DOCUMENT_BATCH_SIZE,
-            ZIP_MAX_COMPRESSION_RATIO,
-            ZIP_MAX_FILE_COUNT,
-            ZIP_MAX_FOLDER_COUNT,
-            ZIP_MAX_FOLDER_DEPTH,
-            ZIP_MAX_PATH_COMPONENT_LENGTH,
-            ZIP_MAX_PATH_LENGTH,
-            ZIP_MAX_SINGLE_FILE_SIZE_BYTES,
-            ZIP_MAX_TOTAL_SIZE_BYTES,
+            get_zip_document_batch_size,
+            get_zip_max_compression_ratio,
+            get_zip_max_file_count,
+            get_zip_max_folder_count,
+            get_zip_max_folder_depth,
+            get_zip_max_path_component_length,
+            get_zip_max_path_length,
+            get_zip_max_single_file_size_bytes,
+            get_zip_max_total_size_bytes,
         )
 
-        self.assertGreater(ZIP_MAX_FILE_COUNT, 0)
-        self.assertGreater(ZIP_MAX_TOTAL_SIZE_BYTES, 0)
-        self.assertGreater(ZIP_MAX_SINGLE_FILE_SIZE_BYTES, 0)
-        self.assertGreater(ZIP_MAX_COMPRESSION_RATIO, 0)
-        self.assertGreater(ZIP_MAX_FOLDER_DEPTH, 0)
-        self.assertGreater(ZIP_MAX_FOLDER_COUNT, 0)
-        self.assertGreater(ZIP_MAX_PATH_COMPONENT_LENGTH, 0)
-        self.assertGreater(ZIP_MAX_PATH_LENGTH, 0)
-        self.assertGreater(ZIP_DOCUMENT_BATCH_SIZE, 0)
+        self.assertGreater(get_zip_max_file_count(), 0)
+        self.assertGreater(get_zip_max_total_size_bytes(), 0)
+        self.assertGreater(get_zip_max_single_file_size_bytes(), 0)
+        self.assertGreater(get_zip_max_compression_ratio(), 0)
+        self.assertGreater(get_zip_max_folder_depth(), 0)
+        self.assertGreater(get_zip_max_folder_count(), 0)
+        self.assertGreater(get_zip_max_path_component_length(), 0)
+        self.assertGreater(get_zip_max_path_length(), 0)
+        self.assertGreater(get_zip_document_batch_size(), 0)
 
     def test_single_file_less_than_total(self):
         from opencontractserver.constants.zip_import import (
-            ZIP_MAX_SINGLE_FILE_SIZE_BYTES,
-            ZIP_MAX_TOTAL_SIZE_BYTES,
+            get_zip_max_single_file_size_bytes,
+            get_zip_max_total_size_bytes,
         )
 
-        self.assertLess(ZIP_MAX_SINGLE_FILE_SIZE_BYTES, ZIP_MAX_TOTAL_SIZE_BYTES)
+        self.assertLess(
+            get_zip_max_single_file_size_bytes(), get_zip_max_total_size_bytes()
+        )
+
+    def test_accessors_fall_back_to_defaults_when_unset(self):
+        """With no setting override, each accessor returns its DEFAULT_*."""
+        from opencontractserver.constants import zip_import as zi
+
+        self.assertEqual(zi.get_zip_max_file_count(), zi.DEFAULT_ZIP_MAX_FILE_COUNT)
+        self.assertEqual(
+            zi.get_zip_max_total_size_bytes(), zi.DEFAULT_ZIP_MAX_TOTAL_SIZE_BYTES
+        )
+        self.assertEqual(
+            zi.get_bulk_upload_owner_cache_ttl_seconds(),
+            zi.DEFAULT_BULK_UPLOAD_OWNER_CACHE_TTL_SECONDS,
+        )
+
+    @override_settings(
+        ZIP_MAX_FILE_COUNT=4242,
+        ZIP_MAX_TOTAL_SIZE_BYTES=123,
+        ZIP_MAX_SIDECAR_SIZE_BYTES=456,
+        ZIP_DOCUMENT_BATCH_SIZE=7,
+        BULK_UPLOAD_OWNER_CACHE_TTL_SECONDS=99,
+    )
+    def test_accessors_reflect_settings_overrides(self):
+        """Regression for the import-time freeze bug (see zip_import.py).
+
+        The limits must be read lazily at call time, so a settings override
+        (env/ConfigMap in production, ``@override_settings`` in tests) is
+        honoured — never frozen to the default at import.
+        """
+        from opencontractserver.constants.zip_import import (
+            get_bulk_upload_owner_cache_ttl_seconds,
+            get_zip_document_batch_size,
+            get_zip_max_file_count,
+            get_zip_max_sidecar_size_bytes,
+            get_zip_max_total_size_bytes,
+        )
+
+        self.assertEqual(get_zip_max_file_count(), 4242)
+        self.assertEqual(get_zip_max_total_size_bytes(), 123)
+        self.assertEqual(get_zip_max_sidecar_size_bytes(), 456)
+        self.assertEqual(get_zip_document_batch_size(), 7)
+        self.assertEqual(get_bulk_upload_owner_cache_ttl_seconds(), 99)
 
 
 class TestConstantsBarrelImport(TestCase):

--- a/opencontractserver/tests/test_zip_import_integration.py
+++ b/opencontractserver/tests/test_zip_import_integration.py
@@ -21,7 +21,7 @@ import pytest
 from django.contrib.auth import get_user_model
 from django.core.files.base import ContentFile
 from django.db import transaction
-from django.test import TestCase, TransactionTestCase
+from django.test import TestCase, TransactionTestCase, override_settings
 
 from opencontractserver.corpuses.models import Corpus, CorpusFolder, TemporaryFileHandle
 from opencontractserver.corpuses.services import FolderCRUDService
@@ -639,73 +639,57 @@ class TestZipValidationFailures(TestCase):
         self.assertTrue(result["completed"])
         self.assertEqual(result["files_processed"], 1)
 
+    @override_settings(ZIP_MAX_FILE_COUNT=5)
     def test_too_many_files_rejected(self):
         """Zip with too many files is rejected at validation."""
         from opencontractserver.tasks.import_tasks import (
             import_zip_with_folder_structure,
         )
-        from opencontractserver.utils import zip_security
 
-        # Temporarily override the constant
-        original = zip_security.ZIP_MAX_FILE_COUNT
-        zip_security.ZIP_MAX_FILE_COUNT = 5
+        files = {f"file{i}.pdf": self.pdf_bytes for i in range(10)}
+        zip_buffer = self._create_test_zip(files)
+        handle = self._create_temp_file_handle(zip_buffer)
 
-        try:
-            files = {f"file{i}.pdf": self.pdf_bytes for i in range(10)}
-            zip_buffer = self._create_test_zip(files)
-            handle = self._create_temp_file_handle(zip_buffer)
+        result = import_zip_with_folder_structure.apply(
+            kwargs={
+                "temporary_file_handle_id": handle.id,
+                "user_id": self.user.id,
+                "job_id": "test-too-many",
+                "corpus_id": self.corpus.id,
+            }
+        ).get()
 
-            result = import_zip_with_folder_structure.apply(
-                kwargs={
-                    "temporary_file_handle_id": handle.id,
-                    "user_id": self.user.id,
-                    "job_id": "test-too-many",
-                    "corpus_id": self.corpus.id,
-                }
-            ).get()
+        self.assertTrue(result["completed"])
+        self.assertFalse(result["validation_passed"])
+        self.assertTrue(any("files" in e.lower() for e in result["validation_errors"]))
 
-            self.assertTrue(result["completed"])
-            self.assertFalse(result["validation_passed"])
-            self.assertTrue(
-                any("files" in e.lower() for e in result["validation_errors"])
-            )
-        finally:
-            zip_security.ZIP_MAX_FILE_COUNT = original
-
+    @override_settings(ZIP_MAX_SINGLE_FILE_SIZE_BYTES=100)  # 100 bytes
     def test_oversized_files_skipped_not_rejected(self):
         """Individual oversized files are skipped, not rejected entirely."""
         from opencontractserver.tasks.import_tasks import (
             import_zip_with_folder_structure,
         )
-        from opencontractserver.utils import zip_security
 
-        # Temporarily set a very small file size limit
-        original = zip_security.ZIP_MAX_SINGLE_FILE_SIZE_BYTES
-        zip_security.ZIP_MAX_SINGLE_FILE_SIZE_BYTES = 100  # 100 bytes
+        files = {
+            "small.txt": b"x" * 50,  # Under limit
+            "large.txt": b"x" * 200,  # Over limit
+        }
+        zip_buffer = self._create_test_zip(files)
+        handle = self._create_temp_file_handle(zip_buffer)
 
-        try:
-            files = {
-                "small.txt": b"x" * 50,  # Under limit
-                "large.txt": b"x" * 200,  # Over limit
+        result = import_zip_with_folder_structure.apply(
+            kwargs={
+                "temporary_file_handle_id": handle.id,
+                "user_id": self.user.id,
+                "job_id": "test-oversized",
+                "corpus_id": self.corpus.id,
             }
-            zip_buffer = self._create_test_zip(files)
-            handle = self._create_temp_file_handle(zip_buffer)
+        ).get()
 
-            result = import_zip_with_folder_structure.apply(
-                kwargs={
-                    "temporary_file_handle_id": handle.id,
-                    "user_id": self.user.id,
-                    "job_id": "test-oversized",
-                    "corpus_id": self.corpus.id,
-                }
-            ).get()
-
-            self.assertTrue(result["completed"])
-            self.assertTrue(result["validation_passed"])
-            self.assertEqual(result["files_skipped_size"], 1)
-            self.assertIn("large.txt", result["skipped_oversized"])
-        finally:
-            zip_security.ZIP_MAX_SINGLE_FILE_SIZE_BYTES = original
+        self.assertTrue(result["completed"])
+        self.assertTrue(result["validation_passed"])
+        self.assertEqual(result["files_skipped_size"], 1)
+        self.assertIn("large.txt", result["skipped_oversized"])
 
 
 class TestDocumentUpversioning(TestCase):

--- a/opencontractserver/tests/test_zip_security.py
+++ b/opencontractserver/tests/test_zip_security.py
@@ -12,7 +12,7 @@ import io
 import stat
 import zipfile
 
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from opencontractserver.utils.zip_security import (
     ZipFileEntry,
@@ -310,114 +310,73 @@ class TestValidateZipForImport(TestCase):
         self.assertEqual(len(manifest.skipped_files), 1)
         self.assertIn("traversal", manifest.skipped_files[0].skip_reason.lower())
 
+    @override_settings(ZIP_MAX_FILE_COUNT=5)
     def test_too_many_files_rejected(self):
         """Zip with too many files is rejected."""
-        # Need to reimport to pick up new settings
-        from opencontractserver.utils import zip_security
+        files = {f"file{i}.pdf": b"content" for i in range(10)}
+        with self._create_test_zip(files) as zf:
+            manifest = validate_zip_for_import(zf)
 
-        # Temporarily override the constant
-        original = zip_security.ZIP_MAX_FILE_COUNT
-        zip_security.ZIP_MAX_FILE_COUNT = 5
+        self.assertFalse(manifest.is_valid)
+        self.assertIn("10 files", manifest.error_message)
+        self.assertIn("5", manifest.error_message)
 
-        try:
-            files = {f"file{i}.pdf": b"content" for i in range(10)}
-            with self._create_test_zip(files) as zf:
-                manifest = validate_zip_for_import(zf)
-
-            self.assertFalse(manifest.is_valid)
-            self.assertIn("10 files", manifest.error_message)
-            self.assertIn("5", manifest.error_message)
-        finally:
-            zip_security.ZIP_MAX_FILE_COUNT = original
-
+    @override_settings(ZIP_MAX_SINGLE_FILE_SIZE_BYTES=100)  # 100 bytes
     def test_oversized_files_marked_for_skipping(self):
         """Files exceeding size limit are marked for skipping."""
-        from opencontractserver.utils import zip_security
+        files = {
+            "small.pdf": b"x" * 50,  # Under limit
+            "large.pdf": b"x" * 200,  # Over limit
+        }
+        with self._create_test_zip(files) as zf:
+            manifest = validate_zip_for_import(zf)
 
-        # Temporarily override the constant
-        original = zip_security.ZIP_MAX_SINGLE_FILE_SIZE_BYTES
-        zip_security.ZIP_MAX_SINGLE_FILE_SIZE_BYTES = 100  # 100 bytes
+        self.assertTrue(manifest.is_valid)
+        self.assertEqual(len(manifest.valid_files), 1)
+        self.assertEqual(manifest.valid_files[0].filename, "small.pdf")
+        self.assertEqual(len(manifest.skipped_files), 1)
+        self.assertEqual(manifest.skipped_files[0].filename, "large.pdf")
+        self.assertTrue(manifest.skipped_files[0].is_oversized)
 
-        try:
-            files = {
-                "small.pdf": b"x" * 50,  # Under limit
-                "large.pdf": b"x" * 200,  # Over limit
-            }
-            with self._create_test_zip(files) as zf:
-                manifest = validate_zip_for_import(zf)
-
-            self.assertTrue(manifest.is_valid)
-            self.assertEqual(len(manifest.valid_files), 1)
-            self.assertEqual(manifest.valid_files[0].filename, "small.pdf")
-            self.assertEqual(len(manifest.skipped_files), 1)
-            self.assertEqual(manifest.skipped_files[0].filename, "large.pdf")
-            self.assertTrue(manifest.skipped_files[0].is_oversized)
-        finally:
-            zip_security.ZIP_MAX_SINGLE_FILE_SIZE_BYTES = original
-
+    @override_settings(ZIP_MAX_TOTAL_SIZE_BYTES=500)  # 500 bytes
     def test_total_size_limit_exceeded(self):
         """Zip exceeding total size limit is rejected."""
-        from opencontractserver.utils import zip_security
+        files = {
+            "file1.pdf": b"x" * 200,
+            "file2.pdf": b"x" * 200,
+            "file3.pdf": b"x" * 200,  # This pushes it over
+        }
+        with self._create_test_zip(files) as zf:
+            manifest = validate_zip_for_import(zf)
 
-        # Temporarily override the constant
-        original = zip_security.ZIP_MAX_TOTAL_SIZE_BYTES
-        zip_security.ZIP_MAX_TOTAL_SIZE_BYTES = 500  # 500 bytes
+        self.assertFalse(manifest.is_valid)
+        self.assertIn("size exceeds", manifest.error_message.lower())
 
-        try:
-            files = {
-                "file1.pdf": b"x" * 200,
-                "file2.pdf": b"x" * 200,
-                "file3.pdf": b"x" * 200,  # This pushes it over
-            }
-            with self._create_test_zip(files) as zf:
-                manifest = validate_zip_for_import(zf)
-
-            self.assertFalse(manifest.is_valid)
-            self.assertIn("size exceeds", manifest.error_message.lower())
-        finally:
-            zip_security.ZIP_MAX_TOTAL_SIZE_BYTES = original
-
+    @override_settings(ZIP_MAX_FOLDER_DEPTH=3)
     def test_folder_depth_limit(self):
         """Files in deeply nested folders are skipped."""
-        from opencontractserver.utils import zip_security
+        files = {
+            "a/b/c/file.pdf": b"content",  # Depth 3 - OK
+            "a/b/c/d/e/file.pdf": b"content",  # Depth 5 - Too deep
+        }
+        with self._create_test_zip(files) as zf:
+            manifest = validate_zip_for_import(zf)
 
-        # Temporarily override the constant
-        original = zip_security.ZIP_MAX_FOLDER_DEPTH
-        zip_security.ZIP_MAX_FOLDER_DEPTH = 3
+        self.assertTrue(manifest.is_valid)
+        self.assertEqual(len(manifest.valid_files), 1)
+        self.assertEqual(len(manifest.skipped_files), 1)
+        self.assertIn("depth", manifest.skipped_files[0].skip_reason.lower())
 
-        try:
-            files = {
-                "a/b/c/file.pdf": b"content",  # Depth 3 - OK
-                "a/b/c/d/e/file.pdf": b"content",  # Depth 5 - Too deep
-            }
-            with self._create_test_zip(files) as zf:
-                manifest = validate_zip_for_import(zf)
-
-            self.assertTrue(manifest.is_valid)
-            self.assertEqual(len(manifest.valid_files), 1)
-            self.assertEqual(len(manifest.skipped_files), 1)
-            self.assertIn("depth", manifest.skipped_files[0].skip_reason.lower())
-        finally:
-            zip_security.ZIP_MAX_FOLDER_DEPTH = original
-
+    @override_settings(ZIP_MAX_FOLDER_COUNT=5)
     def test_folder_count_limit(self):
         """Zip with too many folders is rejected."""
-        from opencontractserver.utils import zip_security
+        # Create files in many different folders
+        files = {f"folder{i}/file.pdf": b"content" for i in range(10)}
+        with self._create_test_zip(files) as zf:
+            manifest = validate_zip_for_import(zf)
 
-        # Temporarily override the constant
-        original = zip_security.ZIP_MAX_FOLDER_COUNT
-        zip_security.ZIP_MAX_FOLDER_COUNT = 5
-
-        try:
-            # Create files in many different folders
-            files = {f"folder{i}/file.pdf": b"content" for i in range(10)}
-            with self._create_test_zip(files) as zf:
-                manifest = validate_zip_for_import(zf)
-
-            self.assertFalse(manifest.is_valid)
-            self.assertIn("folders", manifest.error_message.lower())
-        finally:
-            zip_security.ZIP_MAX_FOLDER_COUNT = original
+        self.assertFalse(manifest.is_valid)
+        self.assertIn("folders", manifest.error_message.lower())
 
     def test_directories_skipped(self):
         """Directory entries in zip are skipped."""

--- a/opencontractserver/utils/zip_security.py
+++ b/opencontractserver/utils/zip_security.py
@@ -21,14 +21,14 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from opencontractserver.constants.zip_import import (
-    ZIP_MAX_COMPRESSION_RATIO,
-    ZIP_MAX_FILE_COUNT,
-    ZIP_MAX_FOLDER_COUNT,
-    ZIP_MAX_FOLDER_DEPTH,
-    ZIP_MAX_PATH_COMPONENT_LENGTH,
-    ZIP_MAX_PATH_LENGTH,
-    ZIP_MAX_SINGLE_FILE_SIZE_BYTES,
-    ZIP_MAX_TOTAL_SIZE_BYTES,
+    get_zip_max_compression_ratio,
+    get_zip_max_file_count,
+    get_zip_max_folder_count,
+    get_zip_max_folder_depth,
+    get_zip_max_path_component_length,
+    get_zip_max_path_length,
+    get_zip_max_single_file_size_bytes,
+    get_zip_max_total_size_bytes,
 )
 from opencontractserver.utils.metadata_file_parser import METADATA_FILE_NAMES
 from opencontractserver.utils.relationship_file_parser import RELATIONSHIP_FILE_NAMES
@@ -128,9 +128,14 @@ def sanitize_zip_path(path: str) -> tuple[str | None, str]:
     if not normalized:
         return None, "Path is empty after normalization"
 
+    # Read configurable limits at call time so settings/env overrides are
+    # honoured (never frozen at import — see constants/zip_import.py).
+    max_path_length = get_zip_max_path_length()
+    max_component_length = get_zip_max_path_component_length()
+
     # Check total path length
-    if len(normalized) > ZIP_MAX_PATH_LENGTH:
-        return None, f"Path exceeds maximum length of {ZIP_MAX_PATH_LENGTH} characters"
+    if len(normalized) > max_path_length:
+        return None, f"Path exceeds maximum length of {max_path_length} characters"
 
     # Split into components and validate each
     components = normalized.split("/")
@@ -145,11 +150,11 @@ def sanitize_zip_path(path: str) -> tuple[str | None, str]:
             continue  # Skip empty components from double slashes
 
         # Check component length
-        if len(component) > ZIP_MAX_PATH_COMPONENT_LENGTH:
+        if len(component) > max_component_length:
             return (
                 None,
                 f"Path component '{component[:50]}...' exceeds maximum length "
-                f"of {ZIP_MAX_PATH_COMPONENT_LENGTH} characters",
+                f"of {max_component_length} characters",
             )
 
         # Check for hidden files/folders at any level (starts with .)
@@ -426,6 +431,16 @@ def validate_zip_for_import(
     """
     manifest = ZipManifest(is_valid=True)
 
+    # Read configurable limits once at call time so @override_settings and
+    # env/deployment overrides are honoured (never frozen at import — see
+    # opencontractserver/constants/zip_import.py for why).
+    max_file_count = get_zip_max_file_count()
+    max_total_size_bytes = get_zip_max_total_size_bytes()
+    max_single_file_size_bytes = get_zip_max_single_file_size_bytes()
+    max_compression_ratio = get_zip_max_compression_ratio()
+    max_folder_depth = get_zip_max_folder_depth()
+    max_folder_count = get_zip_max_folder_count()
+
     try:
         info_list = zip_file.infolist()
     except Exception as e:
@@ -435,12 +450,12 @@ def validate_zip_for_import(
     manifest.total_files_in_zip = len(info_list)
 
     # Check total file count
-    if manifest.total_files_in_zip > ZIP_MAX_FILE_COUNT:
+    if manifest.total_files_in_zip > max_file_count:
         return ZipManifest(
             is_valid=False,
             error_message=(
                 f"Zip contains {manifest.total_files_in_zip} files, "
-                f"maximum allowed is {ZIP_MAX_FILE_COUNT}"
+                f"maximum allowed is {max_file_count}"
             ),
             total_files_in_zip=manifest.total_files_in_zip,
         )
@@ -546,7 +561,7 @@ def validate_zip_for_import(
         folder_path = get_folder_path(sanitized_path)
         if folder_path:
             depth = get_folder_depth(folder_path)
-            if depth > ZIP_MAX_FOLDER_DEPTH:
+            if depth > max_folder_depth:
                 manifest.skipped_files.append(
                     ZipFileEntry(
                         original_path=info.filename,
@@ -557,7 +572,7 @@ def validate_zip_for_import(
                         compressed_size=info.compress_size,
                         skip_reason=(
                             f"Folder depth {depth} exceeds maximum of "
-                            f"{ZIP_MAX_FOLDER_DEPTH}"
+                            f"{max_folder_depth}"
                         ),
                     )
                 )
@@ -571,8 +586,8 @@ def validate_zip_for_import(
         total_size += info.file_size
 
         # Check if total size exceeded
-        if total_size > ZIP_MAX_TOTAL_SIZE_BYTES:
-            size_mb = ZIP_MAX_TOTAL_SIZE_BYTES / (1024 * 1024)
+        if total_size > max_total_size_bytes:
+            size_mb = max_total_size_bytes / (1024 * 1024)
             return ZipManifest(
                 is_valid=False,
                 error_message=(
@@ -583,11 +598,11 @@ def validate_zip_for_import(
             )
 
         # Check individual file size
-        is_oversized = info.file_size > ZIP_MAX_SINGLE_FILE_SIZE_BYTES
+        is_oversized = info.file_size > max_single_file_size_bytes
         skip_reason = ""
         if is_oversized:
             size_mb = info.file_size / (1024 * 1024)
-            limit_mb = ZIP_MAX_SINGLE_FILE_SIZE_BYTES / (1024 * 1024)
+            limit_mb = max_single_file_size_bytes / (1024 * 1024)
             skip_reason = (
                 f"File size ({size_mb:.1f}MB) exceeds limit ({limit_mb:.0f}MB)"
             )
@@ -599,7 +614,7 @@ def validate_zip_for_import(
         # 3. Individual file size is bounded by ZIP_MAX_SINGLE_FILE_SIZE_BYTES
         if info.compress_size > 0:
             ratio = info.file_size / info.compress_size
-            if ratio > ZIP_MAX_COMPRESSION_RATIO:
+            if ratio > max_compression_ratio:
                 logger.warning(
                     f"High compression ratio ({ratio:.1f}:1) for file: "
                     f"{sanitized_path} - monitoring for potential zip bomb"
@@ -664,12 +679,12 @@ def validate_zip_for_import(
         manifest.valid_files = remaining_valid
 
     # Check folder count
-    if len(folder_paths_set) > ZIP_MAX_FOLDER_COUNT:
+    if len(folder_paths_set) > max_folder_count:
         return ZipManifest(
             is_valid=False,
             error_message=(
                 f"Zip contains {len(folder_paths_set)} folders, "
-                f"maximum allowed is {ZIP_MAX_FOLDER_COUNT}"
+                f"maximum allowed is {max_folder_count}"
             ),
             total_files_in_zip=manifest.total_files_in_zip,
             total_uncompressed_size=total_size,


### PR DESCRIPTION
## Problem

The entire "env-configurable zip-import limits" feature was dead in production:
`ZIP_MAX_FILE_COUNT`, `ZIP_MAX_TOTAL_SIZE_BYTES`, `ZIP_MAX_SINGLE_FILE_SIZE_BYTES`,
`ZIP_MAX_FOLDER_COUNT`, `ZIP_MAX_SIDECAR_SIZE_BYTES`, `ZIP_DOCUMENT_BATCH_SIZE`, and
`BULK_UPLOAD_OWNER_CACHE_TTL_SECONDS` always used their hard-coded defaults no
matter what was set via `env`/ConfigMap. These are the zip-bomb / resource-
exhaustion / path-length **security limits**, so an operator tightening them got
the shipped defaults instead.

## Root cause — an import-ordering freeze

1. `config/settings/base.py` imports from `opencontractserver.constants.*` at the
   very top of the settings module.
2. Importing any `constants` submodule first executes the package
   `constants/__init__.py`, which eagerly did
   `from opencontractserver.constants.zip_import import *`.
3. `zip_import.py` read every limit at **module level** via
   `getattr(settings, "ZIP_MAX_…", <default>)`. Because step 1 means this runs
   **while the settings module is still mid-load** (before `base.py` defines the
   `ZIP_*` values), `getattr` saw a half-built settings object, fell back to the
   default, and **froze** it for the life of the process.

`base.py` later sets the real (env-driven) value, but the module constant the
validators bound to never changed. Deterministic every boot — no ConfigMap/env
value could ever take effect.

## Fix

Adopt the pattern the codebase already established in the sibling
`opencontractserver/constants/zip_export.py` (whose comment is effectively a
postmortem of this exact bug class):

- `zip_import.py`: settings-derived limits become `DEFAULT_*` plain constants
  plus `get_*()` accessors that read `getattr(settings, …)` **lazily at call
  time** — never frozen at import.
- `constants/__init__.py`: drop the eager `zip_import` barrel import (matching
  how `zip_export` is already excluded) so nothing reads settings during
  settings load. Defense-in-depth on top of the lazy accessors.
- Consumers call the accessors: `utils/zip_security.py`,
  `tasks/import_tasks.py`, `document_imports/services.py`.
- Tests that monkeypatched `zip_security.ZIP_MAX_*` module attributes are
  migrated to the canonical `@override_settings(...)` — which now actually
  exercises the env-configurability that was broken.

## Verification

Docker/Postgres aren't available in this environment, so the test suite wasn't
run here, but the fix was verified end-to-end against **Django 5.2.15** through
the real import path:

- Accessors return `DEFAULT_*` when the setting is unset.
- A value assigned **after** `zip_import` is imported is honoured (direct
  reproduction of the freeze — old eager code would have stayed at the default).
- `constants/__init__.py` no longer exposes `zip_import` symbols (barrel
  exclusion), submodule import still works.
- `zip_security.validate_zip_for_import` rejects/accepts based on the
  **runtime** `ZIP_MAX_FILE_COUNT`, re-read fresh on each call.

`black`, `isort` (`profile = black`), and `flake8` are clean on all changed
files; the changelog fragment validates.

## Test plan

- [ ] `opencontractserver/tests/test_constants.py` — new
  `test_accessors_reflect_settings_overrides` (regression) + accessor fallbacks
- [ ] `opencontractserver/tests/test_zip_security.py` — limit tests via `@override_settings`
- [ ] `opencontractserver/tests/test_zip_import_integration.py` — file-count / oversized via `@override_settings`
- [ ] `opencontractserver/tests/test_bulk_document_upload.py` — owner-cache TTL accessor

https://claude.ai/code/session_0155vkmUn7WSWVE9G1XJ6Q6i

---
_Generated by [Claude Code](https://claude.ai/code/session_0155vkmUn7WSWVE9G1XJ6Q6i)_