### PR TITLE
Fix corpus Home-tab chat overflowing the viewport via CardLayout padding

### DIFF
--- a/changelog.d/home-chat-viewport-overflow.fixed.md
+++ b/changelog.d/home-chat-viewport-overflow.fixed.md
@@ -1,0 +1,22 @@
+- **Home-tab corpus chat overflowed the viewport, leaving the composer slightly offscreen.**
+  Starting a chat from the corpus **Home** tab (clicking the inline chat bar,
+  typing a query, and pressing Enter) expanded `CorpusQueryView` into its
+  immersive chat layout, which sizes the chat container to
+  `calc(100dvh - var(--oc-navbar-height, 4.5rem))` with the input pinned to the
+  bottom (`frontend/src/views/CorpusQueryView.tsx:28,362-394`). However,
+  `Corpuses.tsx` only stripped `CardLayout`'s default outer padding for the
+  dedicated **Chats** tab (`frontend/src/views/Corpuses.tsx:1716`), so on the
+  Home tab that full-height container was wrapped in `CardLayout`'s default
+  padding (`~0.75rem` per side on desktop,
+  `frontend/src/components/layout/CardLayout.tsx:122-135`). The extra `~1.5rem`
+  of vertical padding pushed the total height past the viewport, leaving the
+  pinned chat input partially clipped at the bottom and requiring a slight
+  scroll. Reaching the same chat "from the chat list" (Chats tab) worked only
+  because that tab's padding was already zeroed. Fix: zero `CardLayout`'s outer
+  padding for the `home` tab as well as `chats`
+  (`frontend/src/views/Corpuses.tsx:1716`), since both are viewport-bounded
+  immersive layouts. This also removes a previously-invisible phantom overflow
+  on the Home dashboard (its `position: fixed` chat bar and `overflow: hidden`
+  content had hidden the same `~1.5rem` page scroll). The landing/details/article
+  views center their own `max-width` content with internal padding, so they are
+  unaffected by losing the thin outer frame.

--- a/frontend/src/views/Corpuses.tsx
+++ b/frontend/src/views/Corpuses.tsx
@@ -1703,11 +1703,19 @@ export const Corpuses = () => {
         display: "flex",
         flexDirection: "column",
         minHeight: 0,
-        // The chats tab owns a viewport-bounded layout (input pinned to
-        // bottom, messages scroll internally). CardLayout's default outer
-        // padding would push the chat past the viewport and shrink-wrap
-        // the input area awkwardly, so we drop the padding for this tab.
-        ...(currentView?.id === "chats" ? { padding: 0 } : {}),
+        // The home and chats tabs both own viewport-bounded layouts:
+        // CorpusQueryView (home) and CorpusChat (chats) each size themselves
+        // to calc(100dvh - navbar) with the composer pinned to the bottom and
+        // messages scrolling internally. CardLayout's default outer padding
+        // (~0.75rem per side on desktop) would wrap that full-height container,
+        // pushing the pinned input ~1.5rem below the viewport so it is
+        // partially clipped behind a slight page scroll. Drop the padding for
+        // both tabs so the height math stays exact. (The landing/details views
+        // on the home tab center their own max-width content with internal
+        // padding, so they are unaffected by losing the thin outer frame.)
+        ...(currentView?.id === "home" || currentView?.id === "chats"
+          ? { padding: 0 }
+          : {}),
       }}
       Modals={
         <>


### PR DESCRIPTION
## Problem

Starting a chat from the corpus **Home** tab (click the inline chat bar → type → Enter) expanded the chat so its total height was *just slightly* too large: the composer was partially clipped at the bottom of the viewport and a small page scroll appeared. Reaching the **same** chat "from the chat list" (the **Chats** tab) fit perfectly.

## Root cause

The Home tab renders `CorpusQueryView`, whose immersive chat layout sizes its container to `height: calc(100dvh - var(--oc-navbar-height, 4.5rem))` with the composer pinned to the bottom (`frontend/src/views/CorpusQueryView.tsx:28,362-394`). That math assumes **zero** surrounding padding.

But `Corpuses.tsx` only stripped `CardLayout`'s default outer padding for the dedicated **Chats** tab:

```js
...(currentView?.id === "chats" ? { padding: 0 } : {}),
```

For every other tab — including `home` — `CardLayout`'s `CardContainer` keeps its default padding (`~0.75rem` per side on desktop, `frontend/src/components/layout/CardLayout.tsx:122-135`). So the `100dvh − navbar` container got wrapped in **~1.5rem of vertical padding**, pushing its bottom (and the pinned input) past the viewport by exactly that amount. The Chats tab worked only because its padding was already zeroed.

The Home **dashboard** didn't *visibly* break because its chat bar is `position: fixed` and its content is `overflow: hidden` — but it carried the same phantom ~1.5rem page scroll underneath.

## Fix

Treat the Home tab like the Chats tab — both are viewport-bounded immersive layouts — and zero `CardLayout`'s outer padding for it too (`frontend/src/views/Corpuses.tsx`):

```js
...(currentView?.id === "home" || currentView?.id === "chats"
  ? { padding: 0 }
  : {}),
```

This makes the height math exact for the expanded chat **and** the conversation-history view (both live on the Home tab), and removes the dashboard's phantom scroll.

## Side effect (intentional, negligible)

The Home tab loses `CardLayout`'s thin `~0.75rem` outer frame — the same look the Chats tab already has. The landing/details/article views center their own `max-width: 800px` content with internal padding (`CorpusHome/styles.ts:73-89`), so their content position is unchanged; only the surrounding gray frame is removed. The map view arguably benefits from being full-bleed.

## Testing notes

- Verified the diff is minimal and focused (no unrelated reformatting).
- `node_modules` is not installed in the CI-clone container, so a local `tsc`/Vitest run isn't possible here; the change is type-identical to the adjacent `currentView?.id === "chats"` comparison that already compiles. CI will run the full type-check.
- Added a `changelog.d` fragment per repo convention.

Suggested manual check: from a corpus Home tab, submit a query and confirm the composer sits flush at the bottom with no page scroll; repeat via the Chats tab to confirm parity.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YTXV46zRZBsyaPhvdk3Vk7)_