### PR TITLE
Deep-link research report body footnotes to cited annotations

### DIFF
--- a/changelog.d/research-report-footnote-deeplinks.fixed.md
+++ b/changelog.d/research-report-footnote-deeplinks.fixed.md
@@ -1,0 +1,20 @@
+- **Deep-research report body: `## Sources` footnotes now deep-link to the cited annotation.**
+  In the research report detail view the rendered report body's footnote
+  definitions (e.g. *"page 41 annotation 395149 — …"*) were plain text, so a
+  reader could not click through to the source — only the separate Citations
+  tab carried links. The footnote definitions in the body are now click-to-source
+  targets that navigate to the cited document with the cited annotation selected
+  (`?ann=<global id>`), mirroring the Citations tab.
+  - `frontend/src/views/ResearchReportDetail.tsx`: extracted the per-citation
+    deep-link logic into a shared `buildCitationHref` helper (used by both the
+    Citations tab rows and the new footnote links so they stay in lock-step),
+    built a `footnote → href` map keyed by the backend's `[^n]` number, and
+    passed a custom `li` renderer to the body markdown that upgrades footnote
+    definitions (`<li id="user-content-fn-n">`) into client-side-routed links.
+    The annotation's canonical global ID is taken from the server's
+    `fullSourceAnnotationList` (typename `ServerAnnotationType`), never
+    reconstructed from the raw PK.
+  - `frontend/src/components/knowledge_base/markdown/SafeMarkdown.tsx`: now
+    accepts an optional `components` override (forwarded to ReactMarkdown) so a
+    caller can customise specific nodes without weakening the shared
+    `urlTransform` safety gate.

--- a/frontend/src/components/knowledge_base/markdown/SafeMarkdown.tsx
+++ b/frontend/src/components/knowledge_base/markdown/SafeMarkdown.tsx
@@ -1,4 +1,5 @@
 import ReactMarkdown from "react-markdown";
+import type { Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 
 /**
@@ -33,10 +34,23 @@ function urlTransform(url: string): string {
   return SAFE_PROTOCOLS.test(url) ? url : "";
 }
 
-export const SafeMarkdown: React.FC<{ children: string }> = ({ children }) => {
+export const SafeMarkdown: React.FC<{
+  children: string;
+  /**
+   * Optional element renderer overrides forwarded to ReactMarkdown. Lets a
+   * caller customise specific nodes (e.g. make research-report footnote
+   * definitions deep-link to their cited annotation) without weakening the
+   * shared safety contract — `urlTransform` still gates every URL.
+   */
+  components?: Components;
+}> = ({ children, components }) => {
   try {
     return (
-      <ReactMarkdown remarkPlugins={[remarkGfm]} urlTransform={urlTransform}>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        urlTransform={urlTransform}
+        components={components}
+      >
         {children}
       </ReactMarkdown>
     );
@@ -46,7 +60,9 @@ export const SafeMarkdown: React.FC<{ children: string }> = ({ children }) => {
       error
     );
     return (
-      <ReactMarkdown urlTransform={urlTransform}>{children}</ReactMarkdown>
+      <ReactMarkdown urlTransform={urlTransform} components={components}>
+        {children}
+      </ReactMarkdown>
     );
   }
 };

--- a/frontend/src/views/ResearchReportDetail.tsx
+++ b/frontend/src/views/ResearchReportDetail.tsx
@@ -31,9 +31,13 @@ import {
   AlertTriangle,
 } from "lucide-react";
 
+import type { Components } from "react-markdown";
+
 import {
+  CorpusType,
   DocumentType,
   JobStatus,
+  ResearchCitation,
   ResearchReportType,
 } from "../types/graphql-api";
 import { openedResearchReport } from "../graphql/cache";
@@ -287,6 +291,27 @@ const MarkdownWrapper = styled.div`
   }
 `;
 
+// A footnote definition that resolves to a cited annotation. Rendered as a
+// click target (not an ``<a>``) so the inner ``↩`` back-reference anchor stays
+// valid — wrapping the whole ``<li>`` in an anchor would nest anchors.
+const FootnoteItem = styled.li`
+  cursor: pointer;
+  border-radius: 6px;
+  padding: 2px 6px;
+  margin: 0 -6px;
+  transition: background 0.15s, color 0.15s;
+
+  &:hover {
+    background: ${OS_LEGAL_COLORS.surfaceLight};
+    color: ${OS_LEGAL_COLORS.textPrimary};
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${OS_LEGAL_COLORS.borderHover};
+    outline-offset: 2px;
+  }
+`;
+
 const List = styled.div`
   display: flex;
   flex-direction: column;
@@ -405,6 +430,39 @@ const TabPanelInner = styled.div`
 // ═══════════════════════════════════════════════════════════════════════════
 
 /**
+ * Build the in-app deep-link for a single citation: the cited document, with
+ * the cited annotation selected via ``?ann=<globalId>``.
+ *
+ * The annotation's *canonical* global ID is taken from ``annGlobalIdByPk``
+ * (seeded from the server's ``fullSourceAnnotationList``) rather than
+ * reconstructed from the raw PK — the GraphQL typename is ``ServerAnnotationType``,
+ * so a ``toGlobalId("AnnotationType", pk)`` guess would deep-link to the wrong
+ * (or no) entity. Returns ``null`` when the document is unknown or slugs are
+ * missing (``getDocumentUrl`` yields ``"#"``). Shared by the Citations tab rows
+ * and the report-body ``## Sources`` footnotes so both stay in lock-step.
+ */
+function buildCitationHref(
+  citation: ResearchCitation,
+  docsByPk: Map<number, DocumentType>,
+  annGlobalIdByPk: Map<number, string>,
+  corpus: CorpusType | null | undefined
+): string | null {
+  const docPk =
+    citation.document_id != null ? Number(citation.document_id) : null;
+  const doc = docPk != null ? docsByPk.get(docPk) : undefined;
+  if (!doc || !corpus) return null;
+
+  const annPk =
+    citation.annotation_id != null ? Number(citation.annotation_id) : null;
+  const annGlobalId = annPk != null ? annGlobalIdByPk.get(annPk) : undefined;
+
+  const href = getDocumentUrl(doc, corpus, {
+    annotationIds: annGlobalId ? [annGlobalId] : undefined,
+  });
+  return href && href !== "#" ? href : null;
+}
+
+/**
  * ResearchReportDetail - read-only detail view for a deep-research report at
  * /research/:slug. Reports are creator-only (v1) — no sharing controls.
  *
@@ -517,6 +575,67 @@ export const ResearchReportDetail: React.FC = () => {
     });
     return map;
   }, [report?.fullSourceAnnotationList]);
+
+  // Map footnote number → cited-source deep-link, so the report body's
+  // ``## Sources`` footnotes (rendered markdown) become click-to-source links,
+  // mirroring the Citations tab. Keyed by the ``[^n]`` footnote number the
+  // backend emits (``citation.footnote``), which is what react-markdown surfaces
+  // on each footnote ``<li id="user-content-fn-n">``.
+  const footnoteHrefByNumber = useMemo(() => {
+    const map = new Map<number, string>();
+    (report?.citations ?? []).forEach((c) => {
+      if (c.footnote == null) return;
+      const href = buildCitationHref(
+        c,
+        docsByPk,
+        annGlobalIdByPk,
+        report?.corpus
+      );
+      if (href) map.set(Number(c.footnote), href);
+    });
+    return map;
+  }, [report?.citations, docsByPk, annGlobalIdByPk, report?.corpus]);
+
+  // Footnote definitions in the report body deep-link to their cited source.
+  // Only footnote ``<li>``s (id ``user-content-fn-<n>``) are upgraded; ordinary
+  // list items render untouched. Navigation is client-side (``navigate``) and a
+  // click on the inner ``↩`` back-reference anchor is left to its native scroll.
+  const reportMarkdownComponents = useMemo<Components>(
+    () => ({
+      li: ({ node, children, ...props }) => {
+        const id = typeof props.id === "string" ? props.id : undefined;
+        const match = id ? /^user-content-fn-(\d+)$/.exec(id) : null;
+        const href = match
+          ? footnoteHrefByNumber.get(Number(match[1]))
+          : undefined;
+        if (!href) {
+          return <li {...props}>{children}</li>;
+        }
+        return (
+          <FootnoteItem
+            {...props}
+            role="link"
+            tabIndex={0}
+            title="Open the cited source"
+            onClick={(e) => {
+              // Defer to the back-reference anchor's native ``#fnref`` scroll.
+              if ((e.target as HTMLElement).closest("a")) return;
+              navigate(href);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                navigate(href);
+              }
+            }}
+          >
+            {children}
+          </FootnoteItem>
+        );
+      },
+    }),
+    [footnoteHrefByNumber, navigate]
+  );
 
   const statusProps = report ? getResearchStatus(status) : null;
   const canCancel =
@@ -722,7 +841,9 @@ export const ResearchReportDetail: React.FC = () => {
                     <TabPanelInner>
                       {report.content ? (
                         <MarkdownWrapper>
-                          <SafeMarkdown>{report.content}</SafeMarkdown>
+                          <SafeMarkdown components={reportMarkdownComponents}>
+                            {report.content}
+                          </SafeMarkdown>
                         </MarkdownWrapper>
                       ) : (
                         <EmptyWrapper>
@@ -750,28 +871,12 @@ export const ResearchReportDetail: React.FC = () => {
                       ) : (
                         <List>
                           {citations.map((c, i) => {
-                            const docPk =
-                              c.document_id != null
-                                ? Number(c.document_id)
-                                : null;
-                            const doc =
-                              docPk != null ? docsByPk.get(docPk) : undefined;
-                            const annPk =
-                              c.annotation_id != null
-                                ? Number(c.annotation_id)
-                                : null;
-                            const annGlobalId =
-                              annPk != null
-                                ? annGlobalIdByPk.get(annPk)
-                                : undefined;
-                            const href =
-                              doc && report.corpus
-                                ? getDocumentUrl(doc, report.corpus, {
-                                    annotationIds: annGlobalId
-                                      ? [annGlobalId]
-                                      : undefined,
-                                  })
-                                : null;
+                            const href = buildCitationHref(
+                              c,
+                              docsByPk,
+                              annGlobalIdByPk,
+                              report.corpus
+                            );
                             const text =
                               c.display || c.raw_text || `Source ${c.footnote}`;
                             // Footnotes are unique per report, so they make a
@@ -789,7 +894,7 @@ export const ResearchReportDetail: React.FC = () => {
                                 </RowBody>
                               </>
                             );
-                            return href && href !== "#" ? (
+                            return href ? (
                               <RowLink key={rowKey} to={href}>
                                 {inner}
                               </RowLink>

--- a/frontend/tests/ResearchReportDetail.ct.tsx
+++ b/frontend/tests/ResearchReportDetail.ct.tsx
@@ -70,6 +70,41 @@ test.describe("ResearchReportDetail", () => {
     await docScreenshot(page, "research--report-detail--citations");
   });
 
+  test("report-body footnotes deep-link to the cited source", async ({
+    mount,
+    page,
+  }) => {
+    const report = buildMockReport();
+    await mount(<ResearchReportDetailTestWrapper report={report} />);
+
+    await expect(
+      page.locator("text=Indemnification Review").first()
+    ).toBeVisible({ timeout: 15000 });
+
+    // The default Report tab renders the markdown body, whose ``## Sources``
+    // footnote definition (``[^1]: Doc A page 2``) must become a click-to-source
+    // target. Clicking it navigates to the cited document with the cited
+    // annotation selected (``?ann=<canonical global id>``).
+    const footnote = page.locator('li[id="user-content-fn-1"]');
+    await expect(footnote).toBeVisible({ timeout: 10000 });
+    await expect(footnote).toHaveAttribute("role", "link");
+
+    await footnote.click();
+
+    // MemoryRouter doesn't touch window.location, so read the navigated path
+    // from the wrapper's hidden location probe.
+    const probe = page.getByTestId("router-location");
+    await expect
+      .poll(async () => {
+        const loc = (await probe.textContent()) ?? "";
+        return new URL(loc, "http://localhost").pathname;
+      })
+      .toBe("/d/john/cases/doc-a");
+    const loc = (await probe.textContent()) ?? "";
+    const annParam = new URL(loc, "http://localhost").searchParams.get("ann");
+    expect(annParam).toBe(toGlobalId("ServerAnnotationType", 10));
+  });
+
   test("renders a failed report with its error message", async ({
     mount,
     page,

--- a/frontend/tests/ResearchReportDetailTestWrapper.tsx
+++ b/frontend/tests/ResearchReportDetailTestWrapper.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { MockedProvider, MockedResponse } from "@apollo/client/testing";
 import { InMemoryCache } from "@apollo/client";
 import { Provider } from "jotai";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, useLocation } from "react-router-dom";
 import { ResearchReportDetail } from "../src/views/ResearchReportDetail";
 import { openedResearchReport, authToken } from "../src/graphql/cache";
 import { GET_RESEARCH_REPORT } from "../src/graphql/queries";
@@ -83,6 +83,21 @@ export function buildMockReport(
   } as unknown as ResearchReportType;
 }
 
+/**
+ * Hidden probe that mirrors the in-memory router location into the DOM.
+ * MemoryRouter never touches ``window.location``, so client-side navigations
+ * (e.g. clicking a report-body footnote) are invisible to ``page.url()``; this
+ * lets a test assert where ``navigate()`` actually went.
+ */
+const LocationProbe: React.FC = () => {
+  const location = useLocation();
+  return (
+    <div data-testid="router-location" style={{ display: "none" }}>
+      {location.pathname + location.search}
+    </div>
+  );
+};
+
 const createTestCache = () =>
   new InMemoryCache({
     typePolicies: {
@@ -133,6 +148,7 @@ export const ResearchReportDetailTestWrapper: React.FC<{
           addTypename={false}
         >
           <div style={{ height: 800 }}>
+            <LocationProbe />
             <ResearchReportDetail />
           </div>
         </MockedProvider>


### PR DESCRIPTION
## Problem

In the deep-research report detail view, the rendered report body's `## Sources` footnotes (e.g. *"page 41 annotation 395149 — …"*) were **plain text**, so a reader couldn't click through to the source annotation. Only the separate **Citations** tab carried working deep-links.

## Fix

The footnote definitions in the report body are now **click-to-source** targets. Clicking one navigates (client-side) to the cited document with the cited annotation selected (`?ann=<global id>`), mirroring the Citations tab.

### Why frontend (not backend)?

The viewer matches selected annotations against the annotation's **canonical GraphQL global ID** (`useVisibleAnnotations.ts` → `selectedAnnotations.includes(annot.id)`), and that typename is `ServerAnnotationType` — not the `AnnotationType` a `toGlobalId(...)` guess would produce. The frontend already holds the server's canonical IDs in `fullSourceAnnotationList`, so building the link here keeps it correct; the backend would have to hard-code the GraphQL typename. This is the same reasoning the existing Citations-tab deep-link already follows.

## Changes

- **`frontend/src/views/ResearchReportDetail.tsx`**
  - Extracted the per-citation deep-link logic into a shared `buildCitationHref` helper, used by **both** the Citations-tab rows and the new footnote links so the two stay in lock-step (DRY).
  - Built a `footnote → href` map keyed by the backend's `[^n]` number (= `citation.footnote`, which react-markdown surfaces on each `<li id="user-content-fn-n">`).
  - Passed a custom `li` renderer to the body markdown that upgrades **only** footnote definitions into client-side-routed links (ordinary list items are untouched). A click on the inner `↩` back-reference anchor is left to its native scroll; keyboard (Enter/Space) activation supported.
- **`frontend/src/components/knowledge_base/markdown/SafeMarkdown.tsx`**
  - Now accepts an optional `components` override (forwarded to ReactMarkdown) so callers can customise specific nodes **without** weakening the shared `urlTransform` safety gate. Kept generic — no research-specific logic leaked into the shared component.

## Tests

- New Playwright CT in `ResearchReportDetail.ct.tsx`: clicks the body footnote and asserts it navigates to `/d/john/cases/doc-a?ann=<ServerAnnotationType global id>`.
- Added a hidden `router-location` probe to `ResearchReportDetailTestWrapper` (MemoryRouter never touches `window.location`, so onClick navigations are otherwise invisible to `page.url()`).
- All 4 `ResearchReportDetail` CT tests pass; `tsc --noEmit` clean; prettier clean; changelog fragment validates.

https://claude.ai/code/session_01VYhmsrBYk3n3xwvps9pt9E