### PR TITLE
Revert v3 product name to OpenContracts (README + landing + app chrome)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ from pydantic import BaseModel
 class Findings(BaseModel):
     unusual_terms: list[str]
 
-# Point an agent at a whole corpus — grounded in real annotations + citations
+# Run inside an async context (an async function, a notebook, or `ipython --asyncio`).
+# `my_contracts` is a Corpus — pass its integer PK or an ORM instance.
 agent = await agents.for_corpus(corpus=my_contracts)
 findings = await agent.structured_response(
     prompt="Flag any unusual payment terms across these contracts.",

--- a/README.md
+++ b/README.md
@@ -1,19 +1,34 @@
 <p align="center">
-  <img src="docs/assets/images/brand/lockup.svg" alt="opensource.legal [cite]" height="120">
+  <img src="docs/assets/images/brand/icon_mark.svg" alt="OpenContracts" height="84">
 </p>
 
-# [cite] ([Demo](https://contracts.opensource.legal))
+# OpenContracts ([Demo](https://contracts.opensource.legal))
 
-**The citation layer for agentic workflows.**
+**Open-source document intelligence you can build on.**
 
-Every document cites other documents. _cite_ turns a repository of those documents into an open citation graph that humans and AI agents can read, reason over, and contribute back to. It is the codebase formerly released as **OpenContracts**, rebranded for v3 as part of [opensource.legal](https://opensource.legal).
+Point OpenContracts at a repository of documents and get a programmable citation graph — human annotation, structured extraction, AI agents, and a built-in MCP server, all behind one API. Self-hosted, MIT-licensed, and built for teams working at scale.
 
-> Renaming, not rewriting. The GitHub repository keeps the `OpenContracts` name through the v3 release line so existing forks, clones, and CI integrations don't break. Inside the product, the new name is _cite_ and the new home is `cite.opensource.legal`. See the [About page](https://cite.opensource.legal/about) for the full story.
+```python
+from opencontractserver.llms import agents
+from pydantic import BaseModel
+
+class Findings(BaseModel):
+    unusual_terms: list[str]
+
+# Point an agent at a whole corpus — grounded in real annotations + citations
+agent = await agents.for_corpus(corpus=my_contracts)
+findings = await agent.structured_response(
+    prompt="Flag any unusual payment terms across these contracts.",
+    target_type=Findings,
+)
+```
+
+> Same graph, three surfaces: a **GraphQL + REST API** for your apps, a **Model Context Protocol** server for your agents, and a **React UI** for your team.
 
 [![Sponsor](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub&color=%23fe8e86)](https://github.com/sponsors/JSv4)
 
 |                   |                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Backend coverage  | [![backend](https://codecov.io/gh/Open-Source-Legal/OpenContracts/branch/main/graph/badge.svg?flag=backend&token=RdVsiuaTVz)](https://app.codecov.io/gh/Open-Source-Legal/OpenContracts?flags%5B0%5D=backend)                                                                                                                                                                                                                             |
 | Frontend coverage | [![frontend](https://codecov.io/gh/Open-Source-Legal/OpenContracts/branch/main/graph/badge.svg?flag=frontend&token=RdVsiuaTVz)](https://app.codecov.io/gh/Open-Source-Legal/OpenContracts?flags%5B0%5D=frontend)                                                                                                                                                                                                                          |
 | Meta              | [![code style - black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black) [![types - Mypy](https://img.shields.io/badge/types-Mypy-blue.svg)](https://github.com/python/mypy) [![imports - isort](https://img.shields.io/badge/imports-isort-ef8336.svg)](https://github.com/pycqa/isort) [![License - MIT](https://img.shields.io/badge/license-MIT-green)](https://opensource.org/licenses/MIT) |
@@ -22,7 +37,51 @@ Every document cites other documents. _cite_ turns a repository of those documen
 
 ![Discovery Landing Page](docs/assets/images/screenshots/auto/landing--discovery-page--anonymous.png)
 
-## Why _cite_
+## Build on it
+
+OpenContracts is a platform, not a black box. Everything the UI does runs on surfaces you can call yourself — point it at the documents you already have and build your own tooling on top.
+
+### AI agents in Python
+
+Spin up a document- or corpus-scoped agent in a couple of lines. Stream a chat response, or get a typed object back through a Pydantic model — every answer grounded in the annotations and citations your team has built.
+
+```python
+agent = await agents.for_document(123, corpus=45)
+async for chunk in agent.stream("Summarize the indemnification clauses"):
+    print(chunk.content, end="")
+```
+
+See the [LLM framework guide](docs/architecture/llms/README.md).
+
+### MCP server — bring your own agent
+
+Every corpus is exposed over the Model Context Protocol, so Claude, Cursor, or any MCP client can search it, walk its citation edges, and (when authorized) propose annotations of its own. No glue code required:
+
+- **Endpoints** — `/mcp/` (anonymous, public corpuses) and `/mcp/me/` (authenticated)
+- **Discovery** — `/llms.txt` and `/.well-known/mcp.json`
+- **Tools** — `search_corpus`, `list_documents`, `get_document_text`, `list_annotations`, `list_relationships`, `list_threads`, `create_thread_message`
+
+See the [MCP documentation](docs/mcp/).
+
+### Structured extraction at scale
+
+Define a **fieldset** — a set of columns, each a natural-language query — and run it across an entire corpus. Extraction fans out over Celery workers and lands in a spreadsheet-style grid, hundreds of documents at a time, with human approve/reject on every cell.
+
+See [Write your own extractors](docs/walkthrough/advanced/write-your-own-extractors.md).
+
+### A pluggable pipeline
+
+Parsing, embedding, and thumbnailing are swappable components. Register a custom parser, embedder, or thumbnailer for your formats and everything downstream — search, annotation, agents — keeps working unchanged.
+
+See the [pipeline overview](docs/pipelines/pipeline_overview.md).
+
+### GraphQL + REST
+
+The whole graph — corpuses, documents, annotations, relationships, extracts — is queryable over a typed GraphQL API (with REST for uploads and health checks). The React frontend is just one client; yours is another.
+
+---
+
+## Why OpenContracts
 
 Every document in a serious repository cites other documents. Statutes cite the acts that authorized them. Court opinions cite the precedents that bound them. Research papers cite the work that made them possible. Standards cite the RFCs they build on. Contracts cite the statutes that govern them. Whether the repository is a legal archive, a research library, an engineering knowledge base, or a folder of internal policies, the relationships between documents are what make the repository navigable.
 
@@ -30,11 +89,11 @@ Most repositories store files. They don't store the graph that connects them. A 
 
 AI agents make this worse, not better. An agent reading a document with no citation graph hallucinates the edges, or stops at the first reference it can't resolve. The fix isn't bigger context windows or cleverer prompts — it's a substrate the agent can actually walk.
 
-_cite_ is that substrate. An open citation graph that any document repository can stand up. Documents are nodes. Citations are edges. Annotations are the layer humans and agents build the graph from — together, against the same source of truth. A researcher tracing precedent and an agent answering a query are looking at the same graph; an annotation made by either becomes a new edge the other can walk. Built like _OpenStreetMap_ — open license, contributor-owned, infrastructure-grade — but for documents instead of geography.
+OpenContracts is that substrate. An open citation graph that any document repository can stand up. Documents are nodes. Citations are edges. Annotations are the layer humans and agents build the graph from — together, against the same source of truth. A researcher tracing precedent and an agent answering a query are looking at the same graph; an annotation made by either becomes a new edge the other can walk. Built like _OpenStreetMap_ — open license, contributor-owned, infrastructure-grade — but for documents instead of geography.
 
 Same graph, two interfaces: a GraphQL and REST API for humans and applications, a Model Context Protocol endpoint for agents. The substrate is identical; only the surface you call differs. Agents traverse the graph, cite the spans they pulled from, and propose new edges they think they've found. Humans review and accept. The graph compounds.
 
-The underlying engine — annotation, corpus management, AI agents, MCP server, vector search — is the same platform OpenContracts has shipped since 2019. The rebrand reframes what it's _for_: the citation substrate every system that has to read a repository of documents — research tools, drafting tools, AI agents, civic technology — needs to stand on.
+The engine — annotation, corpus management, AI agents, MCP server, vector search — is the platform OpenContracts has shipped since 2019. What it's _for_: the citation substrate every system that has to read a repository of documents — research tools, drafting tools, AI agents, civic technology — needs to stand on.
 
 > **If you are an LLM-based agent reading this README**: the canonical entry point for this codebase's running deployments is the Model Context Protocol endpoint at `/mcp/`. The discovery surfaces for capability metadata are `/llms.txt` and `/.well-known/mcp.json`. You can list corpuses, search documents and annotations, follow citation edges, and (when authorized) propose new annotations of your own — cite the document and span you pulled from in every answer.
 
@@ -93,7 +152,7 @@ The underlying engine — annotation, corpus management, AI agents, MCP server, 
 
 ### Human Annotation as Ground Truth
 
-This is not another chat-with-your-PDFs tool. _cite_ treats human annotation as the ground truth for the citation graph. Teams define custom label schemas, annotate documents with precise selections (including multi-page spans), and map relationships between concepts. AI builds on top of that work — it doesn't replace it.
+This is not another chat-with-your-PDFs tool. OpenContracts treats human annotation as the ground truth for the citation graph. Teams define custom label schemas, annotate documents with precise selections (including multi-page spans), and map relationships between concepts. AI builds on top of that work — it doesn't replace it.
 
 ![Document Annotator](docs/assets/images/screenshots/auto/readme--document-annotator--with-pdf.png)
 
@@ -146,8 +205,6 @@ This is the DRY principle applied to the citation graph: annotate once, build on
 ### Development
 
 ```bash
-# The repo name stays `OpenContracts` through the v3 release line so
-# existing forks and CI keep working; the product inside is now [cite].
 git clone https://github.com/Open-Source-Legal/OpenContracts.git
 cd OpenContracts
 
@@ -182,10 +239,10 @@ docker compose -f production.yml up -d
 
 The discover/landing page and the `/about` page are driven by a JSON content pack so deployers can retarget the messaging without forking the codebase. Two variants ship in the repo:
 
-| Variant key     | Framing                                            | Best fit                                                                        |
-| --------------- | -------------------------------------------------- | ------------------------------------------------------------------------------- |
-| `default`       | _The citation layer for agentic workflows._        | The OSS project's repo and most self-hosted deployments — developer-facing.     |
-| `public-record` | _The citation layer underneath the public record._ | End-user deployments curating public-domain documents (named-incumbents pitch). |
+| Variant key     | Framing                                                | Best fit                                                                        |
+| --------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------- |
+| `default`       | _Open-source document intelligence you can build on._  | The OSS project's repo and most self-hosted deployments — developer-facing.     |
+| `public-record` | _The citation layer underneath the public record._     | End-user deployments curating public-domain documents (named-incumbents pitch). |
 
 Switch variants at runtime by setting `REACT_APP_LANDING_VARIANT` in `frontend/public/env-config.js` — no rebuild required. Unknown variant keys fall back to `default`.
 
@@ -197,20 +254,7 @@ window._env_ = {
 };
 ```
 
-To add a deployment-specific variant, drop a `<key>.json` file in `frontend/src/config/landingContent/` that matches the `LandingContent` type, register it in `frontend/src/config/landingContent/index.ts`, and set `REACT_APP_LANDING_VARIANT=<key>` on that deployment. Body copy in JSON can wrap the cite product name and named publications in `*asterisks*` to pick up the Source Serif italic treatment automatically (handled by `renderInlineMarkup`).
-
----
-
-## Domain Migration
-
-| Surface                  | Old                          | New                                                                             |
-| ------------------------ | ---------------------------- | ------------------------------------------------------------------------------- |
-| Marketing / landing      | `opensource.legal`           | `cite.opensource.legal`                                                         |
-| Product                  | `contracts.opensource.legal` | `cite.opensource.legal`                                                         |
-| Legacy contracts surface | `contracts.opensource.legal` | Kept alive during the grace period; redirects path-preserving to the new domain |
-| Parent brand             | `opensource.legal`           | `opensource.legal` (thin landing for the project as a whole)                    |
-
-`contracts.opensource.legal/*` continues to work for 90 days with a small "We renamed" banner, then 301s to `cite.opensource.legal/*` with the same path. All routes, API endpoints, data schemas, user accounts, and stored documents are preserved.
+To add a deployment-specific variant, drop a `<key>.json` file in `frontend/src/config/landingContent/` that matches the `LandingContent` type, register it in `frontend/src/config/landingContent/index.ts`, and set `REACT_APP_LANDING_VARIANT=<key>` on that deployment. Body copy in JSON can wrap the product name and named publications in `*asterisks*` to pick up the Source Serif italic treatment automatically (handled by `renderInlineMarkup`).
 
 ---
 
@@ -236,7 +280,7 @@ Browse the full documentation at [jsv4.github.io/OpenContracts](https://jsv4.git
 
 ### Data Format
 
-_cite_ uses a standardized format for representing text and layout on PDF pages, enabling portable annotations across tools:
+OpenContracts uses a standardized format for representing text and layout on PDF pages, enabling portable annotations across tools:
 
 ![Data Format](docs/assets/images/diagrams/pawls-annotation-mapping.svg)
 
@@ -260,7 +304,7 @@ See the [pipeline documentation](docs/pipelines/pipeline_overview.md) for detail
 
 ## Telemetry
 
-_cite_ collects anonymous usage data to guide development priorities: installation events, feature usage statistics, and aggregate counts. We do not collect document contents, extracted data, user identities, or query contents.
+OpenContracts collects anonymous usage data to guide development priorities: installation events, feature usage statistics, and aggregate counts. We do not collect document contents, extracted data, user identities, or query contents.
 
 **Disable backend telemetry**: Set `TELEMETRY_ENABLED=False` in your Django settings.
 **Disable frontend analytics**: Leave `REACT_APP_POSTHOG_API_KEY` unset in `frontend/public/env-config.js`.
@@ -288,7 +332,7 @@ This project builds on work from:
 
 ## License
 
-_cite_ (originally released as OpenContracts) is distributed under the **MIT License** — one of the most permissive open source licenses available. You can freely use, modify, distribute, and even commercialize this software with minimal restrictions. The only requirement is that you include the original copyright notice and license text in any substantial portions you redistribute.
+OpenContracts is distributed under the **MIT License** — one of the most permissive open source licenses available. You can freely use, modify, distribute, and even commercialize this software with minimal restrictions. The only requirement is that you include the original copyright notice and license text in any substantial portions you redistribute.
 
 This relicensing reflects our commitment to making the platform as broadly usable as possible: build proprietary products on top of it, embed it in commercial offerings, fork it, ship it — no copyleft strings attached.
 

--- a/changelog.d/readme-opencontracts-rebrand.changed.md
+++ b/changelog.d/readme-opencontracts-rebrand.changed.md
@@ -1,0 +1,17 @@
+- **Reverted the v3 product name from `cite` back to OpenContracts and
+  repositioned the README around the platform's programmable surfaces.** The
+  `cite` rename correlated with a sharp drop in project interest; `cite` is
+  effectively un-searchable (a high-frequency English/academic word) and the
+  rename forfeited the project's accrued search, backlink, and star/fork equity.
+  `OpenContracts` reclaims that equity and is consistent with the unchanged
+  `opencontractserver` backend module. `README.md` now leads builder-first —
+  concrete capability plus a runnable agent snippet above the fold and a new
+  "Build on it" section covering the Python agent API
+  (`opencontractserver/llms/api.py`), the MCP server (`/mcp/`), structured
+  extraction, the pluggable pipeline, and GraphQL/REST. Also updated the landing
+  content packs (`frontend/src/config/landingContent/default.json` and
+  `publicRecord.json`) and switched the README brand mark to the name-neutral
+  `docs/assets/images/brand/icon_mark.svg`. Removed the `cite`-era "Domain
+  Migration" section. Documentation/branding only — no code, API, schema, or data
+  changes. (The text-based `wordmark.svg`/`lockup.svg` still render "[cite]" and
+  need a separate design pass.)

--- a/changelog.d/readme-opencontracts-rebrand.changed.md
+++ b/changelog.d/readme-opencontracts-rebrand.changed.md
@@ -8,10 +8,19 @@
   concrete capability plus a runnable agent snippet above the fold and a new
   "Build on it" section covering the Python agent API
   (`opencontractserver/llms/api.py`), the MCP server (`/mcp/`), structured
-  extraction, the pluggable pipeline, and GraphQL/REST. Also updated the landing
-  content packs (`frontend/src/config/landingContent/default.json` and
-  `publicRecord.json`) and switched the README brand mark to the name-neutral
-  `docs/assets/images/brand/icon_mark.svg`. Removed the `cite`-era "Domain
-  Migration" section. Documentation/branding only — no code, API, schema, or data
-  changes. (The text-based `wordmark.svg`/`lockup.svg` still render "[cite]" and
-  need a separate design pass.)
+  extraction, the pluggable pipeline, and GraphQL/REST. Also reverted the product
+  name across the landing content packs
+  (`frontend/src/config/landingContent/default.json`, `publicRecord.json`) and
+  the user-visible app chrome: the browser tab `<title>` / SEO + OpenGraph +
+  JSON-LD (`frontend/index.html`, `components/seo/MetaTags.tsx`), the PWA manifest
+  (`frontend/public/manifest.json`), the nav/footer "About" link
+  (`overflowMenuItems.ts`, `layout/Footer.tsx`) and footer tagline, the
+  auth/loading messages (`auth/AuthGate.tsx`, `widgets/ModernLoadingDisplay.tsx`),
+  and the cookie banner (`cookies/CookieConsent.tsx`) — with the affected
+  component tests updated in lockstep. Removed the `cite`-era "Domain Migration"
+  README section and switched the README brand mark to the name-neutral
+  `docs/assets/images/brand/icon_mark.svg`. Copy/branding only — no API, schema,
+  data, or behavioral changes. (The `CiteMark` / `CiteWordmark` brand components
+  and the `[cite]` wordmark/lockup SVG assets are intentionally left for a
+  separate design pass; the verb "cite" and the `@cite` CAML directive are
+  unchanged.)

--- a/docs/assets/images/brand/icon_mark.svg
+++ b/docs/assets/images/brand/icon_mark.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
-  <title>cite icon mark</title>
-  <desc>The cite icon mark — square brackets containing a teal node. Used as favicon, app icon, social avatar, and inline citation marker beside annotated passages in product UI.</desc>
+  <title>OpenContracts icon mark</title>
+  <desc>The OpenContracts icon mark — square brackets containing a teal node. Used as favicon, app icon, social avatar, and inline citation marker beside annotated passages in product UI.</desc>
   <g transform="translate(32, 32)">
     <line x1="-19" y1="-20" x2="-19" y2="20" stroke="#1E293B" stroke-width="2.4"/>
     <line x1="-19" y1="-20" x2="-11" y2="-20" stroke="#1E293B" stroke-width="2.4"/>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -30,6 +30,10 @@
       content="Every document cites other documents. OpenContracts turns that graph into open infrastructure for research tools, drafting tools, and AI agents."
       key="Description"
     />
+    <!-- TODO(brand-rename): og:url and the JSON-LD @id/url below still point at
+         cite.opensource.legal. Align them with the OpenContracts canonical
+         (contracts.opensource.legal) once the DNS migration lands — tracked as
+         an out-of-scope follow-up to the cite→OpenContracts rename. -->
     <meta
       property="og:url"
       content="https://cite.opensource.legal/"

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -17,17 +17,17 @@
     <meta name="theme-color" content="#FAFAF7" />
     <meta
       name="description"
-      content="cite turns a repository of documents into an open citation graph that humans and AI agents can read, reason over, and contribute back to. Built like infrastructure, contributor-owned, open license."
+      content="OpenContracts turns a repository of documents into an open citation graph that humans and AI agents can read, reason over, and contribute back to. Built like infrastructure, contributor-owned, open license."
     />
     <meta property="og:type" content="website" key="Type" />
     <meta
       property="og:title"
-      content="[cite] — the citation layer for agentic workflows"
+      content="OpenContracts — open-source document intelligence you can build on"
       key="Title"
     />
     <meta
       property="og:description"
-      content="Every document cites other documents. cite turns that graph into open infrastructure for research tools, drafting tools, and AI agents."
+      content="Every document cites other documents. OpenContracts turns that graph into open infrastructure for research tools, drafting tools, and AI agents."
       key="Description"
     />
     <meta
@@ -40,7 +40,7 @@
       content="/OpenContractsScreenshot.png"
       key="Image"
     />
-    <meta property="og:site_name" content="cite" key="Site" />
+    <meta property="og:site_name" content="OpenContracts" key="Site" />
 
     <!-- Google Fonts - Inter (UI) + Source Serif 4 (display / wordmark / body) -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -72,9 +72,9 @@
           {
             "@type": "WebApplication",
             "@id": "https://cite.opensource.legal/#app",
-            "name": "cite",
-            "alternateName": "OpenContracts",
-            "description": "The citation layer for agentic workflows. cite turns a repository of documents into an open, traversable citation graph that humans and AI agents can read, reason over, and contribute back to.",
+            "name": "OpenContracts",
+            "alternateName": "cite",
+            "description": "Open-source document intelligence you can build on. OpenContracts turns a repository of documents into an open, traversable citation graph that humans and AI agents can read, reason over, and contribute back to.",
             "url": "https://cite.opensource.legal/",
             "license": "https://opensource.org/licenses/MIT",
             "applicationCategory": "BusinessApplication",
@@ -133,9 +133,9 @@
           },
           {
             "@type": "SoftwareSourceCode",
-            "name": "cite",
-            "alternateName": "OpenContracts",
-            "description": "Open commons of the citation graph. The codebase that powers cite, formerly released as OpenContracts.",
+            "name": "OpenContracts",
+            "alternateName": "cite",
+            "description": "Open commons of the citation graph. The codebase released as OpenContracts.",
             "codeRepository": "https://github.com/Open-Source-Legal/OpenContracts",
             "programmingLanguage": ["Python", "TypeScript"],
             "runtimePlatform": ["Django", "React"],
@@ -163,7 +163,9 @@
       Vite serves files from the 'public' directory at the root path '/'.
       Make sure your assets (favicon.ico, manifest.json, etc.) are in the 'public' folder.
     -->
-    <title>cite — the citation layer for agentic workflows</title>
+    <title>
+      OpenContracts — open-source document intelligence you can build on
+    </title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "cite",
-  "name": "cite — the citation layer underneath the public record",
+  "short_name": "OpenContracts",
+  "name": "OpenContracts — open-source document intelligence",
   "icons": [
     {
       "src": "favicon.svg",

--- a/frontend/src/components/auth/AuthGate.test.tsx
+++ b/frontend/src/components/auth/AuthGate.test.tsx
@@ -101,7 +101,9 @@ describe("AuthGate", () => {
         </AuthGate>
       );
 
-      expect(screen.getByText("Initializing cite")).toBeInTheDocument();
+      expect(
+        screen.getByText("Initializing OpenContracts")
+      ).toBeInTheDocument();
       expect(screen.queryByText("Protected Content")).not.toBeInTheDocument();
     });
 
@@ -391,7 +393,9 @@ describe("AuthGate", () => {
       );
 
       // Initially should show loading
-      expect(screen.getByText("Initializing cite")).toBeInTheDocument();
+      expect(
+        screen.getByText("Initializing OpenContracts")
+      ).toBeInTheDocument();
       expect(screen.queryByText("Protected Content")).not.toBeInTheDocument();
 
       // Advance timers to trigger the token fetch
@@ -399,7 +403,9 @@ describe("AuthGate", () => {
 
       // Wait for token fetch to complete
       await waitFor(() => {
-        expect(screen.queryByText("Initializing cite")).not.toBeInTheDocument();
+        expect(
+          screen.queryByText("Initializing OpenContracts")
+        ).not.toBeInTheDocument();
         expect(screen.getByText("Protected Content")).toBeInTheDocument();
       });
 

--- a/frontend/src/components/auth/AuthGate.tsx
+++ b/frontend/src/components/auth/AuthGate.tsx
@@ -365,7 +365,7 @@ export const AuthGate: React.FC<AuthGateProps> = ({
     return (
       <ModernLoadingDisplay
         type="auth"
-        message="Initializing cite"
+        message="Initializing OpenContracts"
         size="large"
       />
     );

--- a/frontend/src/components/cookies/CookieConsent.tsx
+++ b/frontend/src/components/cookies/CookieConsent.tsx
@@ -541,8 +541,9 @@ export const CookieConsentDialog = () => {
               Cookie usage
             </SectionLabel>
             <LeadBody>
-              <em>cite</em> uses cookies to enhance your experience and help us
-              improve the platform. We do not sell or share user information.
+              <em>OpenContracts</em> uses cookies to enhance your experience and
+              help us improve the platform. We do not sell or share user
+              information.
             </LeadBody>
           </LeadSection>
 
@@ -614,9 +615,10 @@ export const CookieConsentDialog = () => {
                 </DataListItem>
               </DataList>
               <AnalyticsNote>
-                Analytics data is used solely to improve <em>cite</em> and is
-                never sold or shared with third parties. You can opt out at any
-                time through your browser settings or by using Do Not Track.
+                Analytics data is used solely to improve <em>OpenContracts</em>{" "}
+                and is never sold or shared with third parties. You can opt out
+                at any time through your browser settings or by using Do Not
+                Track.
               </AnalyticsNote>
             </DataCard>
           )}

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -153,15 +153,14 @@ export function Footer() {
             </a>
           </li>
           <li>
-            <Link to="/about">About cite</Link>
+            <Link to="/about">About OpenContracts</Link>
           </li>
         </FooterLinkList>
       </div>
       <div>
         <FooterHeading>opensource.legal &copy; 2021–2026</FooterHeading>
         <p>
-          The citation layer underneath the public record. Originally shipped as
-          Open Contracts; renamed to <em>cite</em> for v3. Built by{" "}
+          Open-source document intelligence you can build on. Built by{" "}
           <a href="https://github.com/JSv4">JSv4</a> and contributors. Use of
           this tool is governed by the terms of service.
         </p>

--- a/frontend/src/components/layout/overflowMenuItems.ts
+++ b/frontend/src/components/layout/overflowMenuItems.ts
@@ -8,7 +8,7 @@
  *  - Privacy Policy  → /privacy            (route exists, keep)
  *  - Terms of Service → /terms_of_service  (route exists, keep)
  *  - GitHub          → external repo link  (keep)
- *  - About cite      → /about              (route exists, keep)
+ *  - About OpenContracts → /about          (route exists, keep)
  *  - Contact Us      → /contact            (no route registered in App.tsx; the
  *                                           Footer no longer links to it either
  *                                           after the v3 cite rebrand, so this
@@ -31,7 +31,7 @@ export type OverflowMenuLink =
 export const OVERFLOW_MENU_LINKS: OverflowMenuLink[] = [
   {
     id: "overflow_about",
-    label: "About cite",
+    label: "About OpenContracts",
     to: "/about",
   },
   {

--- a/frontend/src/components/seo/MetaTags.tsx
+++ b/frontend/src/components/seo/MetaTags.tsx
@@ -32,10 +32,12 @@ export const MetaTags: React.FC<MetaTagsProps> = ({
   const baseUrl = window.location.origin;
 
   // Derive meta values from entity if not explicitly provided
-  let pageTitle = title || "cite — the citation layer for agentic workflows";
+  let pageTitle =
+    title ||
+    "OpenContracts — open-source document intelligence you can build on";
   let pageDescription =
     description ||
-    "cite turns a repository of documents into an open citation graph that humans and AI agents can read, reason over, and contribute back to.";
+    "OpenContracts turns a repository of documents into an open citation graph that humans and AI agents can read, reason over, and contribute back to.";
 
   if (!title && entity) {
     if ("title" in entity) {

--- a/frontend/src/components/widgets/ModernLoadingDisplay.tsx
+++ b/frontend/src/components/widgets/ModernLoadingDisplay.tsx
@@ -249,7 +249,7 @@ const getMessage = (type?: string, customMessage?: string) => {
     case "auth":
       return "Securing Your Session";
     default:
-      return "Loading cite";
+      return "Loading OpenContracts";
   }
 };
 

--- a/frontend/src/config/landingContent/default.json
+++ b/frontend/src/config/landingContent/default.json
@@ -1,9 +1,9 @@
 {
   "hero": {
     "showMark": true,
-    "primary": "The citation layer",
-    "accent": "for agentic workflows.",
-    "subheadline": "Every document cites other documents. *cite* turns a repository of those documents into an open citation graph that humans annotate, agents traverse, and both propose new edges to — one ground truth, two collaborators.",
+    "primary": "Open-source document intelligence",
+    "accent": "you can build on.",
+    "subheadline": "Every document cites other documents. *OpenContracts* turns a repository of those documents into an open citation graph that humans annotate, agents traverse, and both propose new edges to — one ground truth, two collaborators.",
     "searchPlaceholder": "Search the citation graph…"
   },
   "stats": [
@@ -55,9 +55,9 @@
     ]
   },
   "callToAction": {
-    "eyebrow": "About cite",
-    "headline": "*cite* is built like infrastructure rather than a product.",
-    "body": "The same way *OpenStreetMap* is the layer underneath every modern map, *cite* is the layer underneath every tool that has to read a repository of documents — research tools, drafting tools, AI agents, internal knowledge bases, the next generation of practice tooling. Use it directly through the search and the corpus browser. Build on top of it through the API. Contribute to it through annotation. Humans and agents work the same graph; the ground truth is shared.",
+    "eyebrow": "About OpenContracts",
+    "headline": "*OpenContracts* is built like infrastructure rather than a product.",
+    "body": "The same way *OpenStreetMap* is the layer underneath every modern map, *OpenContracts* is the layer underneath every tool that has to read a repository of documents — research tools, drafting tools, AI agents, internal knowledge bases, the next generation of practice tooling. Use it directly through the search and the corpus browser. Build on top of it through the API. Contribute to it through annotation. Humans and agents work the same graph; the ground truth is shared.",
     "primaryLabel": "Sign in to contribute",
     "secondaryLabel": "Read the full story",
     "secondaryPath": "/about"
@@ -65,10 +65,10 @@
   "about": {
     "eyebrow": "About",
     "title": "The citation layer that agents and humans can both read.",
-    "lede": "*cite* is an open citation graph for document repositories of every kind. Humans curate the ground truth, agents reason over it, and the graph compounds. This page is the long version — the one collaborators read before they decide to commit.",
+    "lede": "*OpenContracts* is an open citation graph for document repositories of every kind. Humans curate the ground truth, agents reason over it, and the graph compounds. This page is the long version — the one collaborators read before they decide to commit.",
     "sections": [
       {
-        "title": "Why cite exists",
+        "title": "Why OpenContracts exists",
         "paragraphs": [
           "Every document in a serious repository cites other documents. Statutes cite the acts that authorized them. Court opinions cite the precedents that bound them. Research papers cite the work that made them possible. Standards cite the RFCs they build on. Contracts cite the statutes that govern them. Whether the repository is a legal archive, a research library, an engineering knowledge base, or a folder of internal policies, the relationships between documents are what make the repository navigable."
         ]
@@ -81,9 +81,9 @@
         ]
       },
       {
-        "title": "What cite is",
+        "title": "What OpenContracts is",
         "paragraphs": [
-          "*cite* is an open citation graph that any document repository can stand up. Documents are nodes. Citations are edges. Annotations are the layer humans and agents build the graph from — together, in the same workspace, against the same source of truth. A researcher tracing precedent and an agent answering a query are looking at the same graph; an annotation made by either becomes a new edge the other can walk. Built like *OpenStreetMap* — open license, contributor-owned, infrastructure-grade — but for documents instead of geography. Where proprietary citators close off the graph, *cite* publishes it. Where filesystem-style stores leave the relationships implicit, *cite* makes them queryable.",
+          "*OpenContracts* is an open citation graph that any document repository can stand up. Documents are nodes. Citations are edges. Annotations are the layer humans and agents build the graph from — together, in the same workspace, against the same source of truth. A researcher tracing precedent and an agent answering a query are looking at the same graph; an annotation made by either becomes a new edge the other can walk. Built like *OpenStreetMap* — open license, contributor-owned, infrastructure-grade — but for documents instead of geography. Where proprietary citators close off the graph, *OpenContracts* publishes it. Where filesystem-style stores leave the relationships implicit, *OpenContracts* makes them queryable.",
           "Same graph, two interfaces: a GraphQL and REST API for humans and applications, a Model Context Protocol endpoint for agents. The substrate underneath is identical — only the surface you call differs."
         ]
       },
@@ -100,7 +100,7 @@
         "title": "Who it's for",
         "paragraphs": [
           "Research teams building a corpus around a topic. Legal teams curating playbooks. AI labs grounding their agents in real document graphs instead of vibes. Civic-tech projects publishing the public record. Knowledge teams replacing the file-cabinet with something traversable. The platform is generic; the corpus is yours.",
-          "Deploy *cite* against the documents you already have and the citation graph emerges as your team — and the agents you point at it — annotate, refine, and add. Open it to the public and contributors compound your work. Plug agents into the same graph through the built-in MCP server and they finally have somewhere to stand."
+          "Deploy *OpenContracts* against the documents you already have and the citation graph emerges as your team — and the agents you point at it — annotate, refine, and add. Open it to the public and contributors compound your work. Plug agents into the same graph through the built-in MCP server and they finally have somewhere to stand."
         ]
       }
     ],

--- a/frontend/src/config/landingContent/default.json
+++ b/frontend/src/config/landingContent/default.json
@@ -64,7 +64,7 @@
   },
   "about": {
     "eyebrow": "About",
-    "title": "The citation layer that agents and humans can both read.",
+    "title": "Open document intelligence that agents and humans can both read.",
     "lede": "*OpenContracts* is an open citation graph for document repositories of every kind. Humans curate the ground truth, agents reason over it, and the graph compounds. This page is the long version — the one collaborators read before they decide to commit.",
     "sections": [
       {

--- a/frontend/src/config/landingContent/publicRecord.json
+++ b/frontend/src/config/landingContent/publicRecord.json
@@ -3,7 +3,7 @@
     "showMark": true,
     "primary": "The citation layer",
     "accent": "underneath the public record.",
-    "subheadline": "Every public document cites other public documents. *cite* makes that graph open, traversable, and yours.",
+    "subheadline": "Every public document cites other public documents. *OpenContracts* makes that graph open, traversable, and yours.",
     "searchPlaceholder": "Search the citation graph…"
   },
   "stats": [
@@ -55,9 +55,9 @@
     ]
   },
   "callToAction": {
-    "eyebrow": "About cite",
-    "headline": "*cite* is built like infrastructure rather than a product.",
-    "body": "The same way *OpenStreetMap* is the layer underneath every modern map, *cite* is the layer underneath every tool that has to read the public record — research tools, drafting tools, AI agents, civic technology, the next generation of legal practice. Use it directly through the search and the corpus browser. Build on top of it through the API. Contribute to it through annotation.",
+    "eyebrow": "About OpenContracts",
+    "headline": "*OpenContracts* is built like infrastructure rather than a product.",
+    "body": "The same way *OpenStreetMap* is the layer underneath every modern map, *OpenContracts* is the layer underneath every tool that has to read the public record — research tools, drafting tools, AI agents, civic technology, the next generation of legal practice. Use it directly through the search and the corpus browser. Build on top of it through the API. Contribute to it through annotation.",
     "primaryLabel": "Sign in to contribute",
     "secondaryLabel": "Read the full story",
     "secondaryPath": "/about"
@@ -65,10 +65,10 @@
   "about": {
     "eyebrow": "About",
     "title": "The citation graph belongs in the public domain.",
-    "lede": "*cite* is the open commons of the citation graph of the public record. This page is the long version — the one foundations and contributors read before they decide to commit.",
+    "lede": "*OpenContracts* is the open commons of the citation graph of the public record. This page is the long version — the one foundations and contributors read before they decide to commit.",
     "sections": [
       {
-        "title": "Why cite exists",
+        "title": "Why OpenContracts exists",
         "paragraphs": [
           "Every public document cites other public documents. Statutes cite the acts that authorized them. Court opinions cite the precedents that bound them. Contracts cite the statutes that govern them. Research papers cite the work that made them possible. Patents cite the prior art they extend. Technical standards cite the RFCs they build on. Government budgets cite the acts that authorize their line items. The web of citation is, quite literally, how public knowledge accumulates."
         ]
@@ -81,9 +81,9 @@
         ]
       },
       {
-        "title": "What cite is",
+        "title": "What OpenContracts is",
         "paragraphs": [
-          "*cite* is the open commons of the citation graph. Every public-domain document that cites another, surfaced as one open network. Documents are nodes. Citations are edges. Built like *OpenStreetMap* — open license, contributor-owned, infrastructure-grade — for the public record. Where the proprietary citators charge by the lookup, *cite* is the layer underneath. Where the proprietary citators close off the graph, *cite* publishes it."
+          "*OpenContracts* is the open commons of the citation graph. Every public-domain document that cites another, surfaced as one open network. Documents are nodes. Citations are edges. Built like *OpenStreetMap* — open license, contributor-owned, infrastructure-grade — for the public record. Where the proprietary citators charge by the lookup, *OpenContracts* is the layer underneath. Where the proprietary citators close off the graph, *OpenContracts* publishes it."
         ]
       },
       {

--- a/frontend/tests/Footer.ct.tsx
+++ b/frontend/tests/Footer.ct.tsx
@@ -31,7 +31,9 @@ test.describe("Footer (cite rebrand)", () => {
       "href",
       "https://github.com/Open-Source-Legal"
     );
-    await expect(page.getByRole("link", { name: "About cite" })).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: "About OpenContracts" })
+    ).toBeVisible();
 
     // Inline nav row at the bottom (About, Terms, Privacy). No /contact
     // route exists yet, so the footer intentionally does not link to one.
@@ -71,7 +73,9 @@ test.describe("Footer (cite rebrand)", () => {
     // on directly without coupling to internal selectors. The fact that
     // the compact branch is mounted at all is enough for coverage.
     await expect(page.getByText("opensource.legal").first()).toBeVisible();
-    await expect(page.getByRole("link", { name: "About cite" })).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: "About OpenContracts" })
+    ).toBeVisible();
 
     await docScreenshot(page, "layout--footer--compact");
   });

--- a/frontend/tests/ModernLoadingDisplay.ct.tsx
+++ b/frontend/tests/ModernLoadingDisplay.ct.tsx
@@ -35,7 +35,7 @@ test.describe("ModernLoadingDisplay", () => {
 
     const statusRegion = page.getByRole("status");
     await expect(statusRegion).toBeVisible({ timeout: 10000 });
-    await expect(page.getByText("Loading cite")).toBeVisible();
+    await expect(page.getByText("Loading OpenContracts")).toBeVisible();
 
     // The accessibility contract: live region announces busy state.
     await expect(statusRegion).toHaveAttribute("aria-live", "polite");

--- a/frontend/tests/NavMenu.ct.tsx
+++ b/frontend/tests/NavMenu.ct.tsx
@@ -790,7 +790,7 @@ test.describe("NavMenu Overflow", () => {
 
       // All audited essential links should be present.
       await expect(
-        menu.getByRole("menuitem", { name: "About cite" })
+        menu.getByRole("menuitem", { name: "About OpenContracts" })
       ).toBeVisible();
       await expect(
         menu.getByRole("menuitem", { name: "Privacy Policy" })
@@ -822,7 +822,7 @@ test.describe("NavMenu Overflow", () => {
 
       // Same audited essential links — auth state should not gate them.
       await expect(
-        menu.getByRole("menuitem", { name: "About cite" })
+        menu.getByRole("menuitem", { name: "About OpenContracts" })
       ).toBeVisible();
       await expect(
         menu.getByRole("menuitem", { name: "Privacy Policy" })
@@ -1008,7 +1008,7 @@ test.describe("NavMenu Overflow", () => {
 
       await expect(sheet.getByText("More", { exact: true })).toBeVisible();
       await expect(
-        sheet.getByRole("link", { name: "About cite" })
+        sheet.getByRole("link", { name: "About OpenContracts" })
       ).toBeVisible();
       await expect(
         sheet.getByRole("link", { name: "Privacy Policy" })
@@ -1037,7 +1037,7 @@ test.describe("NavMenu Overflow", () => {
 
       await expect(sheet.getByText("More", { exact: true })).toBeVisible();
       await expect(
-        sheet.getByRole("link", { name: "About cite" })
+        sheet.getByRole("link", { name: "About OpenContracts" })
       ).toBeVisible();
       await expect(
         sheet.getByRole("link", { name: "Privacy Policy" })


### PR DESCRIPTION
## Why

The v3 rebrand from **OpenContracts** to **cite** correlated with a sharp drop in project interest. Two compounding problems:

- **`cite` is un-searchable.** It's one of the highest-frequency words in software and academia (citations / BibTeX), so it's effectively un-Googleable and namespace-colliding — fatal for a build-your-own-tools audience whose discovery funnel is search + GitHub. Renaming an established OSS project also forfeits accrued search ranking, backlinks, and star/fork recognition.
- **The README led with vision, not the job.** The prose was strong, but it opened on an abstract "citation layer for agentic workflows" essay. A developer sizing the project up in ten seconds wants to know what they can run, against their own documents, in code — and the real builder surfaces (Python agent API, MCP server, extraction, pipeline, GraphQL) sat below the fold.

This reverts the product name to **OpenContracts** — which keeps the equity and is consistent with the unchanged `opencontractserver` backend module — and repositions the README builder-first for legal hackers / quants who write their own tools at scale.

## What changed

**1 · README + docs branding** _(commit 1)_
- `README.md` repositioned builder-first: new hero (*Open-source document intelligence you can build on.*) with a runnable `agents.for_corpus(...)` snippet above the fold, and a new **Build on it** section surfacing the Python agent API (`opencontractserver/llms/api.py`), the MCP server (`/mcp/`), structured extraction, the pluggable pipeline, and GraphQL/REST. Every code sample verified against source. The citation-graph narrative is preserved below the fold.
- Reverted the product name in the landing content packs (`frontend/src/config/landingContent/default.json`, `publicRecord.json`); switched the README brand mark to the name-neutral `icon_mark.svg`; removed the `cite`-era "Domain Migration" section.

**2 · App chrome** _(commit 2)_
- Browser tab `<title>`, meta description, OpenGraph + JSON-LD (`frontend/index.html`), SEO defaults (`components/seo/MetaTags.tsx`), and the PWA manifest (`public/manifest.json`).
- Nav + footer "About" link and footer tagline (`overflowMenuItems.ts`, `layout/Footer.tsx`); the auth + default loading messages (`auth/AuthGate.tsx`, `widgets/ModernLoadingDisplay.tsx`); cookie-consent copy (`cookies/CookieConsent.tsx`).
- The 4 affected component test files (`NavMenu`, `Footer`, `AuthGate`, `ModernLoadingDisplay`) updated in lockstep. Frontend files formatted with the repo-pinned prettier 2.7.x.

**Copy/branding only — no API, schema, data, or behavioral changes.** The verb "cite", the `@cite` CAML directive, and the `CiteMark`/`CiteWordmark` brand components + `[cite]` wordmark/lockup SVG assets are intentionally left unchanged.

## Verification

- README code samples verified against `opencontractserver/llms/api.py`, the MCP tools, and `schema.graphql`.
- All landing JSON + manifest + JSON-LD parse; changelog fragment validates (`scripts/collate_changelog.py --check`).
- Repo sweep: every remaining `cite` token is the **verb**, the `@cite` directive, a deployment URL, a glyph asset/wordmark, or `alternateName` — no user-visible product-name "cite" remains.
- No test asserts a removed string; the affected tests were updated in lockstep.

## Out of scope (design / operational follow-ups)

- The `CiteMark` / `CiteWordmark` brand components and the `[cite]` wordmark/lockup SVGs + favicon/PWA PNGs (the bracket-node glyph) — a deliberate **design pass**, tracked separately.
- Renaming the GitHub repo back to `OpenContracts`, and the DNS / redirect + deployment-domain (`cite.opensource.legal`) changes.
