### PR TITLE
feat: add LiteLLM as AI gateway provider

### DIFF
--- a/opencontractserver/llms/client.py
+++ b/opencontractserver/llms/client.py
@@ -19,6 +19,7 @@ class Provider(Enum):
     """Supported LLM providers."""
 
     OPENAI = "openai"
+    LITELLM = "litellm"
     ANTHROPIC = "anthropic"  # Future support
     GOOGLE = "google"  # Future support
 
@@ -78,6 +79,8 @@ class SimpleLLMClient:
         # Initialize provider-specific client
         if provider == Provider.OPENAI:
             self._init_openai(api_key)
+        elif provider == Provider.LITELLM:
+            self._init_litellm(api_key)
         else:
             raise ValueError(f"Provider {provider} not yet supported")
 
@@ -93,6 +96,15 @@ class SimpleLLMClient:
             raise ValueError("OpenAI API key not found in settings")
 
         self.client = OpenAI(api_key=api_key)
+
+    def _init_litellm(self, api_key: Optional[str] = None) -> None:
+        """Initialize LiteLLM client."""
+        try:
+            import litellm  # noqa: F401
+        except ImportError:
+            raise ImportError("LiteLLM library not installed. Run: pip install litellm")
+
+        self._litellm_api_key = api_key or getattr(settings, "LITELLM_API_KEY", None)
 
     def chat(
         self,
@@ -128,6 +140,8 @@ class SimpleLLMClient:
 
         if self.provider == Provider.OPENAI:
             return self._chat_openai(messages, model, temperature, max_tokens)
+        elif self.provider == Provider.LITELLM:
+            return self._chat_litellm(messages, model, temperature, max_tokens)
         else:
             raise ValueError(f"Provider {self.provider} not yet supported")
 
@@ -178,6 +192,56 @@ class SimpleLLMClient:
 
         except Exception as e:
             logger.error(f"OpenAI chat completion failed: {e}")
+            raise
+
+    def _chat_litellm(
+        self,
+        messages: list[ChatMessage],
+        model: str,
+        temperature: float,
+        max_tokens: Optional[int],
+    ) -> ChatResponse:
+        """Execute LiteLLM chat completion."""
+        try:
+            import litellm
+
+            litellm_messages = [
+                {"role": msg.role, "content": msg.content} for msg in messages
+            ]
+
+            params: dict[str, Any] = {
+                "model": model,
+                "messages": litellm_messages,
+                "temperature": temperature,
+                "drop_params": True,
+            }
+            if max_tokens:
+                params["max_tokens"] = max_tokens
+            if self._litellm_api_key:
+                params["api_key"] = self._litellm_api_key
+
+            response = litellm.completion(**params)
+
+            content = response.choices[0].message.content
+            usage = (
+                {
+                    "prompt_tokens": response.usage.prompt_tokens,
+                    "completion_tokens": response.usage.completion_tokens,
+                    "total_tokens": response.usage.total_tokens,
+                }
+                if response.usage
+                else None
+            )
+
+            return ChatResponse(
+                content=content,
+                model=response.model,
+                usage=usage,
+                raw_response=response,
+            )
+
+        except Exception as e:
+            logger.error(f"LiteLLM chat completion failed: {e}")
             raise
 
     async def achat(

--- a/opencontractserver/tests/test_litellm_provider.py
+++ b/opencontractserver/tests/test_litellm_provider.py
@@ -1,0 +1,125 @@
+"""Tests for LiteLLM provider integration in SimpleLLMClient."""
+
+import sys
+import types
+from unittest import mock
+
+from django.test import TestCase, override_settings
+
+from opencontractserver.llms.client import (
+    ChatMessage,
+    ChatResponse,
+    Provider,
+    SimpleLLMClient,
+    create_client,
+)
+
+
+def _install_litellm_stub():
+    """Install a fake litellm module so tests run without the real package."""
+    fake = types.ModuleType("litellm")
+    fake.completion = mock.MagicMock(name="litellm.completion")  # type: ignore[attr-defined]
+    sys.modules["litellm"] = fake
+    return fake
+
+
+class TestLiteLLMProviderEnum(TestCase):
+    def test_litellm_in_provider_enum(self):
+        self.assertEqual(Provider.LITELLM.value, "litellm")
+
+    def test_provider_from_string(self):
+        provider = Provider("litellm")
+        self.assertEqual(provider, Provider.LITELLM)
+
+
+class TestLiteLLMClientInit(TestCase):
+    def setUp(self):
+        self.fake_litellm = _install_litellm_stub()
+
+    def tearDown(self):
+        sys.modules.pop("litellm", None)
+
+    def test_init_with_api_key(self):
+        client = SimpleLLMClient(
+            provider="litellm",
+            api_key="sk-test",
+            model="anthropic/claude-sonnet-4-6",
+        )
+        self.assertEqual(client.provider, Provider.LITELLM)
+        self.assertEqual(client.model, "anthropic/claude-sonnet-4-6")
+        self.assertEqual(client._litellm_api_key, "sk-test")
+
+    @override_settings(LITELLM_API_KEY="sk-from-settings")
+    def test_init_uses_settings_api_key(self):
+        client = SimpleLLMClient(provider="litellm")
+        self.assertEqual(client._litellm_api_key, "sk-from-settings")
+
+    def test_init_without_api_key(self):
+        client = SimpleLLMClient(provider="litellm")
+        self.assertIsNone(client._litellm_api_key)
+
+
+class TestLiteLLMChat(TestCase):
+    def setUp(self):
+        self.fake_litellm = _install_litellm_stub()
+
+    def tearDown(self):
+        sys.modules.pop("litellm", None)
+
+    def test_chat_calls_litellm_completion(self):
+        mock_usage = mock.MagicMock()
+        mock_usage.prompt_tokens = 10
+        mock_usage.completion_tokens = 5
+        mock_usage.total_tokens = 15
+
+        mock_response = mock.MagicMock()
+        mock_response.choices = [mock.MagicMock(message=mock.MagicMock(content="4"))]
+        mock_response.model = "anthropic/claude-sonnet-4-6"
+        mock_response.usage = mock_usage
+        self.fake_litellm.completion.return_value = mock_response
+
+        client = SimpleLLMClient(
+            provider="litellm",
+            api_key="sk-test",
+            model="anthropic/claude-sonnet-4-6",
+        )
+        messages = [ChatMessage(role="user", content="What is 2+2?")]
+        response = client.chat(messages)
+
+        self.assertIsInstance(response, ChatResponse)
+        self.assertEqual(response.content, "4")
+        self.assertEqual(response.model, "anthropic/claude-sonnet-4-6")
+        assert response.usage is not None
+        self.assertEqual(response.usage["total_tokens"], 15)
+
+        call_kwargs = self.fake_litellm.completion.call_args[1]
+        self.assertEqual(call_kwargs["model"], "anthropic/claude-sonnet-4-6")
+        self.assertTrue(call_kwargs["drop_params"])
+        self.assertEqual(call_kwargs["api_key"], "sk-test")
+
+    def test_chat_omits_api_key_when_none(self):
+        mock_response = mock.MagicMock()
+        mock_response.choices = [mock.MagicMock(message=mock.MagicMock(content="ok"))]
+        mock_response.model = "gpt-4o-mini"
+        mock_response.usage = None
+        self.fake_litellm.completion.return_value = mock_response
+
+        client = SimpleLLMClient(provider="litellm")
+        messages = [ChatMessage(role="user", content="test")]
+        client.chat(messages)
+
+        call_kwargs = self.fake_litellm.completion.call_args[1]
+        self.assertNotIn("api_key", call_kwargs)
+
+
+class TestLiteLLMFactory(TestCase):
+    def setUp(self):
+        self.fake_litellm = _install_litellm_stub()
+
+    def tearDown(self):
+        sys.modules.pop("litellm", None)
+
+    @override_settings(LLM_CLIENT_PROVIDER="litellm")
+    def test_create_client_with_litellm_setting(self):
+        client = create_client()
+        self.assertEqual(client.provider, Provider.LITELLM)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -40,6 +40,7 @@ drf-extra-fields==3.7.0  # https://github.com/Hipo/drf-extra-fields
 pypdf>=6.13.2,<7  # https://github.com/py-pdf/pypdf
 plasmapdf==0.1.3  # https://github.com/Jsv4/plasmapdf
 pdf2image>=1.17.0
+litellm>=1.80.0,<1.87.0  # https://github.com/BerriAI/litellm - unified LLM gateway
 openai>=2.41.1,<3  # https://github.com/openai/openai-python (pydantic-ai 1.x requires >=2.11.0)
 # Bumping pydantic-ai is a deliberate decision: this codebase relies on the
 # precedence rule that ``instructions=`` (not ``system_prompt=``) is the only


### PR DESCRIPTION
## Summary

Add LiteLLM as a provider in `SimpleLLMClient`, enabling access to 100+ LLM providers (Anthropic, Azure, Bedrock, Vertex, Groq, Ollama, etc.) via the [LiteLLM](https://github.com/BerriAI/litellm) Python SDK.

The `Provider` enum already had `ANTHROPIC` and `GOOGLE` marked as "Future support". Rather than implementing each provider individually, LiteLLM provides a unified SDK that translates between all major LLM APIs, so adding it once covers all of them.

## Changes

- `opencontractserver/llms/client.py`
  - Added `LITELLM = "litellm"` to `Provider` enum
  - Added `_init_litellm()` for lazy litellm import and API key resolution (from settings or constructor arg)
  - Added `_chat_litellm()` using `litellm.completion()` with `drop_params=True` for cross-provider compatibility
  - Wired into `__init__` and `chat()` dispatch
- `requirements/base.txt` - added `litellm>=1.80.0,<1.87.0`
- `opencontractserver/tests/test_litellm_provider.py` - 7 unit tests covering enum, init, chat dispatch, API key handling, and factory function

## Tests

**Pre-commit:** all hooks pass (black, isort, flake8, mypy).

**Unit tests (7 tests):**
- `TestLiteLLMProviderEnum` - enum value, string parsing
- `TestLiteLLMClientInit` - init with API key, settings fallback, no key
- `TestLiteLLMChat` - completion dispatch with `drop_params=True`, API key omission
- `TestLiteLLMFactory` - `create_client()` with `LLM_CLIENT_PROVIDER="litellm"` setting

## Risk / Compatibility

- Additive only. OpenAI provider path untouched.
- `litellm` is added to `requirements/base.txt` (not optional, since the existing OpenAI dep is also in base).
- `drop_params=True` silently drops per-provider-unsupported kwargs, preventing errors when switching between providers.

## Example usage

```python
from opencontractserver.llms.client import SimpleLLMClient, ChatMessage

client = SimpleLLMClient(
    provider="litellm",
    model="anthropic/claude-sonnet-4-6",
    # api_key auto-resolved from settings.LITELLM_API_KEY if not provided
)

response = client.chat([
    ChatMessage(role="system", content="You are a legal document analyst."),
    ChatMessage(role="user", content="Summarize this clause."),
])
print(response.content)
```

Or via Django settings:
```python
# settings.py
LLM_CLIENT_PROVIDER = "litellm"
LLM_CLIENT_MODEL = "anthropic/claude-sonnet-4-6"
LITELLM_API_KEY = "sk-..."

# Then anywhere in code:
from opencontractserver.llms.client import create_client
client = create_client()
```
