### PR TITLE
Fix AuthorityNamespace seed convergence on reused test DBs (Backend CI)

### DIFF
--- a/changelog.d/ci-authority-namespace-seed.fixed.md
+++ b/changelog.d/ci-authority-namespace-seed.fixed.md
@@ -1,0 +1,13 @@
+- Backend CI: fixed the recurring `AuthorityNamespace` seed-test failures
+  (`test_authority_namespace.py::AuthorityNamespaceSeedTests` and
+  `test_enrichment_discovery.py::DiscoveryTests::test_grammar_tier_finds_open_vocabulary_authorities`)
+  on the self-hosted runner. The one-shot `RunPython` seed (migration `0082`)
+  and its reseed (`0085`) only ever run once per migration ledger, so a
+  persistent `pytest --reuse-db` test-database volume that already records the
+  seed migration as applied keeps an empty `AuthorityNamespace` table forever —
+  a later reseed migration cannot help because it too is recorded applied after
+  its first run. Added an idempotent `post_migrate` receiver
+  (`opencontractserver/enrichment/_namespace_seed.py::ensure_seeded`, wired in
+  `opencontractserver/annotations/apps.py`) that re-runs the `update_or_create`
+  seed on every `migrate`, converging any reused/poisoned database while staying
+  a no-op on freshly-seeded and production databases.

--- a/changelog.d/ci-authority-namespace-seed.fixed.md
+++ b/changelog.d/ci-authority-namespace-seed.fixed.md
@@ -1,13 +1,19 @@
 - Backend CI: fixed the recurring `AuthorityNamespace` seed-test failures
   (`test_authority_namespace.py::AuthorityNamespaceSeedTests` and
-  `test_enrichment_discovery.py::DiscoveryTests::test_grammar_tier_finds_open_vocabulary_authorities`)
-  on the self-hosted runner. The one-shot `RunPython` seed (migration `0082`)
-  and its reseed (`0085`) only ever run once per migration ledger, so a
-  persistent `pytest --reuse-db` test-database volume that already records the
-  seed migration as applied keeps an empty `AuthorityNamespace` table forever —
-  a later reseed migration cannot help because it too is recorded applied after
-  its first run. Added an idempotent `post_migrate` receiver
+  `test_enrichment_discovery.py::DiscoveryTests::test_grammar_tier_finds_open_vocabulary_authorities`).
+  The shipped namespaces are seeded by the one-shot `RunPython` migrations
+  (`0082`/`0085`), so the rows live outside any test's transaction. Django's
+  `flush` — run on every `TransactionTestCase` teardown — truncates
+  `annotations_authoritynamespace` along with every other table
+  (`serialized_rollback` is `False` by default), so under
+  `pytest -n auto --dist loadscope` any `TransactionTestCase` running before
+  these plain-`TestCase` tests on the same worker left them reading an empty
+  registry. An idempotent `post_migrate` receiver
   (`opencontractserver/enrichment/_namespace_seed.py::ensure_seeded`, wired in
-  `opencontractserver/annotations/apps.py`) that re-runs the `update_or_create`
-  seed on every `migrate`, converging any reused/poisoned database while staying
-  a no-op on freshly-seeded and production databases.
+  `opencontractserver/annotations/apps.py`) re-seeds the rows after every
+  `post_migrate`. `migrate` emits that signal with an `apps` kwarg but `flush`
+  emits it without one, so — like Django's own `create_contenttypes` /
+  `create_permissions` receivers — the receiver now falls back to the global
+  app registry instead of bailing when `apps` is absent, which is the
+  flush-path emission that actually has to restore the rows. The seed stays a
+  no-op on freshly-seeded and production databases.

--- a/opencontractserver/annotations/apps.py
+++ b/opencontractserver/annotations/apps.py
@@ -1,5 +1,10 @@
 from django.apps import AppConfig
-from django.db.models.signals import m2m_changed, post_delete, post_save
+from django.db.models.signals import (
+    m2m_changed,
+    post_delete,
+    post_migrate,
+    post_save,
+)
 from django.utils.translation import gettext_lazy as _
 
 
@@ -61,6 +66,21 @@ class AnnotationsConfig(AppConfig):
                 process_relationship_m2m_changed,
                 sender=Relationship.target_annotations.through,
                 dispatch_uid=REL_M2M_TARGETS_UID,
+            )
+
+            # Converge the shipped AuthorityNamespace rows on every migrate.
+            # The one-shot seed/reseed data migrations (0082/0085) cannot
+            # repopulate a persistent test-database volume reused across runs
+            # (``pytest --reuse-db``) once they are recorded applied; this
+            # idempotent post_migrate receiver does. See ``ensure_seeded``.
+            from opencontractserver.enrichment._namespace_seed import (
+                ensure_seeded,
+            )
+
+            post_migrate.connect(
+                ensure_seeded,
+                sender=self,
+                dispatch_uid="annotations_seed_authority_namespaces",
             )
         except ImportError:
             pass

--- a/opencontractserver/annotations/apps.py
+++ b/opencontractserver/annotations/apps.py
@@ -68,11 +68,12 @@ class AnnotationsConfig(AppConfig):
                 dispatch_uid=REL_M2M_TARGETS_UID,
             )
 
-            # Converge the shipped AuthorityNamespace rows on every migrate.
-            # The one-shot seed/reseed data migrations (0082/0085) cannot
-            # repopulate a persistent test-database volume reused across runs
-            # (``pytest --reuse-db``) once they are recorded applied; this
-            # idempotent post_migrate receiver does. See ``ensure_seeded``.
+            # Converge the shipped AuthorityNamespace rows on every
+            # post_migrate. The one-shot seed migrations (0082/0085) commit
+            # rows outside any test transaction, so a ``TransactionTestCase``
+            # flush truncates them mid-suite; this idempotent receiver
+            # re-seeds after each flush (and on reused CI volumes at DB
+            # setup). See ``ensure_seeded``.
             from opencontractserver.enrichment._namespace_seed import (
                 ensure_seeded,
             )

--- a/opencontractserver/enrichment/_namespace_seed.py
+++ b/opencontractserver/enrichment/_namespace_seed.py
@@ -52,21 +52,31 @@ def unseed(apps, schema_editor):
 def ensure_seeded(sender=None, *, apps=None, using=None, **kwargs):
     """``post_migrate`` receiver that converges the shipped namespace rows.
 
-    A one-shot ``RunPython`` seed (0082) only ever runs once per migration
-    ledger, so a persistent test-database volume reused across runs
-    (``pytest --reuse-db`` on the self-hosted CI runner) keeps an empty
-    ``AuthorityNamespace`` table forever once the seed migration is recorded
-    applied — and a follow-up reseed migration (0085) cannot help, because it
-    too is recorded applied on that same volume after its first run. Django
-    emits ``post_migrate`` on *every* ``migrate`` invocation (including the
-    keepdb path pytest-django uses for ``--reuse-db``), so seeding here
-    converges any reused/poisoned database. ``seed`` is idempotent
-    (``update_or_create``), so this is a no-op on freshly-seeded and
-    production databases.
+    The one-shot ``RunPython`` seed (0082) only runs once per migration ledger,
+    so the rows it commits live *outside* any test transaction. Django's
+    ``flush`` — run on every ``TransactionTestCase`` teardown — truncates
+    ``annotations_authoritynamespace`` along with every other table, and with
+    ``serialized_rollback`` disabled (the default) nothing restores it. Under
+    ``pytest -n auto --dist loadscope`` any ``TransactionTestCase`` that runs
+    before the seed/discovery tests on the same worker therefore leaves them
+    reading an empty registry. Re-running the idempotent ``update_or_create``
+    seed on every ``post_migrate`` converges the table again after each flush
+    (and re-seeds reused/poisoned CI volumes at DB setup). It stays a no-op on
+    freshly-seeded and production databases.
 
-    Connected with ``sender=AnnotationsConfig`` so it fires exactly once, after
-    the ``annotations`` app's tables exist.
+    ``migrate`` emits ``post_migrate`` with an ``apps`` kwarg (the historical
+    project state); ``flush`` emits it *without* one
+    (``django/core/management/commands/flush.py`` vs ``migrate.py``). The
+    flush-path emission is precisely the one that has to re-seed, so — exactly
+    like Django's own ``create_contenttypes`` / ``create_permissions``
+    receivers — fall back to the global app registry when ``apps`` is absent
+    rather than bailing.
+
+    Connected with ``sender=AnnotationsConfig`` so it fires exactly once per
+    emission, after the ``annotations`` app's tables exist.
     """
     if apps is None:
-        return
+        from django.apps import apps as global_apps  # flush path: no apps kwarg
+
+        apps = global_apps
     seed(apps, None)

--- a/opencontractserver/enrichment/_namespace_seed.py
+++ b/opencontractserver/enrichment/_namespace_seed.py
@@ -47,3 +47,26 @@ def unseed(apps, schema_editor):
     AuthorityNamespace = apps.get_model("annotations", "AuthorityNamespace")
     prefixes = set(C.AUTHORITY_PREFIX.values()) | {C.SEC_RULE_PREFIX}
     AuthorityNamespace.objects.filter(prefix__in=prefixes).delete()
+
+
+def ensure_seeded(sender=None, *, apps=None, using=None, **kwargs):
+    """``post_migrate`` receiver that converges the shipped namespace rows.
+
+    A one-shot ``RunPython`` seed (0082) only ever runs once per migration
+    ledger, so a persistent test-database volume reused across runs
+    (``pytest --reuse-db`` on the self-hosted CI runner) keeps an empty
+    ``AuthorityNamespace`` table forever once the seed migration is recorded
+    applied — and a follow-up reseed migration (0085) cannot help, because it
+    too is recorded applied on that same volume after its first run. Django
+    emits ``post_migrate`` on *every* ``migrate`` invocation (including the
+    keepdb path pytest-django uses for ``--reuse-db``), so seeding here
+    converges any reused/poisoned database. ``seed`` is idempotent
+    (``update_or_create``), so this is a no-op on freshly-seeded and
+    production databases.
+
+    Connected with ``sender=AnnotationsConfig`` so it fires exactly once, after
+    the ``annotations`` app's tables exist.
+    """
+    if apps is None:
+        return
+    seed(apps, None)

--- a/opencontractserver/tests/test_authority_namespace.py
+++ b/opencontractserver/tests/test_authority_namespace.py
@@ -79,3 +79,55 @@ class AuthorityNamespaceSeedTests(TestCase):
         ns = AuthorityNamespace.objects.get(prefix="dgcl")
         assert "dgcl" in ns.aliases
         assert "delaware general corporation law" in ns.aliases
+
+
+class AuthorityNamespaceFlushReseedTests(TestCase):
+    """The ``post_migrate`` receiver must re-seed on the ``flush`` emission.
+
+    The shipped namespaces are committed by migrations (``0082``/``0085``), so
+    the rows live outside any test's transaction. Django's ``flush`` — run on
+    every ``TransactionTestCase`` teardown — truncates
+    ``annotations_authoritynamespace`` along with every other table
+    (``serialized_rollback`` is ``False`` by default), so under
+    ``pytest -n auto --dist loadscope`` any ``TransactionTestCase`` that runs
+    before the seed/discovery ``TestCase``s on the same worker leaves them
+    reading an empty registry — the exact CI failure this guards.
+
+    The convergence hinges on a difference between the two commands that emit
+    ``post_migrate``: ``migrate`` passes an ``apps`` kwarg (the historical
+    project state) but ``flush`` does **not**
+    (``django/core/management/commands/flush.py`` vs ``migrate.py``). This test
+    emits the signal the apps-less way ``flush`` does and asserts the connected
+    receiver still converges the registry — i.e. it does not bail when ``apps``
+    is absent, mirroring Django's own ``create_contenttypes`` /
+    ``create_permissions`` receivers.
+    """
+
+    def test_post_migrate_without_apps_reseeds(self):
+        from django.apps import apps as global_apps
+        from django.db.models.signals import post_migrate
+
+        # Simulate the truncation a TransactionTestCase flush performs (the
+        # delete rolls back with this TestCase's transaction).
+        AuthorityNamespace.objects.all().delete()
+        self.assertFalse(AuthorityNamespace.objects.exists())
+
+        # Emit post_migrate exactly as flush.py does: sender=app_config and
+        # NO `apps` kwarg. Pre-fix, the receiver returned early here.
+        cfg = global_apps.get_app_config("annotations")
+        post_migrate.send(
+            sender=cfg,
+            app_config=cfg,
+            verbosity=0,
+            interactive=False,
+            using="default",
+        )
+
+        prefixes = set(C.AUTHORITY_PREFIX.values()) | {C.SEC_RULE_PREFIX}
+        seeded = set(
+            AuthorityNamespace.objects.filter(prefix__in=prefixes).values_list(
+                "prefix", flat=True
+            )
+        )
+        self.assertEqual(seeded, prefixes)
+        self.assertTrue(AuthorityNamespace.objects.filter(prefix="dgcl").exists())


### PR DESCRIPTION
## Problem

Backend CI was **failing on `main`** ([run 27528198489](https://github.com/Open-Source-Legal/OpenContracts/actions/runs/27528198489), commit `5c8fb8645`). Three tests fail:

- `test_authority_namespace.py::AuthorityNamespaceSeedTests::test_every_shipped_prefix_seeded` — `AssertionError: <prefix> not seeded`
- `test_authority_namespace.py::AuthorityNamespaceSeedTests::test_dgcl_aliases_seeded`
- `test_enrichment_discovery.py::DiscoveryTests::test_grammar_tier_finds_open_vocabulary_authorities` — `dgcl` surfaced as a *new* namespace because the registry was empty when the test ran.

## Root cause

These are plain `TestCase`s that read the **migration-seeded** rows in `annotations_authoritynamespace`. Because the rows are committed by the `0082`/`0085` data migrations, they live **outside any test transaction**.

Django's `flush` — run on **every `TransactionTestCase` teardown** — `TRUNCATE`s every table, and with `serialized_rollback` disabled (the default) nothing restores them. There are 48 `TransactionTestCase` classes in the suite; under `pytest -n auto --dist loadscope` at least one runs **before** the authority tests on the same worker and wipes the registry. The seed/discovery tests then read an empty table. (The codebase already documents this exact hazard for the `PipelineSettings` singleton — see `test_pii_scan_tool.py:48`.)

This is **not** a `--reuse-db` poisoning problem (the original framing of this PR): a poisoned reused volume would fail the tests when run *alone*, but they pass alone and only fail in the full suite — the signature of mid-suite cross-test interference, not stale data.

### Why the first attempt didn't fix it

The original fix added a `post_migrate` receiver (`ensure_seeded`) that re-seeds on `post_migrate`. The intent is right, but it was a **no-op on the one emission that matters**. The two commands that emit `post_migrate` differ:

- `migrate` → `emit_post_migrate_signal(..., apps=post_migrate_apps, plan=plan)` — **passes `apps`** (`django/core/management/commands/migrate.py`)
- `flush` → `emit_post_migrate_signal(verbosity, interactive, database)` — **no `apps`** (`.../commands/flush.py`)

The receiver guarded `if apps is None: return`, so it only ever seeded on the `migrate` path (DB setup, once), and bailed on the flush-triggered emission that fires right after the table is truncated mid-suite. Django's own `create_contenttypes` / `create_permissions` receivers survive flush precisely because they default `apps=global_apps` instead of bailing.

## Fix

Make `ensure_seeded` fall back to the global app registry when `apps` is absent (`opencontractserver/enrichment/_namespace_seed.py`), mirroring Django's built-in receivers, so the idempotent `update_or_create` seed re-runs after every flush. It remains a no-op on freshly-seeded and production databases (no `flush`/`migrate` churn there). The `0082`/`0085` migrations are retained as the canonical cold-start/production seed path.

## Verification

- New regression test `AuthorityNamespaceFlushReseedTests::test_post_migrate_without_apps_reseeds` emits `post_migrate` the apps-less way `flush` does and asserts the connected receiver converges the registry. It is **red** against the pre-fix receiver (`iaa`/`dgcl`/… not re-seeded — matching CI) and **green** with the fix.
- End-to-end on a fresh DB: a real flushing `TransactionTestCase` (`CorpusForkOrphanedBlobGCTest`) run **before** `test_authority_namespace.py` + `test_enrichment_discovery.py` → all 11 tests pass.
- `pre-commit` (pyupgrade/black/isort/flake8/mypy/changelog) passes.
