### PR TITLE
Add municipal citation grammar (Tier-2a authority discovery)

### DIFF
--- a/changelog.d/1995-municipal-citations.added.md
+++ b/changelog.d/1995-municipal-citations.added.md
@@ -1,0 +1,38 @@
+- **Authority discovery: municipal citation grammar (Tier-2a, issue #1995).**
+  The reference-enrichment engine now detects municipal-code and ordinance
+  citations, completing the federal/state/municipal trio deliberately deferred
+  from Phase 1 (#1990). Two layers, mirroring the established state-code table +
+  bare-act open-vocabulary pattern:
+  - **Known municipal codes** — a new `MUNICIPAL_CODE_ABBREVIATIONS` table
+    (`opencontractserver/enrichment/abbreviations.py`) maps exact code names
+    (e.g. "San Francisco Municipal Code", "S.F. Mun. Code", "N.Y.C. Admin.
+    Code", "Houston Code of Ordinances") to a `muni-<city-slug>` canonical-key
+    prefix, the full hierarchical jurisdiction (`us-ca-san-francisco`), and
+    `authority_type=municipal-ordinance`, at `_CONF_MUNICIPAL` (0.8). Adding a
+    city is a data edit, never a grammar change.
+  - **Open-vocabulary shape grammar** — `GenericCitationExtractor` now matches
+    `[City] Municipal Code § N`, `Mun. Code §`, `Code of Ordinances §`, and
+    `Ordinance No. N` forms for cities outside the table
+    (`opencontractserver/enrichment/grammars.py`), keyed under the SAME
+    `muni-<city-slug>` namespace (jurisdiction left `None` — free text reveals a
+    city but not its state) at `_CONF_MUNICIPAL_GENERIC` (0.6). A captured city
+    therefore shares its prefix with any table entry for the same city, so the
+    two never fragment, and adding the city to the table later upgrades existing
+    mentions instead of orphaning them.
+  - **Precision guards** (held to the federal/state bar): a `§`/`Section`/`Sec.`
+    + number anchor is mandatory (so prose like "the city adopted a new
+    Municipal Code" never matches); the code phrase must be capitalised
+    (lowercase "municipal code" is excluded); "Administrative Code" is kept out
+    of the open-vocab grammar so "Texas Administrative Code" (a STATE
+    regulation) is never mis-tagged municipal; the table pass claims its span so
+    a known code never double-emits with its generic shadow; and every municipal
+    confidence is calibrated below structured federal cites (< 0.9).
+  - `classify_prefix` (`opencontractserver/enrichment/constants.py`) recognises
+    the `muni` / `muni-<city>` prefix family by shape, so a municipal key is
+    never stranded at `(None, None)` authority_type in the frontier or
+    governance graph. No migration or `AuthorityNamespace` seed is required
+    (table candidates carry their taxonomy on the candidate, exactly like the
+    state codes). Tests: golden cross-municipality corpus, false-positive
+    guards, confidence calibration, OCR tolerance, and dedup in
+    `opencontractserver/tests/test_generic_grammars.py`,
+    `test_abbreviations.py`, `test_enrichment_classification_constants.py`.

--- a/opencontractserver/enrichment/abbreviations.py
+++ b/opencontractserver/enrichment/abbreviations.py
@@ -57,6 +57,13 @@ MUNICIPAL_CODE_ABBREVIATIONS: dict[str, tuple[str, str, str]] = {
         "us-ca-san-francisco",
         C.AUTHORITY_TYPE_MUNICIPAL,
     ),
+    # The abbreviated city + spelled-out "Municipal Code" form is tabled too: the
+    # abbreviation slug ("s-f") would otherwise fragment from "san-francisco".
+    "S.F. Municipal Code": (
+        "muni-san-francisco",
+        "us-ca-san-francisco",
+        C.AUTHORITY_TYPE_MUNICIPAL,
+    ),
     # Los Angeles, CA
     "Los Angeles Municipal Code": (
         "muni-los-angeles",
@@ -64,6 +71,12 @@ MUNICIPAL_CODE_ABBREVIATIONS: dict[str, tuple[str, str, str]] = {
         C.AUTHORITY_TYPE_MUNICIPAL,
     ),
     "L.A. Mun. Code": (
+        "muni-los-angeles",
+        "us-ca-los-angeles",
+        C.AUTHORITY_TYPE_MUNICIPAL,
+    ),
+    # As with S.F. above — "l-a" must not fragment from "los-angeles".
+    "L.A. Municipal Code": (
         "muni-los-angeles",
         "us-ca-los-angeles",
         C.AUTHORITY_TYPE_MUNICIPAL,

--- a/opencontractserver/enrichment/abbreviations.py
+++ b/opencontractserver/enrichment/abbreviations.py
@@ -71,17 +71,34 @@ MUNICIPAL_CODE_ABBREVIATIONS: dict[str, tuple[str, str, str]] = {
     # New York City, NY — the consolidated code IS the "Administrative Code"
     # ("Administrative Code" is intentionally kept OUT of the open-vocab grammar
     # because "Texas Administrative Code" is a STATE regulation, not municipal).
-    # NB: the slug is ``muni-new-york`` (NOT ``muni-new-york-city``). The
-    # open-vocab grammar would slug a literal "New York City Municipal Code" cite
-    # as ``muni-new-york-city`` — a DIFFERENT prefix — so any "New York City
-    # Municipal Code"/"Mun. Code" form added here later MUST also key
-    # ``muni-new-york`` to keep the two from fragmenting into rival authorities.
+    # ALL NYC forms key ``muni-new-york`` (NOT ``muni-new-york-city``). The
+    # informal "New York City Municipal Code"/"Mun. Code" spellings are tabled
+    # HERE as aliases precisely so they resolve to this one authority instead of
+    # fragmenting to the open-vocab ``muni-new-york-city`` slug — "New York City"
+    # ends in "City", which the open-vocab city-capture would otherwise carry
+    # into the key. Tabling them eliminates the fragmentation (vs merely warning
+    # about it). Any further NYC spelling added later must also key muni-new-york.
     "New York City Administrative Code": (
         "muni-new-york",
         "us-ny-new-york",
         C.AUTHORITY_TYPE_MUNICIPAL,
     ),
     "N.Y.C. Admin. Code": (
+        "muni-new-york",
+        "us-ny-new-york",
+        C.AUTHORITY_TYPE_MUNICIPAL,
+    ),
+    "New York City Municipal Code": (
+        "muni-new-york",
+        "us-ny-new-york",
+        C.AUTHORITY_TYPE_MUNICIPAL,
+    ),
+    "New York City Mun. Code": (
+        "muni-new-york",
+        "us-ny-new-york",
+        C.AUTHORITY_TYPE_MUNICIPAL,
+    ),
+    "N.Y.C. Mun. Code": (
         "muni-new-york",
         "us-ny-new-york",
         C.AUTHORITY_TYPE_MUNICIPAL,

--- a/opencontractserver/enrichment/abbreviations.py
+++ b/opencontractserver/enrichment/abbreviations.py
@@ -71,6 +71,11 @@ MUNICIPAL_CODE_ABBREVIATIONS: dict[str, tuple[str, str, str]] = {
     # New York City, NY — the consolidated code IS the "Administrative Code"
     # ("Administrative Code" is intentionally kept OUT of the open-vocab grammar
     # because "Texas Administrative Code" is a STATE regulation, not municipal).
+    # NB: the slug is ``muni-new-york`` (NOT ``muni-new-york-city``). The
+    # open-vocab grammar would slug a literal "New York City Municipal Code" cite
+    # as ``muni-new-york-city`` — a DIFFERENT prefix — so any "New York City
+    # Municipal Code"/"Mun. Code" form added here later MUST also key
+    # ``muni-new-york`` to keep the two from fragmenting into rival authorities.
     "New York City Administrative Code": (
         "muni-new-york",
         "us-ny-new-york",

--- a/opencontractserver/enrichment/abbreviations.py
+++ b/opencontractserver/enrichment/abbreviations.py
@@ -26,3 +26,82 @@ STATE_CODE_ABBREVIATIONS: dict[str, tuple[str, str, str]] = {
     "Wash. Rev. Code": ("wa-rcw", "us-wa", C.AUTHORITY_TYPE_STATUTE),
     "Ill. Comp. Stat.": ("il-ilcs", "us-il", C.AUTHORITY_TYPE_STATUTE),
 }
+
+# Municipal codes (Tier-2a, issue #1995). Forms are too heterogeneous for a
+# single precise regex, so KNOWN city codes live here (exact name -> full
+# taxonomy) and the open-vocabulary ``Municipal Code § N`` shape grammar in
+# grammars.py catches the rest at lower confidence.
+#
+# The prefix is deliberately ``muni-<city-slug>`` — the SAME namespace the
+# open-vocab grammar emits for a captured city. A known code therefore shares
+# its canonical-key prefix with any open-vocab mention of the same city, so the
+# two never fragment into rival authorities; the table merely upgrades the
+# jurisdiction (full ``us-ca-san-francisco`` code, which free text can't supply
+# reliably) and the confidence. Both spelled-out and Bluebook-abbreviated forms
+# are listed because the abbreviation's city slug ("S.F." -> "s-f") differs from
+# the canonical one ("san-francisco"), so the grammar can't canonicalise it.
+MUNICIPAL_CODE_ABBREVIATIONS: dict[str, tuple[str, str, str]] = {
+    # San Francisco, CA
+    "San Francisco Municipal Code": (
+        "muni-san-francisco",
+        "us-ca-san-francisco",
+        C.AUTHORITY_TYPE_MUNICIPAL,
+    ),
+    "San Francisco Mun. Code": (
+        "muni-san-francisco",
+        "us-ca-san-francisco",
+        C.AUTHORITY_TYPE_MUNICIPAL,
+    ),
+    "S.F. Mun. Code": (
+        "muni-san-francisco",
+        "us-ca-san-francisco",
+        C.AUTHORITY_TYPE_MUNICIPAL,
+    ),
+    # Los Angeles, CA
+    "Los Angeles Municipal Code": (
+        "muni-los-angeles",
+        "us-ca-los-angeles",
+        C.AUTHORITY_TYPE_MUNICIPAL,
+    ),
+    "L.A. Mun. Code": (
+        "muni-los-angeles",
+        "us-ca-los-angeles",
+        C.AUTHORITY_TYPE_MUNICIPAL,
+    ),
+    # New York City, NY — the consolidated code IS the "Administrative Code"
+    # ("Administrative Code" is intentionally kept OUT of the open-vocab grammar
+    # because "Texas Administrative Code" is a STATE regulation, not municipal).
+    "New York City Administrative Code": (
+        "muni-new-york",
+        "us-ny-new-york",
+        C.AUTHORITY_TYPE_MUNICIPAL,
+    ),
+    "N.Y.C. Admin. Code": (
+        "muni-new-york",
+        "us-ny-new-york",
+        C.AUTHORITY_TYPE_MUNICIPAL,
+    ),
+    # Chicago, IL
+    "Chicago Municipal Code": (
+        "muni-chicago",
+        "us-il-chicago",
+        C.AUTHORITY_TYPE_MUNICIPAL,
+    ),
+    "Municipal Code of Chicago": (
+        "muni-chicago",
+        "us-il-chicago",
+        C.AUTHORITY_TYPE_MUNICIPAL,
+    ),
+    # Seattle, WA
+    "Seattle Municipal Code": (
+        "muni-seattle",
+        "us-wa-seattle",
+        C.AUTHORITY_TYPE_MUNICIPAL,
+    ),
+    # Houston, TX
+    "Houston Code of Ordinances": (
+        "muni-houston",
+        "us-tx-houston",
+        C.AUTHORITY_TYPE_MUNICIPAL,
+    ),
+}

--- a/opencontractserver/enrichment/constants.py
+++ b/opencontractserver/enrichment/constants.py
@@ -178,6 +178,13 @@ REVIEW_CANDIDATE_RAW_TEXT_MAX_LEN = 120
 # --- Phase 3: prefix classifier ---------------------------------------- #
 _USC_PREFIX_RE = _re.compile(r"^usc-\d+$")
 _CFR_PREFIX_RE = _re.compile(r"^cfr-\d+$")
+# Municipal grammar keys (issue #1995): the ``muni`` catch-all (bare "Municipal
+# Code § N") and per-city ``muni-<city-slug>`` keys (both the table-keyed codes
+# and open-vocab city captures). Matched by shape so a city added to the table
+# later needs no entry here. Like the state-code prefixes, these are NOT in
+# PREFIX_CLASSIFICATION — table candidates carry the full jurisdiction, and this
+# rule only supplies the always-known authority_type.
+_MUNI_PREFIX_RE = _re.compile(r"^muni(?:-[a-z0-9-]+)?$")
 
 # Grammar-emitted federal-statute meta-prefixes. Unlike the named registry
 # bodies in PREFIX_CLASSIFICATION, these are catch-alls — ``act`` for an
@@ -194,10 +201,11 @@ GRAMMAR_STATUTE_META_PREFIXES = frozenset({"act", "publ", "stat"})
 def classify_prefix(prefix: str) -> tuple:
     """(jurisdiction, authority_type) for a canonical_key prefix.
 
-    Handles three title-scoped federal families by shape:
+    Handles federal families + municipal keys by shape:
     - ``usc-NN`` (statute): any US Code title number → (us-federal, statute)
     - ``cfr-NN`` (regulation): any CFR title number → (us-federal, regulation)
     - ``fedreg`` (admin-rule): Federal Register → (us-federal, admin-rule)
+    - ``muni`` / ``muni-<city>`` (municipal): → (None, municipal-ordinance)
 
     Falls back to ``PREFIX_CLASSIFICATION`` for named registry bodies (dgcl,
     exchange-act, irc, …) and returns ``(None, None)`` for unknown prefixes.
@@ -210,4 +218,10 @@ def classify_prefix(prefix: str) -> tuple:
         return (JURISDICTION_US_FEDERAL, AUTHORITY_TYPE_ADMIN_RULE)
     if prefix in GRAMMAR_STATUTE_META_PREFIXES:
         return (JURISDICTION_US_FEDERAL, AUTHORITY_TYPE_STATUTE)
+    if _MUNI_PREFIX_RE.match(prefix):
+        # Jurisdiction stays None — free text reveals the city but not its state
+        # (a table-keyed code supplies the full ``us-ca-san-francisco`` instead).
+        # The authority_type is always recoverable, so a muni key is never
+        # stranded at (None, None).
+        return (None, AUTHORITY_TYPE_MUNICIPAL)
     return PREFIX_CLASSIFICATION.get(prefix, (None, None))

--- a/opencontractserver/enrichment/grammars.py
+++ b/opencontractserver/enrichment/grammars.py
@@ -12,13 +12,22 @@ import re
 from collections.abc import Iterator
 
 from opencontractserver.enrichment import constants as C
-from opencontractserver.enrichment.abbreviations import STATE_CODE_ABBREVIATIONS
+from opencontractserver.enrichment.abbreviations import (
+    MUNICIPAL_CODE_ABBREVIATIONS,
+    STATE_CODE_ABBREVIATIONS,
+)
 from opencontractserver.enrichment.extractor import Candidate
 
 # Confidence by grammar family — structured numeric cites are high precision;
 # bare-Act detection (Task 11) is intentionally lower.
 _CONF_STRUCTURED = 0.9
 _CONF_BARE_ACT = 0.55
+# Municipal (issue #1995) — calibrated BELOW structured federal cites. A
+# table-keyed municipal code (known city + full jurisdiction) is more trusted
+# than the open-vocabulary ``Municipal Code § N`` shape (city/jurisdiction
+# uncertain), but neither outranks a numeric federal cite.
+_CONF_MUNICIPAL = 0.8
+_CONF_MUNICIPAL_GENERIC = 0.6
 
 # A section token: digits, optional trailing letter, optional (a)(2) subsections,
 # optional hyphenated rule tail (10b-5, 261.4).
@@ -51,9 +60,56 @@ _BARE_ACT_RE = re.compile(
     r"(?:\s+of\s+(?P<year>\d{4}))?"
 )
 
+# --- Municipal grammars (issue #1995) ------------------------------------- #
+# Municipal section locator: dotted/hyphenated multi-segment numbers
+# ("6.02.010", "27-2004", "12.21"), optional (a)(2) subsections. Distinct from
+# _SEC because municipal codes nest deeper than a single ".N".
+_MUNI_SEC = r"\d+(?:[.\-–]\d+)*(?:\([0-9a-zA-Z]+\))*"
 
-def _slug_act(name: str) -> str:
+# Section anchor REQUIRED by the open-vocab municipal grammar — the strongest
+# false-positive guard: without a §/Section/Sec. + number, prose like "the city
+# adopted a new Municipal Code last year" can never match.
+_MUNI_CONN = r"(?:§+\s*|[Ss]ection\s+|[Ss]ec\.\s*)"
+
+# Open-vocabulary municipal-code citation: an optional capitalised city/place
+# qualifier (up to 3 words, immediately preceding the code phrase) + a municipal
+# code phrase + the required section anchor. Only the UNAMBIGUOUSLY-municipal
+# code phrases are accepted ("Administrative Code" is deliberately absent —
+# "Texas Administrative Code" is a STATE regulation; named municipal admin codes
+# such as NYC's live in MUNICIPAL_CODE_ABBREVIATIONS instead). The leading
+# capital in "Municipal Code"/"Mun. Code"/"Code of Ordinances" excludes
+# lowercase prose ("the city's municipal code").
+_MUNI_GENERIC_RE = re.compile(
+    r"(?P<city>(?:[A-Z][A-Za-z.'&-]*\s+){0,3})"
+    r"(?P<code>Municipal\s+Code|Mun\.\s*Code|Code\s+of\s+Ordinances)\s+"
+    + _MUNI_CONN
+    + r"(?P<sec>"
+    + _MUNI_SEC
+    + r")"
+)
+
+# Ordinance form: "[City] Ordinance No. 2021-15", "Ord. No. 126000". The "No." +
+# number is required so a bare "Ordinance" never matches.
+_MUNI_ORDINANCE_RE = re.compile(
+    r"(?P<city>(?:[A-Z][A-Za-z.'&-]*\s+){0,3})"
+    r"(?:Ordinance|Ord\.)\s+No\.?\s*(?P<num>\d+(?:[.\-–]\d+)*)"
+)
+
+# Leading qualifiers stripped from a captured municipal city before slugging, so
+# "the Seattle Municipal Code" keys under ``muni-seattle`` not ``muni-the-seattle``.
+_CITY_STOPWORDS = frozenset({"the", "this", "said", "a", "an"})
+
+
+def _slugify(name: str) -> str:
     return re.sub(r"[^a-z0-9]+", "-", name.strip().lower()).strip("-")
+
+
+def _city_slug(city: str) -> str:
+    """Slug a captured city qualifier, dropping leading article stopwords."""
+    parts = [p for p in _slugify(city).split("-") if p]
+    while parts and parts[0] in _CITY_STOPWORDS:
+        parts.pop(0)
+    return "-".join(parts)
 
 
 def _canonical_act_prefix(name: str) -> str | None:
@@ -202,7 +258,7 @@ def _bare_acts(text: str) -> Iterator[Candidate]:
         # (federal) from "the Texas Business Organizations Act" (state). The low
         # _CONF_BARE_ACT signal flags the uncertainty; state-act disambiguation
         # is a Phase-1 follow-up.
-        slug = _slug_act(name)
+        slug = _slugify(name)
         key = f"act:{slug}-{year}" if year else f"act:{slug}"
         yield _cand(
             m.start(),
@@ -236,6 +292,26 @@ class GenericCitationExtractor:
             if ordered
             else None
         )
+        # Municipal-code table alternation — same construction as the state
+        # table (longest-first, OCR-tolerant whitespace, normalized lookup).
+        ordered_muni = sorted(MUNICIPAL_CODE_ABBREVIATIONS, key=len, reverse=True)
+        self._muni_alt = "|".join(
+            re.escape(a).replace(r"\ ", r"\s+") for a in ordered_muni
+        )
+        self._muni_canon = {
+            re.sub(r"\s+", " ", a): v for a, v in MUNICIPAL_CODE_ABBREVIATIONS.items()
+        }
+        self._muni_re = (
+            re.compile(
+                r"(?P<abbr>"
+                + self._muni_alt
+                + r")\s+(?:§+\s*)?(?P<sec>"
+                + _MUNI_SEC
+                + r")"
+            )
+            if ordered_muni
+            else None
+        )
 
     def extract(self, text: str) -> list[Candidate]:
         out: list[Candidate] = []
@@ -246,6 +322,12 @@ class GenericCitationExtractor:
         out.extend(_stat(text))
         out.extend(_bare_acts(text))
         out.extend(self._states(text))
+        # Municipal: table pass first (high-precision, full jurisdiction), then
+        # the open-vocab shape pass — which skips any span the table already
+        # claimed so a known code never double-emits with its generic shadow.
+        muni = list(self._municipal(text))
+        out.extend(muni)
+        out.extend(self._municipal_generic(text, [(c.start, c.end) for c in muni]))
         return out
 
     def _states(self, text: str) -> Iterator[Candidate]:
@@ -256,3 +338,61 @@ class GenericCitationExtractor:
             prefix, jur, typ = self._state_canon[abbr]
             key = f"{prefix}:{m.group('sec').lower()}"
             yield _cand(m.start(), m.end(), m.group(0), key, jur, typ)
+
+    def _municipal(self, text: str) -> Iterator[Candidate]:
+        """Known municipal codes (table) → full jurisdiction, high confidence."""
+        if self._muni_re is None:
+            return
+        for m in self._muni_re.finditer(text):
+            abbr = re.sub(r"\s+", " ", m.group("abbr"))
+            prefix, jur, typ = self._muni_canon[abbr]
+            key = f"{prefix}:{m.group('sec').lower()}"
+            yield _cand(
+                m.start(), m.end(), m.group(0), key, jur, typ, conf=_CONF_MUNICIPAL
+            )
+
+    def _municipal_generic(
+        self, text: str, claimed: list[tuple[int, int]]
+    ) -> Iterator[Candidate]:
+        """Open-vocabulary municipal citations (shape + ordinance forms).
+
+        Jurisdiction is left ``None``: a captured city ("Oakland") does not
+        reveal its state ("us-ca"), so the engine refuses to guess one (unlike a
+        table-keyed code, which carries the full ``us-ca-san-francisco``). The
+        city slug is preserved in the ``muni-<city>`` prefix — the SAME prefix a
+        table entry uses — so adding that city to MUNICIPAL_CODE_ABBREVIATIONS
+        later seamlessly upgrades these mentions instead of orphaning them.
+        ``authority_type`` is always ``municipal-ordinance``.
+        """
+
+        def _is_claimed(start: int, end: int) -> bool:
+            return any(not (end <= cs or start >= ce) for cs, ce in claimed)
+
+        for m in _MUNI_GENERIC_RE.finditer(text):
+            if _is_claimed(m.start(), m.end()):
+                continue
+            slug = _city_slug(m.group("city") or "")
+            prefix = f"muni-{slug}" if slug else "muni"
+            yield _cand(
+                m.start(),
+                m.end(),
+                m.group(0),
+                f"{prefix}:{m.group('sec').lower()}",
+                None,
+                C.AUTHORITY_TYPE_MUNICIPAL,
+                conf=_CONF_MUNICIPAL_GENERIC,
+            )
+        for m in _MUNI_ORDINANCE_RE.finditer(text):
+            if _is_claimed(m.start(), m.end()):
+                continue
+            slug = _city_slug(m.group("city") or "")
+            prefix = f"muni-{slug}" if slug else "muni"
+            yield _cand(
+                m.start(),
+                m.end(),
+                m.group(0),
+                f"{prefix}:ord-{m.group('num').lower()}",
+                None,
+                C.AUTHORITY_TYPE_MUNICIPAL,
+                conf=_CONF_MUNICIPAL_GENERIC,
+            )

--- a/opencontractserver/enrichment/grammars.py
+++ b/opencontractserver/enrichment/grammars.py
@@ -97,7 +97,15 @@ _MUNI_ORDINANCE_RE = re.compile(
 
 # Leading qualifiers stripped from a captured municipal city before slugging, so
 # "the Seattle Municipal Code" keys under ``muni-seattle`` not ``muni-the-seattle``.
-_CITY_STOPWORDS = frozenset({"the", "this", "said", "a", "an"})
+# "city"/"county" are stopwords too: a bare "City Municipal Code § 5" (template
+# placeholder, no real city) collapses to the honest ``muni:`` key instead of
+# inventing a ``muni-city`` authority. Only LEADING stopwords drop, so a trailing
+# qualifier in a real name survives ("Kansas City" -> ``muni-kansas-city``,
+# "Marin County" -> ``muni-marin-county``). The common "City of X" form never
+# reaches here as "city": the lowercase "of" breaks the capitalised run, so regex
+# backtracking starts the match at the real city ("City of Portland ..." captures
+# "Portland", keying ``muni-portland``).
+_CITY_STOPWORDS = frozenset({"the", "this", "said", "a", "an", "city", "county"})
 
 
 def _slugify(name: str) -> str:
@@ -363,10 +371,18 @@ class GenericCitationExtractor:
         table entry uses — so adding that city to MUNICIPAL_CODE_ABBREVIATIONS
         later seamlessly upgrades these mentions instead of orphaning them.
         ``authority_type`` is always ``municipal-ordinance``.
+
+        The ordinance form keys ``<prefix>:ord-<num>`` (a locator, not a code
+        section), so unlike the code-section form it is NOT table-upgradeable —
+        the table maps code names, not ordinance numbers. It exists to surface
+        the citation at low confidence, not to resolve to a known authority.
         """
 
         def _is_claimed(start: int, end: int) -> bool:
-            return any(not (end <= cs or start >= ce) for cs, ce in claimed)
+            # Overlap test (De Morgan of ``not (end <= cs or start >= ce)``):
+            # the spans intersect iff this one starts before another ends AND
+            # ends after it begins.
+            return any(start < ce and end > cs for cs, ce in claimed)
 
         for m in _MUNI_GENERIC_RE.finditer(text):
             if _is_claimed(m.start(), m.end()):

--- a/opencontractserver/enrichment/grammars.py
+++ b/opencontractserver/enrichment/grammars.py
@@ -88,8 +88,9 @@ _MUNI_GENERIC_RE = re.compile(
     + r")"
 )
 
-# Ordinance form: "[City] Ordinance No. 2021-15", "Ord. No. 126000". The "No." +
-# number is required so a bare "Ordinance" never matches.
+# Ordinance form: "[City] Ordinance No. 2021-15", "Ord. No 126000". A "No"/"No."
+# token + number is required (the trailing dot is optional, so "No 7" matches too)
+# so a bare "Ordinance" never matches.
 _MUNI_ORDINANCE_RE = re.compile(
     r"(?P<city>(?:[A-Z][A-Za-z.'&-]*\s+){0,3})"
     r"(?:Ordinance|Ord\.)\s+No\.?\s*(?P<num>\d+(?:[.\-–]\d+)*)"
@@ -105,28 +106,15 @@ _MUNI_ORDINANCE_RE = re.compile(
 # reaches here as "city": the lowercase "of" breaks the capitalised run, so regex
 # backtracking starts the match at the real city ("City of Portland ..." captures
 # "Portland", keying ``muni-portland``).
-# The trailing entries are common Bluebook citation signals / sentence-lead words:
-# a capitalised signal directly before the city ("See Oakland Municipal Code § 5")
-# would otherwise be absorbed into the slug as ``muni-see-oakland``. This is a
-# pragmatic denylist of the frequent leads, NOT exhaustive — the open-vocab city
-# capture stays heuristic/provisional (0.6 confidence) for the long tail.
+# "see"/"under" are common capitalised citation/sentence leads that would
+# otherwise be absorbed into the slug ("See Oakland Municipal Code § 5" ->
+# ``muni-see-oakland``). The list is deliberately MINIMAL: only leads that are
+# unambiguous non-place-names qualify. Bluebook signals that collide with real
+# jurisdictions are EXCLUDED — "contra" would corrupt "Contra Costa [County]"
+# into ``muni-costa``, and "accord" collides with Accord, NY. The open-vocab
+# capture stays heuristic/provisional (0.6) for the residual long tail.
 _CITY_STOPWORDS = frozenset(
-    {
-        "the",
-        "this",
-        "said",
-        "a",
-        "an",
-        "city",
-        "county",
-        "see",
-        "under",
-        "per",
-        "accord",
-        "cf",
-        "compare",
-        "contra",
-    }
+    {"the", "this", "said", "a", "an", "city", "county", "see", "under"}
 )
 
 

--- a/opencontractserver/enrichment/grammars.py
+++ b/opencontractserver/enrichment/grammars.py
@@ -383,6 +383,14 @@ class GenericCitationExtractor:
         section), so unlike the code-section form it is NOT table-upgradeable —
         the table maps code names, not ordinance numbers. It exists to surface
         the citation at low confidence, not to resolve to a known authority.
+
+        Downstream note: every candidate from this open-vocab pass carries a
+        ``detection_confidence`` below the table tier and (for non-table cities)
+        ``jurisdiction=None``. Those two signals are the filter — consumers
+        should treat such mentions as PROVISIONAL (surfaced for discovery/review,
+        never promoted to the trusted tier) until corroborated, e.g. the city is
+        tabled. This matters most for the anchorless ordinance form, where any
+        capitalised lead word becomes a pseudo-city ("Employee Ordinance No. 7").
         """
 
         def _is_claimed(start: int, end: int) -> bool:

--- a/opencontractserver/enrichment/grammars.py
+++ b/opencontractserver/enrichment/grammars.py
@@ -105,7 +105,29 @@ _MUNI_ORDINANCE_RE = re.compile(
 # reaches here as "city": the lowercase "of" breaks the capitalised run, so regex
 # backtracking starts the match at the real city ("City of Portland ..." captures
 # "Portland", keying ``muni-portland``).
-_CITY_STOPWORDS = frozenset({"the", "this", "said", "a", "an", "city", "county"})
+# The trailing entries are common Bluebook citation signals / sentence-lead words:
+# a capitalised signal directly before the city ("See Oakland Municipal Code § 5")
+# would otherwise be absorbed into the slug as ``muni-see-oakland``. This is a
+# pragmatic denylist of the frequent leads, NOT exhaustive — the open-vocab city
+# capture stays heuristic/provisional (0.6 confidence) for the long tail.
+_CITY_STOPWORDS = frozenset(
+    {
+        "the",
+        "this",
+        "said",
+        "a",
+        "an",
+        "city",
+        "county",
+        "see",
+        "under",
+        "per",
+        "accord",
+        "cf",
+        "compare",
+        "contra",
+    }
+)
 
 
 def _slugify(name: str) -> str:

--- a/opencontractserver/enrichment/grammars.py
+++ b/opencontractserver/enrichment/grammars.py
@@ -309,6 +309,13 @@ class GenericCitationExtractor:
         self._muni_canon = {
             re.sub(r"\s+", " ", a): v for a, v in MUNICIPAL_CODE_ABBREVIATIONS.items()
         }
+        # NOTE the ``§`` is OPTIONAL here (``(?:§+\s*)?``) — intentional and the
+        # SAME as ``_state_re`` above: a table-matched code is already a KNOWN
+        # authority (the named abbreviation is the precision guard), and Bluebook
+        # cites for known codes sometimes drop the ``§``. This is deliberately
+        # ASYMMETRIC with the open-vocab ``_MUNI_CONN`` (which REQUIRES ``§``/
+        # Section/Sec.): there the anchor is the only thing separating a real
+        # citation from prose, so do not "unify" the two by making this required.
         self._muni_re = (
             re.compile(
                 r"(?P<abbr>"

--- a/opencontractserver/tests/test_abbreviations.py
+++ b/opencontractserver/tests/test_abbreviations.py
@@ -48,8 +48,13 @@ class MunicipalAbbreviationTableTests(SimpleTestCase):
         # Every table prefix must be ``muni-<city-slug>`` so it shares a
         # namespace with the open-vocab grammar (and classify_prefix recognises
         # it). A drifted prefix would silently fragment from its open-vocab twin.
+        # Assert through the PUBLIC classify_prefix surface (not the private
+        # _MUNI_PREFIX_RE) so the test pins the contract, not the implementation.
         for abbr, (prefix, _jur, _typ) in A.MUNICIPAL_CODE_ABBREVIATIONS.items():
-            assert C._MUNI_PREFIX_RE.match(prefix), (abbr, prefix)
+            assert C.classify_prefix(prefix)[1] == C.AUTHORITY_TYPE_MUNICIPAL, (
+                abbr,
+                prefix,
+            )
             assert prefix.startswith("muni-"), (abbr, prefix)
 
     def test_abbreviated_and_spelled_forms_share_one_prefix(self):

--- a/opencontractserver/tests/test_abbreviations.py
+++ b/opencontractserver/tests/test_abbreviations.py
@@ -19,3 +19,43 @@ class AbbreviationTableTests(SimpleTestCase):
         for abbr, value in A.STATE_CODE_ABBREVIATIONS.items():
             assert len(value) == 3, abbr
             assert value[2] in C.ALL_AUTHORITY_TYPES, abbr
+
+
+class MunicipalAbbreviationTableTests(SimpleTestCase):
+    def test_known_municipal_code_classifies(self):
+        prefix, jur, typ = A.MUNICIPAL_CODE_ABBREVIATIONS[
+            "San Francisco Municipal Code"
+        ]
+        assert prefix == "muni-san-francisco"
+        assert jur == "us-ca-san-francisco"
+        assert typ == C.AUTHORITY_TYPE_MUNICIPAL
+
+    def test_all_entries_have_three_tuple_and_municipal_type(self):
+        for abbr, value in A.MUNICIPAL_CODE_ABBREVIATIONS.items():
+            assert len(value) == 3, abbr
+            assert value[2] == C.AUTHORITY_TYPE_MUNICIPAL, abbr
+
+    def test_jurisdiction_codes_are_hierarchical_below_state(self):
+        # Municipal jurisdictions must be us-<state>-<city> (a city sits BELOW a
+        # state in the hierarchy) so the crawl/frontier per-jurisdiction caps and
+        # the governance graph roll them up under the right state.
+        for abbr, (_prefix, jur, _typ) in A.MUNICIPAL_CODE_ABBREVIATIONS.items():
+            parts = jur.split("-")
+            assert parts[0] == "us", abbr
+            assert len(parts) >= 3, (abbr, jur)
+
+    def test_prefix_matches_municipal_shape(self):
+        # Every table prefix must be ``muni-<city-slug>`` so it shares a
+        # namespace with the open-vocab grammar (and classify_prefix recognises
+        # it). A drifted prefix would silently fragment from its open-vocab twin.
+        for abbr, (prefix, _jur, _typ) in A.MUNICIPAL_CODE_ABBREVIATIONS.items():
+            assert C._MUNI_PREFIX_RE.match(prefix), (abbr, prefix)
+            assert prefix.startswith("muni-"), (abbr, prefix)
+
+    def test_abbreviated_and_spelled_forms_share_one_prefix(self):
+        # The Bluebook abbreviation and the spelled-out name of the same city
+        # must collapse to ONE authority (no fragmentation across spellings).
+        assert (
+            A.MUNICIPAL_CODE_ABBREVIATIONS["S.F. Mun. Code"][0]
+            == A.MUNICIPAL_CODE_ABBREVIATIONS["San Francisco Municipal Code"][0]
+        )

--- a/opencontractserver/tests/test_enrichment_classification_constants.py
+++ b/opencontractserver/tests/test_enrichment_classification_constants.py
@@ -37,3 +37,17 @@ class ClassificationConstantsTests(SimpleTestCase):
             assert jur == C.JURISDICTION_US_FEDERAL, prefix
             assert typ == C.AUTHORITY_TYPE_STATUTE, prefix
             assert prefix not in C.PREFIX_CLASSIFICATION, prefix
+
+    def test_municipal_grammar_prefixes_are_classified(self):
+        # The municipal grammar (issue #1995) emits ``muni`` (bare "Municipal
+        # Code § N") and per-city ``muni-<city-slug>`` keys. classify_prefix must
+        # recover authority_type=municipal-ordinance for both so a muni key is
+        # never stranded at (None, None) type. Jurisdiction stays None — free
+        # text yields a city but not its state; table-keyed codes carry the full
+        # ``us-ca-san-francisco`` on the candidate instead. Like the state-code
+        # prefixes, these are NOT in PREFIX_CLASSIFICATION.
+        for prefix in ("muni", "muni-san-francisco", "muni-oakland"):
+            jur, typ = C.classify_prefix(prefix)
+            assert typ == C.AUTHORITY_TYPE_MUNICIPAL, prefix
+            assert jur is None, prefix
+            assert prefix not in C.PREFIX_CLASSIFICATION, prefix

--- a/opencontractserver/tests/test_generic_grammars.py
+++ b/opencontractserver/tests/test_generic_grammars.py
@@ -325,7 +325,7 @@ class MunicipalGoldenCorpusTests(SimpleTestCase):
             "muni-houston:10-1": "us-tx-houston",
         }
         for key, jur in expected.items():
-            assert key in self.by_key, f"missing {key}: {sorted(self.by_key)}"
+            assert key in self.by_key, f"missing {key}: {sorted(map(str, self.by_key))}"
             assert self.by_key[key].jurisdiction == jur, key
             assert self.by_key[key].authority_type == C.AUTHORITY_TYPE_MUNICIPAL
 
@@ -346,7 +346,7 @@ class MunicipalGoldenCorpusTests(SimpleTestCase):
     def test_cross_municipality_coverage(self):
         # At least six distinct municipal authorities across five states.
         prefixes = {
-            c.canonical_key.split(":", 1)[0]
+            (c.canonical_key or "").split(":", 1)[0]
             for c in self.by_key.values()
             if c.authority_type == C.AUTHORITY_TYPE_MUNICIPAL
         }

--- a/opencontractserver/tests/test_generic_grammars.py
+++ b/opencontractserver/tests/test_generic_grammars.py
@@ -146,3 +146,208 @@ class GrammarRobustnessTests(SimpleTestCase):
         assert "tx-boc:21.401" in self._keys(
             "governed by Tex. Bus. Orgs.  Code § 21.401"
         )
+
+
+class MunicipalKnownGrammarTests(SimpleTestCase):
+    """Table-keyed municipal codes (issue #1995) → full jurisdiction."""
+
+    def setUp(self):
+        self.ex = GenericCitationExtractor()
+
+    def _keys(self, text):
+        return {c.canonical_key: c for c in self.ex.extract(text)}
+
+    def test_san_francisco_municipal_code(self):
+        c = self._keys("governed by San Francisco Municipal Code § 1234")[
+            "muni-san-francisco:1234"
+        ]
+        assert c.jurisdiction == "us-ca-san-francisco"
+        assert c.authority_type == C.AUTHORITY_TYPE_MUNICIPAL
+        assert c.detection_tier == C.DETECTION_TIER_GRAMMAR
+        assert c.reference_type == C.REF_LAW
+
+    def test_bluebook_abbreviation_shares_spelled_out_prefix(self):
+        # "S.F. Mun. Code" and "San Francisco Municipal Code" are ONE authority.
+        assert "muni-san-francisco:56.5" in self._keys("see S.F. Mun. Code § 56.5")
+
+    def test_multi_segment_section_locator(self):
+        # Municipal codes nest deeper than a single ".N" (Seattle: 6.02.010).
+        c = self._keys("per Seattle Municipal Code § 6.02.010")["muni-seattle:6.02.010"]
+        assert c.jurisdiction == "us-wa-seattle"
+
+    def test_nyc_administrative_code(self):
+        c = self._keys("violation of N.Y.C. Admin. Code § 27-2004")[
+            "muni-new-york:27-2004"
+        ]
+        assert c.jurisdiction == "us-ny-new-york"
+
+    def test_code_phrase_before_city(self):
+        assert "muni-chicago:1-2" in self._keys(
+            "under the Municipal Code of Chicago § 1-2"
+        )
+
+    def test_code_of_ordinances_form(self):
+        assert "muni-houston:10-1" in self._keys(
+            "Houston Code of Ordinances § 10-1 applies"
+        )
+
+    def test_confidence_below_structured_federal(self):
+        # "calibrated below structured federal cites" (issue #1995).
+        c = self._keys("San Francisco Municipal Code § 1234")["muni-san-francisco:1234"]
+        assert c.detection_confidence < 0.9
+
+    def test_known_code_does_not_double_emit_with_generic_shadow(self):
+        # The table pass claims the span; the open-vocab pass must skip it, so a
+        # known code yields exactly ONE municipal candidate (not table+generic).
+        cands = [
+            c
+            for c in self.ex.extract("San Francisco Municipal Code § 1234")
+            if c.authority_type == C.AUTHORITY_TYPE_MUNICIPAL
+        ]
+        assert len(cands) == 1, [c.canonical_key for c in cands]
+        assert cands[0].jurisdiction == "us-ca-san-francisco"
+
+    def test_tolerates_ocr_double_space(self):
+        assert "muni-san-francisco:1234" in self._keys(
+            "San Francisco  Municipal  Code § 1234"
+        )
+
+
+class MunicipalGenericGrammarTests(SimpleTestCase):
+    """Open-vocabulary municipal shape — cities NOT in the table."""
+
+    def setUp(self):
+        self.ex = GenericCitationExtractor()
+
+    def _keys(self, text):
+        return {c.canonical_key: c for c in self.ex.extract(text)}
+
+    def test_unknown_city_keyed_under_city_slug(self):
+        c = self._keys("Oakland Municipal Code § 5.04.010 requires")[
+            "muni-oakland:5.04.010"
+        ]
+        assert c.authority_type == C.AUTHORITY_TYPE_MUNICIPAL
+        # State unknown from free text — jurisdiction is honestly left None.
+        assert c.jurisdiction is None
+
+    def test_open_vocab_confidence_below_table(self):
+        c = self._keys("Oakland Municipal Code § 5")["muni-oakland:5"]
+        assert c.detection_confidence < 0.8  # below _CONF_MUNICIPAL
+
+    def test_bare_municipal_code_without_city(self):
+        c = self._keys("see the bare Municipal Code § 5.2 here")["muni:5.2"]
+        assert c.authority_type == C.AUTHORITY_TYPE_MUNICIPAL
+        assert c.jurisdiction is None
+
+    def test_section_word_and_sec_connectors(self):
+        assert "muni-oakland:5" in self._keys("Oakland Municipal Code Section 5")
+        assert "muni-oakland:5-1" in self._keys("Oakland Municipal Code Sec. 5-1")
+
+    def test_leading_article_stopword_stripped_from_city(self):
+        # "the Portland Municipal Code" -> muni-portland (not muni-the-portland).
+        assert "muni-portland:1" in self._keys("This Portland Municipal Code § 1")
+
+    def test_ordinance_form(self):
+        c = self._keys("pursuant to Ordinance No. 2021-15")["muni:ord-2021-15"]
+        assert c.authority_type == C.AUTHORITY_TYPE_MUNICIPAL
+        assert c.detection_confidence < 0.8
+
+    def test_city_qualified_ordinance(self):
+        assert "muni-berkeley:ord-7123" in self._keys(
+            "Berkeley Ordinance No. 7123 imposes"
+        )
+
+    def test_open_vocab_prefix_classifies_to_municipal(self):
+        # An open-vocab city prefix must classify (never strand at None type).
+        jur, typ = C.classify_prefix("muni-oakland")
+        assert typ == C.AUTHORITY_TYPE_MUNICIPAL
+        assert jur is None
+
+
+class MunicipalFalsePositiveTests(SimpleTestCase):
+    """Explicit false-positive guards (issue #1995 precision bar)."""
+
+    def setUp(self):
+        self.ex = GenericCitationExtractor()
+
+    def _muni_keys(self, text):
+        return {
+            c.canonical_key
+            for c in self.ex.extract(text)
+            if c.authority_type == C.AUTHORITY_TYPE_MUNICIPAL
+        }
+
+    def test_no_match_without_section_anchor(self):
+        # The required §/Section/Sec. + number is the core guard.
+        assert (
+            self._muni_keys("the city adopted a new Municipal Code last year") == set()
+        )
+
+    def test_lowercase_code_phrase_excluded(self):
+        assert self._muni_keys("the city updated its municipal code recently") == set()
+
+    def test_state_administrative_code_not_municipal(self):
+        # "Texas Administrative Code" is a STATE regulation, NOT a municipal code:
+        # "Administrative Code" must never be open-vocab-matched as municipal.
+        assert self._muni_keys("see the Texas Administrative Code § 1.5 here") == set()
+
+    def test_bare_ordinance_without_number_excluded(self):
+        assert self._muni_keys("the city passed an Ordinance last spring") == set()
+
+    def test_plain_numbers_excluded(self):
+        assert self._muni_keys("the company has 15 offices and 40 employees") == set()
+
+
+class MunicipalGoldenCorpusTests(SimpleTestCase):
+    """Golden cross-municipality corpus — one realistic multi-city paragraph."""
+
+    CORPUS = (
+        "The premises must comply with San Francisco Municipal Code § 1234 and "
+        "the Los Angeles Municipal Code § 12.21, as well as N.Y.C. Admin. Code "
+        "§ 27-2004. Operations in Washington follow Seattle Municipal Code "
+        "§ 6.02.010, while the Illinois site is governed by the Municipal Code "
+        "of Chicago § 1-2 and the Houston facility by the Houston Code of "
+        "Ordinances § 10-1. The Oakland Municipal Code § 5.04.010 also applies, "
+        "as does Ordinance No. 2021-15."
+    )
+
+    def setUp(self):
+        self.ex = GenericCitationExtractor()
+        self.by_key = {c.canonical_key: c for c in self.ex.extract(self.CORPUS)}
+
+    def test_all_known_municipalities_detected_with_jurisdiction(self):
+        expected = {
+            "muni-san-francisco:1234": "us-ca-san-francisco",
+            "muni-los-angeles:12.21": "us-ca-los-angeles",
+            "muni-new-york:27-2004": "us-ny-new-york",
+            "muni-seattle:6.02.010": "us-wa-seattle",
+            "muni-chicago:1-2": "us-il-chicago",
+            "muni-houston:10-1": "us-tx-houston",
+        }
+        for key, jur in expected.items():
+            assert key in self.by_key, f"missing {key}: {sorted(self.by_key)}"
+            assert self.by_key[key].jurisdiction == jur, key
+            assert self.by_key[key].authority_type == C.AUTHORITY_TYPE_MUNICIPAL
+
+    def test_open_vocab_city_and_ordinance_detected(self):
+        assert "muni-oakland:5.04.010" in self.by_key
+        assert self.by_key["muni-oakland:5.04.010"].jurisdiction is None
+        assert "muni:ord-2021-15" in self.by_key
+
+    def test_every_municipal_confidence_below_federal(self):
+        muni = [
+            c
+            for c in self.by_key.values()
+            if c.authority_type == C.AUTHORITY_TYPE_MUNICIPAL
+        ]
+        assert muni  # sanity: the corpus produced municipal mentions
+        assert all(c.detection_confidence < 0.9 for c in muni)
+
+    def test_cross_municipality_coverage(self):
+        # At least six distinct municipal authorities across five states.
+        prefixes = {
+            c.canonical_key.split(":", 1)[0]
+            for c in self.by_key.values()
+            if c.authority_type == C.AUTHORITY_TYPE_MUNICIPAL
+        }
+        assert len(prefixes) >= 6, prefixes

--- a/opencontractserver/tests/test_generic_grammars.py
+++ b/opencontractserver/tests/test_generic_grammars.py
@@ -312,6 +312,43 @@ class MunicipalGenericGrammarTests(SimpleTestCase):
         # within and around the code phrase.
         assert "muni-oakland:5" in self._keys("Oakland  Municipal  Code § 5")
 
+    def test_signal_stopwords_do_not_collide_with_place_names(self):
+        # The signal denylist must never swallow a real jurisdiction whose name
+        # starts with a Bluebook signal — regression guard against re-adding a
+        # colliding stopword like "contra" (would corrupt "Contra Costa" to
+        # ``muni-costa``).
+        assert "muni-contra-costa:4.1" in self._keys(
+            "Contra Costa Code of Ordinances § 4.1"
+        )
+        assert "muni-contra-costa-county:4.1" in self._keys(
+            "Contra Costa County Code of Ordinances § 4.1"
+        )
+
+    def test_real_three_word_city_not_truncated(self):
+        # The {0,3} city bound must keep a genuine 3-word municipality intact
+        # ("San Luis Obispo"); a tighter {0,2} bound would corrupt it to
+        # ``muni-luis-obispo``.
+        assert "muni-san-luis-obispo:5" in self._keys(
+            "San Luis Obispo Municipal Code § 5"
+        )
+
+    def test_nyc_ordinance_form_is_provisional_not_table_resolved(self):
+        # An ordinance-form NYC cite goes through the open-vocab provisional path
+        # (ordinance numbers are NOT table-upgradeable — see _municipal_generic),
+        # so it carries the provisional contract (low confidence, jurisdiction
+        # None) rather than resolving to the table's muni-new-york authority.
+        # Pins the documented behaviour: ordinance numbers are discovery signals,
+        # not resolved authorities.
+        muni = [
+            c
+            for c in self.ex.extract("New York City Ordinance No. 2023-45")
+            if c.authority_type == C.AUTHORITY_TYPE_MUNICIPAL
+        ]
+        assert muni
+        for c in muni:
+            assert c.jurisdiction is None
+            assert c.detection_confidence < 0.8
+
     def test_open_vocab_prefix_classifies_to_municipal(self):
         # An open-vocab city prefix must classify (never strand at None type).
         jur, typ = C.classify_prefix("muni-oakland")

--- a/opencontractserver/tests/test_generic_grammars.py
+++ b/opencontractserver/tests/test_generic_grammars.py
@@ -181,6 +181,17 @@ class MunicipalKnownGrammarTests(SimpleTestCase):
         ]
         assert c.jurisdiction == "us-ny-new-york"
 
+    def test_nyc_municipal_code_form_resolves_to_table_prefix(self):
+        # "New York City Municipal Code" is tabled as an alias of NYC's
+        # Administrative Code, so it resolves to the single ``muni-new-york``
+        # authority (full jurisdiction) and does NOT fragment to the open-vocab
+        # ``muni-new-york-city`` slug that "New York City" (ends in "City") would
+        # otherwise yield. Guards the namespace-sharing invariant for NYC.
+        keys = self._keys("New York City Municipal Code § 27-2004")
+        assert "muni-new-york:27-2004" in keys
+        assert "muni-new-york-city:27-2004" not in keys
+        assert keys["muni-new-york:27-2004"].jurisdiction == "us-ny-new-york"
+
     def test_code_phrase_before_city(self):
         assert "muni-chicago:1-2" in self._keys(
             "under the Municipal Code of Chicago § 1-2"

--- a/opencontractserver/tests/test_generic_grammars.py
+++ b/opencontractserver/tests/test_generic_grammars.py
@@ -298,6 +298,20 @@ class MunicipalGenericGrammarTests(SimpleTestCase):
             "Marin County Code of Ordinances § 7"
         )
 
+    def test_citation_signal_lead_word_not_absorbed_into_city(self):
+        # A capitalised Bluebook signal / sentence-lead directly before the city
+        # ("See Oakland …") must not be absorbed into the slug (muni-see-oakland);
+        # the leading signal is stripped so the real city authority is preserved.
+        see = self._keys("See Oakland Municipal Code § 5")
+        assert "muni-oakland:5" in see
+        assert "muni-see-oakland:5" not in see
+        assert "muni-portland:1" in self._keys("Under Portland Municipal Code § 1")
+
+    def test_open_vocab_tolerates_ocr_double_space(self):
+        # The open-vocab path (not only the table path) tolerates OCR double-space
+        # within and around the code phrase.
+        assert "muni-oakland:5" in self._keys("Oakland  Municipal  Code § 5")
+
     def test_open_vocab_prefix_classifies_to_municipal(self):
         # An open-vocab city prefix must classify (never strand at None type).
         jur, typ = C.classify_prefix("muni-oakland")

--- a/opencontractserver/tests/test_generic_grammars.py
+++ b/opencontractserver/tests/test_generic_grammars.py
@@ -257,6 +257,27 @@ class MunicipalGenericGrammarTests(SimpleTestCase):
             "Berkeley Ordinance No. 7123 imposes"
         )
 
+    def test_ordinance_tolerates_ocr_double_space(self):
+        # The "Ordinance\\s+No." separator is \\s+, so an OCR double-space wrap
+        # between the words still matches.
+        assert "muni:ord-2021-15" in self._keys("see Ordinance  No. 2021-15 here")
+
+    def test_bare_city_placeholder_collapses_to_muni(self):
+        # A template placeholder "City Municipal Code § 5" (no real city name)
+        # must NOT invent a ``muni-city`` authority — "city"/"county" are
+        # stopwords, so it collapses to the honest bare ``muni:`` key.
+        assert "muni:5" in self._keys("City Municipal Code § 5")
+        assert "muni-city:5" not in self._keys("City Municipal Code § 5")
+        assert "muni:5" in self._keys("County Municipal Code § 5")
+
+    def test_trailing_city_qualifier_preserved(self):
+        # Only LEADING stopwords drop: a trailing "City"/"County" in a real
+        # place name survives so the authority isn't fragmented.
+        assert "muni-kansas-city:5" in self._keys("Kansas City Municipal Code § 5")
+        assert "muni-marin-county:7" in self._keys(
+            "Marin County Code of Ordinances § 7"
+        )
+
     def test_open_vocab_prefix_classifies_to_municipal(self):
         # An open-vocab city prefix must classify (never strand at None type).
         jur, typ = C.classify_prefix("muni-oakland")
@@ -296,6 +317,24 @@ class MunicipalFalsePositiveTests(SimpleTestCase):
 
     def test_plain_numbers_excluded(self):
         assert self._muni_keys("the company has 15 offices and 40 employees") == set()
+
+    def test_internal_ordinance_number_low_confidence_no_jurisdiction(self):
+        # The ordinance form has a deliberately LOWER precision bar than the code
+        # grammar (it needs no §/Section anchor), so internal procedural numbering
+        # like "Employee Ordinance No. 7" still matches (here keyed
+        # ``muni-employee`` — any capitalised lead word is taken as a pseudo-city).
+        # The tradeoff is documented by the invariants every such match carries:
+        # confidence below the table tier (<0.8) and a None jurisdiction, so
+        # downstream consumers can filter it. It never reaches the trusted tier.
+        muni = [
+            c
+            for c in self.ex.extract("governed by Employee Ordinance No. 7")
+            if c.authority_type == C.AUTHORITY_TYPE_MUNICIPAL
+        ]
+        assert muni  # the low-precision form does match (documented tradeoff)
+        for c in muni:
+            assert c.jurisdiction is None
+            assert c.detection_confidence < 0.8
 
 
 class MunicipalGoldenCorpusTests(SimpleTestCase):

--- a/opencontractserver/tests/test_generic_grammars.py
+++ b/opencontractserver/tests/test_generic_grammars.py
@@ -170,6 +170,15 @@ class MunicipalKnownGrammarTests(SimpleTestCase):
         # "S.F. Mun. Code" and "San Francisco Municipal Code" are ONE authority.
         assert "muni-san-francisco:56.5" in self._keys("see S.F. Mun. Code § 56.5")
 
+    def test_abbreviated_city_municipal_code_resolves_to_canonical(self):
+        # The abbreviated-city + spelled-"Municipal Code" forms are tabled so the
+        # abbreviation slug (l-a / s-f) never fragments from the canonical
+        # muni-los-angeles / muni-san-francisco authority.
+        la = self._keys("L.A. Municipal Code § 12.21")
+        assert "muni-los-angeles:12.21" in la
+        assert "muni-l-a:12.21" not in la
+        assert "muni-san-francisco:5" in self._keys("S.F. Municipal Code § 5")
+
     def test_multi_segment_section_locator(self):
         # Municipal codes nest deeper than a single ".N" (Seattle: 6.02.010).
         c = self._keys("per Seattle Municipal Code § 6.02.010")["muni-seattle:6.02.010"]

--- a/opencontractserver/tests/test_generic_grammars.py
+++ b/opencontractserver/tests/test_generic_grammars.py
@@ -332,6 +332,21 @@ class MunicipalGenericGrammarTests(SimpleTestCase):
             "San Luis Obispo Municipal Code § 5"
         )
 
+    def test_non_stopword_lead_lands_in_slug_at_provisional_confidence(self):
+        # The stopword list is deliberately MINIMAL (only unambiguous non-place
+        # leads), so a capitalised NON-stopword word before the city is NOT
+        # stripped — it lands in the slug ("Regarding Oakland" ->
+        # muni-regarding-oakland) and is surfaced as a PROVISIONAL candidate
+        # (confidence < 0.8, jurisdiction None) rather than silently mis-keyed as
+        # muni-oakland. Pins the minimal-stopword design + the provisional
+        # contract that downstream consumers tier-filter on.
+        keys = self._keys("Regarding Oakland Municipal Code § 5")
+        assert "muni-regarding-oakland:5" in keys
+        assert "muni-oakland:5" not in keys
+        c = keys["muni-regarding-oakland:5"]
+        assert c.jurisdiction is None
+        assert c.detection_confidence < 0.8
+
     def test_nyc_ordinance_form_is_provisional_not_table_resolved(self):
         # An ordinance-form NYC cite goes through the open-vocab provisional path
         # (ordinance numbers are NOT table-upgradeable — see _municipal_generic),


### PR DESCRIPTION
Closes #1995.

Completes the federal/state/**municipal** trio of Tier-2a citation-shape grammars deliberately deferred from Phase 1 (#1990). Municipal citation forms are too heterogeneous for a single precise regex, so this follows the **exact pattern already established** for state codes (`STATE_CODE_ABBREVIATIONS` table) + bare Acts (open-vocabulary grammar) — no new architecture.

## What it does

Two complementary layers, both emitting `authority_type=municipal-ordinance`:

**1. Known municipal codes — `MUNICIPAL_CODE_ABBREVIATIONS` table** (`opencontractserver/enrichment/abbreviations.py`)

Exact code names → a `muni-` canonical-key prefix, the **full hierarchical jurisdiction** (e.g. `us-ca-san-francisco`), at confidence `0.8`. Seeded across six municipalities / five states (San Francisco, Los Angeles, New York City, Chicago, Seattle, Houston), with both spelled-out and Bluebook-abbreviated forms (`San Francisco Municipal Code`, `S.F. Mun. Code`, `N.Y.C. Admin. Code`, `Houston Code of Ordinances`, …). Adding a city is a data edit, never a grammar change.

**2. Open-vocabulary shape grammar** (`opencontractserver/enrichment/grammars.py`)

Matches `[City] Municipal Code § N`, `Mun. Code §`, `Code of Ordinances §`, and `Ordinance No. N` for cities **outside** the table, keyed under the **same** `muni-` namespace at confidence `0.6`. Jurisdiction is left `None` (free text reveals a city but not its state). Because the prefix is shared with the table, a captured city never fragments from its table entry, and tabling that city later **upgrades** existing mentions instead of orphaning them.

## Precision bar (held to the federal/state standard)

- A `§`/`Section`/`Sec.` + number **anchor is mandatory** — prose like *"the city adopted a new Municipal Code last year"* never matches.
- The code phrase must be **capitalised** (lowercase "municipal code" excluded).
- **"Administrative Code" is intentionally kept out of the open-vocab grammar** so `Texas Administrative Code § 1.5` (a *state* regulation) is never mis-tagged municipal; named municipal admin codes (NYC) live in the table instead.
- The table pass **claims its span** so a known code never double-emits with its generic shadow (verified: exactly one candidate).
- Every municipal confidence is **below structured federal cites** (< 0.9).

`classify_prefix` (`constants.py`) recognises the `muni` / `muni-` prefix family **by shape**, so a municipal key is never stranded at `(None, None)` authority_type in the frontier or governance graph. **No migration or `AuthorityNamespace` seed is required** — table candidates carry their taxonomy inline, exactly like the state codes.

## Tests

`opencontractserver/tests/test_generic_grammars.py`, `test_abbreviations.py`, `test_enrichment_classification_constants.py`:

- **Golden cross-municipality corpus** — one realistic multi-city paragraph asserting all six known codes resolve with the correct jurisdiction.
- False-positive guards (no anchor, lowercase, `Texas Administrative Code`, bare ordinance, plain numbers).
- NYC namespace-sharing regression (the `New York City Municipal Code` form resolves to the table's `muni-new-york`, not a fragmented `muni-new-york-city`).
- Bare-placeholder collapse, trailing city-qualifier preservation, ordinance precision-bar tradeoff, confidence calibration, OCR double-space tolerance, dedup, and `muni`-family classification.

All tests in the affected files pass under the Django `SimpleTestCase` runner (no regressions); `black`/`isort`/`flake8`/`pyupgrade` clean.