### PR TITLE
Permissioning audit follow-ups (#1986): conversation/message visibility parity, safe manager fallback, datacell crash

### DIFF
--- a/changelog.d/1986-perm-followups.fixed.md
+++ b/changelog.d/1986-perm-followups.fixed.md
@@ -1,0 +1,11 @@
+- Fixed an `AttributeError` crash in `Datacell._validate_manual_entry`
+  (`opencontractserver/extracts/models.py`, issue #1986 item 7). The "required"
+  check in the missing-`value` branch called
+  `self.column.validation_config.get("required")` *before* the
+  `config = self.column.validation_config or {}` guard, so validating a
+  manual-entry datacell with no `value` key on a column whose `validation_config`
+  is `None` (a nullable JSONField — legitimately null on explicitly-cleared or
+  legacy rows) raised `'NoneType' object has no attribute 'get'`. The `or {}`
+  guard is now resolved once at the top of the method and reused, so a config-less
+  column validates cleanly (nothing is required) while a column that *does* set
+  `required` still raises the expected `ValidationError`.

--- a/changelog.d/1986-perm-followups.security.md
+++ b/changelog.d/1986-perm-followups.security.md
@@ -1,0 +1,30 @@
+- Permissioning audit follow-ups from issue #1986 (filter/check parity + safe
+  error handling):
+  - **Anonymous chat-message visibility now follows the conversation
+    bifurcation (item 2).** `ChatMessageQuerySet.visible_to_user`
+    (`opencontractserver/conversations/models.py`) previously filtered the
+    anonymous branch on `conversation__is_public=True` alone, which exposed a
+    public **CHAT**'s messages even though `ConversationQuerySet.visible_to_user`
+    keeps the conversation itself hidden from anonymous users (anonymous can
+    only see THREADs). The branch now delegates to
+    `Conversation.objects.visible_to_user`, so message visibility inherits the
+    single-source-of-truth CHAT/THREAD rules — no public-CHAT message leak, and
+    messages in context-inherited public-resource threads are correctly visible.
+  - **Conversation and chat-message querysets now honour group-level READ
+    grants (item 3).** `ConversationQuerySet` / `ChatMessageQuerySet`
+    `visible_to_user` consulted only the USER object-permission tables. Because
+    `ConversationManager.user_can(READ)` / `ChatMessageManager.user_can(READ)`
+    route back through `visible_to_user`, a group-only READ grant was both
+    invisible in lists AND denied by `user_can(READ)` — even though non-READ
+    writes (via `_default_user_can`) honoured the same group grant. Both
+    querysets now join the `*groupobjectpermission` tables (mirroring
+    `BaseVisibilityManager`), closing the same group-grant gap PR #1985 fixed for
+    annotations / relationships / extracts.
+  - **`BaseVisibilityManager.visible_to_user` no longer swallows unexpected
+    errors (item 4).** The guardian-lookup fallback caught
+    `(ImportError, Exception)` — equivalent to a bare `except Exception` — so any
+    error silently degraded the queryset to creator/public filtering,
+    under-disclosing guardian-granted rows while hiding the defect
+    (`opencontractserver/shared/Managers.py`). The catch is narrowed to
+    `(ImportError, LookupError)` so a genuinely-absent permission table still
+    falls back gracefully, but programming/database errors now propagate.

--- a/opencontractserver/conversations/models.py
+++ b/opencontractserver/conversations/models.py
@@ -223,7 +223,15 @@ class ConversationQuerySet(SoftDeleteQuerySet):
             )
             return queryset.filter(anon_filter).distinct().order_by("-created")
 
-        # Get explicitly permitted conversation IDs via guardian
+        # Get explicitly permitted conversation IDs via guardian (user- AND
+        # group-level READ grants). ``ConversationManager.user_can(READ)``
+        # routes back through this queryset, so the filter IS the check — but
+        # non-READ writes delegate to ``_default_user_can``, which honours group
+        # grants by default. Consulting only the USER object-permission table
+        # here therefore made a group-only READ grant entirely non-functional:
+        # invisible in lists AND denied by ``user_can(READ)`` (issue #1986
+        # item 3 — the same filter/check group-grant gap PR #1985 closed for
+        # annotations / relationships / extracts).
         model_name = self.model._meta.model_name
         app_label = self.model._meta.app_label
 
@@ -236,9 +244,28 @@ class ConversationQuerySet(SoftDeleteQuerySet):
         except LookupError:
             permitted_ids = []
 
+        # Group-level READ grants, resolved in their own ``try`` so a missing
+        # group table never discards the already-resolved user-level grants.
+        # The lazy ``values_list`` keeps both lookups as SQL subqueries
+        # (no extra round-trips).
+        try:
+            group_permission_model_name = f"{model_name}groupobjectpermission"
+            group_permission_model_type = apps.get_model(
+                app_label, group_permission_model_name
+            )
+            group_permitted_ids = group_permission_model_type.objects.filter(
+                permission__codename=f"read_{model_name}",
+                group_id__in=user.groups.values_list("id", flat=True),
+            ).values_list("content_object_id", flat=True)
+        except LookupError:
+            group_permitted_ids = []
+
         # Base conditions: apply to BOTH CHAT and THREAD types
         base_conditions = (
-            Q(creator_id=user.id) | Q(is_public=True) | Q(id__in=permitted_ids)
+            Q(creator_id=user.id)
+            | Q(is_public=True)
+            | Q(id__in=permitted_ids)
+            | Q(id__in=group_permitted_ids)
         )
 
         # CHAT type: base conditions only (restrictive)
@@ -374,9 +401,25 @@ class ChatMessageQuerySet(SoftDeleteQuerySet):
 
         # Superusers are computed like any other user (scoped admin access, 2026-05) — no blanket bypass.
 
-        # Anonymous users only see messages in public conversations
+        # Anonymous users see messages only in conversations THEY can see.
+        # Delegating to ``Conversation.objects.visible_to_user`` keeps the
+        # CHAT/THREAD bifurcation the single source of truth (issue #1986
+        # item 2): for an anonymous viewer that is public THREADs plus context
+        # inheritance on public corpuses/documents, and NEVER a CHAT. The
+        # previous ``conversation__is_public=True`` shortcut both leaked a
+        # public *CHAT*'s messages (the conversation itself stays hidden via
+        # ``ConversationQuerySet.visible_to_user``, so the messages were the
+        # odd surface out) and missed messages in context-inherited
+        # public-resource threads. This mirrors the authenticated branch
+        # below, which already routes message visibility through conversation
+        # visibility.
         if user.is_anonymous:
-            return queryset.filter(conversation__is_public=True).order_by("created")
+            visible_conversation_ids = Conversation.objects.visible_to_user(
+                user
+            ).values_list("id", flat=True)
+            return queryset.filter(
+                conversation_id__in=visible_conversation_ids
+            ).order_by("created")
 
         # Primary visibility: messages in visible conversations
         # This inherits the bifurcated CHAT/THREAD permission logic
@@ -386,7 +429,12 @@ class ChatMessageQuerySet(SoftDeleteQuerySet):
         ).values_list("id", flat=True)
         conversation_visible = Q(conversation_id__in=visible_conversation_ids)
 
-        # Additional conditions for explicit message-level access
+        # Additional conditions for explicit message-level access (user- AND
+        # group-level guardian grants). Adding the group branch mirrors the
+        # conversation queryset's group-grant fix (issue #1986 item 3) so a
+        # message shared via a Django group is visible in lists, not only to
+        # direct user grantees. Both branches preserve the existing
+        # any-message-permission shape (a grant of any codename implies READ).
         from django.apps import apps
 
         try:
@@ -401,9 +449,22 @@ class ChatMessageQuerySet(SoftDeleteQuerySet):
         except LookupError:
             has_permission = Q(pk__in=[])
 
+        try:
+            group_permission_model = apps.get_model(
+                "conversations", "chatmessagegroupobjectpermission"
+            )
+            has_group_permission = Q(
+                id__in=group_permission_model.objects.filter(
+                    group_id__in=user.groups.values_list("id", flat=True)
+                ).values_list("content_object_id", flat=True)
+            )
+        except LookupError:
+            has_group_permission = Q(pk__in=[])
+
         base_conditions = (
             Q(creator=user)  # User created the message
-            | has_permission  # User has explicit permission on message
+            | has_permission  # User has explicit user-level permission
+            | has_group_permission  # User has a group-level permission
         )
 
         # Moderator conditions: user can moderate the conversation

--- a/opencontractserver/extracts/models.py
+++ b/opencontractserver/extracts/models.py
@@ -404,14 +404,9 @@ class Datacell(BaseOCModel):
         if not self.data:
             self.data = {}
 
-        # ``validation_config`` is a nullable JSONField (``null=True``), so it
-        # can legitimately be ``None`` (explicitly cleared, or legacy rows —
-        # ``Column.clean`` itself guards with ``and self.validation_config``).
-        # Resolve the ``{}`` fallback once, up front: issue #1986 item 7 — the
-        # "required" check below previously read ``self.column.validation_config
-        # .get("required")`` *before* this guard, raising ``AttributeError:
-        # 'NoneType' object has no attribute 'get'`` whenever a manual-entry cell
-        # with no ``value`` key was validated on a column whose config was None.
+        # ``validation_config`` is a nullable JSONField, so resolve the ``{}``
+        # fallback ONCE before reading any key — calling ``.get(...)`` on a
+        # ``None`` config is the AttributeError fixed in issue #1986 item 7.
         config = self.column.validation_config or {}
 
         if "value" not in self.data:

--- a/opencontractserver/extracts/models.py
+++ b/opencontractserver/extracts/models.py
@@ -404,8 +404,18 @@ class Datacell(BaseOCModel):
         if not self.data:
             self.data = {}
 
+        # ``validation_config`` is a nullable JSONField (``null=True``), so it
+        # can legitimately be ``None`` (explicitly cleared, or legacy rows —
+        # ``Column.clean`` itself guards with ``and self.validation_config``).
+        # Resolve the ``{}`` fallback once, up front: issue #1986 item 7 — the
+        # "required" check below previously read ``self.column.validation_config
+        # .get("required")`` *before* this guard, raising ``AttributeError:
+        # 'NoneType' object has no attribute 'get'`` whenever a manual-entry cell
+        # with no ``value`` key was validated on a column whose config was None.
+        config = self.column.validation_config or {}
+
         if "value" not in self.data:
-            if self.column.validation_config.get("required"):
+            if config.get("required"):
                 raise django.core.exceptions.ValidationError(
                     f"{self.column.name} is required"
                 )
@@ -413,7 +423,6 @@ class Datacell(BaseOCModel):
 
         value = self.data["value"]
         data_type = self.column.data_type
-        config = self.column.validation_config or {}
 
         # Skip further validation if value is None
         if value is None:

--- a/opencontractserver/shared/Managers.py
+++ b/opencontractserver/shared/Managers.py
@@ -338,8 +338,19 @@ class BaseVisibilityManager(UserCanMixin, Manager):
 
             return queryset
 
-        except (ImportError, Exception) as e:
-            # Fall back to creator/public check only if Guardian not available or error
+        except (ImportError, LookupError) as e:
+            # Narrow, intentional fallback (issue #1986 item 4): degrade to
+            # creator/public filtering ONLY when the guardian permission tables
+            # are genuinely absent for this model — ``ImportError`` (guardian /
+            # an app not installed) or ``LookupError`` (``apps.get_model`` cannot
+            # resolve the permission model). The previous ``(ImportError,
+            # Exception)`` envelope was equivalent to a bare ``except Exception``
+            # (``ImportError`` ⊂ ``Exception``): ANY error — a programming bug, a
+            # database error, a malformed grant row — was swallowed and the
+            # queryset silently dropped every guardian-granted row, UNDER-
+            # disclosing (a fail-open-to-less-data security smell) while hiding
+            # the defect. Such errors now propagate so they surface in tests and
+            # monitoring instead of quietly narrowing a user's visible set.
             logger.debug(
                 f"Could not use Guardian permissions for {self.model.__name__}: {e}. "
                 f"Using creator/public filtering only."

--- a/opencontractserver/tests/test_conversation_permissions.py
+++ b/opencontractserver/tests/test_conversation_permissions.py
@@ -766,17 +766,26 @@ class TestConversationGroupGrants(TestCase):
         """Defensive branch (issue #1986 item 3): if the conversation
         group-permission model can't be resolved, the `except LookupError`
         must degrade to user-level grants only — no crash, group grant simply
-        ignored. Mirrors the `BaseVisibilityManager` group-table fallback."""
+        ignored, and already-resolved USER-level grants preserved (the two
+        lookups live in separate try blocks precisely for this). Mirrors the
+        `BaseVisibilityManager` group-table fallback."""
         import django.apps
 
-        chat = Conversation.objects.create(
-            title="Owner's Chat",
+        # Only a GROUP grant -> must vanish when the group table is unreadable.
+        group_only_chat = Conversation.objects.create(
+            title="Group-Only Chat",
             creator=self.owner,
             conversation_type=ConversationTypeChoices.CHAT,
         )
-        # A real group grant exists, but the simulated missing table means it
-        # cannot be consulted on this call.
-        assign_perm("read_conversation", self.group, chat)
+        assign_perm("read_conversation", self.group, group_only_chat)
+
+        # A USER-level grant -> must SURVIVE the missing group table.
+        user_granted_chat = Conversation.objects.create(
+            title="User-Granted Chat",
+            creator=self.owner,
+            conversation_type=ConversationTypeChoices.CHAT,
+        )
+        assign_perm("read_conversation", self.member, user_granted_chat)
 
         real_get_model = django.apps.apps.get_model
 
@@ -791,10 +800,12 @@ class TestConversationGroupGrants(TestCase):
         with patch.object(django.apps.apps, "get_model", side_effect=fake_get_model):
             visible = list(Conversation.objects.visible_to_user(self.member))
 
-        # No crash; the un-consultable group grant is ignored, so the member
-        # does not see the chat. The owner still sees their own (no patch).
-        self.assertNotIn(chat, visible)
-        self.assertIn(chat, Conversation.objects.visible_to_user(self.owner))
+        # No crash; the un-consultable group grant is ignored...
+        self.assertNotIn(group_only_chat, visible)
+        # ...but the separately-resolved user-level grant is NOT discarded.
+        self.assertIn(user_granted_chat, visible)
+        # Owner still sees their own (no patch active here).
+        self.assertIn(group_only_chat, Conversation.objects.visible_to_user(self.owner))
 
     def test_missing_message_group_table_falls_back_gracefully(self):
         """Defensive branch (issue #1986 item 3): the message-level

--- a/opencontractserver/tests/test_conversation_permissions.py
+++ b/opencontractserver/tests/test_conversation_permissions.py
@@ -840,7 +840,9 @@ class TestConversationGroupGrants(TestCase):
     def test_missing_message_group_table_falls_back_gracefully(self):
         """Defensive branch (issue #1986 item 3): the message-level
         `except LookupError` for the chat-message group-permission model must
-        degrade gracefully (group grant ignored, no crash)."""
+        degrade gracefully — group grant ignored, no crash, and already-resolved
+        USER-level message grants preserved (separate try blocks). Mirrors the
+        conversation counterpart's positive/negative assertions."""
         import django.apps
 
         chat = Conversation.objects.create(
@@ -848,13 +850,24 @@ class TestConversationGroupGrants(TestCase):
             creator=self.owner,
             conversation_type=ConversationTypeChoices.CHAT,
         )
-        message = ChatMessage.objects.create(
+        # Only a GROUP grant on the message -> must vanish when the group table
+        # is unreadable (the parent CHAT is hidden from the member too).
+        group_only_message = ChatMessage.objects.create(
             conversation=chat,
             creator=self.owner,
             msg_type=MessageTypeChoices.HUMAN,
             content="group-shared message",
         )
-        assign_perm("read_chatmessage", self.group, message)
+        assign_perm("read_chatmessage", self.group, group_only_message)
+
+        # A USER-level message grant -> must SURVIVE the missing group table.
+        user_granted_message = ChatMessage.objects.create(
+            conversation=chat,
+            creator=self.owner,
+            msg_type=MessageTypeChoices.HUMAN,
+            content="user-shared message",
+        )
+        assign_perm("read_chatmessage", self.member, user_granted_message)
 
         real_get_model = django.apps.apps.get_model
 
@@ -867,9 +880,10 @@ class TestConversationGroupGrants(TestCase):
         with patch.object(django.apps.apps, "get_model", side_effect=fake_get_model):
             visible = list(ChatMessage.objects.visible_to_user(self.member))
 
-        # The message group grant cannot be consulted and the parent CHAT is
-        # hidden, so the member does not see the message — and nothing raised.
-        self.assertNotIn(message, visible)
+        # Group-only message vanishes (table unreadable, parent CHAT hidden)...
+        self.assertNotIn(group_only_message, visible)
+        # ...but the separately-resolved user-level message grant is preserved.
+        self.assertIn(user_granted_message, visible)
 
 
 class TestConversationService(TestCase):

--- a/opencontractserver/tests/test_conversation_permissions.py
+++ b/opencontractserver/tests/test_conversation_permissions.py
@@ -15,6 +15,7 @@ Key test scenarios:
 """
 
 from types import SimpleNamespace
+from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser, Group
@@ -760,6 +761,74 @@ class TestConversationGroupGrants(TestCase):
         )
         # Outsider (not in the group) still cannot see it.
         self.assertNotIn(message, ChatMessage.objects.visible_to_user(self.outsider))
+
+    def test_missing_conversation_group_table_falls_back_gracefully(self):
+        """Defensive branch (issue #1986 item 3): if the conversation
+        group-permission model can't be resolved, the `except LookupError`
+        must degrade to user-level grants only — no crash, group grant simply
+        ignored. Mirrors the `BaseVisibilityManager` group-table fallback."""
+        import django.apps
+
+        chat = Conversation.objects.create(
+            title="Owner's Chat",
+            creator=self.owner,
+            conversation_type=ConversationTypeChoices.CHAT,
+        )
+        # A real group grant exists, but the simulated missing table means it
+        # cannot be consulted on this call.
+        assign_perm("read_conversation", self.group, chat)
+
+        real_get_model = django.apps.apps.get_model
+
+        def fake_get_model(app_label, model_name=None, *args, **kwargs):
+            name = model_name if model_name is not None else app_label
+            # Surgically fail ONLY the conversation group-permission lookup so
+            # the user-level lookup (and Corpus/Document visibility) stay real.
+            if isinstance(name, str) and name == "conversationgroupobjectpermission":
+                raise LookupError("simulated missing group permission table")
+            return real_get_model(app_label, model_name, *args, **kwargs)
+
+        with patch.object(django.apps.apps, "get_model", side_effect=fake_get_model):
+            visible = list(Conversation.objects.visible_to_user(self.member))
+
+        # No crash; the un-consultable group grant is ignored, so the member
+        # does not see the chat. The owner still sees their own (no patch).
+        self.assertNotIn(chat, visible)
+        self.assertIn(chat, Conversation.objects.visible_to_user(self.owner))
+
+    def test_missing_message_group_table_falls_back_gracefully(self):
+        """Defensive branch (issue #1986 item 3): the message-level
+        `except LookupError` for the chat-message group-permission model must
+        degrade gracefully (group grant ignored, no crash)."""
+        import django.apps
+
+        chat = Conversation.objects.create(
+            title="Owner's Chat",
+            creator=self.owner,
+            conversation_type=ConversationTypeChoices.CHAT,
+        )
+        message = ChatMessage.objects.create(
+            conversation=chat,
+            creator=self.owner,
+            msg_type=MessageTypeChoices.HUMAN,
+            content="group-shared message",
+        )
+        assign_perm("read_chatmessage", self.group, message)
+
+        real_get_model = django.apps.apps.get_model
+
+        def fake_get_model(app_label, model_name=None, *args, **kwargs):
+            name = model_name if model_name is not None else app_label
+            if isinstance(name, str) and name == "chatmessagegroupobjectpermission":
+                raise LookupError("simulated missing group permission table")
+            return real_get_model(app_label, model_name, *args, **kwargs)
+
+        with patch.object(django.apps.apps, "get_model", side_effect=fake_get_model):
+            visible = list(ChatMessage.objects.visible_to_user(self.member))
+
+        # The message group grant cannot be consulted and the parent CHAT is
+        # hidden, so the member does not see the message — and nothing raised.
+        self.assertNotIn(message, visible)
 
 
 class TestConversationService(TestCase):

--- a/opencontractserver/tests/test_conversation_permissions.py
+++ b/opencontractserver/tests/test_conversation_permissions.py
@@ -762,6 +762,36 @@ class TestConversationGroupGrants(TestCase):
         # Outsider (not in the group) still cannot see it.
         self.assertNotIn(message, ChatMessage.objects.visible_to_user(self.outsider))
 
+    def test_conversation_group_grant_makes_messages_visible(self):
+        """The common path (issue #1986 item 3): a group grant on the
+        *conversation* surfaces its *messages* via the ``conversation_visible``
+        inheritance branch — distinct from a direct message-level grant. Pins
+        the integration between the conversation group-grant fix and message
+        visibility so removing the ``conversation_visible`` branch can't
+        silently regress it."""
+        chat = Conversation.objects.create(
+            title="Owner's Chat",
+            creator=self.owner,
+            conversation_type=ConversationTypeChoices.CHAT,
+        )
+        message = ChatMessage.objects.create(
+            conversation=chat,
+            creator=self.owner,
+            msg_type=MessageTypeChoices.HUMAN,
+            content="via-conversation-grant",
+        )
+
+        # No grant -> the member sees neither the conversation nor its messages.
+        self.assertNotIn(message, ChatMessage.objects.visible_to_user(self.member))
+
+        # Conversation-level group grant (NOT a message-level grant) -> the
+        # message surfaces through conversation visibility inheritance.
+        assign_perm("read_conversation", self.group, chat)
+
+        self.assertIn(message, ChatMessage.objects.visible_to_user(self.member))
+        # Outsider (not in the group) still cannot see it.
+        self.assertNotIn(message, ChatMessage.objects.visible_to_user(self.outsider))
+
     def test_missing_conversation_group_table_falls_back_gracefully(self):
         """Defensive branch (issue #1986 item 3): if the conversation
         group-permission model can't be resolved, the `except LookupError`

--- a/opencontractserver/tests/test_conversation_permissions.py
+++ b/opencontractserver/tests/test_conversation_permissions.py
@@ -17,7 +17,7 @@ Key test scenarios:
 from types import SimpleNamespace
 
 from django.contrib.auth import get_user_model
-from django.contrib.auth.models import AnonymousUser
+from django.contrib.auth.models import AnonymousUser, Group
 from django.test import TestCase
 from guardian.shortcuts import assign_perm
 
@@ -30,6 +30,7 @@ from opencontractserver.conversations.models import (
 from opencontractserver.conversations.services import ConversationService
 from opencontractserver.corpuses.models import Corpus
 from opencontractserver.documents.models import Document
+from opencontractserver.types.enums import PermissionTypes
 
 User = get_user_model()
 
@@ -588,6 +589,177 @@ class TestChatMessageInheritedPermissions(TestCase):
         # Alice (corpus owner) can see Bob's message as moderator
         visible_to_alice = ChatMessage.objects.visible_to_user(self.alice)
         self.assertIn(message, visible_to_alice)
+
+    def test_anonymous_message_visibility_follows_conversation_bifurcation(self):
+        """Regression for issue #1986 item 2.
+
+        Anonymous ChatMessage visibility must mirror anonymous *conversation*
+        visibility (the CHAT/THREAD bifurcation): public THREADs — and threads
+        on public corpuses via context inheritance — are visible, but a public
+        CHAT's messages are NOT, because the conversation itself stays hidden
+        from anonymous users. The old anonymous branch filtered
+        ``conversation__is_public=True`` alone, which both leaked a public
+        CHAT's messages and missed context-inherited thread messages.
+        """
+        public_corpus = Corpus.objects.create(
+            title="Public Corpus",
+            creator=self.alice,
+            is_public=True,
+        )
+
+        # Public THREAD -> message visible to anonymous.
+        public_thread = Conversation.objects.create(
+            title="Public Thread",
+            creator=self.alice,
+            conversation_type=ConversationTypeChoices.THREAD,
+            is_public=True,
+        )
+        public_thread_msg = ChatMessage.objects.create(
+            conversation=public_thread,
+            creator=self.alice,
+            msg_type=MessageTypeChoices.HUMAN,
+            content="visible to anon",
+        )
+
+        # Public CHAT -> message must stay hidden (the item-2 leak): the
+        # conversation itself is anonymous-hidden, so its messages must be too.
+        public_chat = Conversation.objects.create(
+            title="Public Chat",
+            creator=self.alice,
+            conversation_type=ConversationTypeChoices.CHAT,
+            is_public=True,
+        )
+        public_chat_msg = ChatMessage.objects.create(
+            conversation=public_chat,
+            creator=self.alice,
+            msg_type=MessageTypeChoices.HUMAN,
+            content="must stay hidden from anon",
+        )
+
+        # THREAD on a public corpus (conversation NOT public) -> message
+        # visible via context inheritance, matching conversation visibility.
+        ctx_thread = Conversation.objects.create(
+            title="Thread on Public Corpus",
+            chat_with_corpus=public_corpus,
+            creator=self.alice,
+            conversation_type=ConversationTypeChoices.THREAD,
+            is_public=False,
+        )
+        ctx_thread_msg = ChatMessage.objects.create(
+            conversation=ctx_thread,
+            creator=self.alice,
+            msg_type=MessageTypeChoices.HUMAN,
+            content="visible via context inheritance",
+        )
+
+        # Private THREAD (on the private setUp corpus) -> message hidden.
+        private_thread = Conversation.objects.create(
+            title="Private Thread",
+            chat_with_corpus=self.corpus,
+            creator=self.alice,
+            conversation_type=ConversationTypeChoices.THREAD,
+            is_public=False,
+        )
+        private_thread_msg = ChatMessage.objects.create(
+            conversation=private_thread,
+            creator=self.alice,
+            msg_type=MessageTypeChoices.HUMAN,
+            content="hidden from anon",
+        )
+
+        visible = ChatMessage.objects.visible_to_user(AnonymousUser())
+
+        self.assertIn(public_thread_msg, visible)
+        self.assertNotIn(public_chat_msg, visible)  # the item-2 fix
+        self.assertIn(ctx_thread_msg, visible)
+        self.assertNotIn(private_thread_msg, visible)
+
+        public_corpus.delete()
+
+
+class TestConversationGroupGrants(TestCase):
+    """Group-level guardian READ grants must unlock conversations and messages.
+
+    Regression for issue #1986 item 3: ``ConversationQuerySet`` /
+    ``ChatMessageQuerySet`` consulted only USER object-permission tables.
+    Because ``user_can(READ)`` routes through ``visible_to_user`` for these
+    models, a group-only READ grant was both invisible in lists AND denied by
+    ``user_can(READ)`` — even though non-READ writes (``_default_user_can``)
+    honour the same group grant. The fix joins the group tables so filter and
+    check agree (the same gap PR #1985 closed for annotations / relationships /
+    extracts).
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.owner = User.objects.create_user(
+            username="grant_owner", email="grant_owner@test.com", password="pw"
+        )
+        cls.member = User.objects.create_user(
+            username="grant_member", email="grant_member@test.com", password="pw"
+        )
+        cls.outsider = User.objects.create_user(
+            username="grant_outsider", email="grant_outsider@test.com", password="pw"
+        )
+        cls.group = Group.objects.create(name="conversation-readers")
+        cls.member.groups.add(cls.group)
+
+    def tearDown(self):
+        ChatMessage.all_objects.all().delete()
+        Conversation.all_objects.all().delete()
+
+    def test_group_read_grant_makes_conversation_visible_and_passes_user_can(self):
+        chat = Conversation.objects.create(
+            title="Owner's Chat",
+            creator=self.owner,
+            conversation_type=ConversationTypeChoices.CHAT,
+        )
+
+        # Before the grant: invisible in lists AND user_can(READ) denies.
+        self.assertNotIn(chat, Conversation.objects.visible_to_user(self.member))
+        self.assertFalse(
+            Conversation.objects.user_can(self.member, chat, PermissionTypes.READ)
+        )
+
+        assign_perm("read_conversation", self.group, chat)
+
+        # After the group grant: visible AND user_can(READ) grants (parity).
+        self.assertIn(chat, Conversation.objects.visible_to_user(self.member))
+        self.assertTrue(
+            Conversation.objects.user_can(self.member, chat, PermissionTypes.READ)
+        )
+
+        # A user NOT in the group still cannot see it.
+        self.assertNotIn(chat, Conversation.objects.visible_to_user(self.outsider))
+
+    def test_group_read_grant_makes_message_visible(self):
+        # A CHAT the member cannot otherwise see (not creator, not public).
+        chat = Conversation.objects.create(
+            title="Owner's Chat",
+            creator=self.owner,
+            conversation_type=ConversationTypeChoices.CHAT,
+        )
+        message = ChatMessage.objects.create(
+            conversation=chat,
+            creator=self.owner,
+            msg_type=MessageTypeChoices.HUMAN,
+            content="group-shared message",
+        )
+
+        # No grant -> message invisible (conversation is hidden too).
+        self.assertNotIn(message, ChatMessage.objects.visible_to_user(self.member))
+
+        # Direct message-level group grant unlocks it via the message branch.
+        assign_perm("read_chatmessage", self.group, message)
+
+        self.assertIn(message, ChatMessage.objects.visible_to_user(self.member))
+        # Parity: user_can(READ) on the message agrees with the list filter.
+        self.assertTrue(
+            ChatMessage.objects.user_can(self.member, message, PermissionTypes.READ)
+        )
+        # Outsider (not in the group) still cannot see it.
+        self.assertNotIn(message, ChatMessage.objects.visible_to_user(self.outsider))
 
 
 class TestConversationService(TestCase):

--- a/opencontractserver/tests/test_metadata_columns.py
+++ b/opencontractserver/tests/test_metadata_columns.py
@@ -350,3 +350,65 @@ class TestMetadataColumns(TestCase):
         # Should save without validation errors
         datacell.save()
         self.assertTrue(datacell.id)
+
+    def test_manual_entry_with_null_validation_config_does_not_crash(self):
+        """Regression for issue #1986 item 7.
+
+        ``Column.validation_config`` is a nullable JSONField, so it can be
+        ``None``. ``Datacell._validate_manual_entry`` read
+        ``self.column.validation_config.get("required")`` in the "missing
+        value" branch *before* the ``config = ... or {}`` guard, raising
+        ``AttributeError: 'NoneType' object has no attribute 'get'`` whenever a
+        manual-entry cell with no ``value`` key was validated on a config-less
+        column. With no config nothing is required, so validation must succeed
+        instead of crashing.
+        """
+        column = Column.objects.create(
+            fieldset=self.fieldset,
+            name="No Config",
+            data_type="STRING",
+            validation_config=None,  # nullable JSONField — legitimately None
+            is_manual_entry=True,
+            output_type="string",
+            creator=self.user,
+        )
+        # Confirm ``None`` round-trips through the DB (not coerced to ``{}``),
+        # so the regression path is genuinely exercised.
+        column.refresh_from_db()
+        self.assertIsNone(column.validation_config)
+
+        # No "value" key + no validation_config => nothing required => valid.
+        datacell = Datacell(
+            column=column,
+            document=self.document,
+            data={},
+            data_definition="string",
+            creator=self.user,
+        )
+        datacell.full_clean()  # must not raise AttributeError
+        datacell.save()
+        self.assertTrue(datacell.id)
+
+    def test_manual_entry_null_config_still_enforces_required_when_set(self):
+        """A null config means *nothing* is required; a config with
+        ``required`` still raises. Guards against the item-7 fix accidentally
+        swallowing the genuine "required" error path."""
+        required_col = Column.objects.create(
+            fieldset=self.fieldset,
+            name="Required No-Value",
+            data_type="STRING",
+            validation_config={"required": True},
+            is_manual_entry=True,
+            output_type="string",
+            creator=self.user,
+        )
+        datacell = Datacell(
+            column=required_col,
+            document=self.document,
+            data={},  # no "value" key at all
+            data_definition="string",
+            creator=self.user,
+        )
+        with self.assertRaises(ValidationError) as context:
+            datacell.full_clean()
+        self.assertIn("is required", str(context.exception))

--- a/opencontractserver/tests/test_shared_managers.py
+++ b/opencontractserver/tests/test_shared_managers.py
@@ -270,6 +270,62 @@ class BaseVisibilityManagerSuperuserComputedNormallyTest(TestCase):
         self.assertIn(self.public_embedding.pk, ids)
         self.assertNotIn(self.private_embedding.pk, ids)
 
+    def test_unexpected_permission_lookup_error_propagates(self) -> None:
+        """Regression for issue #1986 item 4.
+
+        ``BaseVisibilityManager.visible_to_user`` used to wrap its guardian
+        lookup in ``except (ImportError, Exception)`` — equivalent to a bare
+        ``except Exception`` (``ImportError`` ⊂ ``Exception``). ANY unexpected
+        error (a programming bug, a DB error, a malformed grant row) was
+        swallowed and the queryset silently degraded to creator/public
+        filtering, UNDER-disclosing guardian-granted rows while hiding the
+        defect. The catch is now ``(ImportError, LookupError)``, so a
+        non-LookupError surfaces instead of quietly narrowing the visible set.
+        """
+        import django.apps
+
+        real_get_model = django.apps.apps.get_model
+
+        def fake_get_model(app_label, model_name=None, *args, **kwargs):
+            name = model_name if model_name is not None else app_label
+            # Only the user-level permission-table lookup blows up; every other
+            # get_model (related-model resolution during query build) is real.
+            if isinstance(name, str) and name.endswith("userobjectpermission"):
+                raise ValueError("simulated unexpected guardian lookup failure")
+            return real_get_model(app_label, model_name, *args, **kwargs)
+
+        with patch.object(django.apps.apps, "get_model", side_effect=fake_get_model):
+            with self.assertRaises(ValueError):
+                # Authenticated, non-owner: reaches the guardian lookup branch.
+                self.Embedding.objects.visible_to_user(user=self.other)
+
+    def test_missing_permission_table_still_falls_back_gracefully(self) -> None:
+        """The narrowed catch must still tolerate a genuinely absent permission
+        table: a ``LookupError`` degrades to creator/public filtering with no
+        raise (the documented fallback). Pins the other half of the item-4
+        envelope so future over-narrowing doesn't turn the legitimate
+        missing-table case into a hard error."""
+        import django.apps
+
+        real_get_model = django.apps.apps.get_model
+
+        def fake_get_model(app_label, model_name=None, *args, **kwargs):
+            name = model_name if model_name is not None else app_label
+            if isinstance(name, str) and name.endswith(
+                ("userobjectpermission", "groupobjectpermission")
+            ):
+                raise LookupError("simulated missing permission table")
+            return real_get_model(app_label, model_name, *args, **kwargs)
+
+        with patch.object(django.apps.apps, "get_model", side_effect=fake_get_model):
+            qs = self.Embedding.objects.visible_to_user(user=self.other)
+            ids = set(qs.values_list("pk", flat=True))
+
+        # Fallback = creator/public only; ``self.other`` is neither owner nor
+        # grantee, so only the public embedding remains visible.
+        self.assertIn(self.public_embedding.pk, ids)
+        self.assertNotIn(self.private_embedding.pk, ids)
+
 
 class PermissionManagerSuperuserComputedNormallyTest(TestCase):
     """


### PR DESCRIPTION
## Summary

Addresses the **surgical, still-present security + correctness items** from the #1986 permissioning-audit tracking issue. #1986 lists 14 follow-ups of widely varying scope; this PR takes the four that are unambiguous, high-value, and genuinely surgical, and dispositions the rest below (rather than forcing risky/architectural changes into one PR — per the "don't run wild" guidance).

Refs #1986 (intentionally **not** `Closes`, since 14 items remain on the tracker).

## Fixes in this PR

### Item 2 — anonymous chat-message visibility now follows the CHAT/THREAD bifurcation *(security)*
`ChatMessageQuerySet.visible_to_user`'s anonymous branch filtered `conversation__is_public=True` alone (`opencontractserver/conversations/models.py`). But `ConversationQuerySet.visible_to_user` keeps a public **CHAT** hidden from anonymous users (anonymous can only see THREADs), so a public CHAT's *messages* were anonymous-visible while the conversation itself was not. The branch now delegates to `Conversation.objects.visible_to_user` — the single source of truth — so messages inherit the bifurcation. This also fixes a latent **under**-disclosure: messages in context-inherited public-resource threads are now visible, matching conversation visibility and the authenticated path (which already delegates the same way).

### Item 3 — conversation/message querysets honour group-level READ grants *(security)*
`ConversationQuerySet` / `ChatMessageQuerySet` consulted only the **user**-level object-permission tables. Because `ConversationManager.user_can(READ)` / `ChatMessageManager.user_can(READ)` route *back through* `visible_to_user`, a group-only READ grant was **entirely non-functional** for these models — invisible in lists *and* denied by `user_can(READ)` — even though non-READ writes (`_default_user_can`) honour the same group grant. Both querysets now join the `*groupobjectpermission` tables (mirroring `BaseVisibilityManager`), closing the same filter/check group-grant gap PR #1985 closed for annotations/relationships/extracts.

### Item 4 — `BaseVisibilityManager.visible_to_user` stops swallowing unexpected errors *(security)*
The guardian-lookup fallback caught `(ImportError, Exception)` — equivalent to a bare `except Exception` (`ImportError ⊂ Exception`). Any error (programming bug, DB error, malformed grant row) silently degraded the queryset to creator/public filtering, **under-disclosing** guardian-granted rows while hiding the defect (`opencontractserver/shared/Managers.py`). Narrowed to `(ImportError, LookupError)`: a genuinely-absent permission table still degrades gracefully, but real errors now propagate.

### Item 7 — `Datacell._validate_manual_entry` AttributeError *(correctness)*
The "required" check read `self.column.validation_config.get("required")` *before* the `config = ... or {}` guard (`opencontractserver/extracts/models.py`). `validation_config` is a nullable JSONField, so validating a manual-entry cell with no `value` key on a config-less column raised `'NoneType' object has no attribute 'get'`. The `or {}` guard is hoisted and reused.

## Tests
- `test_conversation_permissions.py`: anonymous message bifurcation (item 2) + new `TestConversationGroupGrants` (item 3, asserting filter↔`user_can` parity for both conversations and messages).
- `test_shared_managers.py`: item 4 — unexpected error propagates; missing permission table still falls back gracefully (both halves of the narrowed envelope).
- `test_metadata_columns.py`: item 7 — null-config cell validates cleanly; a `required` config still raises.

**Validation note:** `python -m compileall`, `black --check`, `flake8`, and `scripts/collate_changelog.py --check` all pass locally. The dockerized test suite could **not** be executed in this environment — base-image pulls hit Docker Hub's unauthenticated rate limit (HTTP 429) — so the new/affected tests rely on CI to run. They're written against the existing fixtures/patterns in each file.

## Disposition of the remaining #1986 items (not in this PR)

| # | Item | Disposition |
|---|------|-------------|
| 1 | Annotation-creator privacy parity | ✅ **Already fixed** by PR #1985 (`AnnotationManager.user_can` now mirrors the queryset's `Q(creator=user)` source-privacy exemption; the sentinel was replaced by `test_annotation_creator_source_private_row_has_filter_check_parity`). |
| 5 | `ExtractType` has no `get_queryset` | Deferred. graphene-django's `get_queryset` does not guard single-FK traversal (the cited `DatacellType.extract` case), and the real protections (`get_node` + service-filtered `resolve_extracts`/`resolve_analyses`) already exist; adding it risks double-filtering connections. Marginal defense-in-depth value vs. regression risk — wants its own PR + test design. |
| 6 | `DocumentRelationshipService` myPermissions under-report | Deferred. Fail-safe (the mutation gate `user_has_permission` is correct; only the UI affordance under-reports). A correct fix needs per-permission *editable-by-user* subqueries (create/update/delete × source/target doc + corpus) — a new queryset concept that's not surgical. Own PR. |
| 8 | `analysis_id == 0` sentinel | Code-quality; touches the GraphQL contract (`__none__` mapping). Separate PR. |
| 9 | `require_permission` truthiness inversion | Code-quality rename + deprecation shim across call sites. Separate PR. |
| 10 | Mention-autocomplete inline guardian | Service migration; legal under E001 today and documented as an exception. Separate PR. |
| 11 | Weak assertions in `test_query_optimizer_methods.py` | Test tightening; do when next touching that file. |
| 12 | `source_visibility.py` micro-dedup | Explicitly deferred on the issue ("only if profiling shows it matters" — compiles to one SQL statement today). |
| 13 | Guardian codename string literals repo-wide | Large repo-wide pass; explicitly declined in the PR #1985 review to avoid diverging convention in a security PR. Own PR. |
| 14 | `claude-review` workflow malfunction | Tooling/workflow bug, not a codebase fix verifiable here. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y4cYLCSNpV7ApzDggAF63Y)_