### PR TITLE
Fix enrichment linking/provenance robustness (#1996)

### DIFF
--- a/changelog.d/1996-enrichment-linking-robustness.fixed.md
+++ b/changelog.d/1996-enrichment-linking-robustness.fixed.md
@@ -1,0 +1,31 @@
+- **Enrichment linking/provenance robustness — three pre-existing bugs in
+  `opencontractserver/enrichment/services/enrichment_service.py` (issue #1996).**
+  - **Analysis stranded `COMPLETED` when linking failed.** `apply()` stamped the
+    provenance `Analysis` `COMPLETED` and saved it *before* calling
+    `_link_external()` (which issues two `bulk_update`s over potentially
+    thousands of rows). A failure there propagated to the caller while the
+    `Analysis` row stayed permanently `COMPLETED` with `law_references_linked=0`.
+    Fix: `_link_external()` now runs inside `apply()`'s `try` (after
+    `writer.write`, before the `COMPLETED` stamp), so a linking failure marks the
+    `Analysis` `FAILED` and re-raises (`enrichment_service.py:444-458`).
+  - **Nondeterministic / non-navigable `target_corpus_id` for multi-corpus
+    authority documents.** `_link_external()` built `path_corpus_cache` with
+    `dict(DocumentPath…values_list("document_id","corpus_id"))`, which silently
+    kept whatever row Postgres returned last when an authority document had
+    current paths in more than one corpus — yielding a nondeterministic
+    `target_corpus_id` and a mention `link_url` that 404s for the other corpus.
+    Fix: the target corpus is now chosen deterministically *and* navigably —
+    prefer a corpus the citing corpus's audience can actually open, breaking ties
+    on the lowest `corpus_id` (one query for paths + one for the visible-corpus
+    set; no per-target N+1) (`enrichment_service.py:620-655`).
+  - **`refs` queryset iterated twice while lazy.** The `CorpusReference`
+    queryset was walked once to build the target cache and again to
+    promote/demote; rows inserted between the two evaluations by a concurrent
+    `apply()` on the same corpus appeared in pass 2 but not the cache and were
+    silently skipped. Fix: materialize it once with `list(...)` before the first
+    loop (`enrichment_service.py:604-613`).
+  - Regression coverage added in
+    `opencontractserver/tests/test_enrichment_linking.py`
+    (`test_apply_marks_analysis_failed_when_linking_raises`,
+    `test_link_target_corpus_is_deterministic_for_multi_corpus_authority`,
+    `test_link_target_corpus_prefers_audience_visible_corpus`).

--- a/opencontractserver/enrichment/services/enrichment_service.py
+++ b/opencontractserver/enrichment/services/enrichment_service.py
@@ -662,12 +662,21 @@ class EnrichmentService:
                 continue
             target = target_cache.get(key)
             if target is not None:
+                target_corpus_id = path_corpus_cache.get(target.id)
+                if target_corpus_id is None:
+                    # find_authority_target only returns a document with a
+                    # current, non-deleted path, so target_corpus_id is normally
+                    # present; it can go missing only if that path is removed
+                    # between resolution and the path query above. Don't promote
+                    # to RESOLVED without a navigable target_corpus — that would
+                    # render the broken link this pass exists to prevent.
+                    continue
                 if (
                     ref.target_document_id != target.id
                     or ref.resolution_status != C.STATUS_RESOLVED
                 ):
                     ref.target_document = target
-                    ref.target_corpus_id = path_corpus_cache.get(target.id)
+                    ref.target_corpus_id = target_corpus_id
                     ref.resolution_status = C.STATUS_RESOLVED
                     # bulk_update bypasses auto_now — stamp ``modified``.
                     ref.modified = now

--- a/opencontractserver/enrichment/services/enrichment_service.py
+++ b/opencontractserver/enrichment/services/enrichment_service.py
@@ -444,13 +444,18 @@ class EnrichmentService:
         writer = EnrichmentWriter(corpus, creator_id, analysis=analysis)
         try:
             res = writer.write(resolutions)
+            # Cross-corpus linking is part of a successful apply and can raise
+            # (two bulk_updates over potentially thousands of rows), so it must
+            # run INSIDE the try. Stamping the Analysis COMPLETED before it ran
+            # left a permanent COMPLETED provenance row with
+            # law_references_linked=0 whenever _link_external failed (#1996).
+            link = self._link_external(user, corpus)
         except Exception:
             analysis.status = JobStatus.FAILED.value
             analysis.save(update_fields=["status"])
             raise
         analysis.status = JobStatus.COMPLETED.value
         analysis.save(update_fields=["status"])
-        link = self._link_external(user, corpus)
         return {
             "corpus_id": corpus_id,
             "analysis_id": analysis.id,
@@ -596,7 +601,12 @@ class EnrichmentService:
         # only public authorities may link; a private corpus uses its creator.
         audience = None if corpus.is_public else user
 
-        refs = (
+        # Materialize once: this queryset is walked twice (build the target
+        # cache below, then promote/demote). Left lazy, a concurrent apply() on
+        # the same corpus could insert rows that pass 2 sees but that were absent
+        # when the cache was built in pass 1 — those refs would be silently
+        # skipped (#1996).
+        refs = list(
             CorpusReference.objects.filter(corpus=corpus, reference_type=C.REF_LAW)
             .exclude(canonical_key=None)
             .select_related("source_annotation")
@@ -607,16 +617,42 @@ class EnrichmentService:
             key = ref.canonical_key
             if key and key not in target_cache:
                 target_cache[key] = find_authority_target(key, audience)
-        # Batch-fetch corpus membership for all resolved targets in one query
-        # instead of one per target (avoids N+1 on large corpora).
+        # Map each resolved target document to the corpus its in-app link should
+        # point into. A target can have current paths in several corpora, so the
+        # choice is made BOTH deterministic and navigable: prefer a corpus the
+        # citing corpus's audience can actually open, then break ties on the
+        # lowest corpus_id. The previous ``dict(values_list(...))`` did neither —
+        # it kept whatever row Postgres returned last, so target_corpus_id (and
+        # the mention link_url derived from it) was nondeterministic and could
+        # 404 for the audience (#1996). Still one query for the paths plus one
+        # for the visible-corpus set — no per-target N+1.
         resolved_target_ids = {t.id for t in target_cache.values() if t is not None}
-        path_corpus_cache: dict[int, int | None] = dict(
+        path_rows = list(
             DocumentPath.objects.filter(
                 document_id__in=resolved_target_ids,
                 is_current=True,
                 is_deleted=False,
-            ).values_list("document_id", "corpus_id")
+            )
+            .order_by("corpus_id")
+            .values_list("document_id", "corpus_id")
         )
+        audience_visible_corpus_ids = set(
+            Corpus.objects.visible_to_user(audience)
+            .filter(id__in={cid for _doc_id, cid in path_rows})
+            .values_list("id", flat=True)
+        )
+        path_corpus_cache: dict[int, int] = {}
+        for doc_id, path_corpus_id in path_rows:  # ascending corpus_id
+            incumbent = path_corpus_cache.get(doc_id)
+            # First (lowest-id) path seeds the entry; a later audience-visible
+            # corpus then supersedes a non-navigable incumbent. Net result:
+            # lowest audience-visible corpus_id, else lowest corpus_id (so a
+            # resolvable target never loses its corpus).
+            if incumbent is None or (
+                path_corpus_id in audience_visible_corpus_ids
+                and incumbent not in audience_visible_corpus_ids
+            ):
+                path_corpus_cache[doc_id] = path_corpus_id
         now = timezone.now()
         promoted: list[CorpusReference] = []
         demoted: list[CorpusReference] = []

--- a/opencontractserver/enrichment/services/enrichment_service.py
+++ b/opencontractserver/enrichment/services/enrichment_service.py
@@ -661,16 +661,16 @@ class EnrichmentService:
             if not key:  # queryset excludes None; guard for type-narrowing
                 continue
             target = target_cache.get(key)
-            if target is not None:
-                target_corpus_id = path_corpus_cache.get(target.id)
-                if target_corpus_id is None:
-                    # find_authority_target only returns a document with a
-                    # current, non-deleted path, so target_corpus_id is normally
-                    # present; it can go missing only if that path is removed
-                    # between resolution and the path query above. Don't promote
-                    # to RESOLVED without a navigable target_corpus — that would
-                    # render the broken link this pass exists to prevent.
-                    continue
+            # A navigable link needs BOTH a resolved authority document and a
+            # current corpus path to point into. The corpus is absent only in
+            # the tiny TOCTOU window where the target's path is deleted between
+            # find_authority_target (which requires a current path) and the path
+            # query above; treat that as unresolved so a stale RESOLVED ref is
+            # demoted rather than left pointing at a broken link.
+            target_corpus_id = (
+                path_corpus_cache.get(target.id) if target is not None else None
+            )
+            if target is not None and target_corpus_id is not None:
                 if (
                     ref.target_document_id != target.id
                     or ref.resolution_status != C.STATUS_RESOLVED
@@ -685,8 +685,9 @@ class EnrichmentService:
                 ref.target_document_id is not None
                 or ref.resolution_status == C.STATUS_RESOLVED
             ):
-                # Target no longer visible to the corpus's audience — degrade so
-                # the corpus never renders a broken link.
+                # Target gone, no longer audience-visible, or (rarely) its path
+                # vanished mid-pass — degrade so the corpus never renders a
+                # broken link.
                 ref.target_document_id = None
                 ref.target_corpus_id = None
                 ref.resolution_status = C.STATUS_EXTERNAL

--- a/opencontractserver/tests/test_enrichment_linking.py
+++ b/opencontractserver/tests/test_enrichment_linking.py
@@ -295,6 +295,14 @@ class CrossCorpusLinkingTests(TestCase):
         auth = self._bootstrap_dgcl()
         auth_doc = Document.objects.get(custom_meta__canonical_key="dgcl:145")
 
+        # Premise: the bootstrapper left a current path in the auth corpus, so
+        # the tie-break below is between two real corpora (guards against a
+        # future setup change that would leave only the mirror path and make the
+        # assertion exercise nothing).
+        assert DocumentPath.objects.filter(
+            document=auth_doc, corpus_id=auth["corpus_id"], is_current=True
+        ).exists()
+
         # Same authority document, second current path in another visible corpus.
         second = Corpus.objects.create(title="Mirror DGCL", creator=self.user)
         self._mirror_path(auth_doc, second, self.user, "/documents/dgcl-145-mirror")
@@ -343,6 +351,7 @@ class CrossCorpusLinkingTests(TestCase):
         assert out["law_references_linked"] >= 1
         ref = CorpusReference.objects.get(corpus=self.corpus, canonical_key="dgcl:145")
         assert ref.resolution_status == C.STATUS_RESOLVED
+        assert ref.target_document is not None
         # The navigable (public) corpus wins over the lower-id private mirror.
         assert ref.target_corpus_id == auth_corpus.id
         assert ref.target_corpus_id != private_mirror.id

--- a/opencontractserver/tests/test_enrichment_linking.py
+++ b/opencontractserver/tests/test_enrichment_linking.py
@@ -360,3 +360,32 @@ class CrossCorpusLinkingTests(TestCase):
             f"/d/{auth_corpus.creator.slug}/{auth_corpus.slug}"
             f"/{ref.target_document.slug}"
         )
+
+    def test_resolved_target_without_current_path_is_not_promoted(self):
+        """Defensive guard (#1996): a target with no current navigable path must
+        NOT be promoted to RESOLVED with a null target_corpus (which would render
+        a broken link). Normally unreachable — find_authority_target only returns
+        documents with a current path — so it is exercised here by patching the
+        resolver to return a path-less document, simulating a path removed
+        between resolution and the corpus-path query.
+        """
+        EnrichmentService().apply(corpus_id=self.corpus.id, creator_id=self.user.id)
+        # A document with NO DocumentPath -> absent from path_corpus_cache.
+        orphan = Document.objects.create(title="Orphan authority", creator=self.user)
+
+        # Patch the symbol on the authorities module: _link_external imports it
+        # locally (`from ...authorities import find_authority_target`), so the
+        # name is resolved from that module at call time.
+        with mock.patch(
+            "opencontractserver.enrichment.authorities.find_authority_target",
+            return_value=orphan,
+        ):
+            out = EnrichmentService().link_external_references(
+                corpus_id=self.corpus.id, creator_id=self.user.id
+            )
+
+        assert out["law_references_linked"] == 0
+        ref = CorpusReference.objects.get(corpus=self.corpus, canonical_key="dgcl:145")
+        assert ref.resolution_status == C.STATUS_EXTERNAL
+        assert ref.target_document_id is None
+        assert ref.target_corpus_id is None

--- a/opencontractserver/tests/test_enrichment_linking.py
+++ b/opencontractserver/tests/test_enrichment_linking.py
@@ -389,3 +389,31 @@ class CrossCorpusLinkingTests(TestCase):
         assert ref.resolution_status == C.STATUS_EXTERNAL
         assert ref.target_document_id is None
         assert ref.target_corpus_id is None
+
+    def test_resolved_ref_demoted_when_target_loses_navigable_path(self):
+        """The flip side of the guard (#1996): a ref already RESOLVED from a
+        prior pass whose target loses its current navigable path must be DEMOTED
+        to EXTERNAL on the next pass — not left RESOLVED with a stale, broken
+        link. Same path-less-target simulation, but starting from a resolved ref.
+        """
+        self._bootstrap_dgcl()
+        EnrichmentService().apply(corpus_id=self.corpus.id, creator_id=self.user.id)
+        ref = CorpusReference.objects.get(corpus=self.corpus, canonical_key="dgcl:145")
+        assert ref.resolution_status == C.STATUS_RESOLVED  # precondition
+
+        orphan = Document.objects.create(title="Orphan authority", creator=self.user)
+        with mock.patch(
+            "opencontractserver.enrichment.authorities.find_authority_target",
+            return_value=orphan,
+        ):
+            out = EnrichmentService().link_external_references(
+                corpus_id=self.corpus.id, creator_id=self.user.id
+            )
+
+        assert out["links_demoted"] >= 1
+        ref.refresh_from_db()
+        assert ref.resolution_status == C.STATUS_EXTERNAL
+        assert ref.target_document_id is None
+        assert ref.target_corpus_id is None
+        # The mention stops rendering as a clickable link.
+        assert ref.source_annotation.link_url is None

--- a/opencontractserver/tests/test_enrichment_linking.py
+++ b/opencontractserver/tests/test_enrichment_linking.py
@@ -1,18 +1,22 @@
 """Tests for the cross-corpus resolution pass (EXTERNAL law refs -> RESOLVED)."""
 
+from unittest import mock
+
 from django.contrib.auth import get_user_model
 from django.core.files.base import ContentFile
 from django.test import TestCase
 
+from opencontractserver.analyzer.models import Analysis
 from opencontractserver.annotations.models import CorpusReference
 from opencontractserver.corpuses.models import Corpus
-from opencontractserver.documents.models import Document
+from opencontractserver.documents.models import Document, DocumentPath
 from opencontractserver.enrichment import constants as C
 from opencontractserver.enrichment.authorities import (
     AuthorityCorpusBootstrapper,
     AuthoritySection,
 )
 from opencontractserver.enrichment.services import EnrichmentService
+from opencontractserver.types.enums import JobStatus
 
 User = get_user_model()
 
@@ -240,3 +244,110 @@ class CrossCorpusLinkingTests(TestCase):
         ref = CorpusReference.objects.get(corpus=self.corpus, canonical_key="dgcl:145")
         assert ref.resolution_status == C.STATUS_RESOLVED
         assert ref.target_document is not None
+
+    # -- #1996 regressions -------------------------------------------------- #
+
+    @staticmethod
+    def _mirror_path(document, corpus, user, path):
+        """Give ``document`` an additional current path in ``corpus``.
+
+        Authority documents can have current paths in more than one corpus;
+        ``add_document`` makes corpus-isolated copies, so the multi-corpus state
+        is materialised directly via the path record (the shape #1996 hits).
+        """
+        return DocumentPath.objects.create(
+            document=document,
+            corpus=corpus,
+            path=path,
+            version_number=1,
+            parent=None,
+            is_current=True,
+            is_deleted=False,
+            creator=user,
+        )
+
+    def test_apply_marks_analysis_failed_when_linking_raises(self):
+        """Provenance integrity (#1996): when ``_link_external`` raises, the
+        Analysis must end FAILED — not stranded COMPLETED with
+        ``law_references_linked=0``. Linking now runs inside ``apply()``'s
+        try/except, after ``writer.write`` and before the COMPLETED stamp.
+        """
+        with mock.patch.object(
+            EnrichmentService, "_link_external", side_effect=RuntimeError("boom")
+        ):
+            with self.assertRaises(RuntimeError):
+                EnrichmentService().apply(
+                    corpus_id=self.corpus.id, creator_id=self.user.id
+                )
+
+        analysis = (
+            Analysis.objects.filter(analyzed_corpus=self.corpus).order_by("-id").first()
+        )
+        assert analysis is not None
+        assert analysis.status == JobStatus.FAILED.value
+
+    def test_link_target_corpus_is_deterministic_for_multi_corpus_authority(self):
+        """A target reachable from >1 corpus must yield a STABLE
+        ``target_corpus_id`` — the lowest corpus_id — not whatever row Postgres
+        returned last from a bare ``dict(values_list(...))`` (#1996).
+        """
+        EnrichmentService().apply(corpus_id=self.corpus.id, creator_id=self.user.id)
+        auth = self._bootstrap_dgcl()
+        auth_doc = Document.objects.get(custom_meta__canonical_key="dgcl:145")
+
+        # Same authority document, second current path in another visible corpus.
+        second = Corpus.objects.create(title="Mirror DGCL", creator=self.user)
+        self._mirror_path(auth_doc, second, self.user, "/documents/dgcl-145-mirror")
+
+        EnrichmentService().link_external_references(
+            corpus_id=self.corpus.id, creator_id=self.user.id
+        )
+        ref = CorpusReference.objects.get(corpus=self.corpus, canonical_key="dgcl:145")
+        assert ref.resolution_status == C.STATUS_RESOLVED
+        # Deterministic tie-break: lowest corpus_id among the target's corpora.
+        assert ref.target_corpus_id == min(auth["corpus_id"], second.id)
+
+    def test_link_target_corpus_prefers_audience_visible_corpus(self):
+        """Navigability (#1996): a target reachable from several corpora links
+        into one the citing corpus's audience can actually open. For a public
+        citing corpus the audience floor is anonymous, so a private mirror is
+        skipped in favour of the public authority corpus — even when the private
+        mirror has the LOWER corpus_id (so the choice is driven by visibility,
+        not merely the lowest id).
+        """
+        # Private mirror created FIRST -> it gets the lower corpus_id.
+        private_mirror = Corpus.objects.create(
+            title="Private mirror", creator=self.user
+        )
+
+        # Public citing corpus -> audience floor is anonymous.
+        self.corpus.is_public = True
+        self.corpus.save()
+
+        auth = self._bootstrap_dgcl()  # auth corpus gets the HIGHER id
+        auth_corpus = Corpus.objects.select_related("creator").get(pk=auth["corpus_id"])
+        # Publish the authority the production way (propagates is_public to its
+        # documents) so the target is visible to the anonymous floor.
+        auth_corpus.is_public = True
+        auth_corpus.save(update_fields=["is_public", "modified"])
+        auth_doc = Document.objects.get(custom_meta__canonical_key="dgcl:145")
+
+        self._mirror_path(
+            auth_doc, private_mirror, self.user, "/documents/dgcl-145-private"
+        )
+        assert private_mirror.id < auth_corpus.id  # guards the test's premise
+
+        out = EnrichmentService().apply(
+            corpus_id=self.corpus.id, creator_id=self.user.id
+        )
+        assert out["law_references_linked"] >= 1
+        ref = CorpusReference.objects.get(corpus=self.corpus, canonical_key="dgcl:145")
+        assert ref.resolution_status == C.STATUS_RESOLVED
+        # The navigable (public) corpus wins over the lower-id private mirror.
+        assert ref.target_corpus_id == auth_corpus.id
+        assert ref.target_corpus_id != private_mirror.id
+        # …and the rendered mention link points into the public authority corpus.
+        assert ref.source_annotation.link_url == (
+            f"/d/{auth_corpus.creator.slug}/{auth_corpus.slug}"
+            f"/{ref.target_document.slug}"
+        )


### PR DESCRIPTION
Closes #1996.

Fixes the three pre-existing bugs flagged in #1996, all in
`opencontractserver/enrichment/services/enrichment_service.py`. Each was confirmed
still present on `main`. The changes are localized to `apply()` and
`_link_external()` — no architectural changes.

## 1. `Analysis` stranded `COMPLETED` when linking failed
`apply()` stamped the provenance `Analysis` `COMPLETED` and saved it **before**
calling `_link_external()`, which issues two `bulk_update`s over potentially
thousands of rows. If linking raised, the exception propagated to the caller while
the `Analysis` row stayed permanently `COMPLETED` with `law_references_linked=0`.

**Fix:** `_link_external()` now runs **inside** `apply()`'s `try` (after
`writer.write`, before the `COMPLETED` stamp), so a linking failure marks the
`Analysis` `FAILED` and re-raises. The direct agent-tool path (which creates its
own `Analysis`) was fully affected; this also keeps the analyzer-framework path
consistent.

## 2. Nondeterministic / non-navigable `target_corpus_id` for multi-corpus authority documents
`_link_external()` built `path_corpus_cache` with
`dict(DocumentPath…values_list("document_id", "corpus_id"))`. When an authority
document has current paths in **more than one corpus**, `dict()` silently keeps
whatever row Postgres returns last → a nondeterministic `target_corpus_id` and a
mention `link_url` that 404s for the audience.

**Fix:** the target corpus is now chosen **deterministically *and* navigably** —
prefer a corpus the citing corpus's *audience floor* can actually open
(anonymous for a public corpus, the creator otherwise), breaking ties on the
lowest `corpus_id`; fall back to the lowest `corpus_id` so a resolvable target
never loses its corpus. Still one query for the paths plus one for the
visible-corpus set — no per-target N+1. (This addresses both options the issue
suggested: deterministic ordering *and* scoping to a navigable corpus.)

## 3. `refs` queryset iterated twice while lazy
The `CorpusReference` queryset was walked once to build the target cache and again
to promote/demote. Rows inserted between the two evaluations by a concurrent
`apply()` on the same corpus appeared in pass 2 but not the cache → silently
skipped.

**Fix:** materialize it once with `list(...)` before the first loop.

## Tests
Added three regression tests in `opencontractserver/tests/test_enrichment_linking.py`:

- `test_apply_marks_analysis_failed_when_linking_raises` — bug 1; reliably fails
  on the original code (status was `COMPLETED`).
- `test_link_target_corpus_is_deterministic_for_multi_corpus_authority` — bug 2
  determinism; reliably fails on the original code.
- `test_link_target_corpus_prefers_audience_visible_corpus` — bug 2 navigability;
  a private mirror corpus with the *lower* `corpus_id` is correctly skipped in
  favour of the public authority corpus, guarding against a naive "lowest-id only"
  fix.

Bug 3 is a defensive materialization against a true insert race that can't be
cleanly simulated in a unit test; its normal-path correctness is covered by the
existing linking suite.

All 13 tests in `test_enrichment_linking.py` pass, plus 150 adjacent
enrichment/authority/governance tests run green (`test_enrichment_writer`,
`test_enrichment_authorities`, `test_enrichment_analyzer_integration`,
`test_crawl_authorities`, `test_governance_graph`, `test_enrichment_backfill`,
`test_enrichment_tools`, `test_enrichment_run_mutation`,
`test_corpus_reference_model`, `test_corpusreference_backfill`,
`test_corpusreference_classification`). `black`, `isort`, and `flake8` are clean.

Changelog fragment: `changelog.d/1996-enrichment-linking-robustness.fixed.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fg68y5wUE2y5vmwbVW8A3x)_