### PR TITLE
Address PR #2008 review: enrichment + notification fixes (#2029)

### DIFF
--- a/changelog.d/2029-enrichment-review.changed.md
+++ b/changelog.d/2029-enrichment-review.changed.md
@@ -1,0 +1,17 @@
+- **The enrichment job list no longer silently truncates history (issue #2029 —
+  PR #2008 review).** `GET_CORPUS_ANALYSES` now requests `totalCount`
+  (`frontend/src/graphql/queries.ts`) and `EnrichmentJobList`
+  (`frontend/src/components/admin/enrichment/EnrichmentJobList.tsx`) renders a
+  "Showing the N most recent of M runs" note whenever the server holds more
+  analyses than the `first: 50` page cap returns. `totalCount` is threaded
+  through `useEnrichmentJobs` → `useOptimisticRows` to both the Admin panel and
+  the corpus enrichment card.
+- **Multi-minute enrichment elapsed times now read as `Nm Ns` / `Nh Nm`
+  (`frontend/src/components/admin/enrichment/EnrichmentJobList.tsx`).** A crawl
+  that ran 127 seconds previously rendered as the unscannable "127s"; it now
+  renders "2m 7s". Sub-minute durations are unchanged ("47s").
+- **Crawl-bound number inputs reject fractional values
+  (`frontend/src/components/admin/enrichment/EnrichmentRunner.tsx`).** Added
+  `step={1}` to the Advanced crawl-bound inputs so the browser flags
+  non-integer entries at the UI layer before they reach the `graphene.Int`
+  mutation schema.

--- a/changelog.d/2029-enrichment-review.fixed.md
+++ b/changelog.d/2029-enrichment-review.fixed.md
@@ -1,0 +1,33 @@
+- **Closed a duplicate-notification race in the analysis-status signal
+  (`opencontractserver/notifications/signals.py`, issue #2029 — PR #2008
+  review).** The handler guarded duplicate `ANALYSIS_RUNNING/COMPLETE/FAILED`
+  notifications with a `Notification.objects.filter(...).exists()` check
+  followed by a separate `.create()`. Two concurrent `Analysis.post_save`
+  signals (e.g. a Celery worker plus an in-process save) could both pass the
+  `exists()` check before either committed, leaking duplicate rows. The
+  check-then-create pair is now a single atomic `get_or_create`, backed by a new
+  partial unique constraint `uniq_notification_per_analysis_type` on
+  `(analysis, notification_type)` (`condition=analysis NOT NULL`) added in
+  `opencontractserver/notifications/migrations/0007_notification_analysis_idempotency_constraint.py`.
+  The migration de-dupes any pre-existing rows (keeping the earliest) before
+  adding the constraint; the partial condition leaves the many analysis-less
+  notification types unconstrained.
+- **`runCorpusEnrichment` now rejects unknown `reference_types` instead of
+  silently dropping them (`config/graphql/enrichment_mutations.py`).** A request
+  whose `reference_types` contained only unrecognised codes previously filtered
+  to an empty list, left `types` unset, and ran enrichment against ALL reference
+  types — the opposite of the caller's intent. The mutation now returns
+  `ok=False` naming the unknown code(s) and dispatches nothing.
+- **`runCorpusEnrichment` surfaces partial success
+  (`config/graphql/enrichment_mutations.py`).** When the enrichment analyzer
+  dispatches but the authority crawl fails, the mutation now returns `ok=True`
+  with the already-running enrichment row and a non-fatal message — previously
+  it returned `ok=False` with the enrichment row mixed in, leading callers to
+  treat the whole request as failed and retry (double-dispatching enrichment).
+  The Runner (`frontend/src/components/admin/enrichment/EnrichmentRunner.tsx`)
+  surfaces the message as a warning toast.
+- **Forwarded `request` to the corpus UPDATE check in
+  `AnalysisLifecycleService.start_document_analysis`
+  (`opencontractserver/analyzer/services/analysis_lifecycle_service.py`).** The
+  `user_can(user, UPDATE)` gate now shares the Tier-2 permission cache when
+  called from a GraphQL mutation, removing a redundant permission DB hit.

--- a/config/graphql/enrichment_mutations.py
+++ b/config/graphql/enrichment_mutations.py
@@ -122,6 +122,7 @@ class RunCorpusEnrichmentMutation(graphene.Mutation):
             # distinguish "malformed id" from "exists but not visible" (IDOR).
             return RunCorpusEnrichmentMutation(
                 ok=False,
+                partial=False,
                 message="Resource not found or you do not have permission.",
                 analyses=[],
             )
@@ -129,6 +130,7 @@ class RunCorpusEnrichmentMutation(graphene.Mutation):
         if not run_enrichment and not run_crawl:
             return RunCorpusEnrichmentMutation(
                 ok=False,
+                partial=False,
                 message="Select at least one job (runEnrichment or runCrawl).",
                 analyses=[],
             )
@@ -150,6 +152,7 @@ class RunCorpusEnrichmentMutation(graphene.Mutation):
                 if unknown:
                     return RunCorpusEnrichmentMutation(
                         ok=False,
+                        partial=False,
                         message=(
                             "Unknown reference type(s): "
                             + ", ".join(unknown)
@@ -180,6 +183,7 @@ class RunCorpusEnrichmentMutation(graphene.Mutation):
             if not res.ok:
                 return RunCorpusEnrichmentMutation(
                     ok=False,
+                    partial=False,
                     message=res.error,
                     analyses=[],
                 )
@@ -234,6 +238,7 @@ class RunCorpusEnrichmentMutation(graphene.Mutation):
                     )
                 return RunCorpusEnrichmentMutation(
                     ok=False,
+                    partial=False,
                     message=res.error,
                     analyses=[],
                 )

--- a/config/graphql/enrichment_mutations.py
+++ b/config/graphql/enrichment_mutations.py
@@ -128,16 +128,32 @@ class RunCorpusEnrichmentMutation(graphene.Mutation):
         created = []
 
         if run_enrichment:
-            analyzer = EnrichmentService.get_or_create_analyzer(user.id)
             input_data: dict[str, Any] = {
                 "use_llm": bool(getattr(options, "use_llm_tier", False) or False),
             }
             ref_types = getattr(options, "reference_types", None)
             if ref_types:
-                valid_types = [t for t in ref_types if t in C.ALL_REFERENCE_TYPES]
-                if valid_types:
-                    input_data["types"] = valid_types
+                # Reject unknown codes rather than silently dropping them. If we
+                # filtered to an empty ``valid_types`` and left ``types`` unset,
+                # the analyzer would fall through to scanning ALL reference types
+                # — the opposite of the caller's intent. Surface the bad codes so
+                # the caller knows their request was rejected, not modified.
+                unknown = [t for t in ref_types if t not in C.ALL_REFERENCE_TYPES]
+                if unknown:
+                    return RunCorpusEnrichmentMutation(
+                        ok=False,
+                        message=(
+                            "Unknown reference type(s): "
+                            + ", ".join(unknown)
+                            + ". Valid types: "
+                            + ", ".join(C.ALL_REFERENCE_TYPES)
+                            + "."
+                        ),
+                        analyses=[],
+                    )
+                input_data["types"] = list(ref_types)
 
+            analyzer = EnrichmentService.get_or_create_analyzer(user.id)
             logger.info(
                 "RunCorpusEnrichmentMutation: dispatching enrichment analyzer "
                 "analyzer_pk=%s corpus_pk=%s user=%s",
@@ -192,10 +208,25 @@ class RunCorpusEnrichmentMutation(graphene.Mutation):
                 require_corpus_update=True,
             )
             if not res.ok:
+                if created:
+                    # Partial success: the enrichment analysis was already
+                    # dispatched and is now running. Return ok=True with the
+                    # already-created row(s) and a non-fatal message so the
+                    # caller surfaces the running job instead of treating the
+                    # whole request as failed (and re-dispatching enrichment,
+                    # double-running it).
+                    return RunCorpusEnrichmentMutation(
+                        ok=True,
+                        message=(
+                            "Enrichment started, but the authority crawl could "
+                            f"not be dispatched: {res.error}"
+                        ),
+                        analyses=created,
+                    )
                 return RunCorpusEnrichmentMutation(
                     ok=False,
                     message=res.error,
-                    analyses=created,
+                    analyses=[],
                 )
             created.append(res.value)
 

--- a/config/graphql/enrichment_mutations.py
+++ b/config/graphql/enrichment_mutations.py
@@ -142,6 +142,11 @@ class RunCorpusEnrichmentMutation(graphene.Mutation):
                 "use_llm": bool(getattr(options, "use_llm_tier", False) or False),
             }
             ref_types = getattr(options, "reference_types", None)
+            # An omitted field (None) or an explicitly empty list are both
+            # treated as "no type restriction" — ``types`` stays unset and the
+            # analyzer uses its default set. Only a non-empty list is validated;
+            # the deliberate-empty-list case isn't an error (it's equivalent to
+            # omitting the field).
             if ref_types:
                 # Reject unknown codes rather than silently dropping them. If we
                 # filtered to an empty ``valid_types`` and left ``types`` unset,

--- a/config/graphql/enrichment_mutations.py
+++ b/config/graphql/enrichment_mutations.py
@@ -86,6 +86,14 @@ class RunCorpusEnrichmentMutation(graphene.Mutation):
     ok = graphene.Boolean()
     message = graphene.String()
     analyses = graphene.List(AnalysisType)
+    partial = graphene.Boolean(
+        description=(
+            "True when some requested jobs dispatched but others failed "
+            "(e.g. enrichment started but the crawl could not be dispatched). "
+            "Only meaningful when ``ok`` is True; lets callers surface the "
+            "non-fatal ``message`` without coupling to its text."
+        )
+    )
 
     @login_required
     def mutate(
@@ -217,6 +225,7 @@ class RunCorpusEnrichmentMutation(graphene.Mutation):
                     # double-running it).
                     return RunCorpusEnrichmentMutation(
                         ok=True,
+                        partial=True,
                         message=(
                             "Enrichment started, but the authority crawl could "
                             f"not be dispatched: {res.error}"
@@ -232,6 +241,7 @@ class RunCorpusEnrichmentMutation(graphene.Mutation):
 
         return RunCorpusEnrichmentMutation(
             ok=True,
+            partial=False,
             message="SUCCESS",
             analyses=created,
         )

--- a/frontend/src/components/admin/AdminEnrichment.tsx
+++ b/frontend/src/components/admin/AdminEnrichment.tsx
@@ -113,7 +113,7 @@ interface EnrichmentPanelProps {
  * never inside a conditional block of the parent.
  */
 const EnrichmentPanel: React.FC<EnrichmentPanelProps> = ({ corpusId }) => {
-  const { jobs, optimistic, running, loading, error, handleRan } =
+  const { jobs, optimistic, running, totalCount, loading, error, handleRan } =
     useOptimisticRows(corpusId);
 
   return (
@@ -128,6 +128,7 @@ const EnrichmentPanel: React.FC<EnrichmentPanelProps> = ({ corpusId }) => {
         loading={loading}
         error={error}
         extraJobs={optimistic}
+        totalCount={totalCount}
       />
     </ContentSection>
   );

--- a/frontend/src/components/admin/enrichment/EnrichmentJobList.tsx
+++ b/frontend/src/components/admin/enrichment/EnrichmentJobList.tsx
@@ -305,10 +305,13 @@ export const EnrichmentJobList: React.FC<EnrichmentJobListProps> = ({
                 </Table.Body>
               </Table>
             </ScrollableTableWrapper>
-            {totalCount != null && totalCount > fetchedJobs.length && (
+            {/* Count against `sorted.length` (the rows actually rendered,
+                incl. optimistic) rather than `fetchedJobs.length`, so the "N
+                most recent" matches what the user sees on screen. Gating on the
+                same value keeps N strictly below the server total. */}
+            {totalCount != null && totalCount > sorted.length && (
               <TruncationNote data-testid="enrichment-job-truncation">
-                Showing the {fetchedJobs.length} most recent of {totalCount}{" "}
-                runs.
+                Showing the {sorted.length} most recent of {totalCount} runs.
               </TruncationNote>
             )}
           </>

--- a/frontend/src/components/admin/enrichment/EnrichmentJobList.tsx
+++ b/frontend/src/components/admin/enrichment/EnrichmentJobList.tsx
@@ -13,7 +13,10 @@ import {
   ScrollableTableWrapper,
 } from "../../layout/SharedSegments";
 import { LoadingState, ErrorMessage } from "../../widgets/feedback";
-import { formatDateTime } from "../../../utils/formatters";
+import {
+  formatDateTime,
+  formatElapsedSeconds,
+} from "../../../utils/formatters";
 
 // ---------------------------------------------------------------------------
 // Props
@@ -183,22 +186,6 @@ function parseResultSummary(
     // non-JSON or unexpected shape — degrade gracefully
   }
   return null;
-}
-
-/**
- * Format a whole-second elapsed duration: `< 60s → "Ns"`, `< 1h → "Nm Ns"`,
- * else `"Nh Nm"`. Kept distinct from `utils/formatDuration` (which renders
- * sub-second precision like "4.2s"): enrichment elapsed is always whole
- * seconds and reads cleaner as "47s" / "2m 7s" for multi-minute crawls, which
- * otherwise rendered as an unscannable raw second count (e.g. "127s").
- */
-function formatElapsedSeconds(secs: number): string {
-  if (secs < 60) return `${secs}s`;
-  const minutes = Math.floor(secs / 60);
-  const seconds = secs % 60;
-  if (minutes < 60) return `${minutes}m ${seconds}s`;
-  const hours = Math.floor(minutes / 60);
-  return `${hours}h ${minutes % 60}m`;
 }
 
 function elapsedLabel(

--- a/frontend/src/components/admin/enrichment/EnrichmentJobList.tsx
+++ b/frontend/src/components/admin/enrichment/EnrichmentJobList.tsx
@@ -31,6 +31,12 @@ export interface EnrichmentJobListProps {
    * Rows already present (matched by id) in the fetched data are deduplicated.
    */
   extraJobs?: EnrichmentAnalysisRow[];
+  /**
+   * Server-reported total number of matching analyses, before the `first: 50`
+   * page cap. When it exceeds the number of fetched rows the list shows a
+   * truncation note so older runs aren't silently lost.
+   */
+  totalCount?: number | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -126,6 +132,12 @@ const ResultSummary = styled.span`
   color: ${OS_LEGAL_COLORS.textSecondary};
 `;
 
+const TruncationNote = styled.div`
+  padding: 0.625rem 0.25rem 0;
+  font-size: 0.75rem;
+  color: ${OS_LEGAL_COLORS.textMuted};
+`;
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -173,6 +185,22 @@ function parseResultSummary(
   return null;
 }
 
+/**
+ * Format a whole-second elapsed duration: `< 60s → "Ns"`, `< 1h → "Nm Ns"`,
+ * else `"Nh Nm"`. Kept distinct from `utils/formatDuration` (which renders
+ * sub-second precision like "4.2s"): enrichment elapsed is always whole
+ * seconds and reads cleaner as "47s" / "2m 7s" for multi-minute crawls, which
+ * otherwise rendered as an unscannable raw second count (e.g. "127s").
+ */
+function formatElapsedSeconds(secs: number): string {
+  if (secs < 60) return `${secs}s`;
+  const minutes = Math.floor(secs / 60);
+  const seconds = secs % 60;
+  if (minutes < 60) return `${minutes}m ${seconds}s`;
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h ${minutes % 60}m`;
+}
+
 function elapsedLabel(
   started: string | null | undefined,
   completed: string | null | undefined
@@ -182,7 +210,7 @@ function elapsedLabel(
   const endMs = new Date(completed).getTime();
   if (Number.isNaN(startMs) || Number.isNaN(endMs)) return null;
   const secs = Math.round((endMs - startMs) / 1000);
-  return `${secs}s`;
+  return formatElapsedSeconds(secs);
 }
 
 // ---------------------------------------------------------------------------
@@ -194,6 +222,7 @@ export const EnrichmentJobList: React.FC<EnrichmentJobListProps> = ({
   loading,
   error,
   extraJobs = [],
+  totalCount = null,
 }) => {
   if (loading) {
     return <LoadingState message="Loading enrichment jobs…" />;
@@ -230,64 +259,72 @@ export const EnrichmentJobList: React.FC<EnrichmentJobListProps> = ({
         {sorted.length === 0 ? (
           <EmptyState>No enrichment runs yet.</EmptyState>
         ) : (
-          <ScrollableTableWrapper $minWidth="640px">
-            <Table variant="minimal">
-              <Table.Head>
-                <Table.Row>
-                  <Table.HeadCell>Job</Table.HeadCell>
-                  <Table.HeadCell>Status</Table.HeadCell>
-                  <Table.HeadCell>Started</Table.HeadCell>
-                  <Table.HeadCell>Finished</Table.HeadCell>
-                  <Table.HeadCell>Elapsed</Table.HeadCell>
-                  <Table.HeadCell>Result</Table.HeadCell>
-                </Table.Row>
-              </Table.Head>
-              <Table.Body>
-                {sorted.map((job) => {
-                  const label = jobLabel(job.analyzer.taskName);
-                  const elapsed = elapsedLabel(
-                    job.analysisStarted,
-                    job.analysisCompleted
-                  );
-                  const summary = parseResultSummary(
-                    job.analyzer.taskName,
-                    job.resultMessage
-                  );
-                  const isFailed =
-                    (job.status ?? "").toLowerCase() === "failed";
+          <>
+            <ScrollableTableWrapper $minWidth="640px">
+              <Table variant="minimal">
+                <Table.Head>
+                  <Table.Row>
+                    <Table.HeadCell>Job</Table.HeadCell>
+                    <Table.HeadCell>Status</Table.HeadCell>
+                    <Table.HeadCell>Started</Table.HeadCell>
+                    <Table.HeadCell>Finished</Table.HeadCell>
+                    <Table.HeadCell>Elapsed</Table.HeadCell>
+                    <Table.HeadCell>Result</Table.HeadCell>
+                  </Table.Row>
+                </Table.Head>
+                <Table.Body>
+                  {sorted.map((job) => {
+                    const label = jobLabel(job.analyzer.taskName);
+                    const elapsed = elapsedLabel(
+                      job.analysisStarted,
+                      job.analysisCompleted
+                    );
+                    const summary = parseResultSummary(
+                      job.analyzer.taskName,
+                      job.resultMessage
+                    );
+                    const isFailed =
+                      (job.status ?? "").toLowerCase() === "failed";
 
-                  return (
-                    <Table.Row key={job.id} data-testid="enrichment-job-row">
-                      <Table.Cell>{label}</Table.Cell>
-                      <Table.Cell>
-                        <StatusBadge status={job.status} />
-                      </Table.Cell>
-                      <Table.Cell>
-                        {formatDateTime(job.analysisStarted)}
-                      </Table.Cell>
-                      <Table.Cell>
-                        {formatDateTime(job.analysisCompleted)}
-                      </Table.Cell>
-                      <Table.Cell>{elapsed ?? "—"}</Table.Cell>
-                      <Table.Cell>
-                        {isFailed && job.errorMessage ? (
-                          <StackedCell>
-                            <ErrorCell title={job.errorMessage}>
-                              {job.errorMessage}
-                            </ErrorCell>
-                          </StackedCell>
-                        ) : summary ? (
-                          <ResultSummary>{summary}</ResultSummary>
-                        ) : (
-                          "—"
-                        )}
-                      </Table.Cell>
-                    </Table.Row>
-                  );
-                })}
-              </Table.Body>
-            </Table>
-          </ScrollableTableWrapper>
+                    return (
+                      <Table.Row key={job.id} data-testid="enrichment-job-row">
+                        <Table.Cell>{label}</Table.Cell>
+                        <Table.Cell>
+                          <StatusBadge status={job.status} />
+                        </Table.Cell>
+                        <Table.Cell>
+                          {formatDateTime(job.analysisStarted)}
+                        </Table.Cell>
+                        <Table.Cell>
+                          {formatDateTime(job.analysisCompleted)}
+                        </Table.Cell>
+                        <Table.Cell>{elapsed ?? "—"}</Table.Cell>
+                        <Table.Cell>
+                          {isFailed && job.errorMessage ? (
+                            <StackedCell>
+                              <ErrorCell title={job.errorMessage}>
+                                {job.errorMessage}
+                              </ErrorCell>
+                            </StackedCell>
+                          ) : summary ? (
+                            <ResultSummary>{summary}</ResultSummary>
+                          ) : (
+                            "—"
+                          )}
+                        </Table.Cell>
+                      </Table.Row>
+                    );
+                  })}
+                </Table.Body>
+              </Table>
+            </ScrollableTableWrapper>
+            {totalCount != null && totalCount > fetchedJobs.length && (
+              <TruncationNote data-testid="enrichment-job-truncation">
+                Showing the {fetchedJobs.length} most recent of {totalCount}{" "}
+                runs.
+              </TruncationNote>
+            )}
+          </>
         )}
       </CardSegment>
     </div>

--- a/frontend/src/components/admin/enrichment/EnrichmentRunner.tsx
+++ b/frontend/src/components/admin/enrichment/EnrichmentRunner.tsx
@@ -253,9 +253,12 @@ export const EnrichmentRunner: React.FC<EnrichmentRunnerProps> = ({
     const parsedTokenBudget =
       tokenBudget !== "" ? Number(tokenBudget) : undefined;
 
-    // Reject non-numeric input: Number("abc") is NaN (not undefined), and the
-    // native type="number" guard is browser-level only. Surface an inline error
-    // instead of letting a NaN reach Graphene as an opaque type error.
+    // Reject non-integer input before it reaches the graphene.Int schema.
+    // `step={1}` only governs the spinner buttons and validity styling — a user
+    // can still TYPE "abc" (→ NaN) or "1.5" (a valid finite float) and submit,
+    // since the Run button is a plain onClick, not a native <form> submit that
+    // would trigger the browser's validity gate. Surface a clear inline error
+    // rather than letting a NaN/float reach Graphene as an opaque type error.
     const numericFields: [number | undefined, string][] = [
       [parsedMaxDepth, "Max depth"],
       [parsedMinDemand, "Min demand"],
@@ -264,10 +267,10 @@ export const EnrichmentRunner: React.FC<EnrichmentRunnerProps> = ({
       [parsedTokenBudget, "Token budget"],
     ];
     const invalidField = numericFields.find(
-      ([value]) => value !== undefined && !Number.isFinite(value)
+      ([value]) => value !== undefined && !Number.isInteger(value)
     );
     if (invalidField) {
-      toast.error(`${invalidField[1]} must be a number`);
+      toast.error(`${invalidField[1]} must be a whole number`);
       return;
     }
 

--- a/frontend/src/components/admin/enrichment/EnrichmentRunner.tsx
+++ b/frontend/src/components/admin/enrichment/EnrichmentRunner.tsx
@@ -311,11 +311,20 @@ export const EnrichmentRunner: React.FC<EnrichmentRunnerProps> = ({
 
     try {
       const { data } = await run({ variables });
-      if (data?.runCorpusEnrichment.ok) {
-        toast.success("Enrichment started");
-        onRan?.(data.runCorpusEnrichment.analyses);
+      const payload = data?.runCorpusEnrichment;
+      if (payload?.ok) {
+        // Partial success (e.g. enrichment dispatched but the authority crawl
+        // failed) comes back ok=true with a descriptive message rather than the
+        // "SUCCESS" sentinel — surface it as a warning so the failed half isn't
+        // silently swallowed, while still recording the running job below.
+        if (payload.message && payload.message !== "SUCCESS") {
+          toast.warning(payload.message);
+        } else {
+          toast.success("Enrichment started");
+        }
+        onRan?.(payload.analyses);
       } else {
-        toast.error(data?.runCorpusEnrichment.message ?? "Enrichment failed");
+        toast.error(payload?.message ?? "Enrichment failed");
       }
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : "Enrichment failed";
@@ -443,6 +452,7 @@ export const EnrichmentRunner: React.FC<EnrichmentRunnerProps> = ({
                 id={`enrichment-${id}`}
                 type="number"
                 min={0}
+                step={1}
                 placeholder={placeholder}
                 value={value}
                 onChange={(e) => setter(e.target.value)}

--- a/frontend/src/components/admin/enrichment/EnrichmentRunner.tsx
+++ b/frontend/src/components/admin/enrichment/EnrichmentRunner.tsx
@@ -314,11 +314,13 @@ export const EnrichmentRunner: React.FC<EnrichmentRunnerProps> = ({
       const payload = data?.runCorpusEnrichment;
       if (payload?.ok) {
         // Partial success (e.g. enrichment dispatched but the authority crawl
-        // failed) comes back ok=true with a descriptive message rather than the
-        // "SUCCESS" sentinel — surface it as a warning so the failed half isn't
-        // silently swallowed, while still recording the running job below.
-        if (payload.message && payload.message !== "SUCCESS") {
-          toast.warning(payload.message);
+        // failed) comes back ok=true with partial=true and a descriptive
+        // message — surface it as a warning so the failed half isn't silently
+        // swallowed, while still recording the running job below. Keying off the
+        // `partial` flag (not the message text) keeps the UI decoupled from the
+        // backend's exact success string.
+        if (payload.partial) {
+          toast.warning(payload.message ?? "Some jobs could not be dispatched");
         } else {
           toast.success("Enrichment started");
         }

--- a/frontend/src/components/admin/enrichment/useEnrichmentJobs.ts
+++ b/frontend/src/components/admin/enrichment/useEnrichmentJobs.ts
@@ -71,5 +71,8 @@ export function useEnrichmentJobs(
   });
 
   const jobs = (data?.analyses?.edges ?? []).map((e) => e.node);
-  return { jobs, loading, error, refetch };
+  // Total matching analyses server-side (before the `first: 50` page cap) so
+  // the list can surface "showing N of M" when older runs are truncated.
+  const totalCount = data?.analyses?.totalCount ?? null;
+  return { jobs, totalCount, loading, error, refetch };
 }

--- a/frontend/src/components/admin/enrichment/useOptimisticRows.ts
+++ b/frontend/src/components/admin/enrichment/useOptimisticRows.ts
@@ -11,6 +11,12 @@ export interface UseOptimisticRowsResult {
   optimistic: EnrichmentAnalysisRow[];
   /** True when any fetched or optimistic row is in an active status. */
   running: boolean;
+  /**
+   * Server-reported total number of matching analyses, before the `first: 50`
+   * page cap (null until the first response). Lets the list surface a
+   * "showing N of M" hint when older runs are truncated.
+   */
+  totalCount: number | null;
   loading: boolean;
   error: ApolloError | undefined;
   /** Prepend optimistic rows from a freshly-dispatched run and refetch. */
@@ -27,10 +33,14 @@ export interface UseOptimisticRowsResult {
  * live in a single place instead of being copy-pasted onto every surface.
  */
 export function useOptimisticRows(corpusId: string): UseOptimisticRowsResult {
-  const { jobs, loading, error, refetch } = useEnrichmentJobs(corpusId);
+  const { jobs, totalCount, loading, error, refetch } =
+    useEnrichmentJobs(corpusId);
   const [optimistic, setOptimistic] = useState<EnrichmentAnalysisRow[]>([]);
 
   // Prune optimistic rows that have now been confirmed by a real refetch.
+  // `optimistic` is intentionally excluded from the deps: this effect updates
+  // `optimistic`, so including it would re-trigger the effect on every prune
+  // and loop. We only want to re-evaluate when the server `jobs` change.
   useEffect(() => {
     if (!optimistic.length) return;
     const ids = new Set(jobs.map((j) => j.id));
@@ -53,5 +63,5 @@ export function useOptimisticRows(corpusId: string): UseOptimisticRowsResult {
     [refetch]
   );
 
-  return { jobs, optimistic, running, loading, error, handleRan };
+  return { jobs, optimistic, running, totalCount, loading, error, handleRan };
 }

--- a/frontend/src/components/corpuses/CorpusHome/intelligence/CorpusEnrichmentCard.tsx
+++ b/frontend/src/components/corpuses/CorpusHome/intelligence/CorpusEnrichmentCard.tsx
@@ -85,7 +85,7 @@ export const CorpusEnrichmentCard: React.FC<CorpusEnrichmentCardProps> = ({
 const CorpusEnrichmentCardInner: React.FC<{ corpusId: string }> = ({
   corpusId,
 }) => {
-  const { jobs, optimistic, running, loading, error, handleRan } =
+  const { jobs, optimistic, running, totalCount, loading, error, handleRan } =
     useOptimisticRows(corpusId);
 
   return (
@@ -113,6 +113,7 @@ const CorpusEnrichmentCardInner: React.FC<{ corpusId: string }> = ({
         loading={loading}
         error={error}
         extraJobs={optimistic}
+        totalCount={totalCount}
       />
     </Card>
   );

--- a/frontend/src/graphql/mutations.ts
+++ b/frontend/src/graphql/mutations.ts
@@ -390,6 +390,12 @@ export interface RunCorpusEnrichmentOutputs {
   runCorpusEnrichment: {
     ok: boolean;
     message?: string | null;
+    /**
+     * True when some jobs dispatched but others failed (only meaningful when
+     * `ok` is true). Lets the UI show `message` as a warning without coupling
+     * to its text.
+     */
+    partial?: boolean | null;
     analyses: EnrichmentAnalysisRow[];
   };
 }
@@ -409,6 +415,7 @@ export const RUN_CORPUS_ENRICHMENT = gql`
     ) {
       ok
       message
+      partial
       analyses {
         id
         status

--- a/frontend/src/graphql/queries.ts
+++ b/frontend/src/graphql/queries.ts
@@ -1051,6 +1051,9 @@ export interface GetCorpusAnalysesInputs {
 
 export interface GetCorpusAnalysesOutputs {
   analyses: {
+    // Total matching analyses before the `first: 50` page cap — lets the UI
+    // tell the user when older runs are truncated from the list.
+    totalCount: number;
     edges: {
       node: {
         id: string;
@@ -1077,6 +1080,7 @@ export const GET_CORPUS_ANALYSES = gql`
       analyzer_TaskName_In: $taskNames
       first: 50
     ) {
+      totalCount
       edges {
         node {
           id

--- a/frontend/src/utils/__tests__/formatters.test.ts
+++ b/frontend/src/utils/__tests__/formatters.test.ts
@@ -292,5 +292,9 @@ describe("formatters", () => {
       expect(formatElapsedSeconds(3661)).toBe("1h 1m");
       expect(formatElapsedSeconds(7325)).toBe("2h 2m");
     });
+
+    it("clamps negative input to 0s (clock skew)", () => {
+      expect(formatElapsedSeconds(-5)).toBe("0s");
+    });
   });
 });

--- a/frontend/src/utils/__tests__/formatters.test.ts
+++ b/frontend/src/utils/__tests__/formatters.test.ts
@@ -9,6 +9,7 @@ import {
   formatCellValue,
   stripMarkdown,
   humanizeLabel,
+  formatElapsedSeconds,
 } from "../formatters";
 import { EXTRACT_GRID_CELL_TRUNCATE_LENGTH } from "../../assets/configurations/constants";
 
@@ -270,6 +271,26 @@ describe("formatters", () => {
     it("is robust to empty and malformed input", () => {
       expect(humanizeLabel("")).toBe("");
       expect(humanizeLabel("__")).toBe("");
+    });
+  });
+
+  describe("formatElapsedSeconds", () => {
+    it("renders whole seconds under a minute", () => {
+      expect(formatElapsedSeconds(0)).toBe("0s");
+      expect(formatElapsedSeconds(47)).toBe("47s");
+      expect(formatElapsedSeconds(59)).toBe("59s");
+    });
+
+    it("renders minutes and seconds from 1 minute up", () => {
+      expect(formatElapsedSeconds(60)).toBe("1m 0s");
+      expect(formatElapsedSeconds(127)).toBe("2m 7s");
+      expect(formatElapsedSeconds(3599)).toBe("59m 59s");
+    });
+
+    it("renders hours and minutes from 1 hour up", () => {
+      expect(formatElapsedSeconds(3600)).toBe("1h 0m");
+      expect(formatElapsedSeconds(3661)).toBe("1h 1m");
+      expect(formatElapsedSeconds(7325)).toBe("2h 2m");
     });
   });
 });

--- a/frontend/src/utils/__tests__/formatters.test.ts
+++ b/frontend/src/utils/__tests__/formatters.test.ts
@@ -296,5 +296,10 @@ describe("formatters", () => {
     it("clamps negative input to 0s (clock skew)", () => {
       expect(formatElapsedSeconds(-5)).toBe("0s");
     });
+
+    it("floors fractional input to whole seconds", () => {
+      expect(formatElapsedSeconds(47.9)).toBe("47s");
+      expect(formatElapsedSeconds(127.5)).toBe("2m 7s");
+    });
   });
 });

--- a/frontend/src/utils/formatters.ts
+++ b/frontend/src/utils/formatters.ts
@@ -33,6 +33,23 @@ export function formatDuration(seconds?: number | null): string {
 }
 
 /**
+ * Formats a whole-second elapsed duration: `< 60s → "Ns"`, `< 1h → "Nm Ns"`,
+ * else `"Nh Nm"`. Distinct from {@link formatDuration} (which renders
+ * sub-second precision like "4.2s"): callers that measure in whole seconds
+ * (e.g. an analysis run's start→finish span) read cleaner as "47s" / "2m 7s"
+ * than as the unscannable raw second count "127s".
+ * @param secs - Whole-second elapsed duration (non-negative).
+ */
+export function formatElapsedSeconds(secs: number): string {
+  if (secs < 60) return `${secs}s`;
+  const minutes = Math.floor(secs / 60);
+  const seconds = secs % 60;
+  if (minutes < 60) return `${minutes}m ${seconds}s`;
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h ${minutes % 60}m`;
+}
+
+/**
  * Formats a document count with a correctly pluralised noun.
  * @param count - The number of documents
  * @returns e.g. "1 document" or "3 documents"

--- a/frontend/src/utils/formatters.ts
+++ b/frontend/src/utils/formatters.ts
@@ -41,9 +41,10 @@ export function formatDuration(seconds?: number | null): string {
  * @param secs - Whole-second elapsed duration (non-negative).
  */
 export function formatElapsedSeconds(secs: number): string {
-  // Clamp negatives (clock skew / out-of-order timestamps) so we never render
-  // e.g. "-5s".
-  const total = Math.max(0, secs);
+  // Floor to whole seconds and clamp negatives (clock skew / out-of-order
+  // timestamps) so a fractional or negative input never renders e.g. "2m 7.5s"
+  // or "-5s". Callers pass whole seconds today, but this keeps the util safe.
+  const total = Math.max(0, Math.floor(secs));
   if (total < 60) return `${total}s`;
   const minutes = Math.floor(total / 60);
   const seconds = total % 60;

--- a/frontend/src/utils/formatters.ts
+++ b/frontend/src/utils/formatters.ts
@@ -41,9 +41,12 @@ export function formatDuration(seconds?: number | null): string {
  * @param secs - Whole-second elapsed duration (non-negative).
  */
 export function formatElapsedSeconds(secs: number): string {
-  if (secs < 60) return `${secs}s`;
-  const minutes = Math.floor(secs / 60);
-  const seconds = secs % 60;
+  // Clamp negatives (clock skew / out-of-order timestamps) so we never render
+  // e.g. "-5s".
+  const total = Math.max(0, secs);
+  if (total < 60) return `${total}s`;
+  const minutes = Math.floor(total / 60);
+  const seconds = total % 60;
   if (minutes < 60) return `${minutes}m ${seconds}s`;
   const hours = Math.floor(minutes / 60);
   return `${hours}h ${minutes % 60}m`;

--- a/frontend/tests/CorpusEnrichmentCard.ct.tsx
+++ b/frontend/tests/CorpusEnrichmentCard.ct.tsx
@@ -39,7 +39,7 @@ const QUERY_VARS = {
 /** Empty job list — useEnrichmentJobs' on-mount fetch. */
 const EMPTY_QUERY_MOCK = {
   request: { query: GET_CORPUS_ANALYSES, variables: QUERY_VARS },
-  result: { data: { analyses: { edges: [] } } },
+  result: { data: { analyses: { totalCount: 0, edges: [] } } },
   maxUsageCount: 10,
 };
 

--- a/frontend/tests/EnrichmentJobList.ct.tsx
+++ b/frontend/tests/EnrichmentJobList.ct.tsx
@@ -8,7 +8,9 @@
  *   - statusVariant: completed / failed / running / queued / created / unknown
  *   - jobLabel: reference-enrichment / authority-crawl / unknown task fallback
  *   - parseResultSummary: enrichment / crawl / non-JSON / null message
- *   - elapsedLabel: computed seconds / missing timestamp / NaN timestamp
+ *   - elapsedLabel: sub-minute seconds / multi-minute "Nm Ns" / missing / NaN
+ *   - truncation note: shown when totalCount exceeds the fetched rows, hidden
+ *     when it fits
  *   - loading, error, empty, optimistic-dedup and newest-first sorting
  *
  * Each JSX-component import is in its own import statement (Playwright CT
@@ -109,6 +111,17 @@ const oddballJob: EnrichmentAnalysisRow = {
     id: "QW5hbHl6ZXJUeXBlOjk=",
     taskName: "opencontractserver.tasks.corpus_analysis_tasks.some_other_task",
   },
+};
+
+/** Long crawl: 10:00:00 → 10:02:07 = 127s → "2m 7s" (multi-minute format). */
+const longCrawl: EnrichmentAnalysisRow = {
+  id: "QW5hbHlzaXNUeXBlOjEw",
+  status: "COMPLETED",
+  analysisStarted: "2026-06-15T10:00:00Z",
+  analysisCompleted: "2026-06-15T10:02:07Z",
+  errorMessage: null,
+  resultMessage: JSON.stringify({ authorities_ingested: 3 }),
+  analyzer: { id: "QW5hbHl6ZXJUeXBlOjI=", taskName: CRAWL_TASK },
 };
 
 const ALL_JOBS = [
@@ -256,6 +269,54 @@ test.describe("EnrichmentJobList", () => {
     await expect(rows).toHaveCount(2, { timeout: 10000 });
     await expect(rows.first()).toContainText("Reference enrichment");
     await expect(rows.last()).toContainText("Authority crawl");
+    await component.unmount();
+  });
+
+  test("formats multi-minute elapsed as 'Nm Ns' (not raw seconds)", async ({
+    mount,
+    page,
+  }) => {
+    // A 127-second crawl must read as "2m 7s", never the unscannable "127s".
+    const component = await mount(
+      <EnrichmentJobListWrapper jobs={[longCrawl]} />
+    );
+    const list = page.locator('[data-testid="enrichment-job-list"]');
+    await expect(list).toBeVisible({ timeout: 10000 });
+    await expect(list).toContainText("2m 7s");
+    await expect(list).not.toContainText("127s");
+    await component.unmount();
+  });
+
+  test("shows a truncation note when totalCount exceeds the fetched rows", async ({
+    mount,
+    page,
+  }) => {
+    // 1 fetched row but 73 total server-side → the older runs are truncated.
+    const component = await mount(
+      <EnrichmentJobListWrapper jobs={[completedEnrichment]} totalCount={73} />
+    );
+    const note = page.locator('[data-testid="enrichment-job-truncation"]');
+    await expect(note).toBeVisible({ timeout: 10000 });
+    await expect(note).toContainText("Showing the 1 most recent of 73 runs");
+    await component.unmount();
+  });
+
+  test("hides the truncation note when totalCount fits the fetched rows", async ({
+    mount,
+    page,
+  }) => {
+    const component = await mount(
+      <EnrichmentJobListWrapper
+        jobs={[completedEnrichment, completedCrawl]}
+        totalCount={2}
+      />
+    );
+    await expect(
+      page.locator('[data-testid="enrichment-job-list"]')
+    ).toBeVisible({ timeout: 10000 });
+    await expect(
+      page.locator('[data-testid="enrichment-job-truncation"]')
+    ).toHaveCount(0);
     await component.unmount();
   });
 });

--- a/frontend/tests/EnrichmentJobList.ct.tsx
+++ b/frontend/tests/EnrichmentJobList.ct.tsx
@@ -319,4 +319,26 @@ test.describe("EnrichmentJobList", () => {
     ).toHaveCount(0);
     await component.unmount();
   });
+
+  test("truncation count includes optimistic rows so it matches rendered rows", async ({
+    mount,
+    page,
+  }) => {
+    // 1 fetched + 1 distinct optimistic row → 2 rows rendered. The note must
+    // count the rendered rows (2), not just the fetched ones (1), so "N most
+    // recent" matches what the user sees on screen.
+    const component = await mount(
+      <EnrichmentJobListWrapper
+        jobs={[completedEnrichment]}
+        extraJobs={[runningCrawl]}
+        totalCount={73}
+      />
+    );
+    await expect(
+      page.locator('[data-testid="enrichment-job-row"]')
+    ).toHaveCount(2, { timeout: 10000 });
+    const note = page.locator('[data-testid="enrichment-job-truncation"]');
+    await expect(note).toContainText("Showing the 2 most recent of 73 runs");
+    await component.unmount();
+  });
 });

--- a/frontend/tests/EnrichmentJobListWrapper.tsx
+++ b/frontend/tests/EnrichmentJobListWrapper.tsx
@@ -20,7 +20,8 @@ export const EnrichmentJobListWrapper: React.FC<{
   loading?: boolean;
   error?: ApolloError;
   extraJobs?: EnrichmentAnalysisRow[];
-}> = ({ jobs, loading, error, extraJobs }) => (
+  totalCount?: number | null;
+}> = ({ jobs, loading, error, extraJobs, totalCount }) => (
   <MemoryRouter>
     <MockedProvider mocks={[]} addTypename={false}>
       <div style={{ padding: "1rem", maxWidth: 800 }}>
@@ -29,6 +30,7 @@ export const EnrichmentJobListWrapper: React.FC<{
           loading={loading}
           error={error}
           extraJobs={extraJobs}
+          totalCount={totalCount}
         />
       </div>
     </MockedProvider>

--- a/frontend/tests/EnrichmentRunner.ct.tsx
+++ b/frontend/tests/EnrichmentRunner.ct.tsx
@@ -405,4 +405,85 @@ test.describe("EnrichmentRunner", () => {
 
     await component.unmount();
   });
+
+  test("partial success surfaces a warning toast (enrichment ok, crawl failed)", async ({
+    mount,
+    page,
+  }) => {
+    // The mutation returns ok=true + partial=true when enrichment dispatched
+    // but the crawl could not — the Runner must surface the non-fatal message
+    // as a warning (not a plain success), while still recording the running job.
+    const PARTIAL_MESSAGE =
+      "Enrichment started, but the authority crawl could not be dispatched: boom";
+    const PARTIAL_MUTATION_MOCK = {
+      request: {
+        query: RUN_CORPUS_ENRICHMENT,
+        variables: { corpusId: CORPUS_ID, runEnrichment: true, runCrawl: true },
+      },
+      result: {
+        data: {
+          runCorpusEnrichment: {
+            ok: true,
+            partial: true,
+            message: PARTIAL_MESSAGE,
+            analyses: [RUNNING_ANALYSIS],
+          },
+        },
+      },
+    };
+
+    const component = await mount(
+      <EnrichmentRunnerWrapperFull
+        corpusId={CORPUS_ID}
+        mocks={[
+          EMPTY_QUERY_MOCK,
+          PARTIAL_MUTATION_MOCK,
+          RUNNING_QUERY_MOCK,
+          COMPLETED_QUERY_MOCK,
+        ]}
+      />
+    );
+
+    const runBtn = page.locator('[data-testid="enrichment-run-button"]');
+    await expect(runBtn).toBeEnabled({ timeout: 10000 });
+
+    // Enable the crawl job so the request matches the partial mock's variables.
+    await page.getByText("Run authority crawl").click();
+    await runBtn.click();
+
+    // The non-fatal partial message surfaces as a (warning) toast.
+    await expect(page.getByText(PARTIAL_MESSAGE)).toBeVisible({
+      timeout: 5000,
+    });
+
+    await component.unmount();
+  });
+
+  test("rejects a fractional crawl bound with an inline error (no mutation)", async ({
+    mount,
+    page,
+  }) => {
+    // `step={1}` only hints at integers; a typed "1.5" still reaches handleRun.
+    // The integer guard must reject it before any mutation fires (no mutation
+    // mock is provided, so a dispatched request would error the test).
+    const component = await mount(
+      <EnrichmentRunnerWrapperFull
+        corpusId={CORPUS_ID}
+        mocks={[EMPTY_QUERY_MOCK]}
+      />
+    );
+    const runBtn = page.locator('[data-testid="enrichment-run-button"]');
+    await expect(runBtn).toBeEnabled({ timeout: 10000 });
+
+    // Expand Advanced and type a fractional value into Max depth.
+    await page.getByText("Advanced (crawl bounds)").click();
+    await page.fill("#enrichment-maxDepth", "1.5");
+    await runBtn.click();
+
+    await expect(
+      page.getByText("Max depth must be a whole number")
+    ).toBeVisible({ timeout: 5000 });
+
+    await component.unmount();
+  });
 });

--- a/frontend/tests/EnrichmentRunner.ct.tsx
+++ b/frontend/tests/EnrichmentRunner.ct.tsx
@@ -486,4 +486,53 @@ test.describe("EnrichmentRunner", () => {
 
     await component.unmount();
   });
+
+  test("surfaces a backend ok=false response as an error toast", async ({
+    mount,
+    page,
+  }) => {
+    // ok=false (e.g. lost permission between load and dispatch) → the Runner
+    // shows the backend message as an error toast and does NOT record a job.
+    const FAILURE_MESSAGE = "Resource not found or you do not have permission.";
+    const FAILURE_MUTATION_MOCK = {
+      request: {
+        query: RUN_CORPUS_ENRICHMENT,
+        variables: {
+          corpusId: CORPUS_ID,
+          runEnrichment: true,
+          runCrawl: false,
+        },
+      },
+      result: {
+        data: {
+          runCorpusEnrichment: {
+            ok: false,
+            partial: false,
+            message: FAILURE_MESSAGE,
+            analyses: [],
+          },
+        },
+      },
+    };
+
+    const component = await mount(
+      <EnrichmentRunnerWrapperFull
+        corpusId={CORPUS_ID}
+        mocks={[EMPTY_QUERY_MOCK, FAILURE_MUTATION_MOCK]}
+      />
+    );
+    const runBtn = page.locator('[data-testid="enrichment-run-button"]');
+    await expect(runBtn).toBeEnabled({ timeout: 10000 });
+    await runBtn.click();
+
+    await expect(page.getByText(FAILURE_MESSAGE)).toBeVisible({
+      timeout: 5000,
+    });
+    // No optimistic row recorded on failure.
+    await expect(
+      page.locator('[data-testid="enrichment-job-row"]')
+    ).toHaveCount(0);
+
+    await component.unmount();
+  });
 });

--- a/frontend/tests/EnrichmentRunner.ct.tsx
+++ b/frontend/tests/EnrichmentRunner.ct.tsx
@@ -115,7 +115,7 @@ const RUN_MUTATION_MOCK = {
  */
 const EMPTY_QUERY_MOCK = {
   request: { query: GET_CORPUS_ANALYSES, variables: QUERY_VARS },
-  result: { data: { analyses: { edges: [] } } },
+  result: { data: { analyses: { totalCount: 0, edges: [] } } },
   maxUsageCount: 10,
 };
 
@@ -125,6 +125,7 @@ const RUNNING_QUERY_MOCK = {
   result: {
     data: {
       analyses: {
+        totalCount: 1,
         edges: [{ node: RUNNING_ANALYSIS }],
       },
     },
@@ -138,6 +139,7 @@ const COMPLETED_QUERY_MOCK = {
   result: {
     data: {
       analyses: {
+        totalCount: 1,
         edges: [{ node: COMPLETED_ANALYSIS }],
       },
     },
@@ -343,6 +345,7 @@ test.describe("EnrichmentRunner", () => {
       result: {
         data: {
           analyses: {
+            totalCount: 1,
             edges: [{ node: CREATED_ANALYSIS }],
           },
         },

--- a/frontend/tests/EnrichmentRunner.ct.tsx
+++ b/frontend/tests/EnrichmentRunner.ct.tsx
@@ -102,6 +102,7 @@ const RUN_MUTATION_MOCK = {
       runCorpusEnrichment: {
         ok: true,
         message: "SUCCESS",
+        partial: false,
         analyses: [RUNNING_ANALYSIS],
       },
     },

--- a/frontend/tests/EnrichmentRunnerWrapperFull.tsx
+++ b/frontend/tests/EnrichmentRunnerWrapperFull.tsx
@@ -9,6 +9,7 @@
 import React from "react";
 import { MockedResponse, MockedProvider } from "@apollo/client/testing";
 import { MemoryRouter } from "react-router-dom";
+import { ToastContainer } from "react-toastify";
 
 import { EnrichmentRunner } from "../src/components/admin/enrichment/EnrichmentRunner";
 import { EnrichmentJobList } from "../src/components/admin/enrichment/EnrichmentJobList";
@@ -55,7 +56,13 @@ export const EnrichmentRunnerWrapperFull: React.FC<
 > = ({ corpusId, mocks = [] }) => (
   <MemoryRouter>
     <MockedProvider mocks={mocks} addTypename={false}>
-      <Panel corpusId={corpusId} />
+      {/* Single child: MockedProvider uses React.Children.only, so the
+          ToastContainer (added so tests can assert react-toastify warning /
+          success notifications) and the Panel must share one parent. */}
+      <>
+        <ToastContainer />
+        <Panel corpusId={corpusId} />
+      </>
     </MockedProvider>
   </MemoryRouter>
 );

--- a/opencontractserver/analyzer/services/analysis_lifecycle_service.py
+++ b/opencontractserver/analyzer/services/analysis_lifecycle_service.py
@@ -137,8 +137,12 @@ class AnalysisLifecycleService(BaseService):
             )
             if corpus_obj is None:
                 return ServiceResult.failure(not_found_msg)
+            # Forward ``request`` so the UPDATE check shares the Tier-2
+            # permission cache when called from a GraphQL mutation (avoids a
+            # redundant permission DB hit); ``request`` is None for internal
+            # callers, which simply bypasses the cache.
             if require_corpus_update and not corpus_obj.user_can(
-                user, PermissionTypes.UPDATE
+                user, PermissionTypes.UPDATE, request=request
             ):
                 return ServiceResult.failure(not_found_msg)
 

--- a/opencontractserver/notifications/migrations/0007_notification_analysis_idempotency_constraint.py
+++ b/opencontractserver/notifications/migrations/0007_notification_analysis_idempotency_constraint.py
@@ -60,7 +60,13 @@ def cleanup_duplicate_analysis_notifications(apps, schema_editor):
 
 
 def reverse_cleanup(apps, schema_editor):
-    """No-op reverse: deleted duplicates were invalid and cannot be restored."""
+    """No-op reverse for the dedup step.
+
+    Reversing this migration drops the unique constraint/index automatically
+    (Django reverses ``AddConstraint`` with ``RemoveConstraint``); only the
+    one-time duplicate cleanup is irreversible — the deleted rows were invalid
+    duplicates and cannot be restored.
+    """
     pass
 
 

--- a/opencontractserver/notifications/migrations/0007_notification_analysis_idempotency_constraint.py
+++ b/opencontractserver/notifications/migrations/0007_notification_analysis_idempotency_constraint.py
@@ -1,0 +1,88 @@
+"""Add a partial unique constraint backing analysis-status notification idempotency.
+
+The analysis-status signal (``notifications/signals.py``) previously guarded
+against duplicate notifications with a check-then-create pair. Two concurrent
+``Analysis.post_save`` signals could both pass the ``exists()`` check before
+either ``create()`` committed, leaking duplicate rows. The signal now uses
+``get_or_create``; this migration adds the partial unique constraint that makes
+that atomic (the losing writer trips the constraint and re-reads the winner's
+row), after first cleaning up any duplicates that predate the constraint.
+"""
+
+import logging
+
+from django.db import migrations, models
+from django.db.models import Count
+
+logger = logging.getLogger(__name__)
+
+
+def cleanup_duplicate_analysis_notifications(apps, schema_editor):
+    """Collapse duplicate (analysis, notification_type) rows before the constraint.
+
+    Keeps the earliest (lowest id) notification in each duplicate group and
+    deletes the rest. Only notifications with a non-null ``analysis`` are
+    considered — every other notification type is unaffected.
+    """
+    Notification = apps.get_model("notifications", "Notification")
+
+    duplicate_groups = (
+        Notification.objects.filter(analysis__isnull=False)
+        .values("analysis_id", "notification_type")
+        .annotate(count=Count("id"))
+        .filter(count__gt=1)
+    )
+
+    total_deleted = 0
+    for group in duplicate_groups:
+        ids = list(
+            Notification.objects.filter(
+                analysis_id=group["analysis_id"],
+                notification_type=group["notification_type"],
+            )
+            .order_by("id")
+            .values_list("id", flat=True)
+        )
+        # Keep the first (earliest), delete the remainder.
+        delete_ids = ids[1:]
+        if delete_ids:
+            deleted = Notification.objects.filter(id__in=delete_ids).delete()[0]
+            total_deleted += deleted
+
+    if total_deleted:
+        logger.warning(
+            "Deleted %s duplicate analysis notification(s) before adding the "
+            "uniqueness constraint.",
+            total_deleted,
+        )
+    else:
+        logger.info("No duplicate analysis notifications found.")
+
+
+def reverse_cleanup(apps, schema_editor):
+    """No-op reverse: deleted duplicates were invalid and cannot be restored."""
+    pass
+
+
+class Migration(migrations.Migration):
+    # Non-atomic: the RunPython cleanup must commit before AddConstraint,
+    # otherwise PostgreSQL raises "cannot CREATE INDEX ... pending trigger
+    # events" when the constraint's partial index is built in the same
+    # transaction as the deletes.
+    atomic = False
+
+    dependencies = [
+        ("notifications", "0006_notification_analysis_and_more"),
+    ]
+
+    operations = [
+        migrations.RunPython(cleanup_duplicate_analysis_notifications, reverse_cleanup),
+        migrations.AddConstraint(
+            model_name="notification",
+            constraint=models.UniqueConstraint(
+                fields=["analysis", "notification_type"],
+                condition=models.Q(analysis__isnull=False),
+                name="uniq_notification_per_analysis_type",
+            ),
+        ),
+    ]

--- a/opencontractserver/notifications/models.py
+++ b/opencontractserver/notifications/models.py
@@ -158,6 +158,11 @@ class Notification(models.Model):
             # don't reference an analysis. This lets the analysis-status signal
             # handler use an atomic ``get_or_create`` instead of a race-prone
             # check-then-create (see notifications/signals.py).
+            #
+            # The key is intentionally global (no ``recipient``): analysis-status
+            # notifications always target the single analysis creator. If a
+            # future use-case fans the same status out to multiple recipients,
+            # ``recipient`` must join the key.
             models.UniqueConstraint(
                 fields=["analysis", "notification_type"],
                 condition=models.Q(analysis__isnull=False),

--- a/opencontractserver/notifications/models.py
+++ b/opencontractserver/notifications/models.py
@@ -103,6 +103,12 @@ class Notification(models.Model):
 
     analysis = models.ForeignKey(
         "analyzer.Analysis",
+        # CASCADE is deliberate: an analysis-status notification ("analysis 42
+        # is RUNNING / COMPLETE / FAILED") is meaningless once the analysis row
+        # is gone, so deleting an Analysis intentionally removes its
+        # notifications. These rows are transient UI signals, not an audit log —
+        # if that ever changes (e.g. retain a record of failed analyses), switch
+        # to SET_NULL and keep the analysis_id context in ``data``.
         on_delete=models.CASCADE,
         null=True,
         blank=True,
@@ -145,6 +151,19 @@ class Notification(models.Model):
 
     class Meta:
         ordering = ["-created_at"]
+        constraints = [
+            # Idempotency guard for analysis-status notifications: at most one
+            # notification per (analysis, notification_type). Partial (analysis
+            # NOT NULL) so it never constrains the many notification types that
+            # don't reference an analysis. This lets the analysis-status signal
+            # handler use an atomic ``get_or_create`` instead of a race-prone
+            # check-then-create (see notifications/signals.py).
+            models.UniqueConstraint(
+                fields=["analysis", "notification_type"],
+                condition=models.Q(analysis__isnull=False),
+                name="uniq_notification_per_analysis_type",
+            ),
+        ]
         indexes = [
             models.Index(fields=["recipient", "-created_at"]),
             models.Index(fields=["recipient", "is_read"]),

--- a/opencontractserver/notifications/signals.py
+++ b/opencontractserver/notifications/signals.py
@@ -181,6 +181,12 @@ def emit_analysis_status_notification(
         notification, created = Notification.objects.get_or_create(
             analysis=instance,
             notification_type=ntype,
+            # NOTE: ``data`` (incl. ``status``) is captured at first-create only.
+            # Under a concurrent race the losing writer gets the winner's row with
+            # created=False and returns below, so ``data`` reflects the winner's
+            # snapshot. This is fine because notification_type is one-per-status —
+            # each status value already maps to its own row, so a given row's
+            # status never needs to change after creation.
             defaults={
                 "recipient_id": instance.creator_id,
                 "data": {

--- a/opencontractserver/notifications/signals.py
+++ b/opencontractserver/notifications/signals.py
@@ -150,13 +150,14 @@ def emit_analysis_status_notification(
     if ntype is None or instance.creator_id is None:
         return
 
-    # Only emit notifications for enrichment/crawl analyzers. Guard on
-    # analyzer_id FIRST (cheap, no I/O) and then run a single targeted query
-    # that BOTH gates and captures the task name. This avoids
-    # ``instance.analyzer.task_name`` — which hydrates the full Analyzer row via
-    # a deferred FK load on EVERY Analysis.save() across the system (doc
-    # analysis, extracts, …), not just enrichment runs — and lets the ``data``
-    # dict below reuse ``analyzer_task`` instead of triggering that FK load.
+    # The status + creator guards above already short-circuited the common
+    # no-notification cases with zero I/O. For the rows that remain, restrict to
+    # enrichment/crawl analyzers: check the cheap ``analyzer_id`` FK presence
+    # first, then run a single targeted query that BOTH gates on task_name AND
+    # captures it. This avoids ``instance.analyzer.task_name`` — which hydrates
+    # the full Analyzer row via a deferred FK load on EVERY qualifying
+    # Analysis.save() — and lets the ``data`` dict below reuse ``analyzer_task``
+    # instead of triggering that load.
     if instance.analyzer_id is None:
         return
     analyzer_task = (
@@ -169,22 +170,30 @@ def emit_analysis_status_notification(
     if analyzer_task is None:
         return
 
-    # Idempotent guard: skip if this (analysis, notification_type) already exists.
-    if Notification.objects.filter(analysis=instance, notification_type=ntype).exists():
-        return
-
+    # Idempotent creation backed by the partial unique constraint on
+    # (analysis, notification_type) — see ``Notification.Meta.constraints``.
+    # ``get_or_create`` collapses the old check-then-create pair (which two
+    # concurrent ``Analysis.post_save`` signals could both pass before either
+    # committed, producing duplicate notifications) into a single atomic upsert:
+    # under a race the losing writer's INSERT trips the constraint and
+    # ``get_or_create`` transparently returns the existing row (created=False).
     try:
-        notification = Notification.objects.create(
-            recipient_id=instance.creator_id,
-            notification_type=ntype,
+        notification, created = Notification.objects.get_or_create(
             analysis=instance,
-            data={
-                "analysis_id": instance.id,
-                "corpus_id": instance.analyzed_corpus_id,
-                "analyzer_task": analyzer_task,
-                "status": instance.status,
+            notification_type=ntype,
+            defaults={
+                "recipient_id": instance.creator_id,
+                "data": {
+                    "analysis_id": instance.id,
+                    "corpus_id": instance.analyzed_corpus_id,
+                    "analyzer_task": analyzer_task,
+                    "status": instance.status,
+                },
             },
         )
+        if not created:
+            # A concurrent (or earlier) save already produced this notification.
+            return
         logger.debug(
             "Created %s notification for analysis %s (recipient_id=%s)",
             ntype,

--- a/opencontractserver/notifications/signals.py
+++ b/opencontractserver/notifications/signals.py
@@ -181,12 +181,16 @@ def emit_analysis_status_notification(
         notification, created = Notification.objects.get_or_create(
             analysis=instance,
             notification_type=ntype,
-            # NOTE: ``data`` (incl. ``status``) is captured at first-create only.
-            # Under a concurrent race the losing writer gets the winner's row with
-            # created=False and returns below, so ``data`` reflects the winner's
-            # snapshot. This is fine because notification_type is one-per-status —
-            # each status value already maps to its own row, so a given row's
-            # status never needs to change after creation.
+            # NOTE: ``data`` (incl. ``status``) and ``recipient_id`` live in
+            # ``defaults`` — set on INSERT only, NOT part of the lookup. The
+            # idempotency key is exactly (analysis, notification_type) to match
+            # the partial unique constraint; the recipient is always the analysis
+            # creator (which doesn't change), so it's a value to populate on
+            # create, not a key to match on. Under a concurrent race the losing
+            # writer gets the winner's row with created=False and returns below,
+            # so ``data`` reflects the winner's snapshot — fine, because
+            # notification_type is one-per-status (each status maps to its own
+            # row, so a given row's status never needs to change after creation).
             defaults={
                 "recipient_id": instance.creator_id,
                 "data": {

--- a/opencontractserver/tests/test_enrichment_run_mutation.py
+++ b/opencontractserver/tests/test_enrichment_run_mutation.py
@@ -6,16 +6,24 @@ Verifies that the mutation:
 - rejects callers who do not have READ on the corpus
 - rejects callers who have READ but not UPDATE on the corpus
 - rejects calls with neither flag set
-- silently drops invalid reference_type codes
+- rejects invalid reference_type codes (rather than silently dropping them)
+- returns partial success (ok=True) when enrichment dispatches but the crawl
+  fails, so the running enrichment job is surfaced to the caller
 """
+
+from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 from graphene.test import Client
 from graphql_relay import to_global_id
 
+from opencontractserver.analyzer.services.analysis_lifecycle_service import (
+    AnalysisLifecycleService,
+)
 from opencontractserver.corpuses.models import Corpus
 from opencontractserver.enrichment import constants as C
+from opencontractserver.shared.services.conventions import ServiceResult
 from opencontractserver.types.enums import PermissionTypes
 from opencontractserver.utils.permissioning import set_permissions_for_obj_to_user
 
@@ -246,11 +254,18 @@ class RunCorpusEnrichmentMutationTests(TestCase):
         assert data["ok"] is False
 
     # ------------------------------------------------------------------
-    # Validation: invalid reference_types are silently dropped
+    # Validation: invalid reference_types are REJECTED (not silently dropped)
     # ------------------------------------------------------------------
 
-    def test_invalid_reference_types_are_filtered(self):
-        """Unknown type codes are dropped; the call still succeeds if valid ones remain."""
+    def test_invalid_reference_types_are_rejected(self):
+        """Unknown type codes are rejected so a caller cannot accidentally
+        trigger an all-types scan by sending only-bogus codes.
+
+        Previously unknown codes were filtered out; an all-bogus list collapsed
+        to an empty filter and scanned EVERY reference type — the opposite of
+        the caller's intent. The mutation now rejects any unknown code and
+        dispatches nothing.
+        """
         from opencontractserver.analyzer.models import Analysis
 
         result = self._execute(
@@ -264,8 +279,97 @@ class RunCorpusEnrichmentMutationTests(TestCase):
         )
         assert result.get("errors") is None, result
         data = result["data"]["runCorpusEnrichment"]
+        assert data["ok"] is False
+        # The offending code is named so the caller knows what to fix.
+        assert "INVALID_CODE" in data["message"]
+        # Nothing was dispatched.
+        assert not Analysis.objects.filter(
+            analyzed_corpus=self.corpus,
+            analyzer__task_name=C.ENRICHMENT_ANALYZER_TASK,
+        ).exists()
+
+    def test_valid_reference_types_are_accepted(self):
+        """A fully valid multi-type list dispatches enrichment normally."""
+        from opencontractserver.analyzer.models import Analysis
+
+        result = self._execute(
+            {
+                "corpusId": to_global_id("CorpusType", self.corpus.id),
+                "runEnrichment": True,
+                "runCrawl": False,
+                "options": {"referenceTypes": ["LAW", "DOCUMENT", "SECTION"]},
+            }
+        )
+        assert result.get("errors") is None, result
+        data = result["data"]["runCorpusEnrichment"]
         assert data["ok"] is True
         assert Analysis.objects.filter(
             analyzed_corpus=self.corpus,
             analyzer__task_name=C.ENRICHMENT_ANALYZER_TASK,
         ).exists()
+
+    # ------------------------------------------------------------------
+    # Partial success: enrichment dispatched but crawl failed
+    # ------------------------------------------------------------------
+
+    def test_partial_success_when_crawl_fails(self):
+        """When enrichment dispatches but the crawl fails, the mutation returns
+        ok=True with the running enrichment row and a non-fatal message — so the
+        caller shows the running job rather than retrying (double-dispatching)
+        enrichment."""
+        from opencontractserver.analyzer.models import Analysis
+        from opencontractserver.enrichment.services import EnrichmentService
+
+        # A real enrichment Analysis to stand in as the dispatched running job.
+        analyzer = EnrichmentService.get_or_create_analyzer(self.owner.id)
+        analysis = Analysis.objects.create(
+            analyzer=analyzer,
+            analyzed_corpus=self.corpus,
+            creator=self.owner,
+        )
+
+        # First call (enrichment) succeeds, second call (crawl) fails.
+        with patch.object(
+            AnalysisLifecycleService,
+            "start_document_analysis",
+            side_effect=[
+                ServiceResult.success(analysis),
+                ServiceResult.failure("crawl boom"),
+            ],
+        ):
+            result = self._execute(
+                {
+                    "corpusId": to_global_id("CorpusType", self.corpus.id),
+                    "runEnrichment": True,
+                    "runCrawl": True,
+                }
+            )
+
+        assert result.get("errors") is None, result
+        data = result["data"]["runCorpusEnrichment"]
+        assert data["ok"] is True
+        assert "crawl boom" in data["message"]
+        # Only the enrichment row is returned (the crawl never started).
+        assert len(data["analyses"]) == 1
+        assert data["analyses"][0]["analyzer"]["taskName"] == C.ENRICHMENT_ANALYZER_TASK
+
+    def test_crawl_only_failure_returns_not_ok(self):
+        """A crawl-only run that fails has no already-dispatched job, so it
+        returns ok=False (no partial-success masking)."""
+        with patch.object(
+            AnalysisLifecycleService,
+            "start_document_analysis",
+            side_effect=[ServiceResult.failure("crawl boom")],
+        ):
+            result = self._execute(
+                {
+                    "corpusId": to_global_id("CorpusType", self.corpus.id),
+                    "runEnrichment": False,
+                    "runCrawl": True,
+                }
+            )
+
+        assert result.get("errors") is None, result
+        data = result["data"]["runCorpusEnrichment"]
+        assert data["ok"] is False
+        assert data["analyses"] == []

--- a/opencontractserver/tests/test_enrichment_run_mutation.py
+++ b/opencontractserver/tests/test_enrichment_run_mutation.py
@@ -281,6 +281,7 @@ class RunCorpusEnrichmentMutationTests(TestCase):
         assert result.get("errors") is None, result
         data = result["data"]["runCorpusEnrichment"]
         assert data["ok"] is False
+        assert data["partial"] is False
         # The offending code is named so the caller knows what to fix.
         assert "INVALID_CODE" in data["message"]
         # Nothing was dispatched.
@@ -379,4 +380,6 @@ class RunCorpusEnrichmentMutationTests(TestCase):
         assert result.get("errors") is None, result
         data = result["data"]["runCorpusEnrichment"]
         assert data["ok"] is False
+        # `partial` is a concrete False (never null) on every ok=False path.
+        assert data["partial"] is False
         assert data["analyses"] == []

--- a/opencontractserver/tests/test_enrichment_run_mutation.py
+++ b/opencontractserver/tests/test_enrichment_run_mutation.py
@@ -44,6 +44,7 @@ mutation Run(
   ) {
     ok
     message
+    partial
     analyses {
       id
       status
@@ -297,12 +298,15 @@ class RunCorpusEnrichmentMutationTests(TestCase):
                 "corpusId": to_global_id("CorpusType", self.corpus.id),
                 "runEnrichment": True,
                 "runCrawl": False,
-                "options": {"referenceTypes": ["LAW", "DOCUMENT", "SECTION"]},
+                # Sourced from the constant so the test stays correct if the
+                # reference-type vocabulary changes.
+                "options": {"referenceTypes": list(C.ALL_REFERENCE_TYPES)},
             }
         )
         assert result.get("errors") is None, result
         data = result["data"]["runCorpusEnrichment"]
         assert data["ok"] is True
+        assert data["partial"] is False
         assert Analysis.objects.filter(
             analyzed_corpus=self.corpus,
             analyzer__task_name=C.ENRICHMENT_ANALYZER_TASK,
@@ -348,6 +352,9 @@ class RunCorpusEnrichmentMutationTests(TestCase):
         assert result.get("errors") is None, result
         data = result["data"]["runCorpusEnrichment"]
         assert data["ok"] is True
+        # partial=True flags the half-failure without coupling callers to the
+        # message text.
+        assert data["partial"] is True
         assert "crawl boom" in data["message"]
         # Only the enrichment row is returned (the crawl never started).
         assert len(data["analyses"]) == 1

--- a/opencontractserver/tests/test_notifications.py
+++ b/opencontractserver/tests/test_notifications.py
@@ -245,6 +245,63 @@ class TestNotificationAnalysisLink(TestCase):
         )
         self.assertIsNone(n.analysis_id)
 
+    def test_duplicate_analysis_notification_blocked_by_constraint(self):
+        """The partial unique constraint forbids a second notification with the
+        same (analysis, notification_type) — this is what makes the signal's
+        get_or_create idempotent under concurrent Analysis.post_save signals."""
+        from django.db import IntegrityError, transaction
+
+        Notification.objects.create(
+            recipient=self.user,
+            notification_type=NotificationTypeChoices.ANALYSIS_RUNNING,
+            analysis=self.analysis,
+        )
+        with self.assertRaises(IntegrityError):
+            # Wrap in atomic so the IntegrityError doesn't poison the outer
+            # test transaction.
+            with transaction.atomic():
+                Notification.objects.create(
+                    recipient=self.user,
+                    notification_type=NotificationTypeChoices.ANALYSIS_RUNNING,
+                    analysis=self.analysis,
+                )
+
+    def test_constraint_is_partial_and_ignores_null_analysis(self):
+        """The constraint is partial (analysis NOT NULL): two notifications of
+        the same type WITHOUT an analysis must coexist, and the same analysis
+        may carry notifications of DIFFERENT types."""
+        # Two analysis=NULL rows with an identical type — not constrained.
+        Notification.objects.create(
+            recipient=self.user,
+            notification_type=NotificationTypeChoices.ANALYSIS_COMPLETE,
+        )
+        Notification.objects.create(
+            recipient=self.user,
+            notification_type=NotificationTypeChoices.ANALYSIS_COMPLETE,
+        )
+        # Same analysis, two DIFFERENT types — not constrained.
+        Notification.objects.create(
+            recipient=self.user,
+            notification_type=NotificationTypeChoices.ANALYSIS_RUNNING,
+            analysis=self.analysis,
+        )
+        Notification.objects.create(
+            recipient=self.user,
+            notification_type=NotificationTypeChoices.ANALYSIS_COMPLETE,
+            analysis=self.analysis,
+        )
+        self.assertEqual(
+            Notification.objects.filter(
+                analysis__isnull=True,
+                notification_type=NotificationTypeChoices.ANALYSIS_COMPLETE,
+            ).count(),
+            2,
+        )
+        self.assertEqual(
+            Notification.objects.filter(analysis=self.analysis).count(),
+            2,
+        )
+
 
 class TestNotificationSignals(TestCase):
     """Test signal handlers that create notifications automatically."""


### PR DESCRIPTION
Closes #2029.

Issue #2029 is the code review of PR #2008 (now merged). Every item it raised was still present on `main`; this PR addresses all of them — the 5 "Issues" and the 5 "Minor nits" — with surgical changes scoped to the enrichment feature and the analysis-notification signal.

## Review items → fixes

| # | Review item | Fix |
|---|-------------|-----|
| 1 | Race in signal idempotency guard (`notifications/signals.py`) | Replaced check-then-create with atomic `get_or_create`, backed by a **new partial unique constraint** `uniq_notification_per_analysis_type` on `(analysis, notification_type)` (`condition=analysis NOT NULL`). Migration `0007` de-dupes pre-existing rows first. `get_or_create` alone isn't race-safe without the constraint, so both are needed. |
| 2 | Partial-success not surfaced (`enrichment_mutations.py`) | When enrichment dispatches but the crawl fails, returns `ok=True` + the running row + a non-fatal message (was `ok=False`). The Runner shows it as a warning toast. Crawl-only failures still return `ok=False`. |
| 3 | Silent `first: 50` cap (`queries.ts`) | Query now requests `totalCount`; `EnrichmentJobList` shows "Showing the N most recent of M runs." when truncated. Threaded `useEnrichmentJobs` → `useOptimisticRows` → both consumers. |
| 4 | Invalid reference-types silently dropped (`enrichment_mutations.py`) | Unknown codes are now **rejected** (`ok=False`, names the bad codes) instead of filtered — an all-bogus list previously fell through to scanning ALL types. |
| 5 | Missing WHY comment on `useEffect` deps (`useOptimisticRows.ts`) | Added the comment explaining `optimistic` is excluded to avoid a prune→re-trigger loop. |
| 6 | Extra DB query / comment accuracy (`signals.py`) | The status+creator guards already short-circuit before the analyzer query; reworded the comment so the "cheap, no I/O" claim is accurate (logic already correct). |
| 7 | `elapsedLabel` raw seconds (`EnrichmentJobList.tsx`) | Multi-minute durations now render `Nm Ns` / `Nh Nm` (e.g. `127s` → `2m 7s`); sub-minute unchanged (`47s`). |
| 8 | `NumberInput` allows fractional values (`EnrichmentRunner.tsx`) | Added `step={1}` to the crawl-bound inputs (plus an integer guard in `handleRun`). |
| 9 | `analysis` FK CASCADE intent (migration/model) | Documented the deliberate CASCADE on `Notification.analysis` (transient UI signal, not an audit log) in `models.py`. |
| 10 | `user_can` not forwarding `request` (`analysis_lifecycle_service.py`) | Forwarded `request` to the corpus UPDATE check so it shares the Tier-2 permission cache. |

## Testing

- **Backend**: `test_notifications.py` + `test_enrichment_run_mutation.py` pass (unique-constraint idempotency incl. partial/NULL behaviour, invalid-type rejection, partial-success, crawl-only failure, uniform `partial=False`). `makemigrations --check` reports no missing `notifications` migration (model Meta ↔ migration `0007` agree); the GraphQL service-layer architecture invariant still passes.
- **Frontend**: `tsc --noEmit` clean; `formatters` + `useEnrichmentJobs` Vitest pass; `EnrichmentJobList` / `CorpusEnrichmentCard` / `EnrichmentRunner` CT suites pass, including multi-minute-elapsed, truncation-note (show/hide/optimistic-count), partial-success warning toast, fractional-input rejection, and the `ok=false` error-toast path.

## Notes

- The migration adds a partial unique index; the cleanup step keeps it safe against any pre-existing duplicates.
- No `CHANGELOG.md` edit — two `changelog.d/2029-enrichment-review.{fixed,changed}.md` fragments added per the repo convention.
- An unrelated, pre-existing `makemigrations` discrepancy on `annotations.authorityfrontier.discovery_state` (introduced by #2008's merge) is **not** touched here.