### PR TITLE
Address PR #2030 review nits on bulk_soft_delete_documents (#2036)

### DIFF
--- a/changelog.d/2036-bulk-soft-delete-review-polish.changed.md
+++ b/changelog.d/2036-bulk-soft-delete-review-polish.changed.md
@@ -1,0 +1,15 @@
+- **Folded in code-review follow-ups (#2036) on the bulk-trash primitive**
+  `DocumentLifecycleService.bulk_soft_delete_documents`
+  (`opencontractserver/corpuses/services/lifecycle.py`). Moved the success
+  `logger.info` + `return` *inside* the `transaction.atomic()` block so the
+  `trashed_doc_ids` set is referenced only within its defining scope (matching
+  the early `return 0` in the same block) — purely a clarity change, no
+  behavioural difference. Surfaced the existing in-body PERF/MEMORY note as a
+  "Scaling caveat" in the method docstring so callers eyeing an `empty_corpus` /
+  folder cascade-delete size limit see that the primitive is O(1) in *queries*
+  but still materializes the full doc set in memory (no built-in document-count
+  ceiling). The review's `_dispatch_document_path_created_signals` rename
+  suggestion was intentionally **not** taken: the `_`-prefix is consistent with
+  five other cross-service helpers in `corpuses/services/` (e.g.
+  `CorpusDocumentService._check_document_in_corpus`), so renaming one in
+  isolation would break that convention rather than clarify it.

--- a/changelog.d/2036-bulk-soft-delete-review-polish.changed.md
+++ b/changelog.d/2036-bulk-soft-delete-review-polish.changed.md
@@ -1,17 +1,11 @@
-- **Folded in code-review follow-ups (#2036) on the bulk-trash primitive**
+- **Hardened the bulk-trash audit log (#2036, follow-up to #1951).**
   `DocumentLifecycleService.bulk_soft_delete_documents`
-  (`opencontractserver/corpuses/services/lifecycle.py`). The success audit log
-  now fires via `transaction.on_commit`, so it reports only durably committed
-  trashing (no false "soft-deleted N" line if the block rolls back or the
-  `COMMIT` fails) — the same rollback-safety contract the primitive's dispatched
-  `post_save` signals already rely on; the count is captured inside the
-  `atomic()` block so `trashed_doc_ids` is referenced only within its defining
-  scope. Also surfaced the existing in-body PERF/MEMORY note as a "Scaling
-  caveat" in the method docstring so callers eyeing an `empty_corpus` / folder
-  cascade-delete size limit see that the primitive is O(1) in *queries* but
-  still materializes the full doc set in memory (no built-in document-count
-  ceiling). The review's `_dispatch_document_path_created_signals` rename
-  suggestion was intentionally **not** taken: the `_`-prefix is consistent with
-  five other cross-service helpers in `corpuses/services/` (e.g.
-  `CorpusDocumentService._check_document_in_corpus`), so renaming one in
-  isolation would break that convention rather than clarify it.
+  (`opencontractserver/corpuses/services/lifecycle.py`) now emits its
+  "Bulk soft-deleted N document(s)" log via `transaction.on_commit`, so the line
+  is written only for durably committed trashing (no false success on a
+  rolled-back or failed-`COMMIT` block) — matching the rollback-safety contract
+  the primitive's dispatched `post_save` signals already use. Also promoted the
+  in-body PERF/MEMORY note to a "Scaling caveat" in the method docstring: the
+  primitive is O(1) in queries but still materializes the full document set in
+  memory, so it carries no built-in document-count ceiling for the
+  `empty_corpus` / folder cascade-delete callers.

--- a/changelog.d/2036-bulk-soft-delete-review-polish.changed.md
+++ b/changelog.d/2036-bulk-soft-delete-review-polish.changed.md
@@ -1,13 +1,15 @@
 - **Folded in code-review follow-ups (#2036) on the bulk-trash primitive**
   `DocumentLifecycleService.bulk_soft_delete_documents`
-  (`opencontractserver/corpuses/services/lifecycle.py`). Moved the success
-  `logger.info` + `return` *inside* the `transaction.atomic()` block so the
-  `trashed_doc_ids` set is referenced only within its defining scope (matching
-  the early `return 0` in the same block) — purely a clarity change, no
-  behavioural difference. Surfaced the existing in-body PERF/MEMORY note as a
-  "Scaling caveat" in the method docstring so callers eyeing an `empty_corpus` /
-  folder cascade-delete size limit see that the primitive is O(1) in *queries*
-  but still materializes the full doc set in memory (no built-in document-count
+  (`opencontractserver/corpuses/services/lifecycle.py`). The success audit log
+  now fires via `transaction.on_commit`, so it reports only durably committed
+  trashing (no false "soft-deleted N" line if the block rolls back or the
+  `COMMIT` fails) — the same rollback-safety contract the primitive's dispatched
+  `post_save` signals already rely on; the count is captured inside the
+  `atomic()` block so `trashed_doc_ids` is referenced only within its defining
+  scope. Also surfaced the existing in-body PERF/MEMORY note as a "Scaling
+  caveat" in the method docstring so callers eyeing an `empty_corpus` / folder
+  cascade-delete size limit see that the primitive is O(1) in *queries* but
+  still materializes the full doc set in memory (no built-in document-count
   ceiling). The review's `_dispatch_document_path_created_signals` rename
   suggestion was intentionally **not** taken: the `_`-prefix is consistent with
   five other cross-service helpers in `corpuses/services/` (e.g.

--- a/opencontractserver/corpuses/services/lifecycle.py
+++ b/opencontractserver/corpuses/services/lifecycle.py
@@ -611,14 +611,14 @@ class DocumentLifecycleService(BaseService):
             # Defer the audit log to on_commit so it reports only durably
             # committed trashing (never a false "soft-deleted N" on a rolled-back
             # block) — the rollback-safety contract the signals above rely on.
-            # Capturing the count keeps ``trashed_doc_ids`` consumed in-scope.
             trashed_count = len(trashed_doc_ids)
+            corpus_id, user_id = corpus.id, user.id
             transaction.on_commit(
                 lambda: logger.info(
                     "Bulk soft-deleted %s document(s) in corpus %s by user %s",
                     trashed_count,
-                    corpus.id,
-                    user.id,
+                    corpus_id,
+                    user_id,
                 )
             )
             return trashed_count

--- a/opencontractserver/corpuses/services/lifecycle.py
+++ b/opencontractserver/corpuses/services/lifecycle.py
@@ -464,11 +464,10 @@ class DocumentLifecycleService(BaseService):
 
         Scaling caveat — O(1) in *queries*, not in *memory*: this primitive
         still materializes both ``document_ids`` and the locked ``active_paths``
-        fully into Python lists (see the in-body PERF/MEMORY comment), so there
-        is **no built-in document-count ceiling**. That is fine for realistic
-        corpus sizes, but chunk/iterate the doc set here before exposing an
-        unbounded ``empty_corpus`` / folder cascade-delete to arbitrarily large
-        corpora (memory follow-up to #1951).
+        fully into Python lists, so there is **no built-in document-count
+        ceiling**. That is fine for realistic corpus sizes, but chunk/iterate
+        the doc set here before exposing an unbounded ``empty_corpus`` / folder
+        cascade-delete to arbitrarily large corpora (memory follow-up to #1951).
 
         NOTE: This is an internal primitive that performs **no permission
         check** — callers (``empty_corpus``, folder cascade-delete) must already
@@ -513,12 +512,10 @@ class DocumentLifecycleService(BaseService):
             # absent here (skipped, never double-trashed) and one added after it
             # is left alone — the same semantics as the prior per-document loop.
             #
-            # PERF/MEMORY: both ``document_ids`` and ``active_paths`` are fully
-            # materialized in memory, bounded by the in-scope document count —
-            # which the current callers (empty_corpus, folder cascade-delete)
-            # leave unbounded. Fine for realistic corpus sizes; this is the
-            # allocation point to revisit (chunk/iterate the doc set) before
-            # raising any hard document-count ceiling on these paths (#1951).
+            # PERF/MEMORY: this ``list()`` (plus the caller's ``document_ids``
+            # snapshot) is the unbounded allocation point behind the docstring
+            # "Scaling caveat" — chunk/iterate here to add a document-count
+            # ceiling for the empty_corpus / cascade-delete callers (#1951).
             active_paths = list(
                 DocumentPath.objects.select_for_update(of=("self",))
                 .select_related("document")

--- a/opencontractserver/corpuses/services/lifecycle.py
+++ b/opencontractserver/corpuses/services/lifecycle.py
@@ -462,6 +462,14 @@ class DocumentLifecycleService(BaseService):
         ``Corpus.remove_document`` produces, so trashed documents stay in the
         trash listing and remain restorable.
 
+        Scaling caveat — O(1) in *queries*, not in *memory*: this primitive
+        still materializes both ``document_ids`` and the locked ``active_paths``
+        fully into Python lists (see the in-body PERF/MEMORY comment), so there
+        is **no built-in document-count ceiling**. That is fine for realistic
+        corpus sizes, but chunk/iterate the doc set here before exposing an
+        unbounded ``empty_corpus`` / folder cascade-delete to arbitrarily large
+        corpora (memory follow-up to #1951).
+
         NOTE: This is an internal primitive that performs **no permission
         check** — callers (``empty_corpus``, folder cascade-delete) must already
         have verified corpus DELETE permission. It does not touch the folder
@@ -600,10 +608,14 @@ class DocumentLifecycleService(BaseService):
                         is_public=False
                     )
 
-        logger.info(
-            "Bulk soft-deleted %s document(s) in corpus %s by user %s",
-            len(trashed_doc_ids),
-            corpus.id,
-            user.id,
-        )
-        return len(trashed_doc_ids)
+            # ``trashed_doc_ids`` is defined and consumed entirely inside this
+            # atomic block (like the early ``return 0`` above), so the success
+            # log + return live here too — keeping the set's scope obvious
+            # instead of referencing it after the ``with`` has exited.
+            logger.info(
+                "Bulk soft-deleted %s document(s) in corpus %s by user %s",
+                len(trashed_doc_ids),
+                corpus.id,
+                user.id,
+            )
+            return len(trashed_doc_ids)

--- a/opencontractserver/corpuses/services/lifecycle.py
+++ b/opencontractserver/corpuses/services/lifecycle.py
@@ -608,14 +608,17 @@ class DocumentLifecycleService(BaseService):
                         is_public=False
                     )
 
-            # ``trashed_doc_ids`` is defined and consumed entirely inside this
-            # atomic block (like the early ``return 0`` above), so the success
-            # log + return live here too — keeping the set's scope obvious
-            # instead of referencing it after the ``with`` has exited.
-            logger.info(
-                "Bulk soft-deleted %s document(s) in corpus %s by user %s",
-                len(trashed_doc_ids),
-                corpus.id,
-                user.id,
+            # Defer the audit log to on_commit so it reports only durably
+            # committed trashing (never a false "soft-deleted N" on a rolled-back
+            # block) — the rollback-safety contract the signals above rely on.
+            # Capturing the count keeps ``trashed_doc_ids`` consumed in-scope.
+            trashed_count = len(trashed_doc_ids)
+            transaction.on_commit(
+                lambda: logger.info(
+                    "Bulk soft-deleted %s document(s) in corpus %s by user %s",
+                    trashed_count,
+                    corpus.id,
+                    user.id,
+                )
             )
-            return len(trashed_doc_ids)
+            return trashed_count


### PR DESCRIPTION
## Summary

Issue #2036 is the code review of PR #2030 (the shared bulk-trash primitive `DocumentLifecycleService.bulk_soft_delete_documents`, #1951). It raised **four** findings. This PR closes the two that are still applicable, confirms the one already fixed, and documents why the fourth was deliberately **not** taken.

## Findings assessment

| # | Review finding | Status on `main` | Action |
|---|----------------|------------------|--------|
| 1 | `TestBulkSoftDeletePrimitive.setUp` missing `super().setUp()` | ✅ **Already fixed** — landed in PR #2030 (commit `fa75fd1`, `test_corpus_objs_service.py:1011`) | None needed |
| 2 | O(N) memory bound not surfaced in the docstring | Still present — only an in-body comment had it | **Fixed** — added a "Scaling caveat" to the docstring |
| 3 | Drop the `_` from `_dispatch_document_path_created_signals` | Still `_`-prefixed | **Deliberately kept** — see rationale below |
| 4 | `logger.info` / `return` sit outside the `transaction.atomic()` block | Still present | **Fixed** — deferred the audit log via `transaction.on_commit` |

## Changes

**`opencontractserver/corpuses/services/lifecycle.py`**

- **(Finding 4)** The success audit log now fires via **`transaction.on_commit`**, so the "Bulk soft-deleted N document(s)" line is written **only for durably committed trashing** — never a false positive if the block rolls back or the `COMMIT` fails. This is the *rollback-safety contract the primitive's dispatched `post_save` signals already use*, and it is the only option that satisfies **both** the original finding #4 (don't reference the block-local `trashed_doc_ids` after the `with`) *and* the audit-accuracy concern raised in review: the callback is registered inside the `atomic()` block (so the set stays in-scope) but fires after the outermost `COMMIT`. **This is a behavioral improvement, not a cosmetic move** — under `ATOMIC_REQUESTS` the primitive always runs inside the request transaction, so the pre-PR log fired before the durable commit.
- **(Finding 2)** Surfaced the existing in-body `PERF/MEMORY` note as a docstring "Scaling caveat" so callers eyeing an `empty_corpus` / folder cascade-delete size limit see that the primitive is O(1) in *queries* but still materializes the full doc set in memory (no built-in document-count ceiling). The in-body comment was trimmed to a non-redundant allocation-point marker that points to the docstring (DRY — no verbatim duplication).

**`changelog.d/2036-bulk-soft-delete-review-polish.changed.md`** — changelog fragment.

## Why finding #3 (rename) was intentionally not taken

`_dispatch_document_path_created_signals` is **one of six** `_`-prefixed helpers in `corpuses/services/` that are deliberately called across sibling services:

| Helper | Cross-service call sites |
|--------|--------------------------|
| `CorpusDocumentService._check_document_in_corpus` | 4 |
| `CorpusPathService._dispatch_document_path_created_signals` | 3 |
| `CorpusPathService._compute_moved_path` | 3 |
| `CorpusPathService._fetch_occupied_paths_in_directory` | 2 |
| `CorpusPathService._create_successor_path_with_retry` | 2 |
| `CorpusPathService._target_directory_string_from_path` | 1 |

The convention in this service layer is: **no underscore = public per-app service API** (consumed by GraphQL / MCP / REST / Celery), **underscore = implementation helper that may be shared across sibling services in the same app** but isn't part of that public surface. Every caller of `_dispatch_document_path_created_signals` lives inside `corpuses/services/`. Renaming just this one would make it inconsistent with `_check_document_in_corpus` (which has *more* callers), so it would reduce consistency rather than improve it — and renaming all six is out of scope for a review nit. The reviewer themselves flagged this as a hedged "naming convention question … not a blocker."

## Out of scope (tracked for follow-up)

A later review round noted that the **caller** audit logs — `empty_corpus`'s "Emptied corpus" (`lifecycle.py:421`, outside its own `atomic()`) and `delete_folder`'s "Deleted folder" (`folders.py:802`) — are *not* `on_commit`-deferred, so they have the same rollback-safety gap under `ATOMIC_REQUESTS` and now log slightly before this primitive's deferred line. That is a **pre-existing**, independent hardening concern about *other* methods, not part of #2036's scope (the bulk primitive). Keeping this PR surgical; the caller-log sweep is better handled as its own change.

## Testing

- `python scripts/collate_changelog.py --check` → 136 fragments valid.
- `black --check` and `flake8` clean on the edited file.
- The backend suite couldn't be run in this environment (no Docker daemon), but the changes are safe for `TestBulkSoftDeletePrimitive`: the return value, query count, and DB-state semantics are unchanged, and no test asserts on the log message. (Note: `on_commit` callbacks don't fire under Django `TestCase`'s rolled-back transaction, so any *future* log-assertion test would need `TransactionTestCase` or `captureOnCommitCallbacks()`.)

Closes #2036.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GYGZZDf1ecbBt8cSzhZxMg)_