### PR TITLE
Harden bounded authority crawl: atomic dequeue + per-corpus Analysis reuse (#2027)

### DIFF
--- a/changelog.d/2027-authority-crawl.fixed.md
+++ b/changelog.d/2027-authority-crawl.fixed.md
@@ -1,0 +1,41 @@
+- Harden the bounded authority crawl against a concurrency race and provenance
+  bloat (issue #2027, a code review of the Phase-5 BFS engine):
+  - **Atomic dequeue claim.**
+    `AuthorityFrontierService.dequeue_queued()`
+    (`opencontractserver/enrichment/services/authority_frontier_service.py`)
+    was a plain `filter(discovery_state="queued")` read — the `in_progress`
+    transition only happened later inside `discover_and_bootstrap`, leaving a
+    TOCTOU window where two concurrent `crawl_authorities` tasks (e.g. two
+    manual triggers on the same corpus) could dequeue the SAME frontier row and
+    `discover_and_bootstrap` it twice (wasted provider calls, distorted summary
+    counters). It now claims the rows it returns inside a single
+    `SELECT … FOR UPDATE SKIP LOCKED` transaction, flipping them to
+    `in_progress`; a second worker skips locked rows and grabs the next ones.
+    Rows excluded by `max_depth` / `min_demand` are never claimed, so the
+    `frontier_drained` residual census still counts them as `queued`.
+  - **One provenance `Analysis` per authority corpus.** Every section of an
+    authority bootstraps into ONE corpus (the provider `title` is a constant —
+    all `usc-*` sections land in the single "United States Code" corpus), so the
+    BFS calls `EnrichmentService.apply()` on that corpus once per ingested
+    section. Each call previously minted a fresh `Analysis`
+    (`_get_analysis` → `Analysis.objects.create`), so a deep crawl left dozens
+    of provenance rows on one corpus. `CrawlAuthoritiesService.crawl()`
+    (`opencontractserver/enrichment/services/crawl_authorities_service.py`) now
+    caches the `Analysis` the first apply creates per corpus and threads it back
+    into the rest via `apply(analysis=…)`, capping it at one per corpus. A
+    misleading "this apply scan is bounded (one small document per section)"
+    comment was corrected.
+  - **Honest `blocked_by_bound` accounting.** Clarified (in comments) that
+    `blocked_by_bound["min_demand_or_depth"]` is populated only on the
+    `frontier_drained` stop — where every residual `queued` row is provably
+    bound-excluded — and intentionally NOT on the `max_authorities` /
+    `token_budget` early stops, whose unreached rows may be perfectly eligible
+    and are accounted for by the `frontier_residual` census instead.
+  - **Uniform tool signature.** `crawl_authorities` / `acrawl_authorities`
+    (`opencontractserver/llms/tools/core_tools/corpus_references.py`) now apply
+    `C.CRAWL_DEFAULT_*` constants to all five bound parameters instead of using
+    `None` sentinels for two of them and constants for the other three.
+- Regression tests: `test_authority_frontier.py` (dequeue atomically claims
+  returned rows / leaves filtered-out rows `queued`) and
+  `test_crawl_authorities.py::ApplyAnalysisReuseTests` (a crawl that ingests
+  multiple sections of one authority reuses a single provenance `Analysis`).

--- a/opencontractserver/enrichment/services/authority_frontier_service.py
+++ b/opencontractserver/enrichment/services/authority_frontier_service.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import dataclass
 
+from django.db import transaction
 from django.db.models import Count, Q
 from django.utils import timezone
 
@@ -143,19 +144,47 @@ class AuthorityFrontierService(BaseService):
         max_depth: int | None = None,
         min_demand: int = 0,
     ) -> list[AuthorityFrontier]:
-        """Highest-demand queued rows regardless of assigned provider.
+        """Atomically CLAIM the highest-demand queued rows for the crawl driver.
 
         Unlike ``dequeue_for_provider`` (which requires a stamped provider),
         this serves the crawl driver: it picks ``discovery_state="queued"`` rows
         ranked by ``-mention_count``, optionally bounded by depth and a minimum
         demand floor.  Provider selection happens later in the discovery service.
+
+        The returned rows are transitioned to ``in_progress`` inside a single
+        ``SELECT ... FOR UPDATE SKIP LOCKED`` transaction, so the dequeue is an
+        atomic *claim* rather than a plain read: two ``crawl_authorities`` tasks
+        running concurrently (e.g. two manual triggers on the same corpus) can
+        never return — and therefore never ``discover_and_bootstrap`` — the same
+        frontier row twice (issue #2027). ``skip_locked`` lets a second worker
+        pick the next available rows instead of blocking on the first worker's
+        lock. Rows excluded by ``max_depth`` / ``min_demand`` are never claimed,
+        so the crawl's ``frontier_drained`` residual census still sees them as
+        ``queued``.
         """
         qs = AuthorityFrontier.objects.filter(discovery_state="queued")
         if max_depth is not None:
             qs = qs.filter(depth__lte=max_depth)
         if min_demand:
             qs = qs.filter(mention_count__gte=min_demand)
-        return list(qs.order_by("-mention_count")[:limit])
+        with transaction.atomic():
+            rows = list(
+                qs.select_for_update(skip_locked=True).order_by("-mention_count")[
+                    :limit
+                ]
+            )
+            if rows:
+                now = timezone.now()
+                for row in rows:
+                    row.discovery_state = "in_progress"
+                    row.last_attempt = now
+                    # bulk_update bypasses auto_now — stamp ``modified`` so the
+                    # claim matches the single-row ``mark()`` writer.
+                    row.modified = now
+                AuthorityFrontier.objects.bulk_update(
+                    rows, ["discovery_state", "last_attempt", "modified"]
+                )
+        return rows
 
     @classmethod
     def seed_child_keys(

--- a/opencontractserver/enrichment/services/crawl_authorities_service.py
+++ b/opencontractserver/enrichment/services/crawl_authorities_service.py
@@ -136,8 +136,27 @@ class CrawlAuthoritiesService(BaseService):
         # iterations rather than constructing a fresh object on every BFS hop.
         enrichment = EnrichmentService()
 
+        # One provenance Analysis per authority corpus, reused across the run.
+        # Every section of a given authority bootstraps into ONE corpus — the
+        # provider's ``title`` is a constant, so every ``usc-*`` section lands in
+        # the single "United States Code" corpus — so a crawl that ingests N
+        # sections of an authority calls apply() on the SAME corpus N times.
+        # Letting each call mint its own Analysis (apply()'s default when
+        # ``analysis=None``) would leave N provenance rows on that one corpus;
+        # instead we capture the Analysis the first apply creates and feed it back
+        # into the rest, capping it at one per corpus (issue #2027).
+        from opencontractserver.analyzer.models import Analysis
+
+        apply_analyses: dict[int, Analysis] = {}
+
         while True:
-            # Hard cap checks before dequeue so the summary is honest.
+            # Hard cap checks before dequeue so the summary is honest. On these
+            # early stops we intentionally do NOT populate
+            # blocked_by_bound["min_demand_or_depth"]: rows still queued when a cap
+            # fires were simply not reached, and may be perfectly eligible (above
+            # min_demand, within max_depth) — attributing them to a bound would be
+            # a lie. The frontier_residual census (computed below for EVERY stop
+            # reason) accounts for them, so the summary is still non-silent.
             if ingested >= max_authorities:
                 stop_reason = "max_authorities"
                 break
@@ -150,10 +169,13 @@ class CrawlAuthoritiesService(BaseService):
                 limit=1, max_depth=max_depth, min_demand=min_demand
             )
             if not rows:
-                # Count how many queued rows remain so the summary is non-silent
-                # about what was left. This is the UNION of rows excluded by the
-                # min_demand floor and/or the max_depth bound — the single key
-                # does not attribute each row to one cause or the other.
+                # frontier_drained: dequeue returned nothing, so EVERY remaining
+                # queued row failed the (min_demand AND max_depth) filters. Here —
+                # and only here — is attributing the residual queued count to those
+                # bounds correct (the early max_authorities / token_budget breaks
+                # above leave their unreached-but-eligible rows to
+                # frontier_residual instead). The single key is the UNION of the
+                # two exclusions; it does not split each row by cause.
                 blocked_by_bound["min_demand_or_depth"] = (
                     AuthorityFrontier.objects.filter(discovery_state="queued").count()
                 )
@@ -206,14 +228,26 @@ class CrawlAuthoritiesService(BaseService):
             # Re-extract the authority's OWN outbound citations and seed the
             # frontier at depth+1 — only when we haven't reached max_depth.
             if row.depth < max_depth:
-                # Authority corpora hold one small document per statute section,
-                # so this apply scan is bounded (not a large-corpus scan).
+                # Reuse this corpus's provenance Analysis across sections (see the
+                # apply_analyses note above) so the BFS doesn't accumulate one
+                # Analysis row per section on a shared authority corpus.
+                apply_analysis = apply_analyses.get(authority_corpus_id)
                 apply_res = enrichment.apply(
                     corpus_id=authority_corpus_id,
                     creator_id=creator_id,
                     types=[C.REF_LAW],
                     extra_tiers=[C.DETECTION_TIER_GRAMMAR],
+                    analysis=apply_analysis,
                 )
+                if apply_analysis is None:
+                    # First apply on this corpus created the provenance Analysis;
+                    # cache it so the corpus's remaining sections reattach to it
+                    # instead of each minting a fresh one.
+                    new_analysis_id = apply_res.get("analysis_id")
+                    if new_analysis_id is not None:
+                        apply_analyses[authority_corpus_id] = Analysis.objects.get(
+                            pk=new_analysis_id
+                        )
 
                 outbound = list(
                     CorpusReferenceService.for_corpus(user, authority_corpus_id)

--- a/opencontractserver/llms/tools/core_tools/corpus_references.py
+++ b/opencontractserver/llms/tools/core_tools/corpus_references.py
@@ -247,14 +247,18 @@ def crawl_authorities(
     max_depth: int = C.CRAWL_DEFAULT_MAX_DEPTH,
     min_demand: int = C.CRAWL_DEFAULT_MIN_DEMAND,
     max_authorities: int = C.CRAWL_DEFAULT_MAX_AUTHORITIES,
-    per_jurisdiction_cap: int | None = None,
-    token_budget: int | None = None,
+    per_jurisdiction_cap: int = C.CRAWL_DEFAULT_PER_JURISDICTION_CAP,
+    token_budget: int = C.CRAWL_DEFAULT_TOKEN_BUDGET,
 ) -> dict:
     """Bounded recursive crawl: discover & ingest the authorities a corpus
     cites, then the authorities THOSE cite, up to ``max_depth`` hops. Returns a
     summary with per-state counts, per-jurisdiction tallies, the stop reason,
     and the full frontier residual census. Idempotent: already-ingested
     authorities are skipped, re-crawling creates zero duplicate documents.
+
+    All five bound parameters default to the ``C.CRAWL_DEFAULT_*`` constants —
+    a uniform signature so a caller reading it sees the same default style for
+    every bound (no None-sentinel for two of them and constants for the rest).
     """
     from opencontractserver.enrichment.services.crawl_authorities_service import (
         CrawlAuthoritiesService,
@@ -266,14 +270,8 @@ def crawl_authorities(
         max_depth=max_depth,
         min_demand=min_demand,
         max_authorities=max_authorities,
-        per_jurisdiction_cap=(
-            per_jurisdiction_cap
-            if per_jurisdiction_cap is not None
-            else C.CRAWL_DEFAULT_PER_JURISDICTION_CAP
-        ),
-        token_budget=(
-            token_budget if token_budget is not None else C.CRAWL_DEFAULT_TOKEN_BUDGET
-        ),
+        per_jurisdiction_cap=per_jurisdiction_cap,
+        token_budget=token_budget,
     )
 
 
@@ -284,8 +282,8 @@ async def acrawl_authorities(
     max_depth: int = C.CRAWL_DEFAULT_MAX_DEPTH,
     min_demand: int = C.CRAWL_DEFAULT_MIN_DEMAND,
     max_authorities: int = C.CRAWL_DEFAULT_MAX_AUTHORITIES,
-    per_jurisdiction_cap: int | None = None,
-    token_budget: int | None = None,
+    per_jurisdiction_cap: int = C.CRAWL_DEFAULT_PER_JURISDICTION_CAP,
+    token_budget: int = C.CRAWL_DEFAULT_TOKEN_BUDGET,
 ) -> dict:
     return await _db_sync_to_async(crawl_authorities)(
         creator_id=creator_id,

--- a/opencontractserver/tests/test_authority_frontier.py
+++ b/opencontractserver/tests/test_authority_frontier.py
@@ -509,6 +509,59 @@ class DequeueQueuedTests(TestCase):
         self.assertNotIn("usc-15:7b", keys)
         self.assertNotIn("usc-15:7c", keys)
 
+    def test_dequeue_atomically_claims_rows_in_progress(self):
+        """dequeue_queued is an atomic CLAIM, not a plain read (issue #2027).
+
+        Each returned row must be flipped to ``in_progress`` — both in the
+        returned object and in the DB — so a second concurrent dequeue cannot
+        re-return it and re-run ``discover_and_bootstrap`` on the same key.
+        """
+        self._make_row("usc-15:claim-a", mention_count=10)
+        self._make_row("usc-15:claim-b", mention_count=5)
+
+        first = AuthorityFrontierService.dequeue_queued(limit=1)
+        self.assertEqual(len(first), 1)
+        self.assertEqual(first[0].canonical_key, "usc-15:claim-a")
+        # Claimed in the returned object AND persisted to the DB.
+        self.assertEqual(first[0].discovery_state, "in_progress")
+        self.assertEqual(
+            AuthorityFrontier.objects.get(
+                canonical_key="usc-15:claim-a"
+            ).discovery_state,
+            "in_progress",
+        )
+        self.assertIsNotNone(first[0].last_attempt)
+
+        # A second dequeue must skip the already-claimed row and pick the next.
+        second = AuthorityFrontierService.dequeue_queued(limit=10)
+        keys = {r.canonical_key for r in second}
+        self.assertNotIn("usc-15:claim-a", keys)
+        self.assertIn("usc-15:claim-b", keys)
+
+    def test_filtered_out_rows_are_not_claimed(self):
+        """Rows excluded by min_demand/max_depth must stay ``queued`` (unclaimed).
+
+        The crawl's frontier_drained residual census counts ``queued`` rows, so
+        the claim must touch only rows it actually returns.
+        """
+        self._make_row("usc-15:keep", mention_count=5, depth=0)
+        self._make_row("usc-15:low", mention_count=1, depth=0)  # below min_demand
+        self._make_row("usc-15:deep", mention_count=5, depth=9)  # beyond max_depth
+
+        claimed = AuthorityFrontierService.dequeue_queued(
+            limit=10, max_depth=2, min_demand=2
+        )
+        self.assertEqual({r.canonical_key for r in claimed}, {"usc-15:keep"})
+        # The excluded rows are untouched — still queued for a later, looser pass.
+        self.assertEqual(
+            AuthorityFrontier.objects.get(canonical_key="usc-15:low").discovery_state,
+            "queued",
+        )
+        self.assertEqual(
+            AuthorityFrontier.objects.get(canonical_key="usc-15:deep").discovery_state,
+            "queued",
+        )
+
 
 class SeedChildKeysTests(TestCase):
     """Tests for AuthorityFrontierService.seed_child_keys (Phase-5 idempotent seeding)."""

--- a/opencontractserver/tests/test_crawl_authorities.py
+++ b/opencontractserver/tests/test_crawl_authorities.py
@@ -306,7 +306,7 @@ class ApplyAnalysisReuseTests(TransactionTestCase):
                 "canonical_key": frontier_row.canonical_key,
             }
 
-        seen_analyses: list[object] = []
+        seen_analyses: list[Analysis | None] = []
 
         def _mock_apply(
             *, corpus_id, creator_id, types=None, analysis=None, extra_tiers=None
@@ -352,8 +352,9 @@ class ApplyAnalysisReuseTests(TransactionTestCase):
         # First section lets apply mint the provenance Analysis (None passed in);
         # the second section REUSES it rather than minting a second row.
         self.assertIsNone(seen_analyses[0])
-        self.assertIsNotNone(seen_analyses[1])
-        self.assertEqual(seen_analyses[1].id, provenance.id)
+        reused = seen_analyses[1]
+        assert reused is not None  # narrows Analysis | None -> Analysis for mypy
+        self.assertEqual(reused.id, provenance.id)
         # No second enrichment Analysis was created for the corpus.
         self.assertEqual(
             Analysis.objects.filter(analyzed_corpus=corpus).count(),

--- a/opencontractserver/tests/test_crawl_authorities.py
+++ b/opencontractserver/tests/test_crawl_authorities.py
@@ -248,6 +248,120 @@ def _make_empty_corpus_ref_mock():
     return mock_qs
 
 
+class ApplyAnalysisReuseTests(TransactionTestCase):
+    """A crawl must reuse ONE provenance Analysis per authority corpus.
+
+    Every section of an authority bootstraps into the SAME corpus (the
+    provider ``title`` is constant — all ``usc-*`` sections land in the single
+    "United States Code" corpus), so the BFS calls apply() on that one corpus
+    once per ingested section. Without reuse, each apply() would mint a fresh
+    Analysis, leaving N provenance rows on one corpus (issue #2027).
+    """
+
+    def test_apply_reuses_one_analysis_per_authority_corpus(self):
+        from opencontractserver.analyzer.models import Analysis
+        from opencontractserver.corpuses.models import Corpus
+        from opencontractserver.enrichment.services import (
+            AuthorityFrontierService,
+            EnrichmentService,
+        )
+        from opencontractserver.types.enums import JobStatus
+
+        user = _make_user("apply-reuse-user")
+
+        # Two depth-0 rows of the same authority; both bootstrap into ONE corpus.
+        for i in range(2):
+            AuthorityFrontier.objects.create(
+                canonical_key=f"usc-15:{500 + i}",
+                authority="usc-15",
+                jurisdiction="us-federal",
+                authority_type=C.AUTHORITY_TYPE_STATUTE,
+                mention_count=5,
+                depth=0,
+                discovery_state="queued",
+            )
+
+        # The shared authority corpus + the provenance Analysis the FIRST apply
+        # "creates" (apply is mocked, so we stand it up here and hand back its id).
+        corpus = Corpus.objects.create(title="United States Code", creator=user)
+        analyzer = EnrichmentService.get_or_create_analyzer(user.id)
+        provenance = Analysis.objects.create(
+            analyzer=analyzer,
+            analyzed_corpus=corpus,
+            creator_id=user.id,
+            status=JobStatus.RUNNING.value,
+        )
+
+        def _ingest_same_corpus(
+            *, creator_id, frontier_row, make_public=True, relink_async=True
+        ):
+            AuthorityFrontierService.mark(frontier_row, "ingested")
+            return {
+                "status": "ingested",
+                "corpus_id": corpus.id,
+                "documents_created": 1,
+                "documents_updated": 0,
+                "documents_skipped": 0,
+                "documents_restamped": 0,
+                "canonical_key": frontier_row.canonical_key,
+            }
+
+        seen_analyses: list[object] = []
+
+        def _mock_apply(
+            *, corpus_id, creator_id, types=None, analysis=None, extra_tiers=None
+        ):
+            # Record what the crawl threaded in, and mimic apply()'s real return
+            # contract: a fresh provenance Analysis on the first (analysis=None)
+            # call, the same one echoed back when reused.
+            seen_analyses.append(analysis)
+            return {
+                "references_created": 0,
+                "analysis_id": provenance.id if analysis is None else analysis.id,
+            }
+
+        with patch(
+            "opencontractserver.enrichment.services.crawl_authorities_service"
+            ".AuthorityDiscoveryService.discover_and_bootstrap",
+            side_effect=_ingest_same_corpus,
+        ), patch(
+            "opencontractserver.enrichment.services.crawl_authorities_service"
+            ".EnrichmentService.apply",
+            side_effect=_mock_apply,
+        ), patch(
+            "opencontractserver.enrichment.services.crawl_authorities_service"
+            ".CorpusReferenceService.for_corpus",
+            return_value=_make_empty_corpus_ref_mock(),
+        ), patch(
+            "opencontractserver.enrichment.services.crawl_authorities_service"
+            ".AuthorityFrontierService.seed_from_wanted_authorities",
+            return_value={"frontier_created": 0, "frontier_updated": 0},
+        ):
+            summary = CrawlAuthoritiesService.crawl(
+                creator_id=user.id,
+                max_depth=1,
+                min_demand=1,
+                max_authorities=50,
+                per_jurisdiction_cap=100,
+                token_budget=0,
+            )
+
+        self.assertEqual(summary["authorities_ingested"], 2)
+        # apply() ran once per ingested section, both on the shared corpus.
+        self.assertEqual(len(seen_analyses), 2)
+        # First section lets apply mint the provenance Analysis (None passed in);
+        # the second section REUSES it rather than minting a second row.
+        self.assertIsNone(seen_analyses[0])
+        self.assertIsNotNone(seen_analyses[1])
+        self.assertEqual(seen_analyses[1].id, provenance.id)
+        # No second enrichment Analysis was created for the corpus.
+        self.assertEqual(
+            Analysis.objects.filter(analyzed_corpus=corpus).count(),
+            1,
+            "crawl must reuse one provenance Analysis per authority corpus",
+        )
+
+
 class BoundsTerminationTests(TransactionTestCase):
     """Each bound must set the matching stop_reason and the loop must terminate."""
 


### PR DESCRIPTION
## Summary

Addresses the code review in #2027 (*Authority Discovery Phase 5 — Bounded Recursive Crawl*). I re-verified each flagged item against the current codebase and fixed the three substantive ones plus the minor sentinel observation.

### Issue #1 — `dequeue_queued` has no atomic dequeue guard (moderate) ✅
`AuthorityFrontierService.dequeue_queued()` was a plain `filter(discovery_state="queued")` read; the `in_progress` transition only happened later inside `discover_and_bootstrap`. So two concurrent `crawl_authorities` tasks (e.g. two manual triggers on the same corpus) could dequeue the **same** frontier row and `discover_and_bootstrap` it twice — wasted provider calls and distorted summary counters.

**Fix:** the method now claims the rows it returns inside a single `SELECT … FOR UPDATE SKIP LOCKED` transaction, flipping them to `in_progress`. `skip_locked` lets a second worker grab the next available rows instead of blocking. Rows excluded by `max_depth`/`min_demand` are never claimed, so the crawl's `frontier_drained` residual census still sees them as `queued`.

### Issue #2 — fresh `Analysis` per `apply()` (low-moderate) ✅ — confirmed, and broader than suspected
The review asked whether `_get_analysis` is idempotent per corpus. It isn't (`Analysis.objects.create(...)`), **and** the impact is larger than a per-section row count: `provider.title` is a **constant** (`"United States Code"`, `"Code of Federal Regulations"`, …) and the authority corpus is `get_or_create(title=corpus_title, creator=user)` — so *every* `usc-*` section lands in **one** corpus. The BFS therefore calls `apply()` on that single corpus once per ingested section, each call minting a new `Analysis`.

**Fix:** `crawl()` caches the `Analysis` the first apply creates per corpus (via the existing `apply_res["analysis_id"]`) and threads it back through `apply(analysis=…)` for that corpus's remaining sections — capping it at one provenance `Analysis` per corpus. The writer's claim/finalize rules already make reusing one `Analysis` across applies safe. The stale "this apply scan is bounded (one small document per section)" comment was corrected.

### Issue #3 — `blocked_by_bound` only set on `frontier_drained` (minor) ✅
The review tentatively suggested also populating `blocked_by_bound["min_demand_or_depth"]` on the `max_authorities`/`token_budget` stops. That would be **incorrect**: rows still `queued` when a cap fires were simply *not reached* and may be perfectly eligible (above `min_demand`, within `max_depth`) — attributing them to a bound is a lie. The attribution is only valid on `frontier_drained`, where dequeue returning nothing proves every residual `queued` row failed the filters. Added precise comments documenting this; the `frontier_residual` census already covers the early-stop residue (no silent truncation).

### Minor — sentinel inconsistency ✅
`crawl_authorities` / `acrawl_authorities` (`corpus_references.py`) now apply the `C.CRAWL_DEFAULT_*` constants to **all five** bound parameters instead of mixing `None` sentinels for two of them with constants for the other three. The tool schema is declared manually in `tool_registry.py`, so the agent-facing surface is unchanged.

### `candidate_keys` observation
No change — the review confirmed the suffix-stripping regex works as intended with good coverage.

## Tests
All run green inside the test image (`120 passed`):
- `test_authority_frontier.py` — **new:** dequeue atomically claims returned rows (`in_progress`, second dequeue skips them); filtered-out rows stay `queued`.
- `test_crawl_authorities.py::ApplyAnalysisReuseTests` — **new:** a crawl ingesting multiple sections of one authority reuses a single provenance `Analysis`.
- Existing suites unaffected: `test_authority_frontier`, `test_authority_frontier_actions`, `test_crawl_authorities`, `test_enrichment_tools`, `test_authority_discovery_subset`.

`black`, `isort`, `flake8` clean. Changelog fragment added at `changelog.d/2027-authority-crawl.fixed.md`.

Closes #2027

---
_Generated by [Claude Code](https://claude.ai/code/session_01Avpvc2f1H9cuV2jfysXoXD)_