### PR TITLE
Remote-ingest worker: offload parse+embed, stream faithful documents via worker-upload

### DIFF
--- a/changelog.d/remote-ingest-enrichment.added.md
+++ b/changelog.d/remote-ingest-enrichment.added.md
@@ -1,0 +1,30 @@
+- **Remote-ingest pre-processing / enrichment stage.** The remote-ingest worker
+  (`scripts/remote_ingest/`) can now run pluggable enrichers that CALCULATE and
+  INJECT extra artifacts onto each document after parsing and before
+  embedding+upload, so injected annotations are embedded and ingested like the
+  parser's own:
+  - `scripts/remote_ingest/enrichers.py` — an `EnricherContext` (exposes the
+    parsed export + text, plus correctness helpers `find_token_matches(regex)`
+    and `token_annotation(label, match)` that build a valid `annotation_json`),
+    an `Enrichment` result type (structured `custom_meta`, `title`/`description`,
+    `doc_labels`, injected `annotations`, `relationships`, label definitions),
+    a dotted-path loader (`--enricher module:callable` / `OC_ENRICHERS`), and
+    `validate_enrichment()` which enforces the worker-upload correctness rules
+    (valid token indices, label definitions present, unique ids, resolvable
+    relationship references) so a buggy enricher fails the document loudly
+    instead of shipping a broken annotation.
+  - `scripts/remote_ingest/example_enrichers.py` — three runnable examples
+    (filename → `custom_meta`, detected dates → TOKEN_LABEL annotations,
+    content → DOC_TYPE_LABEL).
+  - Driver wiring (`oc_remote_ingest.py`): enrichment runs in `_process_one`
+    before embedding (injected annotations get embedded) and folds into the
+    worker-upload metadata; new `--enricher` flag / `OC_ENRICHERS` env.
+- **Worker-upload accepts structured document metadata.** Added an optional
+  `custom_meta` field to `WorkerDocumentUploadMetadataType`
+  (`opencontractserver/types/dicts.py`); `_process_single_upload`
+  (`opencontractserver/worker_uploads/tasks.py`) now writes it to
+  `Document.custom_meta` (on both the standalone doc and the corpus-isolated
+  copy) and the serializer validates it is a JSON object. Previously worker
+  uploads could attach categorical metadata only via `doc_labels`; arbitrary
+  structured metadata (jurisdiction, parsed dates, contract number, …) now
+  round-trips.

--- a/changelog.d/remote-ingest-typed-metadata.added.md
+++ b/changelog.d/remote-ingest-typed-metadata.added.md
@@ -1,0 +1,24 @@
+- **Remote-ingest enrichment can set TYPED corpus metadata (Column/Datacell), not
+  just the freeform `custom_meta` field.** The enrichment stage can now populate
+  the document metadata system (`Fieldset` → `Column` → `Datacell` — the UI's
+  document-metadata grid, successor to legacy "metadata annotations"):
+  - `MetadataService.upsert_document_metadata(corpus, document, user, column_name,
+    data_type, value, validation_config=None)`
+    (`opencontractserver/extracts/services/metadata.py`) — internal ingestion
+    entry point that get-or-creates a manual-entry `Column` in the corpus metadata
+    schema (auto-creating the `corpus.metadata_schema` `Fieldset`) and
+    update_or_creates the `extract=NULL` `Datacell` (`data={"value": value}`),
+    type-validated by `Datacell.clean()`. Reuses the same model path as the
+    `SetMetadataValue` GraphQL mutation.
+  - Worker-upload accepts a `metadata` list on `WorkerDocumentUploadMetadataType`
+    (`opencontractserver/types/dicts.py`, new `WorkerMetadataFieldType`);
+    `_process_single_upload` (`opencontractserver/worker_uploads/tasks.py`) sets
+    each value via the service; the serializer validates entry shape + data_type.
+    A value that violates its column's `data_type` fails the upload instead of
+    silently landing a bad value.
+  - Driver: `Enrichment.metadata` + `metadata_field(name, value, data_type=…)`
+    (`scripts/remote_ingest/enrichers.py`) with client-side type validation
+    (`validate_enrichment`) mirroring the server rules; example enrichers updated
+    to emit typed metadata (`Contract Number`/`Revision`/`Category` STRING,
+    `Effective Date` DATE, `Contract Type` CHOICE). The freeform `custom_meta`
+    path remains available for non-schema data.

--- a/changelog.d/remote-ingest-worker.added.md
+++ b/changelog.d/remote-ingest-worker.added.md
@@ -1,0 +1,30 @@
+- **Remote-ingest worker: offload parsing + enrichment to off-cluster hosts.**
+  Added a driver and Docker bundle (`scripts/remote_ingest/`) that run the FULL
+  ingestion pipeline (Docling parse + embeddings) on a remote workstation and
+  stream fully-processed, faithfully-mirrored documents to a target instance via
+  the worker-upload REST API (`/api/worker-uploads/documents/`) — no access to
+  the target's database required. Because the worker runs the same Docling
+  microservice image and the same `DoclingParser` code, the PAWLs token layer,
+  structural annotations and embeddings are identical to an in-cluster
+  ingestion (faithful by construction). Components:
+  - `scripts/remote_ingest/oc_remote_ingest.py` — resumable per-document driver
+    (SQLite ledger; `plan`/`run`/`verify`/`status` subcommands; thread-pool
+    concurrency; back-pressure against the target's worker-upload backlog;
+    bounded retry/backoff honouring `429 Retry-After`).
+  - `scripts/remote_ingest/remote_worker.yml` + `worker-entrypoint.sh` — a
+    self-contained bundle (docling-parser + vector-embedder + worker) the remote
+    host brings up with a few commands.
+  - `config/settings/remote_worker.py` — a lean Django settings module that
+    points at a throwaway SQLite file so the worker needs no Postgres/Redis. The
+    parse path is database-free; settings are sourced from `DOCLING_*` /
+    `EMBEDDINGS_*` env vars.
+  - `opencontractserver/worker_uploads/management/commands/mint_worker_token.py`
+    — one-command server-side setup: creates/reuses a worker account and prints a
+    one-time corpus-scoped `CorpusAccessToken`.
+  - `BaseChunkedParser.parse_pdf_bytes()`
+    (`opencontractserver/pipeline/base/chunked_parser.py`) — a new database-free
+    entry point that turns raw PDF bytes into an `OpenContractDocExport` (chunk
+    split → parse → reassemble → image extraction) without reading a `Document`
+    row, so the parser can be driven headlessly. `_parse_document_impl` now
+    fetches the PDF bytes and delegates to it (behaviour unchanged).
+  See `scripts/remote_ingest/README.md`.

--- a/changelog.d/worker-upload-fidelity.changed.md
+++ b/changelog.d/worker-upload-fidelity.changed.md
@@ -1,0 +1,32 @@
+- **Worker-upload ingestion now produces a faithful mirror of the parser
+  pipeline.** Closed three fidelity gaps in
+  `opencontractserver/worker_uploads/tasks.py::_process_single_upload` so a
+  document pushed through `/api/worker-uploads/documents/` ends up
+  byte-for-byte equivalent to one ingested in-cluster:
+  - **Structural annotation set materialisation.** Previously the parser's
+    structural annotations (which are nearly *all* of a Docling parse) were
+    imported as plain per-document annotations (`structural=True` but
+    `structural_set=NULL`), diverging from in-cluster ingestion where they live
+    in a shared `StructuralAnnotationSet` (`document=NULL`) and resolve through
+    the structural-set join in `AnnotationService.get_document_annotations`. The
+    worker path now calls `build_subtree_groups_for_document` +
+    `create_structural_annotation_set` (the same steps as
+    `BaseParser.save_parsed_data`). The migration logic was extracted from
+    `BaseParser._create_structural_annotation_set` into a shared
+    `opencontractserver/utils/structural_sets.py::create_structural_annotation_set`
+    (no behaviour change to the parser path; DRY).
+  - **Thumbnail generation.** The worker path now dispatches `extract_thumbnail`
+    after ingest (the uploaded PDF is stored, so the server can regenerate
+    `Document.icon` exactly as the parser pipeline does). This is the standalone
+    thumbnail task — it does not trigger a re-parse.
+  - **Embedding ownership.** `import_annotations` gained a
+    `dispatch_embeddings: bool = True` parameter
+    (`opencontractserver/utils/importing.py`). When a worker upload supplies
+    pre-computed embeddings, `_process_single_upload` passes
+    `dispatch_embeddings=False` so the server does not redundantly re-embed every
+    annotation — the remote worker owns the embedding layer (the point of
+    offloading enrichment). With no embeddings supplied, the server embeds as
+    before.
+  - `WorkerDocumentUploadMetadataType` gained optional `parser_name` /
+    `parser_version` fields so a remotely-parsed document records the same
+    structural-set provenance as an in-cluster parse.

--- a/config/settings/remote_worker.py
+++ b/config/settings/remote_worker.py
@@ -1,0 +1,36 @@
+"""
+Django settings for the remote-ingest worker (``scripts/remote_ingest``).
+
+The remote worker runs the OpenContracts parsing pipeline (DoclingParser) on a
+beefy off-cluster host and streams finished documents to a target instance via
+the worker-upload REST API. It NEVER touches the target's database — it only
+needs Django importable so the real parser code (and its model imports) loads.
+
+To keep the remote host dependency-free (no Postgres, no Redis), this module
+points ``DATABASE_URL`` at a throwaway SQLite file. No migrations are run, so the
+tables do not exist — but the only DB access on the parse path is
+``PipelineComponentBase._load_settings`` querying ``PipelineSettings``, which
+catches the resulting error and falls back to dataclass defaults + the
+``DOCLING_*`` / ``EMBEDDINGS_*`` environment variables. The parse itself
+(``DoclingParser.parse_pdf_bytes``) is entirely database-free.
+
+If a deployment prefers a real database (e.g. to pin parser settings via the
+``PipelineSettings`` table), point ``DATABASE_URL`` at any reachable Postgres —
+this module's only job is to provide safe defaults so Django boots without one.
+"""
+
+import os
+
+# These MUST be set before importing base.py: base reads ``DATABASE_URL`` via
+# ``env.db(...)`` (no default) at import time. A throwaway SQLite path keeps the
+# remote host free of any database service.
+os.environ.setdefault("DATABASE_URL", "sqlite:////tmp/oc_remote_worker.sqlite3")
+os.environ.setdefault("DJANGO_SECRET_KEY", "remote-worker-not-a-secret-no-web-surface")
+
+from .base import *  # noqa: E402,F401,F403
+
+# The worker exposes no web/admin surface, runs no Celery, serves no requests.
+DEBUG = False
+
+# Belt-and-suspenders: never run ATOMIC_REQUESTS against the placeholder DB.
+DATABASES["default"]["ATOMIC_REQUESTS"] = False  # noqa: F405

--- a/docs/upload_methods/index.md
+++ b/docs/upload_methods/index.md
@@ -15,6 +15,7 @@ effects that certain annotation types trigger on import.
 | [Corpus Export/Import](corpus_export_import.md) | Exporting and re-importing full corpuses with annotations, labels, and configuration |
 | [Annotated Document Import](annotated_document_import.md) | Importing a single document with pre-built annotations into an existing corpus |
 | [Worker Uploads (REST API)](worker_uploads.md) | Token-scoped REST API for external pipelines to push pre-processed documents with annotations and embeddings |
+| [Remote Ingest Worker](remote_ingest_worker.md) | Run the full parse + embed pipeline on your own hardware and stream finished documents (with calculated metadata/annotations) to a target instance |
 | [Annotation Side Effects](annotation_side_effects.md) | Special annotation types that create document indexes, hierarchies, and structural data on import |
 
 ## Quick Reference: Which Method to Use
@@ -23,7 +24,8 @@ effects that certain annotation types trigger on import.
 |----------|--------|
 | Upload a few documents for manual annotation | [Single Upload](single_upload.md) |
 | Upload hundreds of documents preserving folder organization | [Bulk ZIP Import](bulk_zip_import.md) |
-| Bulk-load a very large local PDF tree (100k+ files), resumably | [Bulk ZIP Import](bulk_zip_import.md) (`scripts/bulk_import` CLI driver) |
+| Bulk-load a very large local PDF tree (100k+ files), resumably -- server parses | [Bulk ZIP Import](bulk_zip_import.md) (`scripts/bulk_import` CLI driver) |
+| Bulk-load a very large local tree, offloading parse + embed to your own hardware | [Remote Ingest Worker](remote_ingest_worker.md) (`scripts/remote_ingest` CLI driver) |
 | Migrate a fully-annotated corpus to another instance | [Corpus Export/Import](corpus_export_import.md) |
 | Programmatically inject a document with pre-built annotations | [Annotated Document Import](annotated_document_import.md) |
 | Feed documents from an external processing pipeline via REST API | [Worker Uploads](worker_uploads.md) |

--- a/docs/upload_methods/remote_ingest_worker.md
+++ b/docs/upload_methods/remote_ingest_worker.md
@@ -1,0 +1,186 @@
+# Remote Ingest Worker
+
+The remote ingest worker runs the **full OpenContracts ingestion pipeline**
+(Docling parse + embeddings) on a beefy off-cluster host and streams the
+finished documents -- PAWLs token layer, text layer, structural annotations,
+relationships, embeddings, and any metadata you calculate -- into a corpus via
+the [Worker Uploads](worker_uploads.md) REST API.
+
+It is the tool for the "I have spare workstations and a 100k--1M document corpus
+to populate" problem: the expensive parsing and enrichment happen on **your**
+hardware, and the target instance just ingests the finished artifacts.
+
+## When to Use It
+
+- You want to **offload parsing and embedding** to your own machines instead of
+  paying for it on the OpenContracts server.
+- You have a **very large** local document tree (hundreds of thousands of files)
+  to ingest resumably.
+- You want each document to carry **calculated metadata and annotations**
+  (detected dates, clause tags, typed metadata fields) produced by your own code.
+
+### Versus the Bulk ZIP CLI
+
+Both `scripts/bulk_import/` and `scripts/remote_ingest/` are CLI drivers for
+large local corpora, but they offload different work:
+
+| | Bulk ZIP driver (`scripts/bulk_import`) | Remote ingest worker (`scripts/remote_ingest`) |
+|---|---|---|
+| What it ships | **raw** PDFs (ZIP) | **fully-processed** documents |
+| Who parses + embeds | the **server** | the **remote worker** (your hardware) |
+| Offloads compute? | No | **Yes** |
+| Endpoint | `/api/imports/zip-to-corpus/` | `/api/worker-uploads/documents/` |
+| Pre-processing hook | -- | Yes (calc + inject metadata/annotations) |
+
+Use the bulk ZIP driver when the server has spare capacity; use the remote
+ingest worker when you want to throw your own hardware at ingestion.
+
+## Faithful by Construction
+
+The worker runs the **same Docling microservice image** and the **same
+`DoclingParser` code** the server runs, and embeds against the **same
+vector-embedder image**. So the result is indistinguishable from an in-cluster
+ingestion:
+
+- **PAWLs token layer** -- identical tokenization (no drift); the worker-upload
+  path trusts these tokens verbatim.
+- **Text layer** -- rebuilt from the shipped PAWLs with the same
+  `plasmapdf.build_translation_layer` the server uses.
+- **Structural annotations + relationships** -- produced by the real parser; the
+  worker-upload path materializes a `StructuralAnnotationSet` and subtree-group
+  relationships exactly as in-cluster ingestion does.
+- **Embeddings** -- same model, same inputs (full text for the document,
+  `rawText` per annotation).
+- **Thumbnail** -- regenerated server-side from the uploaded PDF.
+
+## How It Works
+
+A small **docker-compose bundle** runs on the remote host: the Docling parser
+microservice, the vector embedder microservice, and a worker driver. The driver
+is a resumable, per-document CLI:
+
+1. `plan` scans the PDF tree into a SQLite ledger.
+2. `run` parses each PDF (real `DoclingParser`), runs your enrichers, computes
+   embeddings, and `POST`s a `multipart/form-data` payload (PDF + metadata JSON)
+   to `/api/worker-uploads/documents/` with `Authorization: WorkerKey <token>`.
+3. `verify` polls the target for each upload's terminal status.
+
+It streams per document (no archive is ever built), runs a thread pool of
+workers, and paces itself against the target's worker-upload backlog. The ledger
+makes the whole run crash-resumable -- re-running `run` skips finished documents.
+The worker needs **no database access** to the target: it only makes outbound
+HTTPS calls to the worker-upload endpoint.
+
+## Setup
+
+### 1. On the server -- mint a corpus-scoped token (one command)
+
+```bash
+python manage.py mint_worker_token --corpus <CORPUS_PK> --worker-name <name>
+```
+
+This prints a one-time `OC_WORKER_TOKEN` bound to exactly one corpus (the remote
+host can never target another). The corpus must already exist. See
+[Worker Uploads](worker_uploads.md) for the token model.
+
+### 2. On the remote host -- run the bundle (a few commands)
+
+```bash
+git clone <opencontracts repo>          # the worker runs the real parser code
+cd opencontracts/scripts/remote_ingest
+
+export OC_TARGET_URL=https://opencontracts.example.com
+export OC_WORKER_TOKEN=<token from step 1>
+export OC_DATA_DIR=/data/pdfs           # your directory tree of PDFs
+export VECTOR_EMBEDDER_API_KEY=<key>    # must match the embedder's API_KEY
+
+docker compose -f remote_worker.yml up -d --build docling-parser vector-embedder
+docker compose -f remote_worker.yml run --rm worker plan
+docker compose -f remote_worker.yml run --rm worker run --max-workers 8
+docker compose -f remote_worker.yml run --rm worker verify
+```
+
+The directory tree under `OC_DATA_DIR` is mirrored into the corpus's folder
+structure. See [`scripts/remote_ingest/README.md`](https://github.com/Open-Source-Legal/OpenContracts/blob/main/scripts/remote_ingest/README.md)
+for the full flag reference (`--no-embeddings`, `--flat`, `--limit`,
+`--queue-high/--queue-low`, etc.).
+
+## Pre-processing / Enrichment: Calculate and Inject Metadata + Annotations
+
+Often you want each document to carry **more than the parser produces**: typed
+metadata, a document-type label, or extra annotations you calculate (detected
+dates, parties, clauses, an LLM classification). The worker runs a pluggable
+**enrichment stage** after parsing and *before* embedding + upload -- so anything
+you inject is embedded and ingested like the parser's own output.
+
+An enricher is a callable `(EnricherContext) -> Enrichment`, wired in with
+`--enricher module:function` (repeatable) or the `OC_ENRICHERS` env var. The
+context provides correctness helpers (`find_token_matches(regex)`,
+`token_annotation(label, match)`) that build valid `annotation_json`, and the
+worker **validates** every enrichment before upload so a buggy enricher fails the
+document loudly instead of shipping a broken annotation.
+
+```python
+import re
+from enrichers import Enrichment, EnricherContext, label_def, metadata_field, TOKEN_LABEL
+
+def enrich(ctx: EnricherContext) -> Enrichment:
+    enr = Enrichment(
+        # Typed corpus metadata (Column/Datacell -- the document metadata grid):
+        metadata=[
+            metadata_field("Contract Number", "058000"),                 # STRING (inferred)
+            metadata_field("Effective Date", "2025-01-01", data_type="DATE"),
+        ],
+        # Label definitions for any annotations we inject:
+        annotation_labels={"EFFECTIVE_DATE": label_def("EFFECTIVE_DATE", TOKEN_LABEL)},
+    )
+    # Inject token annotations for matched text (faithful annotation_json built for you):
+    for m in ctx.find_token_matches(r"\b\w+ \d{1,2}, \d{4}\b"):
+        enr.annotations.append(ctx.token_annotation("EFFECTIVE_DATE", m))
+    return enr
+```
+
+```bash
+docker compose -f remote_worker.yml run --rm worker run --enricher my_enrichers:enrich
+```
+
+What an `Enrichment` can carry (all optional, additive):
+
+| Field | Effect |
+|---|---|
+| `metadata` (`metadata_field`) | **typed corpus metadata** -- `Column`/`Datacell` values (the UI's document metadata grid, successor to legacy metadata annotations). Corpus-scoped, typed, queryable. |
+| `custom_meta` (dict) | a freeform JSON blob on `Document.custom_meta` (not the typed schema) |
+| `doc_labels` (+ defs) | apply `DOC_TYPE_LABEL`s |
+| `annotations` (+ labels) | inject token/span annotations; they get embedded + rendered |
+| `relationships` | annotation-to-annotation relationships |
+| `title` / `description` | override document title/description |
+
+### Two metadata mechanisms
+
+OpenContracts has two ways to attach document metadata, and the enrichment stage
+supports both:
+
+- **Typed corpus metadata** -- the `Fieldset` -> `Column` -> `Datacell` system
+  (see [Metadata Fields](../metadata/metadata_fields.md)). This is what the UI
+  shows as document metadata, it is typed and queryable, and it is the preferred
+  mechanism. Emit it with `metadata_field(name, value, data_type=...)`. On ingest
+  the worker get-or-creates a manual-entry `Column` (by name) in the corpus
+  metadata schema and sets the document's value, type-validated against the
+  column. Supported types: `STRING, TEXT, BOOLEAN, INTEGER, FLOAT, DATE
+  (YYYY-MM-DD), DATETIME (ISO), URL, EMAIL, CHOICE, MULTI_CHOICE, JSON`.
+- **`Document.custom_meta`** -- a freeform JSON blob for ad-hoc data that does not
+  belong in the corpus schema.
+
+## Security
+
+- **Auth**: a corpus-scoped `CorpusAccessToken` sent as
+  `Authorization: WorkerKey <token>` over TLS. The corpus is fixed by the token
+  binding -- the remote host cannot reach another corpus or any other API.
+- **No database access**: the worker only makes outbound HTTPS calls to
+  `/api/worker-uploads/`.
+- **No inbound ports**: the worker initiates all connections.
+- **Enricher trust model**: enrichers are first-party Python you write and run on
+  your own worker host; do not load enricher modules you did not write.
+
+For production, run the target behind a reverse proxy with `limit_req` for hard
+rate limiting (the per-token limit is best-effort).

--- a/docs/upload_methods/worker_uploads.md
+++ b/docs/upload_methods/worker_uploads.md
@@ -134,3 +134,13 @@ Settings for accounts, Corpus Settings for tokens) and via GraphQL mutations.
 For the complete setup walkthrough with examples, UI screenshots, and the full
 metadata schema reference, see the
 [Worker Upload System Walkthrough](../worker_uploads/walkthrough.md).
+
+## Higher-Level Driver: The Remote Ingest Worker
+
+You usually do not call this REST API by hand. The
+[Remote Ingest Worker](remote_ingest_worker.md) (`scripts/remote_ingest`) is a
+turnkey, resumable CLI + docker-compose bundle that runs the **real** Docling
+parser and embedder on your own hardware, optionally calculates extra metadata
+and annotations, and streams the finished documents to this endpoint -- so the
+upload metadata above is produced faithfully for you rather than assembled by
+hand. Also mints tokens with one command: `python manage.py mint_worker_token`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,6 +79,7 @@ nav:
       - Single Upload: upload_methods/single_upload.md
       - Bulk Zip Import: upload_methods/bulk_zip_import.md
       - Worker Uploads (REST): upload_methods/worker_uploads.md
+      - Remote Ingest Worker: upload_methods/remote_ingest_worker.md
       - Annotated Document Import: upload_methods/annotated_document_import.md
       - Corpus Export / Import: upload_methods/corpus_export_import.md
       - Annotation Side Effects: upload_methods/annotation_side_effects.md

--- a/mypy.ini
+++ b/mypy.ini
@@ -528,6 +528,9 @@ ignore_errors = True
 [mypy-opencontractserver.tests.test_worker_uploads]
 ignore_errors = True
 
+[mypy-opencontractserver.tests.test_mint_worker_token_command]
+ignore_errors = True
+
 [mypy-opencontractserver.tests.test_zip_import_integration]
 ignore_errors = True
 

--- a/opencontractserver/extracts/services/metadata.py
+++ b/opencontractserver/extracts/services/metadata.py
@@ -577,3 +577,105 @@ class MetadataService(BaseService):
             return False, "Only manual entry columns can be modified", None
 
         return True, "", column
+
+    # Valid metadata column data types (mirrors CreateMetadataColumn mutation).
+    METADATA_DATA_TYPES = (
+        "STRING",
+        "TEXT",
+        "BOOLEAN",
+        "INTEGER",
+        "FLOAT",
+        "DATE",
+        "DATETIME",
+        "URL",
+        "EMAIL",
+        "CHOICE",
+        "MULTI_CHOICE",
+        "JSON",
+    )
+
+    @classmethod
+    def upsert_document_metadata(
+        cls,
+        *,
+        corpus,
+        document,
+        user,
+        column_name: str,
+        data_type: str,
+        value,
+        validation_config: dict | None = None,
+    ) -> Datacell:
+        """Set a manual metadata value on *document* in *corpus*, creating the
+        corpus metadata fieldset and column on demand.
+
+        This is the INTERNAL ingestion entry point (worker upload / pipeline) for
+        the same Column/Datacell metadata an end user sets via the
+        ``SetMetadataValue`` GraphQL mutation. It does NOT run the request-scoped
+        permission gate: callers (e.g. the worker-upload task) operate as the
+        corpus owner and have already established that context. The created
+        Datacell is ``extract=NULL`` manual metadata, with the value wrapped as
+        ``{"value": value}`` and type-validated by ``Datacell.clean()`` against
+        the column's ``data_type`` (a mismatch raises ``ValidationError``).
+
+        Returns the created/updated ``Datacell``.
+        """
+        from django.utils import timezone
+
+        from opencontractserver.extracts.models import Datacell, Fieldset
+        from opencontractserver.types.enums import PermissionTypes
+        from opencontractserver.utils.permissioning import (
+            set_permissions_for_obj_to_user,
+        )
+
+        if data_type not in cls.METADATA_DATA_TYPES:
+            raise ValueError(
+                f"Invalid metadata data_type {data_type!r}; must be one of "
+                f"{', '.join(cls.METADATA_DATA_TYPES)}"
+            )
+
+        # Get-or-create the corpus metadata fieldset (OneToOne corpus.metadata_schema).
+        fieldset = getattr(corpus, "metadata_schema", None)
+        if fieldset is None:
+            fieldset = Fieldset.objects.create(
+                name=f"{corpus.title} Metadata",
+                description=f"Metadata schema for {corpus.title}",
+                corpus=corpus,
+                creator=user,
+            )
+            set_permissions_for_obj_to_user(
+                user, fieldset, [PermissionTypes.CRUD], is_new=True
+            )
+
+        # Get-or-create the manual-entry metadata column by name in the fieldset.
+        # The FIRST writer defines the column's data_type; later values must
+        # conform to it (Datacell.clean validates).
+        column = Column.objects.filter(
+            fieldset=fieldset, name=column_name, is_manual_entry=True
+        ).first()
+        if column is None:
+            column = Column.objects.create(
+                fieldset=fieldset,
+                name=column_name,
+                data_type=data_type,
+                validation_config=validation_config or {},
+                is_manual_entry=True,
+                output_type=data_type.lower(),
+                creator=user,
+            )
+            set_permissions_for_obj_to_user(
+                user, column, [PermissionTypes.CRUD], is_new=True
+            )
+
+        datacell, _created = Datacell.objects.update_or_create(
+            document=document,
+            column=column,
+            extract=None,
+            defaults={
+                "data": {"value": value},
+                "data_definition": column.output_type,
+                "creator": user,
+                "completed": timezone.now(),
+            },
+        )
+        return datacell

--- a/opencontractserver/pipeline/base/chunked_parser.py
+++ b/opencontractserver/pipeline/base/chunked_parser.py
@@ -272,12 +272,9 @@ class BaseChunkedParser(BaseParser):
         """
         Parse a document, automatically chunking large PDFs.
 
-        The method reads the PDF from storage, counts pages, and decides
-        whether to chunk.  If chunking is needed, it splits the PDF, parses
-        each chunk via ``_parse_single_chunk_impl``, and reassembles.
-
-        Otherwise it delegates to ``_parse_single_chunk_impl`` with the
-        full PDF as a single chunk.
+        The method reads the PDF from storage, then delegates the entire
+        (database-free) parse to :meth:`parse_pdf_bytes`.  Persistence
+        (``save_parsed_data``) is handled separately by ``process_document``.
         """
         document = Document.objects.get(pk=doc_id)
         doc_path = document.pdf_file.name
@@ -296,6 +293,46 @@ class BaseChunkedParser(BaseParser):
                 is_transient=True,
             )
 
+        return self.parse_pdf_bytes(
+            pdf_bytes, user_id=user_id, doc_id=doc_id, **all_kwargs
+        )
+
+    def parse_pdf_bytes(
+        self,
+        pdf_bytes: bytes,
+        *,
+        user_id: int = 0,
+        doc_id: int = 0,
+        **all_kwargs,
+    ) -> Optional[OpenContractDocExport]:
+        """
+        Parse raw PDF bytes into an ``OpenContractDocExport`` **without any
+        database access**.
+
+        This is the database-free core of the chunked parse path: it counts
+        pages, decides whether to chunk, parses each chunk via the pure
+        :meth:`_parse_single_chunk_impl`, reassembles with correct global page
+        offsets, and runs :meth:`_post_reassemble_hook` (e.g. image extraction).
+        No ``Document`` row is read or written, and ``save_parsed_data`` (the
+        only DB-writing step) is intentionally not called.
+
+        Because it is DB-free, this method can be driven headlessly by a remote
+        worker that mirrors the server's ingestion pipeline and ships the result
+        through the worker-upload API (see ``scripts/remote_ingest``).
+        ``_parse_document_impl`` is a thin wrapper that fetches the PDF bytes
+        from a stored ``Document`` and delegates here.
+
+        Args:
+            pdf_bytes: Raw bytes of the PDF to parse.
+            user_id: Optional; used only for logging.
+            doc_id: Optional; used only for logging and image storage path keys.
+            **all_kwargs: Merged pipeline + direct kwargs (``force_ocr``,
+                ``extract_images``, ...).
+
+        Returns:
+            ``OpenContractDocExport`` with globally-indexed pages, or ``None``
+            if the underlying chunk parse returned nothing.
+        """
         # Determine page count and chunk boundaries
         try:
             page_count = get_pdf_page_count(pdf_bytes)

--- a/opencontractserver/pipeline/base/parser.py
+++ b/opencontractserver/pipeline/base/parser.py
@@ -7,12 +7,7 @@ from django.conf import settings
 from django.core.files.base import ContentFile
 from plasmapdf.models.PdfDataLayer import build_translation_layer
 
-from opencontractserver.annotations.models import (
-    RELATIONSHIP_LABEL,
-    Annotation,
-    Relationship,
-    StructuralAnnotationSet,
-)
+from opencontractserver.annotations.models import RELATIONSHIP_LABEL
 from opencontractserver.documents.models import Document
 from opencontractserver.pipeline.base.exceptions import DocumentParsingError
 from opencontractserver.pipeline.base.file_types import FileTypeEnum
@@ -23,6 +18,7 @@ from opencontractserver.utils.importing import (
     import_relationships,
     load_or_create_labels,
 )
+from opencontractserver.utils.structural_sets import create_structural_annotation_set
 from opencontractserver.utils.subtree_groups import build_subtree_groups_for_document
 
 from .base_component import PipelineComponentBase
@@ -299,90 +295,19 @@ class BaseParser(PipelineComponentBase, ABC):
         annotations and relationships to it.
 
         This ensures structural annotations are properly isolated per document and
-        can be embedded using corpus-specific embedders.
+        can be embedded using corpus-specific embedders. The migration logic lives
+        in :func:`opencontractserver.utils.structural_sets.create_structural_annotation_set`
+        so the worker-upload ingestion path produces an identical structural layer.
 
         Args:
             document: The Document object
             user: The user creating the set
         """
-        # Check if document already has a structural annotation set
-        if document.structural_annotation_set:
-            logger.info(
-                f"Document {document.pk} already has StructuralAnnotationSet "
-                f"{document.structural_annotation_set.pk}"
-            )
-            return
-
-        # Find structural annotations on this document
-        structural_annotations = Annotation.objects.filter(
-            document=document, structural=True, structural_set__isnull=True
-        )
-
-        if not structural_annotations.exists():
-            logger.info(
-                f"Document {document.pk} has no structural annotations to migrate"
-            )
-            return
-
-        # Generate content hash for the set
-        content_hash = document.pdf_file_hash or f"doc_{document.pk}"
-
-        # Use get_or_create to handle retry scenarios where the set was created
-        # but the document link wasn't saved (e.g., task failed after line 298
-        # but before document.save() at line 337)
-        struct_set, created = StructuralAnnotationSet.objects.get_or_create(
-            content_hash=content_hash,
-            defaults={
-                "creator": user,
-                "parser_name": self.title or self.__class__.__name__,
-                "parser_version": "1.0",
-                "page_count": document.page_count,
-                "pawls_parse_file": document.pawls_parse_file,
-                "txt_extract_file": document.txt_extract_file,
-            },
-        )
-
-        if created:
-            logger.info(
-                f"Created StructuralAnnotationSet {struct_set.pk} for document {document.pk}"
-            )
-        else:
-            logger.info(
-                f"Reusing existing StructuralAnnotationSet {struct_set.pk} "
-                f"for document {document.pk} (retry scenario)"
-            )
-
-        # Migrate structural annotations to the set
-        structural_annotation_ids = set(
-            structural_annotations.values_list("id", flat=True)
-        )
-
-        for annot in structural_annotations:
-            annot.structural_set = struct_set
-            annot.document = None  # XOR constraint: either document or structural_set
-            annot.save()
-
-        # Migrate structural relationships to the set
-        structural_relationships = Relationship.objects.filter(
-            document=document, structural=True, structural_set__isnull=True
-        ).filter(
-            source_annotations__id__in=structural_annotation_ids,
-            target_annotations__id__in=structural_annotation_ids,
-        )
-
-        for rel in structural_relationships:
-            rel.structural_set = struct_set
-            rel.document = None  # XOR constraint
-            rel.save()
-
-        # Link document to the structural set
-        document.structural_annotation_set = struct_set
-        document.save()
-
-        logger.info(
-            f"Migrated {structural_annotations.count()} annotations and "
-            f"{structural_relationships.count()} relationships to StructuralAnnotationSet "
-            f"{struct_set.pk}"
+        create_structural_annotation_set(
+            document,
+            user,
+            parser_name=self.title or self.__class__.__name__,
+            parser_version="1.0",
         )
 
     def _run_enrichment_stage(

--- a/opencontractserver/tests/test_chunked_parser.py
+++ b/opencontractserver/tests/test_chunked_parser.py
@@ -513,6 +513,57 @@ class TestBaseChunkedParserIntegration(TestCase):
         assert result is not None
         self.assertEqual(result["title"], "HOOKED")
 
+    def test_parse_pdf_bytes_no_database_single_chunk(self):
+        """parse_pdf_bytes produces a full export from raw bytes with NO Document
+        row and NO storage access — the headless entry point the remote-ingest
+        worker relies on."""
+        parser = ConcreteChunkedParser()
+        parser.min_pages_for_chunking = 75
+
+        # No Document, no doc_id, no default_storage mock — pure bytes in.
+        result = parser.parse_pdf_bytes(make_test_pdf(10))
+
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result["page_count"], 2)  # from _make_chunk_result default
+        # Single-chunk docs still get consistent c0_-prefixed IDs.
+        self.assertEqual(result["labelled_text"][0]["id"], "c0_ann-1")
+
+    def test_parse_pdf_bytes_no_database_chunked(self):
+        """parse_pdf_bytes chunks + reassembles large PDFs without a Document."""
+        parser = ConcreteChunkedParser()
+        parser.max_pages_per_chunk = 50
+        parser.min_pages_for_chunking = 75
+        parser.max_concurrent_chunks = 1  # sequential for determinism
+
+        result = parser.parse_pdf_bytes(make_test_pdf(100))
+
+        assert result is not None
+        self.assertEqual(result["page_count"], 4)
+        indices = [p["page"]["index"] for p in result["pawls_file_content"]]
+        self.assertEqual(indices, [0, 1, 50, 51])
+
+    @patch("opencontractserver.pipeline.base.chunked_parser.default_storage.open")
+    def test_parse_document_impl_delegates_to_parse_pdf_bytes(self, mock_open):
+        """_parse_document_impl reads the Document's bytes then delegates to the
+        DB-free parse_pdf_bytes — proving the two paths share one implementation."""
+        small_pdf = make_test_pdf(10)
+        mock_file = MagicMock()
+        mock_file.read.return_value = small_pdf
+        mock_open.return_value.__enter__.return_value = mock_file
+
+        parser = ConcreteChunkedParser()
+        parser.min_pages_for_chunking = 75
+
+        with patch.object(
+            parser, "parse_pdf_bytes", wraps=parser.parse_pdf_bytes
+        ) as spy:
+            parser._parse_document_impl(user_id=self.user.id, doc_id=self.doc.id)
+
+        spy.assert_called_once()
+        # The PDF bytes read from storage are passed positionally.
+        self.assertEqual(spy.call_args.args[0], small_pdf)
+
     @patch("opencontractserver.pipeline.base.chunked_parser.default_storage.open")
     @patch("opencontractserver.pipeline.base.chunked_parser.time.sleep")
     def test_chunk_retry_on_transient_error(self, mock_sleep, mock_open):

--- a/opencontractserver/tests/test_mint_worker_token_command.py
+++ b/opencontractserver/tests/test_mint_worker_token_command.py
@@ -1,0 +1,132 @@
+"""``manage.py mint_worker_token`` — the one-command server-side setup step for
+the remote-ingest worker (``scripts/remote_ingest``).
+
+The command resolves an acting superuser, creates (or reuses) a worker service
+account, mints a corpus-scoped ``CorpusAccessToken``, and prints the plaintext
+token exactly once. These tests pin every branch: account create / reuse /
+deactivated-reject, the superuser resolution paths (named, unknown, non-super,
+default, none), and the two service-failure → ``CommandError`` mappings.
+"""
+
+from __future__ import annotations
+
+from io import StringIO
+from unittest import mock
+
+from django.contrib.auth import get_user_model
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import TestCase
+
+from opencontractserver.annotations.models import LabelSet
+from opencontractserver.corpuses.models import Corpus
+from opencontractserver.shared.services.conventions import ServiceResult
+from opencontractserver.worker_uploads.models import WorkerAccount
+
+User = get_user_model()
+
+_CMD = "opencontractserver.worker_uploads.management.commands.mint_worker_token"
+
+
+class MintWorkerTokenCommandTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.superuser = User.objects.create_superuser(
+            username="mint_root",
+            password="testpass",
+            email="mint_root@test.com",
+        )
+        cls.label_set = LabelSet.objects.create(title="Mint LS", creator=cls.superuser)
+        cls.corpus = Corpus.objects.create(
+            title="Rig Corpus",
+            creator=cls.superuser,
+            label_set=cls.label_set,
+        )
+
+    def _call(self, **kwargs) -> str:
+        out = StringIO()
+        call_command("mint_worker_token", stdout=out, **kwargs)
+        return out.getvalue()
+
+    def test_mints_token_for_new_worker_account(self):
+        out = self._call(
+            corpus=self.corpus.id,
+            worker_name="rig-new",
+            description="Fort Worth rig",
+            rate_limit=10,
+            expires_days=30,
+        )
+        self.assertIn("Created worker account 'rig-new'", out)
+        self.assertIn("OC_WORKER_TOKEN=", out)
+        self.assertIn(f"OC_CORPUS_ID={self.corpus.id}", out)
+
+        account = WorkerAccount.objects.get(name="rig-new")
+        self.assertEqual(account.access_tokens.count(), 1)
+        token = account.access_tokens.first()
+        self.assertEqual(token.corpus_id, self.corpus.id)
+        self.assertIsNotNone(token.expires_at)  # --expires-days was supplied
+
+    def test_reuses_existing_active_account(self):
+        WorkerAccount.create_with_user(name="rig-reuse", creator=self.superuser)
+        out = self._call(corpus=self.corpus.id, worker_name="rig-reuse")
+        self.assertIn("Reusing existing worker account 'rig-reuse'", out)
+        self.assertIn("OC_WORKER_TOKEN=", out)
+        # No duplicate account was created.
+        self.assertEqual(WorkerAccount.objects.filter(name="rig-reuse").count(), 1)
+
+    def test_deactivated_account_is_rejected(self):
+        account = WorkerAccount.create_with_user(
+            name="rig-dead", creator=self.superuser
+        )
+        account.is_active = False
+        account.save(update_fields=["is_active"])
+        with self.assertRaisesMessage(CommandError, "deactivated"):
+            self._call(corpus=self.corpus.id, worker_name="rig-dead")
+
+    def test_as_user_resolves_named_superuser(self):
+        out = self._call(
+            corpus=self.corpus.id, worker_name="rig-named", as_user="mint_root"
+        )
+        self.assertIn("OC_WORKER_TOKEN=", out)
+
+    def test_as_user_unknown_username_errors(self):
+        with self.assertRaisesMessage(CommandError, "not found"):
+            self._call(corpus=self.corpus.id, worker_name="rig-x", as_user="ghost")
+
+    def test_as_user_non_superuser_errors(self):
+        User.objects.create_user(username="plain_joe", password="p")
+        with self.assertRaisesMessage(CommandError, "not a superuser"):
+            self._call(corpus=self.corpus.id, worker_name="rig-x", as_user="plain_joe")
+
+    def test_unreachable_corpus_surfaces_token_mint_error(self):
+        # A nonexistent corpus id collapses onto the IDOR-safe "not found"
+        # failure, which the command maps to a CommandError.
+        with self.assertRaisesMessage(CommandError, "Could not mint token"):
+            self._call(corpus=999999, worker_name="rig-badcorpus")
+
+    def test_worker_account_creation_failure_surfaces_command_error(self):
+        with mock.patch(
+            f"{_CMD}.WorkerAccountService.create_worker_account",
+            return_value=ServiceResult.failure("synthetic create failure"),
+        ):
+            with self.assertRaisesMessage(
+                CommandError, "Could not create worker account"
+            ):
+                self._call(corpus=self.corpus.id, worker_name="rig-failcreate")
+
+
+class MintWorkerTokenNoSuperuserTests(TestCase):
+    """No acting superuser can be resolved → the command aborts up front."""
+
+    def test_no_active_superuser_errors(self):
+        # The migrated baseline may already contain a superuser; deactivate every
+        # superuser inside this test's transaction so the default resolution path
+        # genuinely finds none. (Rolled back at test teardown.)
+        User.objects.filter(is_superuser=True).update(is_active=False)
+        with self.assertRaisesMessage(CommandError, "No active superuser"):
+            call_command(
+                "mint_worker_token",
+                corpus=1,
+                worker_name="rig-nosu",
+                stdout=StringIO(),
+            )

--- a/opencontractserver/tests/test_remote_ingest_enrichers.py
+++ b/opencontractserver/tests/test_remote_ingest_enrichers.py
@@ -1,0 +1,360 @@
+"""
+Unit tests for the remote-ingest pre-processing / enrichment stage
+(``scripts/remote_ingest/enrichers.py`` + ``example_enrichers.py``).
+
+These are pure-Python tests over synthetic PAWLs exports — no Django DB, no
+docling, no network. They lock in the correctness of the annotation-building
+helpers (token anchoring, annotation_json shape), the enrichment merge, and the
+validation guard that stops a buggy enricher from shipping a broken annotation.
+"""
+
+import os
+import sys
+
+# The enrichment modules live under scripts/remote_ingest (they run inside the
+# worker image, not the Django app), so add that dir to the path for import.
+_REMOTE_INGEST = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+    "scripts",
+    "remote_ingest",
+)
+if _REMOTE_INGEST not in sys.path:
+    sys.path.insert(0, _REMOTE_INGEST)
+
+import enrichers as E  # noqa: E402
+import example_enrichers as EX  # noqa: E402
+from django.test import SimpleTestCase  # noqa: E402
+
+
+def _page(tokens, width=612.0, height=792.0, index=0):
+    return {
+        "page": {"width": width, "height": height, "index": index},
+        "tokens": tokens,
+    }
+
+
+def _tok(x, y, w, h, text):
+    return {"x": x, "y": y, "width": w, "height": h, "text": text}
+
+
+def _export(pages):
+    return {
+        "pawls_file_content": pages,
+        "page_count": len(pages),
+        "labelled_text": [],
+        "relationships": [],
+        "doc_labels": [],
+        "content": "",
+    }
+
+
+def _ctx(export, *, rel_path="dir/doc.pdf", content="some content"):
+    return E.EnricherContext(
+        rel_path=rel_path, abs_path="/data/" + rel_path, export=export, content=content
+    )
+
+
+class TokenAnchoringTests(SimpleTestCase):
+    def setUp(self):
+        self.tokens = [
+            _tok(10, 100, 40, 12, "Effective"),
+            _tok(55, 100, 30, 12, "Date:"),
+            _tok(90, 100, 50, 12, "January"),
+            _tok(145, 100, 15, 12, "1,"),
+            _tok(165, 100, 35, 12, "2025"),
+        ]
+        self.ctx = _ctx(_export([_page(self.tokens)]))
+
+    def test_find_token_matches_maps_indices(self):
+        matches = self.ctx.find_token_matches(r"January 1, 2025")
+        self.assertEqual(len(matches), 1)
+        m = matches[0]
+        self.assertEqual(m.page, 0)
+        self.assertEqual(m.token_indices, [2, 3, 4])
+        self.assertEqual(m.text, "January 1, 2025")
+
+    def test_find_token_matches_single_token(self):
+        matches = self.ctx.find_token_matches(r"\bEffective\b")
+        self.assertEqual([m.token_indices for m in matches], [[0]])
+
+    def test_token_annotation_shape(self):
+        match = self.ctx.find_token_matches(r"January 1, 2025")[0]
+        ann = self.ctx.token_annotation("DATE", match)
+        self.assertEqual(ann["annotationLabel"], "DATE")
+        self.assertEqual(ann["annotation_type"], "TOKEN_LABEL")
+        self.assertFalse(ann["structural"])
+        self.assertEqual(ann["page"], 0)
+        self.assertEqual(ann["rawText"], "January 1, 2025")
+
+        page = ann["annotation_json"]["0"]
+        # bounds = union of tokens 2,3,4
+        self.assertEqual(page["bounds"]["left"], 90)
+        self.assertEqual(page["bounds"]["top"], 100)
+        self.assertEqual(page["bounds"]["right"], 200)  # 165 + 35
+        self.assertEqual(page["bounds"]["bottom"], 112)  # 100 + 12
+        self.assertEqual(
+            page["tokensJsons"],
+            [
+                {"pageIndex": 0, "tokenIndex": 2},
+                {"pageIndex": 0, "tokenIndex": 3},
+                {"pageIndex": 0, "tokenIndex": 4},
+            ],
+        )
+
+
+class EnrichmentMergeTests(SimpleTestCase):
+    def test_apply_assigns_unique_ids_and_merges(self):
+        export = _export([_page([_tok(0, 0, 10, 10, "X")])])
+        # one pre-existing parser annotation id, to prove no collision
+        export["labelled_text"].append({"id": "c0_#/texts/0", "annotationLabel": "p"})
+        enr = E.Enrichment(
+            annotations=[
+                {"annotationLabel": "L", "rawText": "x", "annotation_json": {}},
+                {"annotationLabel": "L", "rawText": "y", "annotation_json": {}},
+            ],
+            annotation_labels={"L": E.label_def("L")},
+            doc_labels=["dt"],
+            doc_label_defs={"dt": E.label_def("dt", E.DOC_TYPE_LABEL)},
+            custom_meta={"k": "v"},
+        )
+        overlay = E.apply_enrichment(export, enr)
+        ids = [a["id"] for a in export["labelled_text"]]
+        self.assertIn("enr-0", ids)
+        self.assertIn("enr-1", ids)
+        self.assertEqual(len(set(ids)), len(ids))  # unique
+        self.assertEqual(export["doc_labels"], ["dt"])
+        self.assertEqual(overlay.custom_meta, {"k": "v"})
+        self.assertIn("L", overlay.text_label_defs)
+        self.assertIn("dt", overlay.doc_label_defs)
+
+    def test_merge_combines_parts(self):
+        a = E.Enrichment(custom_meta={"a": 1}, doc_labels=["x"])
+        b = E.Enrichment(custom_meta={"b": 2}, doc_labels=["x", "y"], title="T")
+        merged = E.Enrichment.merge([a, None, b])
+        self.assertEqual(merged.custom_meta, {"a": 1, "b": 2})
+        self.assertEqual(merged.doc_labels, ["x", "y"])
+        self.assertEqual(merged.title, "T")
+
+
+class ValidationTests(SimpleTestCase):
+    def setUp(self):
+        self.export = _export(
+            [_page([_tok(0, 0, 10, 10, "A"), _tok(10, 0, 10, 10, "B")])]
+        )
+
+    def _valid_token_ann(self):
+        return {
+            "id": "e1",
+            "annotationLabel": "L",
+            "rawText": "A",
+            "page": 0,
+            "annotation_type": "TOKEN_LABEL",
+            "annotation_json": {
+                "0": {
+                    "bounds": {"top": 0, "bottom": 10, "left": 0, "right": 10},
+                    "tokensJsons": [{"pageIndex": 0, "tokenIndex": 0}],
+                    "rawText": "A",
+                }
+            },
+        }
+
+    def test_valid_passes(self):
+        enr = E.Enrichment(
+            annotations=[self._valid_token_ann()],
+            annotation_labels={"L": E.label_def("L")},
+        )
+        self.assertEqual(E.validate_enrichment(self.export, enr), [])
+
+    def test_token_index_out_of_range(self):
+        ann = self._valid_token_ann()
+        ann["annotation_json"]["0"]["tokensJsons"][0]["tokenIndex"] = 99
+        enr = E.Enrichment(annotations=[ann], annotation_labels={"L": E.label_def("L")})
+        errs = E.validate_enrichment(self.export, enr)
+        self.assertTrue(any("tokenIndex" in e for e in errs))
+
+    def test_missing_label_def(self):
+        enr = E.Enrichment(annotations=[self._valid_token_ann()])  # no label def
+        errs = E.validate_enrichment(self.export, enr)
+        self.assertTrue(any("no definition" in e for e in errs))
+
+    def test_empty_raw_text(self):
+        ann = self._valid_token_ann()
+        ann["rawText"] = "  "
+        enr = E.Enrichment(annotations=[ann], annotation_labels={"L": E.label_def("L")})
+        errs = E.validate_enrichment(self.export, enr)
+        self.assertTrue(any("rawText is empty" in e for e in errs))
+
+    def test_relationship_unknown_id(self):
+        ann = self._valid_token_ann()
+        enr = E.Enrichment(
+            annotations=[ann],
+            annotation_labels={
+                "L": E.label_def("L"),
+                "R": E.label_def("R", E.RELATIONSHIP_LABEL),
+            },
+            relationships=[
+                {
+                    "relationshipLabel": "R",
+                    "source_annotation_ids": ["e1"],
+                    "target_annotation_ids": ["does-not-exist"],
+                }
+            ],
+        )
+        # validate runs BEFORE apply (as the driver calls it). The injected
+        # annotation's explicit id "e1" resolves; "does-not-exist" does not.
+        errs = E.validate_enrichment(self.export, enr)
+        self.assertTrue(
+            any("unknown annotation id 'does-not-exist'" in e for e in errs)
+        )
+        self.assertFalse(any("'e1'" in e for e in errs))
+
+    def test_relationship_to_injected_id_valid_without_apply(self):
+        a1 = self._valid_token_ann()  # id "e1"
+        a2 = dict(self._valid_token_ann(), id="e2")
+        enr = E.Enrichment(
+            annotations=[a1, a2],
+            annotation_labels={
+                "L": E.label_def("L"),
+                "R": E.label_def("R", E.RELATIONSHIP_LABEL),
+            },
+            relationships=[
+                {
+                    "relationshipLabel": "R",
+                    "source_annotation_ids": ["e1"],
+                    "target_annotation_ids": ["e2"],
+                }
+            ],
+        )
+        self.assertEqual(E.validate_enrichment(self.export, enr), [])
+
+    def test_structural_injection_rejected(self):
+        ann = dict(self._valid_token_ann(), structural=True)
+        enr = E.Enrichment(annotations=[ann], annotation_labels={"L": E.label_def("L")})
+        errs = E.validate_enrichment(self.export, enr)
+        self.assertTrue(any("non-structural" in e for e in errs))
+
+    def test_unresolvable_parent_id_rejected(self):
+        ann = dict(self._valid_token_ann(), parent_id="ghost")
+        enr = E.Enrichment(annotations=[ann], annotation_labels={"L": E.label_def("L")})
+        errs = E.validate_enrichment(self.export, enr)
+        self.assertTrue(any("parent_id 'ghost'" in e for e in errs))
+
+    def test_explicit_id_collision_with_parser_rejected(self):
+        # a parser annotation with id "c0_x" already on the export
+        self.export["labelled_text"].append({"id": "c0_x", "annotationLabel": "p"})
+        ann = dict(self._valid_token_ann(), id="c0_x")
+        enr = E.Enrichment(annotations=[ann], annotation_labels={"L": E.label_def("L")})
+        errs = E.validate_enrichment(self.export, enr)
+        self.assertTrue(any("collides with a parser annotation id" in e for e in errs))
+
+    def test_duplicate_injected_id_rejected(self):
+        a1 = self._valid_token_ann()
+        a2 = self._valid_token_ann()  # same id "e1"
+        enr = E.Enrichment(
+            annotations=[a1, a2], annotation_labels={"L": E.label_def("L")}
+        )
+        errs = E.validate_enrichment(self.export, enr)
+        self.assertTrue(any("duplicate injected annotation id" in e for e in errs))
+
+    def test_doc_type_label_in_annotations_rejected(self):
+        ann = dict(self._valid_token_ann(), annotation_type="DOC_TYPE_LABEL")
+        enr = E.Enrichment(annotations=[ann], annotation_labels={"L": E.label_def("L")})
+        errs = E.validate_enrichment(self.export, enr)
+        self.assertTrue(any("DOC_TYPE_LABEL belongs in" in e for e in errs))
+
+
+def _md_by_name(enr):
+    return {m["column_name"]: m for m in enr.metadata}
+
+
+class MetadataFieldTests(SimpleTestCase):
+    def test_metadata_field_infers_type(self):
+        self.assertEqual(E.metadata_field("c", "x")["data_type"], "STRING")
+        self.assertEqual(E.metadata_field("c", 3)["data_type"], "INTEGER")
+        self.assertEqual(E.metadata_field("c", True)["data_type"], "BOOLEAN")
+        self.assertEqual(E.metadata_field("c", 1.5)["data_type"], "FLOAT")
+        self.assertEqual(E.metadata_field("c", {"a": 1})["data_type"], "JSON")
+        self.assertEqual(
+            E.metadata_field("c", "x", data_type="DATE")["data_type"], "DATE"
+        )
+
+    def test_metadata_validation_value_type(self):
+        export = _export([_page([_tok(0, 0, 10, 10, "x")])])
+        bad = E.Enrichment(
+            metadata=[E.metadata_field("Year", "2025", data_type="INTEGER")]
+        )
+        errs = E.validate_enrichment(export, bad)
+        self.assertTrue(any("must be an integer" in e for e in errs))
+
+    def test_metadata_validation_bad_data_type(self):
+        export = _export([_page([_tok(0, 0, 10, 10, "x")])])
+        bad = E.Enrichment(
+            metadata=[{"column_name": "X", "data_type": "WIDGET", "value": 1}]
+        )
+        errs = E.validate_enrichment(export, bad)
+        self.assertTrue(any("must be one of" in e for e in errs))
+
+    def test_metadata_choice_valid(self):
+        export = _export([_page([_tok(0, 0, 10, 10, "x")])])
+        ok = E.Enrichment(
+            metadata=[
+                E.metadata_field(
+                    "Type",
+                    "A",
+                    data_type="CHOICE",
+                    validation_config={"choices": ["A", "B"]},
+                )
+            ]
+        )
+        self.assertEqual(E.validate_enrichment(export, ok), [])
+
+    def test_apply_carries_metadata_to_overlay(self):
+        export = _export([_page([_tok(0, 0, 10, 10, "x")])])
+        enr = E.Enrichment(metadata=[E.metadata_field("Number", "058000")])
+        overlay = E.apply_enrichment(export, enr)
+        self.assertEqual(overlay.metadata[0]["column_name"], "Number")
+        self.assertEqual(overlay.metadata[0]["data_type"], "STRING")
+
+
+class ExampleEnricherTests(SimpleTestCase):
+    def test_filename_metadata(self):
+        ctx = _ctx(
+            _export([_page([_tok(0, 0, 10, 10, "x")])]),
+            rel_path="050000's/058000-R3 - General - Contract - Acme.pdf",
+        )
+        enr = EX.filename_metadata(ctx)
+        md = _md_by_name(enr)
+        self.assertEqual(md["Contract Number"]["value"], "058000")
+        self.assertEqual(md["Revision"]["value"], "R3")
+        self.assertEqual(md["Category"]["value"], "General")
+        self.assertEqual(enr.custom_meta["source_path"], ctx.rel_path)
+        self.assertEqual(E.validate_enrichment(ctx.export, enr), [])
+
+    def test_effective_date_annotations(self):
+        tokens = [
+            _tok(0, 0, 50, 12, "January"),
+            _tok(55, 0, 15, 12, "1,"),
+            _tok(75, 0, 35, 12, "2025"),
+        ]
+        ctx = _ctx(_export([_page(tokens)]))
+        enr = EX.effective_date_annotations(ctx)
+        self.assertEqual(len(enr.annotations), 1)
+        self.assertIn("DETECTED_DATE", enr.annotation_labels)
+        md = _md_by_name(enr)
+        self.assertEqual(md["Effective Date"]["value"], "2025-01-01")
+        self.assertEqual(md["Effective Date"]["data_type"], "DATE")
+        # the injected annotation + metadata are valid against the export
+        self.assertEqual(E.validate_enrichment(ctx.export, enr), [])
+
+    def test_contract_type_label(self):
+        ctx = _ctx(
+            _export([_page([_tok(0, 0, 10, 10, "x")])]),
+            content="This CONSTRUCTION agreement ...",
+        )
+        enr = EX.contract_type_label(ctx)
+        self.assertEqual(enr.doc_labels, ["contract:Construction-Related"])
+        md = _md_by_name(enr)
+        self.assertEqual(md["Contract Type"]["value"], "Construction-Related")
+        self.assertEqual(md["Contract Type"]["data_type"], "CHOICE")
+        self.assertIn("contract:Construction-Related", enr.doc_label_defs)
+        self.assertEqual(E.validate_enrichment(ctx.export, enr), [])

--- a/opencontractserver/tests/test_worker_upload_metadata_validation.py
+++ b/opencontractserver/tests/test_worker_upload_metadata_validation.py
@@ -1,0 +1,91 @@
+"""Worker-upload metadata validation (no DB).
+
+Two fail-fast surfaces guard the metadata a remote worker ships alongside a
+faithful document:
+
+* ``WorkerDocumentUploadSerializer.validate_metadata`` rejects a malformed
+  ``custom_meta`` / ``metadata`` block at the API boundary, and
+* ``MetadataService.upsert_document_metadata`` rejects an unknown ``data_type``
+  before it touches the database.
+
+Both raise before any persistence, so these run as ``SimpleTestCase``.
+"""
+
+from __future__ import annotations
+
+import json
+
+from django.test import SimpleTestCase
+from rest_framework import serializers as drf_serializers
+
+from opencontractserver.extracts.services.metadata import MetadataService
+from opencontractserver.worker_uploads.serializers import (
+    WorkerDocumentUploadSerializer,
+)
+
+# The four required keys validate_metadata checks before reaching the
+# custom_meta / metadata blocks under test.
+_BASE = {
+    "title": "T",
+    "content": "C",
+    "page_count": 1,
+    "pawls_file_content": [],
+}
+
+
+class ValidateMetadataBlockTests(SimpleTestCase):
+    @staticmethod
+    def _validate(payload: dict):
+        return WorkerDocumentUploadSerializer().validate_metadata(json.dumps(payload))
+
+    def test_valid_payload_returns_parsed_dict(self):
+        out = self._validate({**_BASE, "custom_meta": {"k": "v"}})
+        self.assertEqual(out["title"], "T")
+        self.assertEqual(out["custom_meta"], {"k": "v"})
+
+    def test_custom_meta_must_be_object(self):
+        with self.assertRaisesMessage(
+            drf_serializers.ValidationError, "custom_meta must be a JSON object"
+        ):
+            self._validate({**_BASE, "custom_meta": ["not", "an", "object"]})
+
+    def test_metadata_must_be_a_list(self):
+        with self.assertRaisesMessage(
+            drf_serializers.ValidationError, "metadata must be a list"
+        ):
+            self._validate({**_BASE, "metadata": "scalar"})
+
+    def test_metadata_entry_must_be_an_object(self):
+        with self.assertRaisesMessage(
+            drf_serializers.ValidationError, "must be a JSON object"
+        ):
+            self._validate({**_BASE, "metadata": [123]})
+
+    def test_metadata_entry_requires_column_name(self):
+        with self.assertRaisesMessage(
+            drf_serializers.ValidationError, "column_name is required"
+        ):
+            self._validate({**_BASE, "metadata": [{"data_type": "STRING"}]})
+
+    def test_metadata_entry_rejects_unknown_data_type(self):
+        with self.assertRaisesMessage(
+            drf_serializers.ValidationError, "data_type must be one of"
+        ):
+            self._validate(
+                {**_BASE, "metadata": [{"column_name": "c", "data_type": "BOGUS"}]}
+            )
+
+
+class UpsertDocumentMetadataDataTypeTests(SimpleTestCase):
+    def test_unknown_data_type_rejected_before_db_access(self):
+        # The data_type guard fires before any corpus/document/fieldset access,
+        # so dummy (None) args are sufficient to exercise it.
+        with self.assertRaisesMessage(ValueError, "Invalid metadata data_type"):
+            MetadataService.upsert_document_metadata(
+                corpus=None,
+                document=None,
+                user=None,
+                column_name="c",
+                data_type="BOGUS",
+                value="x",
+            )

--- a/opencontractserver/tests/test_worker_uploads.py
+++ b/opencontractserver/tests/test_worker_uploads.py
@@ -25,8 +25,10 @@ from rest_framework.test import APIClient
 
 from config.graphql.schema import schema
 from opencontractserver.annotations.models import (
+    Annotation,
     Embedding,
     LabelSet,
+    StructuralAnnotationSet,
 )
 from opencontractserver.corpuses.models import Corpus
 from opencontractserver.types.enums import PermissionTypes
@@ -1599,3 +1601,359 @@ class TestWorkerGraphQLQueries(TestCase):
             variables={"workerId": inactive_worker.id},
         )
         self.assertIsNotNone(result.get("errors"))
+
+
+# ============================================================================
+# Worker-upload fidelity: structural set, thumbnail, embedding ownership
+# ============================================================================
+
+# 384 is the default MicroserviceEmbedder dimension and is in EMBEDDING_DIMENSIONS.
+_VEC = [0.01] * 384
+
+
+def _structural_metadata(with_embeddings: bool = False, **overrides):
+    """Metadata with two structural TOKEN_LABEL annotations (parent -> child),
+    mirroring what a remote Docling parse ships."""
+    labelled_text = [
+        {
+            "id": "c0_sec-1",
+            "annotationLabel": "section_header",
+            "rawText": "SECTION 1",
+            "page": 0,
+            "annotation_type": "TOKEN_LABEL",
+            "structural": True,
+            "parent_id": None,
+            "annotation_json": {
+                "0": {
+                    "bounds": {
+                        "left": 10.0,
+                        "top": 10.0,
+                        "right": 60.0,
+                        "bottom": 22.0,
+                    },
+                    "tokensJsons": [{"pageIndex": 0, "tokenIndex": 0}],
+                    "rawText": "SECTION 1",
+                }
+            },
+        },
+        {
+            "id": "c0_txt-1",
+            "annotationLabel": "text",
+            "rawText": "Body paragraph.",
+            "page": 0,
+            "annotation_type": "TOKEN_LABEL",
+            "structural": True,
+            "parent_id": "c0_sec-1",
+            "annotation_json": {
+                "0": {
+                    "bounds": {
+                        "left": 10.0,
+                        "top": 24.0,
+                        "right": 80.0,
+                        "bottom": 36.0,
+                    },
+                    "tokensJsons": [{"pageIndex": 0, "tokenIndex": 0}],
+                    "rawText": "Body paragraph.",
+                }
+            },
+        },
+    ]
+    text_labels = {
+        "section_header": {
+            "label_type": "TOKEN_LABEL",
+            "color": "grey",
+            "description": "Parser Structural Label",
+            "icon": "expand",
+            "text": "section_header",
+        },
+        "text": {
+            "label_type": "TOKEN_LABEL",
+            "color": "grey",
+            "description": "Parser Structural Label",
+            "icon": "expand",
+            "text": "text",
+        },
+    }
+    meta = _make_metadata(
+        labelled_text=labelled_text,
+        text_labels=text_labels,
+        parser_name="Docling Parser (REST)",
+        parser_version="1.0",
+        **overrides,
+    )
+    if with_embeddings:
+        meta["embeddings"] = {
+            "embedder_path": "opencontractserver.pipeline.embedders."
+            "sent_transformer_microservice.MicroserviceEmbedder",
+            "document_embedding": list(_VEC),
+            "annotation_embeddings": {"c0_sec-1": list(_VEC), "c0_txt-1": list(_VEC)},
+        }
+    return meta
+
+
+class TestWorkerUploadFidelity(TestCase):
+    """The worker-upload path must mirror the parser pipeline: structural
+    annotations migrate into a StructuralAnnotationSet, a thumbnail is generated,
+    and supplied embeddings suppress server-side re-embedding."""
+
+    def setUp(self):
+        self.admin = User.objects.create_superuser(
+            username="admin_fidelity",
+            password="testpass",
+            email="admin_fidelity@test.com",
+        )
+        self.label_set = LabelSet.objects.create(
+            title="Fidelity LS", creator=self.admin
+        )
+        self.corpus = Corpus.objects.create(
+            title="Fidelity Corpus", creator=self.admin, label_set=self.label_set
+        )
+        set_permissions_for_obj_to_user(self.admin, self.corpus, [PermissionTypes.ALL])
+        self.account = WorkerAccount.create_with_user(
+            name="fidelity-worker", creator=self.admin
+        )
+        self.token, _ = CorpusAccessToken.create_token(
+            worker_account=self.account, corpus=self.corpus
+        )
+
+    def _stage(self, metadata):
+        return WorkerDocumentUpload.objects.create(
+            corpus_access_token=self.token,
+            corpus=self.corpus,
+            file=_make_fake_pdf(),
+            metadata=metadata,
+            status=UploadStatus.PENDING,
+        )
+
+    def _process(self, upload):
+        from opencontractserver.worker_uploads.tasks import process_pending_uploads
+
+        # Thumbnail generation is dispatched post-commit; patch it out (it needs a
+        # real PDF + thumbnailer that the fake test PDF can't satisfy).
+        with patch(
+            "opencontractserver.tasks.doc_tasks.extract_thumbnail.apply_async"
+        ) as mock_thumb:
+            process_pending_uploads.apply().get()
+        upload.refresh_from_db()
+        return upload, mock_thumb
+
+    def test_structural_annotations_migrated_to_set(self):
+        upload = self._stage(_structural_metadata())
+        upload, _ = self._process(upload)
+
+        self.assertEqual(upload.status, UploadStatus.COMPLETED)
+        doc = upload.result_document
+        self.assertIsNotNone(doc)
+
+        # The document is now linked to a StructuralAnnotationSet...
+        self.assertIsNotNone(doc.structural_annotation_set)
+        self.assertIsInstance(doc.structural_annotation_set, StructuralAnnotationSet)
+
+        # ...and the structural annotations live on the set (document=NULL),
+        # exactly as in-cluster ingestion produces.
+        on_set = Annotation.objects.filter(
+            structural_set=doc.structural_annotation_set, structural=True
+        )
+        self.assertEqual(on_set.count(), 2)
+        self.assertFalse(on_set.filter(document__isnull=False).exists())
+
+        # No structural annotations were left dangling on the document.
+        self.assertFalse(
+            Annotation.objects.filter(
+                document=doc, structural=True, structural_set__isnull=True
+            ).exists()
+        )
+
+        # The parent->child tree survived the migration.
+        child = on_set.get(raw_text="Body paragraph.")
+        parent = on_set.get(raw_text="SECTION 1")
+        self.assertEqual(child.parent_id, parent.id)
+
+    def test_thumbnail_dispatched(self):
+        upload = self._stage(_structural_metadata())
+        upload, mock_thumb = self._process(upload)
+
+        self.assertEqual(upload.status, UploadStatus.COMPLETED)
+        mock_thumb.assert_called_once()
+        # Dispatched for the corpus-linked document.
+        self.assertEqual(
+            mock_thumb.call_args.kwargs["kwargs"]["doc_id"],
+            upload.result_document.id,
+        )
+
+    def test_custom_meta_stored_on_corpus_doc(self):
+        """Structured metadata calculated by the worker's enrichment stage is
+        persisted on the corpus-linked Document.custom_meta."""
+        meta = {"jurisdiction": "TX", "contract_number": "058000", "year": 2025}
+        upload = self._stage(_structural_metadata(custom_meta=meta))
+        upload, _ = self._process(upload)
+
+        self.assertEqual(upload.status, UploadStatus.COMPLETED)
+        corpus_doc = upload.result_document
+        self.assertEqual(corpus_doc.custom_meta, meta)
+
+    def test_no_custom_meta_leaves_default(self):
+        """Uploads without custom_meta do not break (field keeps its default)."""
+        upload = self._stage(_structural_metadata())
+        upload, _ = self._process(upload)
+        self.assertEqual(upload.status, UploadStatus.COMPLETED)
+
+    def test_injected_nonstructural_annotation_lands_on_document(self):
+        """An enricher-injected NON-structural annotation is created on the
+        corpus document (NOT migrated to the structural set) with its label
+        auto-created — the server-side half of the enrichment stage."""
+        injected = {
+            "id": "enr-0",
+            "annotationLabel": "DETECTED_DATE",
+            "rawText": "January 1, 2025",
+            "page": 0,
+            "annotation_type": "TOKEN_LABEL",
+            "structural": False,
+            "annotation_json": {
+                "0": {
+                    "bounds": {
+                        "top": 10.0,
+                        "bottom": 22.0,
+                        "left": 10.0,
+                        "right": 90.0,
+                    },
+                    "tokensJsons": [{"pageIndex": 0, "tokenIndex": 0}],
+                    "rawText": "January 1, 2025",
+                }
+            },
+        }
+        meta = _structural_metadata()
+        meta["labelled_text"].append(injected)
+        meta["text_labels"]["DETECTED_DATE"] = {
+            "label_type": "TOKEN_LABEL",
+            "color": "#2563EB",
+            "description": "Worker enrichment label",
+            "icon": "tag",
+            "text": "DETECTED_DATE",
+        }
+        upload = self._stage(meta)
+        upload, _ = self._process(upload)
+
+        self.assertEqual(upload.status, UploadStatus.COMPLETED)
+        doc = upload.result_document
+        ann = Annotation.objects.get(document=doc, raw_text="January 1, 2025")
+        # Non-structural -> stays on the document, NOT migrated to the set.
+        self.assertFalse(ann.structural)
+        self.assertIsNone(ann.structural_set_id)
+        self.assertEqual(ann.annotation_label.text, "DETECTED_DATE")
+
+    def test_metadata_datacells_created(self):
+        """Typed metadata entries create manual-entry Columns in the corpus
+        metadata schema + extract=NULL Datacells on the document (the
+        Column/Datacell metadata system)."""
+        from opencontractserver.extracts.models import Column, Datacell, Fieldset
+
+        meta = _structural_metadata(
+            metadata=[
+                {
+                    "column_name": "Contract Number",
+                    "data_type": "STRING",
+                    "value": "058000",
+                },
+                {
+                    "column_name": "Contract Type",
+                    "data_type": "CHOICE",
+                    "value": "General",
+                    "validation_config": {"choices": ["General", "Amendment"]},
+                },
+                {"column_name": "Pages", "data_type": "INTEGER", "value": 6},
+            ]
+        )
+        upload = self._stage(meta)
+        upload, _ = self._process(upload)
+
+        self.assertEqual(upload.status, UploadStatus.COMPLETED)
+        corpus_doc = upload.result_document
+
+        fieldset = Fieldset.objects.filter(corpus=self.corpus).first()
+        self.assertIsNotNone(fieldset)  # auto-created metadata schema
+        cols = {c.name: c for c in Column.objects.filter(fieldset=fieldset)}
+        self.assertEqual(set(cols), {"Contract Number", "Contract Type", "Pages"})
+        self.assertTrue(all(c.is_manual_entry for c in cols.values()))
+
+        for name, expected in [
+            ("Contract Number", "058000"),
+            ("Contract Type", "General"),
+            ("Pages", 6),
+        ]:
+            dc = Datacell.objects.get(
+                document=corpus_doc, column=cols[name], extract__isnull=True
+            )
+            self.assertEqual(dc.data, {"value": expected})
+
+    def test_metadata_idempotent_reuses_column(self):
+        """A second document with the same metadata column reuses the Column
+        (one column per corpus, one datacell per (doc, column))."""
+        from opencontractserver.extracts.models import Column, Fieldset
+
+        for value in ("058000", "059000"):
+            up = self._stage(
+                _structural_metadata(
+                    metadata=[
+                        {
+                            "column_name": "Contract Number",
+                            "data_type": "STRING",
+                            "value": value,
+                        }
+                    ]
+                )
+            )
+            up, _ = self._process(up)
+            self.assertEqual(up.status, UploadStatus.COMPLETED)
+
+        fieldset = Fieldset.objects.filter(corpus=self.corpus).first()
+        self.assertEqual(
+            Column.objects.filter(fieldset=fieldset, name="Contract Number").count(), 1
+        )
+
+    def test_metadata_bad_value_type_fails_upload(self):
+        """A value that violates the column's data_type fails the upload loudly."""
+        meta = _structural_metadata(
+            metadata=[
+                {"column_name": "Year", "data_type": "INTEGER", "value": "not-an-int"}
+            ]
+        )
+        upload = self._stage(meta)
+        upload, _ = self._process(upload)
+        self.assertEqual(upload.status, UploadStatus.FAILED)
+
+    def test_supplied_embeddings_suppress_server_dispatch(self):
+        upload = self._stage(_structural_metadata(with_embeddings=True))
+
+        with patch(
+            "opencontractserver.tasks.embeddings_task."
+            "calculate_embeddings_for_annotation_batch.delay"
+        ) as mock_batch:
+            upload, _ = self._process(upload)
+
+        self.assertEqual(upload.status, UploadStatus.COMPLETED)
+        # The worker owns the embedding layer -> server must NOT re-embed.
+        mock_batch.assert_not_called()
+
+        # The supplied embeddings were stored (document + both annotations).
+        doc = upload.result_document
+        self.assertTrue(Embedding.objects.filter(document=doc).exists())
+        ann_pks = Annotation.objects.filter(
+            structural_set=doc.structural_annotation_set
+        ).values_list("id", flat=True)
+        self.assertEqual(
+            Embedding.objects.filter(annotation_id__in=list(ann_pks)).count(), 2
+        )
+
+    def test_no_embeddings_server_dispatches(self):
+        upload = self._stage(_structural_metadata(with_embeddings=False))
+
+        with patch(
+            "opencontractserver.tasks.embeddings_task."
+            "calculate_embeddings_for_annotation_batch.delay"
+        ) as mock_batch:
+            upload, _ = self._process(upload)
+
+        self.assertEqual(upload.status, UploadStatus.COMPLETED)
+        # With no embeddings supplied, the server falls back to embedding.
+        mock_batch.assert_called()

--- a/opencontractserver/types/dicts.py
+++ b/opencontractserver/types/dicts.py
@@ -896,3 +896,29 @@ class WorkerDocumentUploadMetadataType(TypedDict):
 
     # Pre-computed embeddings from the external worker
     embeddings: NotRequired[WorkerEmbeddingsType]
+
+    # Provenance of the parser that produced the structural layer on the remote
+    # worker. Recorded on the document's StructuralAnnotationSet so a remotely
+    # parsed document carries the same provenance as one parsed in-cluster.
+    parser_name: NotRequired[Optional[str]]
+    parser_version: NotRequired[Optional[str]]
+
+    # Arbitrary structured document metadata calculated by the remote worker's
+    # pre-processing/enrichment stage. Stored verbatim on Document.custom_meta.
+    custom_meta: NotRequired[Optional[dict]]
+
+    # Typed corpus metadata (the Column/Datacell metadata system — the UI's
+    # "document metadata", successor to legacy metadata annotations). Each entry
+    # get-or-creates a manual-entry Column in the corpus metadata schema and sets
+    # the document's value.
+    metadata: NotRequired[list["WorkerMetadataFieldType"]]
+
+
+class WorkerMetadataFieldType(TypedDict):
+    """One typed metadata value to set on a worker-uploaded document."""
+
+    column_name: str  # metadata column name (created on demand in the corpus)
+    data_type: str  # STRING / TEXT / BOOLEAN / INTEGER / FLOAT / DATE / DATETIME /
+    #                 URL / EMAIL / CHOICE / MULTI_CHOICE / JSON
+    value: Any  # the value (must match data_type; wrapped as {"value": value})
+    validation_config: NotRequired[Optional[dict]]  # e.g. {"choices": [...]}

--- a/opencontractserver/utils/importing.py
+++ b/opencontractserver/utils/importing.py
@@ -79,6 +79,7 @@ def import_annotations(
     label_lookup: dict[str, AnnotationLabel],
     label_type: str = TOKEN_LABEL,
     pawls_data: list[dict] | None = None,
+    dispatch_embeddings: bool = True,
 ) -> dict[str | int, int]:
     """
     Import annotations, handling parent relationships, and return a mapping of old IDs
@@ -94,6 +95,11 @@ def import_annotations(
         pawls_data (List[dict]): Optional PAWLs data for extracting image content.
             If provided, annotations with IMAGE modality will have their images
             pre-extracted for faster embedding.
+        dispatch_embeddings (bool): When True (default), dispatch server-side
+            batch embedding tasks for the created annotations. Set False when the
+            caller supplies pre-computed embeddings (e.g. the worker-upload path,
+            where an external worker already embedded every annotation) so the
+            server does not redundantly re-embed them.
 
     Returns:
         Dict[Union[str, int], int]: A dictionary mapping the "id" field from each incoming annotation
@@ -190,38 +196,44 @@ def import_annotations(
         # strategy here: dispatch one batch task with the default embedder
         # for global search, plus a second batch task with the corpus's
         # preferred embedder when it differs.
-        from opencontractserver.constants.document_processing import (
-            EMBEDDING_BATCH_SIZE,
-        )
-        from opencontractserver.pipeline.utils import get_default_embedder_path
-        from opencontractserver.tasks.embeddings_task import (
-            calculate_embeddings_for_annotation_batch,
-        )
+        #
+        # Skipped entirely when ``dispatch_embeddings`` is False: a caller that
+        # supplies pre-computed embeddings (worker-upload) owns the embedding
+        # layer, and re-embedding here would both waste the target's embedder
+        # and defeat the point of offloading enrichment to a remote worker.
+        if dispatch_embeddings:
+            from opencontractserver.constants.document_processing import (
+                EMBEDDING_BATCH_SIZE,
+            )
+            from opencontractserver.pipeline.utils import get_default_embedder_path
+            from opencontractserver.tasks.embeddings_task import (
+                calculate_embeddings_for_annotation_batch,
+            )
 
-        annotation_ids = [a.pk for a in instances]
-        corpus_id_for_batch = corpus_obj.id if corpus_obj is not None else None
+            annotation_ids = [a.pk for a in instances]
+            corpus_id_for_batch = corpus_obj.id if corpus_obj is not None else None
 
-        embedder_paths_to_dispatch: list[str] = []
-        default_embedder_path = get_default_embedder_path()
-        if default_embedder_path:
-            embedder_paths_to_dispatch.append(default_embedder_path)
-        # If the corpus has a different preferred embedder, dual-embed too.
-        if corpus_obj is not None:
-            corpus_pref = getattr(corpus_obj, "preferred_embedder", None)
-            if corpus_pref and corpus_pref != default_embedder_path:
-                embedder_paths_to_dispatch.append(corpus_pref)
+            embedder_paths_to_dispatch: list[str] = []
+            default_embedder_path = get_default_embedder_path()
+            if default_embedder_path:
+                embedder_paths_to_dispatch.append(default_embedder_path)
+            # If the corpus has a different preferred embedder, dual-embed too.
+            if corpus_obj is not None:
+                corpus_pref = getattr(corpus_obj, "preferred_embedder", None)
+                if corpus_pref and corpus_pref != default_embedder_path:
+                    embedder_paths_to_dispatch.append(corpus_pref)
 
-        # Sub-batch by EMBEDDING_BATCH_SIZE to match corpus_tasks dispatch
-        # pattern; the embedder's own ``embed_texts_batch`` further
-        # sub-batches by EMBEDDING_API_BATCH_SIZE for the wire request.
-        for embedder_path in embedder_paths_to_dispatch:
-            for i in range(0, len(annotation_ids), EMBEDDING_BATCH_SIZE):
-                chunk = annotation_ids[i : i + EMBEDDING_BATCH_SIZE]
-                calculate_embeddings_for_annotation_batch.delay(
-                    annotation_ids=chunk,
-                    corpus_id=corpus_id_for_batch,
-                    embedder_path=embedder_path,
-                )
+            # Sub-batch by EMBEDDING_BATCH_SIZE to match corpus_tasks dispatch
+            # pattern; the embedder's own ``embed_texts_batch`` further
+            # sub-batches by EMBEDDING_API_BATCH_SIZE for the wire request.
+            for embedder_path in embedder_paths_to_dispatch:
+                for i in range(0, len(annotation_ids), EMBEDDING_BATCH_SIZE):
+                    chunk = annotation_ids[i : i + EMBEDDING_BATCH_SIZE]
+                    calculate_embeddings_for_annotation_batch.delay(
+                        annotation_ids=chunk,
+                        corpus_id=corpus_id_for_batch,
+                        embedder_path=embedder_path,
+                    )
 
     # Second pass: Set parent relationships.
     # Legacy V1 exports — and V2 exports written before parent_id was

--- a/opencontractserver/utils/structural_sets.py
+++ b/opencontractserver/utils/structural_sets.py
@@ -1,0 +1,135 @@
+"""
+Shared helper for materialising a document's structural annotations into a
+:class:`~opencontractserver.annotations.models.StructuralAnnotationSet`.
+
+The parser pipeline (``BaseParser.save_parsed_data``) and the worker-upload
+ingestion path (``opencontractserver.worker_uploads.tasks``) both need to take
+the structural annotations a parser produced (``structural=True``, still bound
+to ``document``) and migrate them into a shared ``StructuralAnnotationSet`` so
+they are stored once, embedded with corpus-specific embedders, and resolved
+through the same structural-set join the rest of the platform relies on (see
+``AnnotationService.get_document_annotations``). Keeping the logic in one place
+guarantees the two ingestion paths produce an identical end-state — a document
+ingested locally by the parser and the same document ingested remotely and
+pushed through worker-upload are byte-for-byte equivalent in their structural
+layer.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from opencontractserver.annotations.models import (
+    Annotation,
+    Relationship,
+    StructuralAnnotationSet,
+)
+from opencontractserver.documents.models import Document
+
+logger = logging.getLogger(__name__)
+
+
+def create_structural_annotation_set(
+    document: Document,
+    user: Any,
+    *,
+    parser_name: str,
+    parser_version: str = "1.0",
+) -> StructuralAnnotationSet | None:
+    """
+    Create a :class:`StructuralAnnotationSet` for *document* and migrate its
+    structural annotations and relationships into it.
+
+    The migration enforces the model's XOR constraint (an annotation/relationship
+    belongs to *either* a ``document`` *or* a ``structural_set``, never both) by
+    nulling ``document`` as each row is re-homed onto the set, then links the
+    document to the set.
+
+    Idempotent: a document that already has a structural set, or that has no
+    structural annotations, is a no-op (returns the existing set or ``None``).
+    ``get_or_create`` on the content hash tolerates retry scenarios where the
+    set was created but the document link was not saved.
+
+    Args:
+        document: The ``Document`` whose structural annotations should migrate.
+        user: The user to credit as the set's creator.
+        parser_name: Name of the parser that produced the structural layer
+            (stored on the set for provenance / dedup bookkeeping).
+        parser_version: Version string for the parser.
+
+    Returns:
+        The (created or reused) ``StructuralAnnotationSet``, or ``None`` if the
+        document had no structural annotations to migrate.
+    """
+    # Already linked — nothing to do.
+    if document.structural_annotation_set:
+        logger.info(
+            f"Document {document.pk} already has StructuralAnnotationSet "
+            f"{document.structural_annotation_set.pk}"
+        )
+        return document.structural_annotation_set
+
+    structural_annotations = Annotation.objects.filter(
+        document=document, structural=True, structural_set__isnull=True
+    )
+
+    if not structural_annotations.exists():
+        logger.info(f"Document {document.pk} has no structural annotations to migrate")
+        return None
+
+    # Stable content hash so re-ingesting the same source PDF reuses the set.
+    content_hash = document.pdf_file_hash or f"doc_{document.pk}"
+
+    struct_set, created = StructuralAnnotationSet.objects.get_or_create(
+        content_hash=content_hash,
+        defaults={
+            "creator": user,
+            "parser_name": parser_name,
+            "parser_version": parser_version,
+            "page_count": document.page_count,
+            "pawls_parse_file": document.pawls_parse_file,
+            "txt_extract_file": document.txt_extract_file,
+        },
+    )
+
+    if created:
+        logger.info(
+            f"Created StructuralAnnotationSet {struct_set.pk} for document {document.pk}"
+        )
+    else:
+        logger.info(
+            f"Reusing existing StructuralAnnotationSet {struct_set.pk} "
+            f"for document {document.pk} (retry/dedup scenario)"
+        )
+
+    structural_annotation_ids = set(structural_annotations.values_list("id", flat=True))
+
+    for annot in structural_annotations:
+        annot.structural_set = struct_set
+        annot.document = None  # XOR constraint: either document or structural_set
+        annot.save()
+
+    # Migrate structural relationships whose endpoints are both structural
+    # annotations that we just migrated.
+    structural_relationships = Relationship.objects.filter(
+        document=document, structural=True, structural_set__isnull=True
+    ).filter(
+        source_annotations__id__in=structural_annotation_ids,
+        target_annotations__id__in=structural_annotation_ids,
+    )
+
+    for rel in structural_relationships:
+        rel.structural_set = struct_set
+        rel.document = None  # XOR constraint
+        rel.save()
+
+    document.structural_annotation_set = struct_set
+    document.save()
+
+    logger.info(
+        f"Migrated {structural_annotations.count()} annotations and "
+        f"{structural_relationships.count()} relationships to "
+        f"StructuralAnnotationSet {struct_set.pk}"
+    )
+    return struct_set

--- a/opencontractserver/worker_uploads/management/commands/mint_worker_token.py
+++ b/opencontractserver/worker_uploads/management/commands/mint_worker_token.py
@@ -1,0 +1,173 @@
+"""
+Management command: mint a corpus-scoped worker-upload token from the CLI.
+
+This is the one-command server-side setup step for the remote-ingest worker
+(``scripts/remote_ingest``). It creates (or reuses) a worker service account and
+issues a ``CorpusAccessToken`` bound to a single corpus, then prints the plaintext
+token — which is shown only ONCE (the row stores only its SHA-256 hash).
+
+Example::
+
+    python manage.py mint_worker_token --corpus 7 --worker-name fortworth-rig
+
+All authorisation and lifecycle logic is delegated to the worker-upload services
+(``WorkerAccountService`` / ``CorpusAccessTokenService``); the command only
+resolves an acting superuser and projects the result to stdout.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import TYPE_CHECKING, Any, cast
+
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand, CommandError
+from django.utils import timezone
+
+from opencontractserver.worker_uploads.models import WorkerAccount
+from opencontractserver.worker_uploads.services import (
+    CorpusAccessTokenService,
+    WorkerAccountService,
+)
+
+if TYPE_CHECKING:
+    from opencontractserver.worker_uploads.models import CorpusAccessToken
+
+User = get_user_model()
+
+
+class Command(BaseCommand):
+    help = (
+        "Mint a corpus-scoped worker-upload token (for scripts/remote_ingest). "
+        "Creates or reuses a worker account and prints the one-time token."
+    )
+
+    def add_arguments(self, parser: Any) -> None:
+        parser.add_argument(
+            "--corpus",
+            type=int,
+            required=True,
+            help="Raw integer PK of the corpus to bind the token to.",
+        )
+        parser.add_argument(
+            "--worker-name",
+            type=str,
+            required=True,
+            help="Name of the worker service account (created if it doesn't exist).",
+        )
+        parser.add_argument(
+            "--description",
+            type=str,
+            default="",
+            help="Optional description for a newly-created worker account.",
+        )
+        parser.add_argument(
+            "--rate-limit",
+            type=int,
+            default=0,
+            help="Uploads-per-minute cap for the token (0 = unlimited).",
+        )
+        parser.add_argument(
+            "--expires-days",
+            type=int,
+            default=None,
+            help="Token lifetime in days (default: never expires).",
+        )
+        parser.add_argument(
+            "--as-user",
+            type=str,
+            default=None,
+            help=(
+                "Username of the superuser to act as. Defaults to the first "
+                "active superuser found."
+            ),
+        )
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        acting_user = self._resolve_superuser(options.get("as_user"))
+
+        worker_name = options["worker_name"]
+        existing = WorkerAccount.objects.filter(name=worker_name).first()
+        if existing is None:
+            create_result = WorkerAccountService.create_worker_account(
+                acting_user,
+                name=worker_name,
+                description=options.get("description", ""),
+            )
+            if not create_result.ok:
+                raise CommandError(
+                    f"Could not create worker account: {create_result.error}"
+                )
+            # ``ok`` invariant: success carries a non-None value (cast narrows
+            # for mypy without relying on assert, which -O strips).
+            account = cast(WorkerAccount, create_result.value)
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"Created worker account '{account.name}' (id={account.id})."
+                )
+            )
+        elif not existing.is_active:
+            raise CommandError(
+                f"Worker account '{worker_name}' exists but is deactivated. "
+                f"Reactivate it before minting tokens."
+            )
+        else:
+            account = existing
+            self.stdout.write(
+                f"Reusing existing worker account '{account.name}' (id={account.id})."
+            )
+
+        expires_at = None
+        if options.get("expires_days") is not None:
+            expires_at = timezone.now() + timedelta(days=options["expires_days"])
+
+        token_result = CorpusAccessTokenService.create_token(
+            acting_user,
+            worker_account_id=account.id,
+            corpus_id=options["corpus"],
+            expires_at=expires_at,
+            rate_limit_per_minute=options.get("rate_limit", 0),
+        )
+        if not token_result.ok:
+            raise CommandError(f"Could not mint token: {token_result.error}")
+
+        token, plaintext_key = cast("tuple[CorpusAccessToken, str]", token_result.value)
+
+        self.stdout.write("")
+        self.stdout.write(self.style.SUCCESS("=" * 70))
+        self.stdout.write(
+            self.style.SUCCESS("Worker token minted (shown ONCE — copy it now):")
+        )
+        self.stdout.write(self.style.SUCCESS("=" * 70))
+        self.stdout.write(f"  OC_WORKER_TOKEN={plaintext_key}")
+        self.stdout.write(f"  OC_CORPUS_ID={token.corpus_id}")
+        self.stdout.write("")
+        self.stdout.write("Use it on the remote worker host, e.g.:")
+        self.stdout.write(
+            f"  export OC_WORKER_TOKEN={plaintext_key}\n"
+            f"  export OC_CORPUS_ID={token.corpus_id}\n"
+            f"  export OC_TARGET_URL=https://<your-opencontracts-host>"
+        )
+        self.stdout.write(self.style.SUCCESS("=" * 70))
+
+    def _resolve_superuser(self, username: str | None) -> Any:
+        if username:
+            try:
+                named = User.objects.get(username=username)
+            except User.DoesNotExist:
+                raise CommandError(f"User '{username}' not found.")
+            if not named.is_superuser:
+                raise CommandError(f"User '{username}' is not a superuser.")
+            return named
+
+        user = (
+            User.objects.filter(is_superuser=True, is_active=True)
+            .order_by("id")
+            .first()
+        )
+        if user is None:
+            raise CommandError(
+                "No active superuser found. Create one with "
+                "`python manage.py createsuperuser` or pass --as-user."
+            )
+        return user

--- a/opencontractserver/worker_uploads/serializers.py
+++ b/opencontractserver/worker_uploads/serializers.py
@@ -5,11 +5,13 @@ from typing import Any
 from rest_framework import serializers
 
 from opencontractserver.annotations.models import EMBEDDING_DIMENSIONS
+from opencontractserver.extracts.services.metadata import MetadataService
 from opencontractserver.worker_uploads.models import WorkerDocumentUpload
 
 logger = logging.getLogger(__name__)
 
 _SUPPORTED_DIMS = frozenset(dim for dim, _ in EMBEDDING_DIMENSIONS)
+_METADATA_DATA_TYPES = frozenset(MetadataService.METADATA_DATA_TYPES)
 
 
 class WorkerDocumentUploadSerializer(serializers.Serializer):
@@ -68,6 +70,36 @@ class WorkerDocumentUploadSerializer(serializers.Serializer):
                     _validate_vector(
                         vec,
                         f"embeddings.annotation_embeddings[{annot_id}]",
+                    )
+
+        # Structured document metadata, if present, must be a JSON object —
+        # it is stored verbatim on Document.custom_meta.
+        custom_meta = data.get("custom_meta")
+        if custom_meta is not None and not isinstance(custom_meta, dict):
+            raise serializers.ValidationError("custom_meta must be a JSON object.")
+
+        # Typed corpus metadata (Column/Datacell): a list of entries, each with a
+        # column_name + data_type. Value type is validated server-side against the
+        # column on ingestion (Datacell.clean).
+        md = data.get("metadata")
+        if md is not None:
+            if not isinstance(md, list):
+                raise serializers.ValidationError("metadata must be a list.")
+            for i, entry in enumerate(md):
+                if not isinstance(entry, dict):
+                    raise serializers.ValidationError(
+                        f"metadata[{i}] must be a JSON object."
+                    )
+                if not entry.get("column_name") or not isinstance(
+                    entry.get("column_name"), str
+                ):
+                    raise serializers.ValidationError(
+                        f"metadata[{i}].column_name is required (string)."
+                    )
+                if entry.get("data_type") not in _METADATA_DATA_TYPES:
+                    raise serializers.ValidationError(
+                        f"metadata[{i}].data_type must be one of "
+                        f"{sorted(_METADATA_DATA_TYPES)}."
                     )
 
         return data

--- a/opencontractserver/worker_uploads/tasks.py
+++ b/opencontractserver/worker_uploads/tasks.py
@@ -39,6 +39,7 @@ from opencontractserver.documents.models import (
     DocumentPath,
     DocumentProcessingStatus,
 )
+from opencontractserver.extracts.services.metadata import MetadataService
 from opencontractserver.types.enums import PermissionTypes
 from opencontractserver.utils.compact_pawls import compact_pawls_pages
 from opencontractserver.utils.importing import (
@@ -47,6 +48,8 @@ from opencontractserver.utils.importing import (
     load_or_create_labels,
 )
 from opencontractserver.utils.permissioning import set_permissions_for_obj_to_user
+from opencontractserver.utils.structural_sets import create_structural_annotation_set
+from opencontractserver.utils.subtree_groups import build_subtree_groups_for_document
 from opencontractserver.worker_uploads.models import (
     UploadStatus,
     WorkerDocumentUpload,
@@ -253,23 +256,33 @@ def _process_single_upload(upload_id: UUID) -> None:
             name="extracted_text.txt",
         )
 
+        # Optional structured metadata calculated by the remote worker's
+        # pre-processing stage (e.g. jurisdiction, parsed dates, contract
+        # number). Stored verbatim on Document.custom_meta. Only applied when
+        # provided so non-enriched uploads keep the field's default.
+        custom_meta = metadata.get("custom_meta")
+
+        create_kwargs: dict[str, Any] = {
+            "title": safe_title,
+            "description": metadata.get("description", ""),
+            "pdf_file": File(upload.file, doc_filename),
+            "pawls_parse_file": pawls_file,
+            "txt_extract_file": txt_file,
+            "file_type": metadata.get("file_type", "application/pdf"),
+            "page_count": metadata.get("page_count", len(pawls_content)),
+            "backend_lock": True,
+            "creator": user,
+            # Mark as already processed — worker did the processing
+            "processing_started": timezone.now(),
+            "processing_status": DocumentProcessingStatus.COMPLETED,
+        }
+        if custom_meta is not None:
+            create_kwargs["custom_meta"] = custom_meta
+
         # Open the uploaded file
         upload.file.open("rb")
         try:
-            doc = Document.objects.create(
-                title=safe_title,
-                description=metadata.get("description", ""),
-                pdf_file=File(upload.file, doc_filename),
-                pawls_parse_file=pawls_file,
-                txt_extract_file=txt_file,
-                file_type=metadata.get("file_type", "application/pdf"),
-                page_count=metadata.get("page_count", len(pawls_content)),
-                backend_lock=True,
-                creator=user,
-                # Mark as already processed — worker did the processing
-                processing_started=timezone.now(),
-                processing_status=DocumentProcessingStatus.COMPLETED,
-            )
+            doc = Document.objects.create(**create_kwargs)
         finally:
             upload.file.close()
 
@@ -290,6 +303,12 @@ def _process_single_upload(upload_id: UUID) -> None:
             path=target_path,
         )
 
+        # add_document creates a corpus-isolated COPY; make sure the worker's
+        # structured metadata is present on the copy users actually see.
+        if custom_meta is not None and corpus_doc.custom_meta != custom_meta:
+            corpus_doc.custom_meta = custom_meta
+            corpus_doc.save(update_fields=["custom_meta"])
+
         # 4. Import document-level labels
         for doc_label_name in metadata.get("doc_labels", []):
             label_obj = doc_label_lookup.get(doc_label_name)
@@ -302,13 +321,21 @@ def _process_single_upload(upload_id: UUID) -> None:
                 )
                 set_permissions_for_obj_to_user(user, annot, [PermissionTypes.ALL])
 
-        # 5. Import text annotations
+        # 5. Import text annotations.
+        # When the worker shipped pre-computed embeddings it OWNS the embedding
+        # layer, so suppress the server-side batch-embedding dispatch that
+        # import_annotations would otherwise fire (re-embedding here both wastes
+        # the target's embedder and defeats the point of offloading enrichment
+        # to the remote worker). When no embeddings are supplied, fall back to
+        # the default behaviour and let the server embed.
+        embeddings_data = metadata.get("embeddings")
         annot_id_map = import_annotations(
             user_id=user.id,
             doc_obj=corpus_doc,
             corpus_obj=corpus,
             annotations_data=metadata.get("labelled_text", []),
             label_lookup=label_lookup,
+            dispatch_embeddings=not bool(embeddings_data),
         )
 
         # 6. Import relationships
@@ -323,13 +350,46 @@ def _process_single_upload(upload_id: UUID) -> None:
             )
 
         # 7. Store pre-computed embeddings
-        embeddings_data = metadata.get("embeddings")
         if embeddings_data:
             _store_embeddings(
                 embeddings_data=embeddings_data,
                 corpus_doc=corpus_doc,
                 annot_id_map=annot_id_map,
                 user=user,
+            )
+
+        # 7.5. Materialise the structural layer exactly as the parser pipeline
+        # does (save_parsed_data): build subtree-group relationships from the
+        # structural parent-child tree, then migrate structural annotations and
+        # relationships into a StructuralAnnotationSet (document=NULL,
+        # structural_set=set). This is what makes a remotely-parsed document a
+        # FAITHFUL mirror: structural annotations resolve through the same
+        # structural-set join the rest of the platform relies on
+        # (AnnotationService.get_document_annotations), instead of lingering as
+        # plain per-document annotations.
+        build_subtree_groups_for_document(document=corpus_doc, user_id=user.id)
+        create_structural_annotation_set(
+            corpus_doc,
+            user,
+            parser_name=metadata.get("parser_name") or "Remote Worker",
+            parser_version=metadata.get("parser_version") or "1.0",
+        )
+
+        # 7.6. Structured metadata (datacells) — the corpus Column/Datacell
+        # metadata system (what the UI calls document metadata, successor to the
+        # old "metadata annotations"). Each entry get-or-creates a manual-entry
+        # Column in the corpus metadata schema and sets the document's value. A
+        # type mismatch raises (Datacell.clean) and fails the upload, surfacing
+        # the bad value rather than silently dropping it.
+        for md in metadata.get("metadata", []) or []:
+            MetadataService.upsert_document_metadata(
+                corpus=corpus,
+                document=corpus_doc,
+                user=user,
+                column_name=md["column_name"],
+                data_type=md["data_type"],
+                value=md.get("value"),
+                validation_config=md.get("validation_config"),
             )
 
         # 8. Place in target folder if specified
@@ -346,6 +406,22 @@ def _process_single_upload(upload_id: UUID) -> None:
         upload.result_document = corpus_doc
         upload.processing_finished = timezone.now()
         upload.save(update_fields=["status", "result_document", "processing_finished"])
+
+    # Generate the document thumbnail after commit. The worker-upload metadata
+    # carries no thumbnail, but the source file IS stored, so the server can
+    # regenerate Document.icon the same way the parser pipeline does. This is a
+    # standalone task (NOT the ingest chain), so it only thumbnails — it never
+    # re-parses the already-processed document. Dispatched post-commit so the
+    # row is visible to the worker.
+    try:
+        from opencontractserver.tasks.doc_tasks import extract_thumbnail
+
+        extract_thumbnail.apply_async(kwargs={"doc_id": corpus_doc.id})
+    except Exception:
+        logger.warning(
+            f"Failed to dispatch thumbnail generation for upload {upload_id}",
+            exc_info=True,
+        )
 
     # Clean up staging file after successful commit
     if upload.file:
@@ -430,8 +506,12 @@ def _store_embeddings(
     for old_annot_id, vector in annot_embeddings.items():
         new_pk = annot_id_map.get(old_annot_id) or annot_id_map.get(str(old_annot_id))
         if not new_pk:
-            logger.debug(
-                f"Skipping embedding for unknown annotation ID: {old_annot_id}"
+            # A supplied annotation embedding whose id does not map to a created
+            # annotation is dropped — surface it (a worker that ships embeddings
+            # keyed by a stale/duplicate id loses that vector silently otherwise).
+            logger.warning(
+                f"Skipping embedding for unmapped annotation id "
+                f"{old_annot_id!r} (not in annotation_id_map)."
             )
             continue
 

--- a/scripts/remote_ingest/README.md
+++ b/scripts/remote_ingest/README.md
@@ -1,0 +1,267 @@
+# Remote Ingest Worker
+
+Run the OpenContracts ingestion pipeline (Docling parse + embeddings) on a
+beefy **off-cluster** host and stream **fully-processed, faithfully-mirrored**
+documents into a target OpenContracts corpus — without giving the remote host
+any access to the target's database.
+
+This is the tool for the "I have spare workstations and a 100k–1M document
+corpus to populate" problem. The expensive work (parsing + enrichment) happens
+on your hardware; the target instance just ingests the finished artifacts.
+
+---
+
+## Why this is different from `scripts/bulk_import`
+
+| | `bulk_import/oc_bulk_import.py` | `remote_ingest/oc_remote_ingest.py` (this tool) |
+|---|---|---|
+| What it ships | **raw** PDFs (ZIP) | **fully-processed** documents (PAWLs, text, annotations, relationships, embeddings) |
+| Who parses | the **server** (`/api/imports/zip-to-corpus/`) | the **remote worker** (this host) |
+| Offloads compute? | ❌ no — server still parses + embeds | ✅ yes — parse + embed run remotely |
+| Endpoint | `/api/imports/zip-to-corpus/` | `/api/worker-uploads/documents/` |
+
+Use `bulk_import` when the server has spare capacity. Use `remote_ingest` when
+you want to throw your own hardware at ingestion and keep the target instance
+cheap.
+
+## Faithful by construction
+
+The worker runs the **same Docling microservice image** and the **same
+`DoclingParser` code** the server runs, and embeds against the **same
+vector-embedder image**. So:
+
+- **PAWLs token layer** — identical tokenisation (no drift; the worker-upload
+  path trusts these tokens verbatim, and they *are* what the server would
+  produce).
+- **Text layer (`content`)** — rebuilt from the shipped PAWLs with the same
+  `plasmapdf.build_translation_layer` the server's `save_parsed_data` uses.
+- **Structural annotations + relationships** — produced by the real parser; the
+  server's worker-upload path then materialises a `StructuralAnnotationSet` and
+  subtree-group relationships exactly as in-cluster ingestion does.
+- **Embeddings** — same 384-dim model, same inputs (full text for the document,
+  `rawText` per annotation).
+- **Thumbnail** — regenerated server-side from the uploaded PDF.
+
+The net result: a document ingested through this worker is indistinguishable
+from one ingested in-cluster.
+
+---
+
+## Setup
+
+### 1. On the target server — mint a corpus-scoped token (one command)
+
+```bash
+python manage.py mint_worker_token --corpus <CORPUS_PK> --worker-name <name>
+```
+
+This prints a one-time `OC_WORKER_TOKEN` (and the `OC_CORPUS_ID`). The token is
+bound to exactly one corpus — the remote host can never target another. Only the
+SHA-256 hash is stored server-side; copy the plaintext now.
+
+> The corpus must already exist (create it in the UI or via the API). To cap
+> throughput, pass `--rate-limit <uploads/min>`; to expire the token, pass
+> `--expires-days <N>`.
+
+### 2. On the remote worker host — run the bundle (a few commands)
+
+```bash
+git clone <opencontracts repo>           # the worker runs the real parser code
+cd opencontracts/scripts/remote_ingest
+
+export OC_TARGET_URL=https://opencontracts.example.com
+export OC_WORKER_TOKEN=<token from step 1>
+export OC_DATA_DIR=/data/pdfs            # your directory tree of PDFs
+export VECTOR_EMBEDDER_API_KEY=<key>     # any value; the embedder enforces it
+
+# Start the parser + embedder microservices (one-time, ~minutes to pull):
+docker compose -f remote_worker.yml up -d --build docling-parser vector-embedder
+
+# Plan (scan the tree into the resumable ledger), then run:
+docker compose -f remote_worker.yml run --rm worker plan
+docker compose -f remote_worker.yml run --rm worker run --max-workers 8
+
+# Confirm everything landed:
+docker compose -f remote_worker.yml run --rm worker verify
+docker compose -f remote_worker.yml run --rm worker status
+```
+
+That's it. The directory tree under `OC_DATA_DIR` is mirrored into the corpus's
+folder structure (each PDF's path becomes its folder path). `run` is resumable —
+if it's interrupted, just run it again; finished documents are skipped.
+
+---
+
+## Subcommands
+
+| Command | What it does |
+|---|---|
+| `plan` | Scan `OC_DATA_DIR` and record every PDF in the SQLite ledger. No network, no parsing. |
+| `run` | Parse + embed + upload all `PENDING`/`FAILED` docs. Resumable, concurrent, back-pressure-aware. |
+| `verify` | Poll the target for each uploaded doc's terminal status; mark `COMPLETED`/`FAILED`. |
+| `status` | Print ledger counts + the target's live worker-upload backlog. |
+
+Useful flags (append after the subcommand):
+
+- `--max-workers N` — parse/upload concurrency (default 4). The Docling parse is
+  the bottleneck; scale this to your CPU.
+- `--no-embeddings` — skip remote embedding and let the **server** embed instead
+  (the worker still offloads parsing). By default the worker embeds and the
+  server is told not to re-embed.
+- `--limit N` — (on `plan`) cap how many documents are recorded; handy for a
+  trial run.
+- `--flat` — do not mirror the directory tree into corpus folders.
+- `--queue-high / --queue-low` — back-pressure thresholds against the target's
+  worker-upload backlog (pause when `PENDING+PROCESSING` exceeds high, resume
+  below low).
+- `--enricher MODULE:CALLABLE` — run a pre-processing enricher (repeatable; also
+  `OC_ENRICHERS`, comma-separated). See below.
+
+---
+
+## Pre-processing / enrichment — inject metadata + annotations
+
+Often you want each document to carry **more than the parser produces**: a
+structured metadata blob, a document-type label, or extra annotations you
+calculate (detected dates, parties, clauses, regex/NER hits, an LLM
+classification). The worker runs a **pluggable enrichment stage** after parsing
+and *before* embedding + upload — so anything you inject is embedded and
+ingested exactly like the parser's own output.
+
+An enricher is a callable `(EnricherContext) -> Enrichment`. Point the worker at
+it with `--enricher module:function` (repeatable) or `OC_ENRICHERS`. The context
+gives you the parsed token layer + text and **correctness helpers** so injected
+annotations are faithful (valid `annotation_json` — bounds, token indices,
+`rawText`). The worker **validates** every enrichment before upload, so a buggy
+enricher fails that document loudly (in the ledger) instead of silently shipping
+a broken annotation.
+
+```python
+# my_enrichers.py  (mount it into the worker, or drop it next to the driver)
+import re
+from enrichers import Enrichment, EnricherContext, label_def, TOKEN_LABEL, DOC_TYPE_LABEL
+
+def enrich(ctx: EnricherContext) -> Enrichment:
+    enr = Enrichment(
+        # 1. structured metadata  -> Document.custom_meta
+        custom_meta={"jurisdiction": "TX"},
+        # 2. a document-type label -> DOC_TYPE_LABEL
+        doc_labels=["contract:construction"],
+        doc_label_defs={"contract:construction": label_def("contract:construction", DOC_TYPE_LABEL)},
+        # 3. label definitions for any annotations we inject
+        annotation_labels={"EFFECTIVE_DATE": label_def("EFFECTIVE_DATE", TOKEN_LABEL)},
+    )
+    # 4. inject token annotations for matched text (faithful annotation_json built for you)
+    for m in ctx.find_token_matches(r"\b\w+ \d{1,2}, \d{4}\b"):
+        enr.annotations.append(ctx.token_annotation("EFFECTIVE_DATE", m))
+    return enr
+```
+
+```bash
+docker compose -f remote_worker.yml run --rm worker run \
+    --enricher my_enrichers:enrich
+```
+
+What an `Enrichment` can carry (all optional, additive):
+
+| Field | Effect on the document |
+|---|---|
+| `metadata` (via `metadata_field`) | **typed corpus metadata** — Column/Datacell values (the UI's document metadata, successor to legacy "metadata annotations"). Corpus-scoped, typed, queryable. |
+| `custom_meta` (dict) | merged onto `Document.custom_meta` (a freeform JSON blob — not the typed metadata schema) |
+| `title` / `description` | override the document title/description |
+| `doc_labels` + `doc_label_defs` | apply DOC_TYPE_LABELs |
+| `annotations` + `annotation_labels` | inject token (or span) annotations; they get embedded + rendered |
+| `relationships` | annotation-to-annotation relationships (reference annotation `id`s) |
+
+### Typed metadata (the metadata system, not `custom_meta`)
+
+OpenContracts has two metadata mechanisms: the freeform `Document.custom_meta`
+JSON blob, and the **typed corpus metadata** system (`Fieldset` → `Column` →
+`Datacell` — what the UI shows in the document metadata grid). Prefer the latter
+for real metadata: it's corpus-scoped, typed, validated, and queryable.
+
+Emit typed metadata with `metadata_field(name, value, data_type=…)`:
+
+```python
+from enrichers import Enrichment, metadata_field
+
+def enrich(ctx):
+    return Enrichment(metadata=[
+        metadata_field("Contract Number", "058000"),                 # STRING (inferred)
+        metadata_field("Effective Date", "2025-01-01", data_type="DATE"),
+        metadata_field("Pages", 6),                                  # INTEGER (inferred)
+        metadata_field("Contract Type", "Service",
+                       data_type="CHOICE",
+                       validation_config={"choices": ["Service", "NDA"]}),
+    ])
+```
+
+On ingest the worker get-or-creates a manual-entry `Column` (by name) in the
+corpus's metadata schema and sets the document's `Datacell` value. Data types:
+`STRING, TEXT, BOOLEAN, INTEGER, FLOAT, DATE (YYYY-MM-DD), DATETIME (ISO), URL,
+EMAIL, CHOICE, MULTI_CHOICE, JSON`. Values are type-checked both client-side
+(`validate_enrichment`) and server-side (`Datacell.clean`) — a mismatch fails the
+document rather than landing a bad value. The first document to use a column name
+defines its type for the corpus.
+
+Context helpers (`EnricherContext`):
+
+- `ctx.export` / `ctx.content` — the parsed `OpenContractDocExport` + text layer.
+- `ctx.find_token_matches(regex)` — regex over each page's token text, returns the
+  matching token runs (`TokenMatch`).
+- `ctx.token_annotation(label, match)` — build a valid TOKEN_LABEL annotation
+  (union bounds + token indices + `rawText`) for a match. Injected annotation
+  `id`s are assigned automatically (`enr-0`, ...) so they never collide with the
+  parser's, and they participate in embeddings + relationships.
+
+Three runnable examples ship in `example_enrichers.py` (filename → metadata,
+detected dates → annotations, content → document-type label). Use them directly:
+`--enricher example_enrichers:effective_date_annotations`.
+
+---
+
+## Security
+
+- **Auth**: a `CorpusAccessToken` sent as `Authorization: WorkerKey <token>` over
+  TLS. The token is corpus-scoped and the corpus is fixed by the binding — the
+  remote host cannot reach another corpus or any other API.
+- **No database access**: the worker never connects to the target's database. It
+  only makes outbound HTTPS calls to `/api/worker-uploads/`.
+- **No inbound ports**: the worker initiates all connections.
+- **Revocation**: deactivate the token (or its worker account) server-side and
+  in-flight + future uploads stop.
+
+For production, run the target behind a reverse proxy with `limit_req` for hard
+rate limiting (the per-token limit is best-effort).
+
+---
+
+## How it works (per document)
+
+1. Read the PDF bytes.
+2. `DoclingParser.parse_pdf_bytes(bytes)` → `OpenContractDocExport` (PAWLs,
+   structural annotations, relationships) — the real parser, no database.
+3. Rebuild the text layer from the PAWLs (`build_translation_layer`).
+4. Embed the document text + each annotation's `rawText` against the
+   vector-embedder.
+5. POST `multipart/form-data` (the PDF + a metadata JSON) to
+   `/api/worker-uploads/documents/`.
+6. The server stages the upload and a Celery worker ingests it: creates the
+   document, imports annotations/relationships, stores the embeddings,
+   materialises the structural set, and regenerates the thumbnail.
+
+The ledger (`/ledger/ledger.sqlite3`, a named volume) records each document's
+state so the whole run is crash-resumable.
+
+---
+
+## Requirements on the remote host
+
+- Docker + Docker Compose.
+- The OpenContracts repo (the worker image is built from it).
+- Outbound HTTPS to the target.
+- Enough RAM for the Docling microservice (~2 GB) plus the worker.
+
+The driver itself runs inside the OpenContracts image and uses
+`config.settings.remote_worker`, which points Django at a throwaway SQLite file
+so the worker needs **no Postgres and no Redis**.

--- a/scripts/remote_ingest/enrichers.py
+++ b/scripts/remote_ingest/enrichers.py
@@ -1,0 +1,667 @@
+#!/usr/bin/env python3
+"""
+Pluggable pre-processing / enrichment stage for the remote-ingest worker.
+
+After the remote worker parses a PDF (faithful Docling output) and before it
+embeds + uploads it, user-supplied *enrichers* run to CALCULATE and INJECT
+additional artifacts onto the document:
+
+* typed corpus metadata         -> Column/Datacell (the UI's "document
+                                   metadata", successor to legacy metadata
+                                   annotations) via Enrichment.metadata /
+                                   metadata_field()
+* freeform document metadata    -> Document.custom_meta (a JSON blob)
+* document-type labels          -> DOC_TYPE_LABEL annotations
+* extra token annotations       -> labelled_text (e.g. detected clauses, dates,
+                                   parties) — these get embedded + ingested just
+                                   like the parser's own annotations
+* annotation-to-annotation relationships
+
+An enricher is any callable ``(EnricherContext) -> Enrichment | None`` discovered
+from a dotted path (``--enricher pkg.module:func`` / ``OC_ENRICHERS``). The
+context exposes correctness helpers — ``find_token_matches(regex)`` and
+``token_annotation(label, match)`` — that build a *valid* ``annotation_json``
+(union bounds + token indices + rawText) so injected annotations are faithful
+and render correctly. ``validate_enrichment`` enforces the worker-upload rules
+before upload, so a buggy enricher fails the document loudly instead of silently
+shipping a broken annotation.
+
+This module is intentionally light on imports (only ``expand_pawls_pages`` from
+OpenContracts, which pulls in no Django models) so it is unit-testable without a
+full Django bootstrap.
+
+Trust model: enrichers are arbitrary Python the OPERATOR supplies and runs on
+THEIR OWN worker host (``--enricher module:callable``). The worker imports and
+executes them with the worker's privileges — they are first-party code, exactly
+like the rest of the worker, not untrusted input. Don't load enricher modules you
+didn't write. Output (``custom_meta``, annotations) is sent to the target like
+any worker upload; ``custom_meta`` is stored verbatim on ``Document.custom_meta``
+(GenericScalar JSON, escaped at the GraphQL/UI layer per the project's
+XSS-prevention rule). Note the authority-corpus system also writes
+``custom_meta`` — avoid colliding with its keys (``canonical_key``, ``authority``,
+``authority_aliases``, ``source_url``) on authority corpora.
+"""
+
+from __future__ import annotations
+
+import importlib
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from re import Pattern
+from typing import Callable, Optional
+
+from opencontractserver.utils.compact_pawls import expand_pawls_pages
+
+# Annotation type / label-type constants (mirrors opencontractserver.annotations).
+TOKEN_LABEL = "TOKEN_LABEL"
+SPAN_LABEL = "SPAN_LABEL"
+DOC_TYPE_LABEL = "DOC_TYPE_LABEL"
+RELATIONSHIP_LABEL = "RELATIONSHIP_LABEL"
+
+
+# ---------------------------------------------------------------------------
+# Public result + context types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TokenMatch:
+    """A run of PAWLs tokens on a single page that matched a query."""
+
+    page: int
+    token_indices: list[int]
+    text: str
+
+
+@dataclass
+class Enrichment:
+    """What an enricher returns. All fields optional / additive."""
+
+    # Document-level overrides (None = leave the worker's default).
+    title: str | None = None
+    description: str | None = None
+    # Structured metadata merged onto Document.custom_meta.
+    custom_meta: dict = field(default_factory=dict)
+    # Document-type label NAMES to apply, plus their definitions.
+    doc_labels: list[str] = field(default_factory=list)
+    doc_label_defs: dict[str, dict] = field(default_factory=dict)
+    # Extra annotations (labelled_text entries) to inject, plus label defs.
+    annotations: list[dict] = field(default_factory=list)
+    annotation_labels: dict[str, dict] = field(default_factory=dict)
+    # Annotation-to-annotation relationships referencing injected/parser ids.
+    relationships: list[dict] = field(default_factory=list)
+    # Typed corpus metadata (Column/Datacell — the UI's document metadata). Each
+    # entry: {column_name, data_type, value, validation_config?}. Build with
+    # metadata_field().
+    metadata: list[dict] = field(default_factory=list)
+
+    @classmethod
+    def merge(cls, parts: Iterable[Enrichment | None]) -> Enrichment:
+        """Combine several enrichers' outputs into one (last-writer-wins for
+        scalar/dict fields; lists concatenated)."""
+        out = cls()
+        for p in parts:
+            if p is None:
+                continue
+            if p.title is not None:
+                out.title = p.title
+            if p.description is not None:
+                out.description = p.description
+            out.custom_meta = {**out.custom_meta, **(p.custom_meta or {})}
+            for name in p.doc_labels:
+                if name not in out.doc_labels:
+                    out.doc_labels.append(name)
+            out.doc_label_defs.update(p.doc_label_defs or {})
+            out.annotations.extend(p.annotations or [])
+            out.annotation_labels.update(p.annotation_labels or {})
+            out.relationships.extend(p.relationships or [])
+            out.metadata.extend(p.metadata or [])
+        return out
+
+    def is_empty(self) -> bool:
+        return not any(
+            [
+                self.title,
+                self.description,
+                self.custom_meta,
+                self.doc_labels,
+                self.annotations,
+                self.relationships,
+                self.metadata,
+            ]
+        )
+
+
+class EnricherContext:
+    """Read-only view of one parsed document, plus annotation-building helpers."""
+
+    def __init__(self, *, rel_path: str, abs_path: str, export: dict, content: str):
+        self.rel_path = rel_path
+        self.abs_path = abs_path
+        self.export = export
+        self.content = content
+        # Normalise PAWLs to the v1 (page dict) form once.
+        self._pages = expand_pawls_pages(export.get("pawls_file_content") or [])
+        self._page_index: dict[int, tuple[str, list[tuple[int, int, int]]]] = {}
+
+    @property
+    def pages(self) -> list[dict]:
+        return self._pages
+
+    @property
+    def page_count(self) -> int:
+        return self.export.get("page_count") or len(self._pages)
+
+    def _page_token_index(self, page: int) -> tuple[str, list[tuple[int, int, int]]]:
+        """Return (joined_text, [(token_index, start_char, end_char), ...]) for a page.
+
+        Tokens are space-joined; the char spans let a regex match map back to the
+        exact token indices it covers."""
+        if page in self._page_index:
+            return self._page_index[page]
+        joined = ""
+        spans: list[tuple[int, int, int]] = []
+        if 0 <= page < len(self._pages):
+            for idx, tok in enumerate(self._pages[page].get("tokens", [])):
+                text = tok.get("text") or ""
+                if tok.get("is_image"):
+                    # image tokens have no text; keep index alignment with a gap
+                    if joined:
+                        joined += " "
+                    spans.append((idx, len(joined), len(joined)))
+                    continue
+                if joined:
+                    joined += " "
+                start = len(joined)
+                joined += text
+                spans.append((idx, start, len(joined)))
+        self._page_index[page] = (joined, spans)
+        return self._page_index[page]
+
+    def page_text(self, page: int) -> str:
+        """The space-joined token text of a page (what find_token_matches searches)."""
+        return self._page_token_index(page)[0]
+
+    def find_token_matches(
+        self,
+        pattern: str | Pattern,
+        *,
+        flags: int = re.IGNORECASE,
+        pages: Iterable[int] | None = None,
+    ) -> list[TokenMatch]:
+        """Find regex matches over each page's token text and map them back to
+        token indices. Returns one TokenMatch per match."""
+        rx = re.compile(pattern, flags) if isinstance(pattern, str) else pattern
+        page_iter = list(pages) if pages is not None else range(len(self._pages))
+        out: list[TokenMatch] = []
+        for page in page_iter:
+            joined, spans = self._page_token_index(page)
+            if not joined:
+                continue
+            for m in rx.finditer(joined):
+                s, e = m.start(), m.end()
+                if s == e:
+                    continue
+                idxs = [i for (i, ts, te) in spans if ts < e and te > s and te > ts]
+                if idxs:
+                    out.append(
+                        TokenMatch(page=page, token_indices=idxs, text=m.group(0))
+                    )
+        return out
+
+    def token_annotation(
+        self,
+        label: str,
+        match: TokenMatch,
+        *,
+        raw_text: str | None = None,
+        content_modalities: list[str] | None = None,
+        data: dict | None = None,
+        link_url: str | None = None,
+    ) -> dict:
+        """Build a faithful TOKEN_LABEL annotation (labelled_text entry) for a
+        matched run of tokens. ``id`` is assigned later, at merge time."""
+        page = match.page
+        if not match.token_indices:
+            raise ValueError("token_annotation requires at least one token index")
+        tokens = (
+            self._pages[page].get("tokens", []) if 0 <= page < len(self._pages) else []
+        )
+        lefts, tops, rights, bottoms = [], [], [], []
+        for idx in match.token_indices:
+            tok = tokens[idx]
+            x, y = float(tok["x"]), float(tok["y"])
+            w, h = float(tok["width"]), float(tok["height"])
+            lefts.append(x)
+            tops.append(y)
+            rights.append(x + w)
+            bottoms.append(y + h)
+        bounds = {
+            "left": min(lefts),
+            "top": min(tops),
+            "right": max(rights),
+            "bottom": max(bottoms),
+        }
+        rtext = raw_text if raw_text is not None else match.text
+        annotation: dict = {
+            "annotationLabel": label,
+            "rawText": rtext,
+            "page": page,
+            "annotation_type": TOKEN_LABEL,
+            "structural": False,
+            "content_modalities": content_modalities or ["TEXT"],
+            "annotation_json": {
+                str(page): {
+                    "bounds": bounds,
+                    "tokensJsons": [
+                        {"pageIndex": page, "tokenIndex": idx}
+                        for idx in match.token_indices
+                    ],
+                    "rawText": rtext,
+                }
+            },
+        }
+        if data is not None:
+            annotation["data"] = data
+        if link_url is not None:
+            annotation["link_url"] = link_url
+        return annotation
+
+
+Enricher = Callable[[EnricherContext], Optional[Enrichment]]
+
+
+# ---------------------------------------------------------------------------
+# Label-definition helper
+# ---------------------------------------------------------------------------
+
+
+def label_def(
+    text: str,
+    label_type: str = TOKEN_LABEL,
+    *,
+    color: str = "#2563EB",
+    description: str = "Worker enrichment label",
+    icon: str = "tag",
+) -> dict:
+    """Build an AnnotationLabel definition dict (validated by the server's
+    AnnotationLabelSerializer when auto-created)."""
+    return {
+        "label_type": label_type,
+        "color": color,
+        "description": description,
+        "icon": icon,
+        "text": text,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Typed corpus-metadata (Column/Datacell) helper
+# ---------------------------------------------------------------------------
+
+# The 12 metadata column data types (mirror MetadataService.METADATA_DATA_TYPES).
+METADATA_DATA_TYPES = (
+    "STRING",
+    "TEXT",
+    "BOOLEAN",
+    "INTEGER",
+    "FLOAT",
+    "DATE",
+    "DATETIME",
+    "URL",
+    "EMAIL",
+    "CHOICE",
+    "MULTI_CHOICE",
+    "JSON",
+)
+
+
+def _infer_data_type(value) -> str:
+    """Best-effort data_type for a Python value (bool before int!)."""
+    if isinstance(value, bool):
+        return "BOOLEAN"
+    if isinstance(value, int):
+        return "INTEGER"
+    if isinstance(value, float):
+        return "FLOAT"
+    if isinstance(value, (dict, list)):
+        return "JSON"
+    return "STRING"
+
+
+def metadata_field(
+    column_name: str,
+    value,
+    *,
+    data_type: str | None = None,
+    validation_config: dict | None = None,
+) -> dict:
+    """Build one typed metadata entry (a Column/Datacell value) to set on the
+    document. ``data_type`` is inferred from ``value`` when omitted. The value is
+    type-checked against ``data_type`` server-side (and by validate_enrichment).
+    """
+    dt = data_type or _infer_data_type(value)
+    entry: dict = {"column_name": column_name, "data_type": dt, "value": value}
+    if validation_config is not None:
+        entry["validation_config"] = validation_config
+    return entry
+
+
+def _metadata_value_error(entry: dict) -> str | None:
+    """Return an error string if a metadata entry's value does not match its
+    declared data_type (mirrors the server's Datacell.clean rules), else None."""
+    dt = entry.get("data_type")
+    value = entry.get("value")
+    cfg = entry.get("validation_config") or {}
+    if value is None:
+        return None  # null is allowed unless the column marks it required
+    if dt == "BOOLEAN" and not isinstance(value, bool):
+        return "must be a boolean"
+    if dt == "INTEGER" and (not isinstance(value, int) or isinstance(value, bool)):
+        return "must be an integer"
+    if dt == "FLOAT" and (
+        not isinstance(value, (int, float)) or isinstance(value, bool)
+    ):
+        return "must be a number"
+    if dt in ("STRING", "TEXT", "URL", "EMAIL") and not isinstance(value, str):
+        return "must be a string"
+    if dt in ("DATE", "DATETIME") and not isinstance(value, str):
+        return f"must be a {dt.lower()} string"
+    if dt == "CHOICE" and value not in (cfg.get("choices") or []):
+        return "must be one of the configured choices"
+    if dt == "MULTI_CHOICE":
+        if not isinstance(value, list):
+            return "must be a list"
+        bad = [v for v in value if v not in (cfg.get("choices") or [])]
+        if bad:
+            return "values must be from the configured choices"
+    if dt == "JSON" and not isinstance(value, (dict, list)):
+        return "must be a JSON object or array"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Loading + running enrichers
+# ---------------------------------------------------------------------------
+
+
+def load_enrichers(specs: Iterable[str]) -> list[tuple[str, Enricher]]:
+    """Resolve ``module.path:callable`` specs into callables. Raises a clear
+    error if a spec is malformed or the attribute is not callable."""
+    loaded: list[tuple[str, Enricher]] = []
+    for spec in specs:
+        spec = spec.strip()
+        if not spec:
+            continue
+        if ":" not in spec:
+            raise ValueError(
+                f"Invalid enricher spec {spec!r}; expected 'module.path:callable'."
+            )
+        module_path, _, attr = spec.partition(":")
+        module = importlib.import_module(module_path)
+        fn = getattr(module, attr, None)
+        if not callable(fn):
+            raise ValueError(f"Enricher {spec!r} is not callable.")
+        loaded.append((spec, fn))
+    return loaded
+
+
+def run_enrichers(
+    enrichers: list[tuple[str, Enricher]], ctx: EnricherContext
+) -> Enrichment:
+    """Run every enricher over the context and merge their results."""
+    parts: list[Enrichment | None] = []
+    for name, fn in enrichers:
+        result = fn(ctx)
+        if result is not None and not isinstance(result, Enrichment):
+            raise TypeError(
+                f"Enricher {name!r} returned {type(result).__name__}, expected Enrichment."
+            )
+        parts.append(result)
+    return Enrichment.merge(parts)
+
+
+# ---------------------------------------------------------------------------
+# Applying enrichment to the parsed export + building the metadata overlay
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MetadataOverlay:
+    """Document-level enrichment to fold into the worker-upload metadata."""
+
+    title: str | None = None
+    description: str | None = None
+    custom_meta: dict = field(default_factory=dict)
+    text_label_defs: dict[str, dict] = field(default_factory=dict)
+    doc_label_defs: dict[str, dict] = field(default_factory=dict)
+    doc_labels: list[str] = field(default_factory=list)
+    metadata: list[dict] = field(default_factory=list)
+
+
+def apply_enrichment(
+    export: dict, enrichment: Enrichment, *, id_prefix: str = "enr"
+) -> MetadataOverlay:
+    """Merge ``enrichment`` into ``export`` (in place) and return the
+    document-level overlay for the metadata payload.
+
+    Injected annotations get unique, collision-free ids (``enr-0``, ...). Their
+    labels + relationships are merged into the export. Embeddings are computed
+    downstream over ``export['labelled_text']`` so injected annotations are
+    embedded too.
+    """
+    labelled = export.setdefault("labelled_text", [])
+    existing_ids = {a.get("id") for a in labelled if a.get("id") is not None}
+
+    n = 0
+    for ann in enrichment.annotations:
+        if not ann.get("id"):
+            new_id = f"{id_prefix}-{n}"
+            while new_id in existing_ids:
+                n += 1
+                new_id = f"{id_prefix}-{n}"
+            ann["id"] = new_id
+            n += 1
+        existing_ids.add(ann["id"])
+        labelled.append(ann)
+
+    if enrichment.relationships:
+        export.setdefault("relationships", []).extend(enrichment.relationships)
+
+    if enrichment.doc_labels:
+        doc_labels = export.setdefault("doc_labels", [])
+        for name in enrichment.doc_labels:
+            if name not in doc_labels:
+                doc_labels.append(name)
+
+    return MetadataOverlay(
+        title=enrichment.title,
+        description=enrichment.description,
+        custom_meta=dict(enrichment.custom_meta),
+        text_label_defs=dict(enrichment.annotation_labels),
+        doc_label_defs=dict(enrichment.doc_label_defs),
+        doc_labels=list(enrichment.doc_labels),
+        metadata=list(enrichment.metadata),
+    )
+
+
+def validate_enrichment(export: dict, enrichment: Enrichment) -> list[str]:
+    """Return a list of human-readable problems with the enrichment. Empty list
+    means it is safe to upload. Catches the worker-upload correctness rules so a
+    buggy enricher fails the document instead of shipping a broken annotation."""
+    errors: list[str] = []
+    pages = expand_pawls_pages(export.get("pawls_file_content") or [])
+    page_token_counts = [len(p.get("tokens", [])) for p in pages]
+
+    # Labels referenced by injected annotations must be defined (so the server
+    # auto-creates them) or already present on a parser annotation.
+    parser_labels = {
+        a.get("annotationLabel")
+        for a in export.get("labelled_text", [])
+        if a.get("annotationLabel")
+    }
+    defined = set(enrichment.annotation_labels.keys()) | parser_labels
+
+    # Injected annotation ids must be unique and must not collide with the
+    # parser's ids: import_annotations keys its old_id->new_pk map by id, so a
+    # collision silently maps two annotations to one row (and drops one
+    # embedding). Auto-assigned ids are collision-safe by construction; this
+    # guards explicit ids an enricher set by hand.
+    parser_ids = {a.get("id") for a in export.get("labelled_text", []) if a.get("id")}
+    seen_injected: set = set()
+
+    for i, ann in enumerate(enrichment.annotations):
+        where = f"annotation[{i}]"
+        aid = ann.get("id")
+        if aid is not None:
+            if aid in parser_ids:
+                errors.append(
+                    f"{where}: id {aid!r} collides with a parser annotation id"
+                )
+            if aid in seen_injected:
+                errors.append(f"{where}: duplicate injected annotation id {aid!r}")
+            seen_injected.add(aid)
+        label = ann.get("annotationLabel")
+        if not label:
+            errors.append(f"{where}: missing annotationLabel")
+        elif label not in defined:
+            errors.append(
+                f"{where}: label {label!r} has no definition "
+                f"(add it to Enrichment.annotation_labels)"
+            )
+        if not (ann.get("rawText") or "").strip():
+            errors.append(f"{where}: rawText is empty")
+        if (ann.get("annotation_type") or "") == DOC_TYPE_LABEL:
+            errors.append(
+                f"{where}: a DOC_TYPE_LABEL belongs in Enrichment.doc_labels, "
+                f"not in annotations"
+            )
+        if ann.get("structural"):
+            # Structural annotations are the parser's (they get migrated into the
+            # StructuralAnnotationSet server-side). Enricher annotations are
+            # content annotations and must stay non-structural.
+            errors.append(
+                f"{where}: injected annotations must be non-structural "
+                f"(structural=True is parser-owned)"
+            )
+
+        aj = ann.get("annotation_json")
+        atype = ann.get("annotation_type") or TOKEN_LABEL
+        if atype == SPAN_LABEL:
+            # text-doc span shape: {"start": int, "end": int, "text": str}
+            if not isinstance(aj, dict) or "start" not in aj or "end" not in aj:
+                errors.append(f"{where}: SPAN_LABEL annotation_json needs start/end")
+            continue
+        # TOKEN_LABEL page-keyed shape
+        if not isinstance(aj, dict) or not aj:
+            errors.append(
+                f"{where}: TOKEN_LABEL annotation_json must be a NON-EMPTY "
+                f"page-keyed dict (e.g. via ctx.token_annotation())"
+            )
+            continue
+        for page_key, page_data in aj.items():
+            try:
+                page_idx = int(page_key)
+            except (TypeError, ValueError):
+                errors.append(f"{where}: page key {page_key!r} is not an int string")
+                continue
+            if page_idx < 0 or page_idx >= len(pages):
+                errors.append(
+                    f"{where}: page {page_idx} out of range (0..{len(pages)-1})"
+                )
+                continue
+            bounds = (page_data or {}).get("bounds") or {}
+            if not all(k in bounds for k in ("top", "bottom", "left", "right")):
+                errors.append(f"{where}: bounds must have top/bottom/left/right")
+            for tj in (page_data or {}).get("tokensJsons", []):
+                if tj.get("pageIndex") != page_idx:
+                    errors.append(
+                        f"{where}: tokensJsons.pageIndex {tj.get('pageIndex')} != page {page_idx}"
+                    )
+                ti = tj.get("tokenIndex")
+                if (
+                    not isinstance(ti, int)
+                    or ti < 0
+                    or ti >= page_token_counts[page_idx]
+                ):
+                    errors.append(
+                        f"{where}: tokenIndex {ti} out of range on page {page_idx} "
+                        f"(0..{page_token_counts[page_idx]-1})"
+                    )
+
+    # doc_labels must be defined (server auto-creates from doc_labels_definitions).
+    for name in enrichment.doc_labels:
+        if name not in enrichment.doc_label_defs:
+            errors.append(
+                f"doc_label {name!r} has no definition (add it to Enrichment.doc_label_defs)"
+            )
+
+    # relationships must reference resolvable annotation ids + a defined label.
+    # Resolve against BOTH the parser annotations already on the export AND the
+    # enrichment's own injected annotations' explicit ids — validate_enrichment
+    # runs BEFORE apply_enrichment merges/ids them, so a relationship that
+    # references an injected annotation (by the explicit id its author set) must
+    # still resolve here. (Auto-assigned ids can't be referenced anyway — the
+    # author doesn't know them — so only explicit ids matter.)
+    all_ids = {a.get("id") for a in export.get("labelled_text", []) if a.get("id")}
+    all_ids |= {a.get("id") for a in enrichment.annotations if a.get("id")}
+
+    # An injected annotation's parent_id must resolve to a real annotation id
+    # (parser or injected) — import_annotations silently skips an unresolvable
+    # parent_id, so catch it here instead of losing the hierarchy quietly.
+    for i, ann in enumerate(enrichment.annotations):
+        pid = ann.get("parent_id")
+        if pid is not None and pid not in all_ids:
+            errors.append(
+                f"annotation[{i}]: parent_id {pid!r} does not resolve to any "
+                f"annotation id"
+            )
+
+    rel_label_defs = {
+        n
+        for n, d in enrichment.annotation_labels.items()
+        if d.get("label_type") == RELATIONSHIP_LABEL
+    }
+    for i, rel in enumerate(enrichment.relationships):
+        where = f"relationship[{i}]"
+        srcs = rel.get("source_annotation_ids") or []
+        tgts = rel.get("target_annotation_ids") or []
+        if not srcs or not tgts:
+            errors.append(
+                f"{where}: needs non-empty source_annotation_ids + target_annotation_ids"
+            )
+        for rid in list(srcs) + list(tgts):
+            if rid not in all_ids:
+                errors.append(f"{where}: references unknown annotation id {rid!r}")
+        rlabel = rel.get("relationshipLabel")
+        if rlabel and rlabel not in (rel_label_defs | _parser_rel_labels(export)):
+            errors.append(
+                f"{where}: relationshipLabel {rlabel!r} has no RELATIONSHIP_LABEL definition"
+            )
+
+    # Typed corpus metadata: each entry needs a column_name + a valid data_type,
+    # and its value must match the data_type (server-side Datacell.clean enforces
+    # the same — catch it here so the document isn't failed mid-ingest).
+    for i, md in enumerate(enrichment.metadata):
+        where = f"metadata[{i}]"
+        if not md.get("column_name") or not isinstance(md.get("column_name"), str):
+            errors.append(f"{where}: column_name is required (string)")
+        if md.get("data_type") not in METADATA_DATA_TYPES:
+            errors.append(
+                f"{where}: data_type {md.get('data_type')!r} must be one of "
+                f"{', '.join(METADATA_DATA_TYPES)}"
+            )
+            continue
+        verr = _metadata_value_error(md)
+        if verr:
+            errors.append(f"{where} ({md.get('column_name')}): value {verr}")
+    return errors
+
+
+def _parser_rel_labels(export: dict) -> set:
+    return {
+        r.get("relationshipLabel")
+        for r in export.get("relationships", [])
+        if r.get("relationshipLabel")
+    }

--- a/scripts/remote_ingest/example_enrichers.py
+++ b/scripts/remote_ingest/example_enrichers.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""
+Example enrichers for the remote-ingest worker's pre-processing stage.
+
+Each function is a complete, runnable enricher: ``(EnricherContext) -> Enrichment``.
+Use them directly or copy them as a starting point. Wire one in with:
+
+    docker compose -f remote_worker.yml run --rm worker run \
+        --enricher example_enrichers:filename_metadata \
+        --enricher example_enrichers:effective_date_annotations \
+        --enricher example_enrichers:contract_type_label
+
+(The module is importable because ``/app/scripts/remote_ingest`` is on the path
+inside the worker container.)
+
+These examples emit BOTH kinds of document metadata so you can see the
+difference:
+
+* ``custom_meta`` — a freeform JSON blob stored on ``Document.custom_meta``.
+* ``metadata`` (via ``metadata_field``) — typed values in the corpus
+  Column/Datacell metadata schema (what the UI shows as document metadata, the
+  successor to the old "metadata annotations"). These are corpus-scoped, typed,
+  and queryable.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime
+
+from enrichers import (
+    DOC_TYPE_LABEL,
+    TOKEN_LABEL,
+    EnricherContext,
+    Enrichment,
+    label_def,
+    metadata_field,
+)
+
+# --- 1. Structured metadata from the file path -----------------------------
+# Fort Worth contracts are named like "058000-R3 - General - Contract - Acme.pdf".
+_FW_NAME = re.compile(
+    r"(?P<number>\d{6})-(?P<rev>[A-Z0-9]+)\s*-\s*(?P<category>[^-]+)-"
+)
+
+
+def filename_metadata(ctx: EnricherContext) -> Enrichment:
+    """Parse the contract number / revision / category out of the file path and
+    attach them as TYPED corpus metadata (datacells), plus the raw path as a
+    freeform custom_meta value."""
+    name = ctx.rel_path.rsplit("/", 1)[-1]
+    enr = Enrichment(custom_meta={"source_path": ctx.rel_path})
+    m = _FW_NAME.search(name)
+    if m:
+        enr.metadata.extend(
+            [
+                metadata_field("Contract Number", m.group("number")),
+                metadata_field("Revision", m.group("rev")),
+                metadata_field("Category", m.group("category").strip()),
+            ]
+        )
+    return enr
+
+
+# --- 2. Token annotations + a typed DATE datacell for detected dates -------
+_DATE = re.compile(
+    r"\b(?P<month>January|February|March|April|May|June|July|August|September|"
+    r"October|November|December)\s+(?P<day>\d{1,2}),?\s+(?P<year>\d{4})\b"
+)
+_DATE_LABEL = "DETECTED_DATE"
+
+
+def effective_date_annotations(ctx: EnricherContext) -> Enrichment:
+    """Tag every long-form date with a DETECTED_DATE token annotation, and record
+    the FIRST date as a typed DATE metadata datacell ("Effective Date")."""
+    enr = Enrichment(
+        annotation_labels={_DATE_LABEL: label_def(_DATE_LABEL, TOKEN_LABEL)}
+    )
+    first_iso: str | None = None
+    for match in ctx.find_token_matches(_DATE):
+        enr.annotations.append(ctx.token_annotation(_DATE_LABEL, match))
+        if first_iso is None:
+            try:
+                first_iso = datetime.strptime(
+                    match.text.replace(",", ""), "%B %d %Y"
+                ).strftime("%Y-%m-%d")
+            except ValueError:
+                first_iso = None
+    if first_iso:
+        enr.metadata.append(
+            metadata_field("Effective Date", first_iso, data_type="DATE")
+        )
+    return enr
+
+
+# --- 3. Document-type label + a CHOICE metadata datacell -------------------
+def contract_type_label(ctx: EnricherContext) -> Enrichment:
+    """Classify the document, applying both a DOC_TYPE_LABEL and a typed CHOICE
+    metadata datacell ("Contract Type")."""
+    text = ctx.content.lower()
+    if "construction" in text:
+        value = "Construction-Related"
+    elif "amendment" in text or "renewal" in text:
+        value = "Amendment"
+    else:
+        value = "General"
+
+    label = f"contract:{value}"
+    return Enrichment(
+        doc_labels=[label],
+        doc_label_defs={label: label_def(label, DOC_TYPE_LABEL, icon="file-text")},
+        metadata=[
+            metadata_field(
+                "Contract Type",
+                value,
+                data_type="CHOICE",
+                validation_config={
+                    "choices": ["Construction-Related", "Amendment", "General"]
+                },
+            )
+        ],
+    )

--- a/scripts/remote_ingest/oc_remote_ingest.py
+++ b/scripts/remote_ingest/oc_remote_ingest.py
@@ -1,0 +1,1096 @@
+#!/usr/bin/env python3
+"""
+oc_remote_ingest.py — run the OpenContracts ingestion pipeline on a remote host
+and stream FAITHFUL, fully-processed documents into a target OpenContracts
+corpus via the worker-upload REST API.
+
+WHY THIS EXISTS
+---------------
+``scripts/bulk_import/oc_bulk_import.py`` ships *raw* PDFs to the server and lets
+the SERVER parse them (Docling + embeddings). That offloads nothing — the
+expensive work still runs in-cluster. This driver instead does the heavy lifting
+(Docling parse + embedding) on a beefy *remote* worker and ships the finished
+artifacts — PAWLs token layer, text layer, structural annotations, relationships
+and pre-computed embeddings — to the target via ``POST /api/worker-uploads/
+documents/``, which bypasses the server parser entirely. The result is a faithful
+mirror: because the worker runs the SAME Docling microservice and the SAME
+``DoclingParser`` code the server would run, the PAWLs and structural layer are
+identical to an in-cluster ingestion (no tokenizer drift).
+
+FAITHFUL-BY-CONSTRUCTION
+------------------------
+* PAWLs / structural annotations / relationships: produced by the real
+  ``DoclingParser.parse_pdf_bytes`` (same parser, same docling service).
+* Text layer (``content``): rebuilt from the shipped PAWLs with the same
+  ``plasmapdf.build_translation_layer`` the server's ``save_parsed_data`` uses,
+  so the stored text layer matches byte-for-byte.
+* Embeddings: computed against the same vector-embedder microservice the server
+  uses, over the same inputs (full text for the doc, ``rawText`` per annotation).
+* Structural set + thumbnail: materialised server-side by the worker-upload
+  ingestion path (see opencontractserver/worker_uploads/tasks.py).
+
+DESIGN
+------
+* Resumable: a SQLite ledger records every document's state (PENDING / UPLOADED /
+  COMPLETED / FAILED / PARKED). Re-running ``run`` skips finished work. Each doc
+  is keyed by its path relative to ``--root-dir`` (its corpus folder path).
+* Per-document streaming (NO archive): scales to 100k–1M docs without ever
+  building a ZIP. The slow step is the remote Docling parse, so the driver runs
+  a thread pool of workers and paces itself against the server's worker-upload
+  backlog (the ``documents/list/`` counts) instead of detonating the queue.
+* Secure: auth is a corpus-scoped ``CorpusAccessToken`` sent as
+  ``Authorization: WorkerKey <token>`` over TLS. The corpus is fixed by the
+  token binding — the remote host cannot target another corpus. NO database
+  access to the target is required or possible.
+
+SUBCOMMANDS
+-----------
+    plan     Scan ``--root-dir`` and record every PDF in the ledger (no network,
+             no parsing).
+    run      Parse + embed + upload PENDING/FAILED docs (resumable, paced,
+             concurrent).
+    verify   Poll the target for each uploaded doc's terminal status and update
+             the ledger (UPLOADED -> COMPLETED / FAILED).
+    status   Print ledger counts + the target's live worker-upload backlog.
+
+ENVIRONMENT / FLAGS (flags override env)
+----------------------------------------
+    OC_TARGET_URL     Base URL of the target OC instance (e.g. https://oc.example.com)
+    OC_WORKER_TOKEN   CorpusAccessToken plaintext (WorkerKey auth)
+    OC_CORPUS_ID      Informational; the bound corpus is enforced by the token
+    DOCLING_PARSER_SERVICE_URL    Docling microservice (default from Django settings)
+    EMBEDDINGS_MICROSERVICE_URL   Vector embedder microservice
+
+This script runs INSIDE the OpenContracts image (it imports the real parser),
+so Django must be importable. Only the ``run`` subcommand needs Django/Docling;
+``plan`` / ``status`` / ``verify`` are pure HTTP + SQLite.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import random
+import sqlite3
+import sys
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import TYPE_CHECKING
+
+import requests
+
+if TYPE_CHECKING:  # avoid importing enrichers (needs Django path) at module load
+    from enrichers import MetadataOverlay
+
+logger = logging.getLogger("oc_remote_ingest")
+
+# --- Defaults --------------------------------------------------------------
+DEFAULT_EXTENSIONS = ".pdf"
+DEFAULT_MAX_WORKERS = 4
+DEFAULT_EMBED_BATCH = 100
+DEFAULT_MAX_ATTEMPTS = 5
+# Backpressure: pause submitting when the target has more than HIGH worker
+# uploads still PENDING+PROCESSING, resume once it drains below LOW.
+DEFAULT_QUEUE_HIGH = 2000
+DEFAULT_QUEUE_LOW = 500
+_HTTP_MAX_RETRIES = 6
+_JITTER_MIN = 0.5
+
+# Ledger statuses
+PENDING = "PENDING"
+UPLOADED = "UPLOADED"  # staged on the server (202 accepted), not yet confirmed
+COMPLETED = "COMPLETED"  # server confirmed terminal success
+FAILED = "FAILED"  # retry-eligible
+PARKED = "PARKED"  # retries exhausted (terminal)
+
+
+# ======================================================================
+# Ledger
+# ======================================================================
+
+
+class Ledger:
+    """Crash-resumable SQLite ledger of per-document ingest state."""
+
+    def __init__(self, path: str):
+        self.path = path
+        self._local = threading.local()
+        with self._conn() as conn:
+            conn.executescript("""
+                CREATE TABLE IF NOT EXISTS docs (
+                    rel_path   TEXT PRIMARY KEY,
+                    abs_path   TEXT NOT NULL,
+                    size       INTEGER,
+                    sha256     TEXT,
+                    status     TEXT NOT NULL DEFAULT 'PENDING',
+                    upload_id  TEXT,
+                    attempts   INTEGER NOT NULL DEFAULT 0,
+                    page_count INTEGER,
+                    last_error TEXT,
+                    created_at REAL,
+                    uploaded_at REAL,
+                    completed_at REAL
+                );
+                CREATE INDEX IF NOT EXISTS idx_docs_status ON docs(status);
+                CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT);
+                PRAGMA journal_mode=WAL;
+                PRAGMA synchronous=NORMAL;
+                """)
+
+    def _conn(self) -> sqlite3.Connection:
+        # One connection per thread (sqlite connections are not thread-safe).
+        conn = getattr(self._local, "conn", None)
+        if conn is None:
+            conn = sqlite3.connect(self.path, timeout=60, isolation_level=None)
+            conn.row_factory = sqlite3.Row
+            conn.execute("PRAGMA busy_timeout=60000;")
+            self._local.conn = conn
+        return conn
+
+    def set_meta(self, key: str, value: str) -> None:
+        self._conn().execute(
+            "INSERT INTO meta(key, value) VALUES(?, ?) "
+            "ON CONFLICT(key) DO UPDATE SET value=excluded.value",
+            (key, value),
+        )
+
+    def get_meta(self, key: str) -> str | None:
+        row = (
+            self._conn()
+            .execute("SELECT value FROM meta WHERE key=?", (key,))
+            .fetchone()
+        )
+        return row["value"] if row else None
+
+    def upsert_doc(
+        self, rel_path: str, abs_path: str, size: int, sha256: str, now: float
+    ) -> bool:
+        """Insert a doc if new. Returns True if inserted, False if it already existed."""
+        cur = self._conn().execute(
+            "INSERT INTO docs(rel_path, abs_path, size, sha256, status, created_at) "
+            "VALUES(?, ?, ?, ?, 'PENDING', ?) "
+            "ON CONFLICT(rel_path) DO NOTHING",
+            (rel_path, abs_path, size, sha256, now),
+        )
+        return cur.rowcount > 0
+
+    def claimable(self) -> list[sqlite3.Row]:
+        return list(
+            self._conn()
+            .execute(
+                "SELECT * FROM docs WHERE status IN ('PENDING', 'FAILED') "
+                "ORDER BY rel_path"
+            )
+            .fetchall()
+        )
+
+    def uploaded_unconfirmed(self) -> list[sqlite3.Row]:
+        return list(
+            self._conn()
+            .execute(
+                "SELECT * FROM docs WHERE status='UPLOADED' AND upload_id IS NOT NULL"
+            )
+            .fetchall()
+        )
+
+    def mark_uploaded(
+        self, rel_path: str, upload_id: str, page_count: int, now: float
+    ) -> None:
+        self._conn().execute(
+            "UPDATE docs SET status='UPLOADED', upload_id=?, page_count=?, "
+            "uploaded_at=?, last_error=NULL WHERE rel_path=?",
+            (upload_id, page_count, now, rel_path),
+        )
+
+    def mark_completed(self, rel_path: str, now: float) -> None:
+        self._conn().execute(
+            "UPDATE docs SET status='COMPLETED', completed_at=? WHERE rel_path=?",
+            (now, rel_path),
+        )
+
+    def mark_failed(self, rel_path: str, error: str, max_attempts: int) -> None:
+        conn = self._conn()
+        row = conn.execute(
+            "SELECT attempts FROM docs WHERE rel_path=?", (rel_path,)
+        ).fetchone()
+        attempts = (row["attempts"] if row else 0) + 1
+        status = PARKED if attempts >= max_attempts else FAILED
+        conn.execute(
+            "UPDATE docs SET status=?, attempts=?, last_error=? WHERE rel_path=?",
+            (status, attempts, error[:1000], rel_path),
+        )
+
+    def status_counts(self) -> dict[str, int]:
+        rows = (
+            self._conn()
+            .execute("SELECT status, COUNT(*) AS n FROM docs GROUP BY status")
+            .fetchall()
+        )
+        return {r["status"]: r["n"] for r in rows}
+
+
+# ======================================================================
+# Target client (worker-upload REST)
+# ======================================================================
+
+
+@dataclass
+class Config:
+    target_url: str
+    worker_token: str
+    corpus_id: str | None
+    root_dir: str
+    ledger_path: str
+    extensions: tuple[str, ...]
+    max_workers: int
+    max_attempts: int
+    queue_high: int
+    queue_low: int
+    embeddings: bool
+    target_folder_from_tree: bool
+    verify_tls: bool
+    limit: int
+    enrichers: list[str]
+
+
+class TargetClient:
+    """HTTP client for the target's worker-upload endpoints with retry/backoff."""
+
+    def __init__(self, cfg: Config):
+        self.cfg = cfg
+        self.base = cfg.target_url.rstrip("/")
+        self.session = requests.Session()
+        self.session.headers["Authorization"] = f"WorkerKey {cfg.worker_token}"
+        self._verify = cfg.verify_tls
+
+    @staticmethod
+    def _backoff(attempt: int) -> float:
+        return min(2.0 * (2 ** (attempt - 1)), 60.0) * random.uniform(_JITTER_MIN, 1.0)
+
+    def upload(self, pdf_path: str, metadata: dict) -> str:
+        """POST a document. Returns the server upload_id. Raises on permanent failure."""
+        url = f"{self.base}/api/worker-uploads/documents/"
+        meta_json = json.dumps(metadata)
+        last_error = "unknown"
+        for attempt in range(1, _HTTP_MAX_RETRIES + 1):
+            try:
+                with open(pdf_path, "rb") as fh:
+                    resp = self.session.post(
+                        url,
+                        files={
+                            "file": (
+                                PurePosixPath(pdf_path).name,
+                                fh,
+                                "application/pdf",
+                            )
+                        },
+                        data={"metadata": meta_json},
+                        timeout=300,
+                        verify=self._verify,
+                    )
+                if resp.status_code == 202:
+                    return resp.json()["upload_id"]
+                if resp.status_code == 429:
+                    wait = float(resp.headers.get("Retry-After", "60"))
+                    logger.warning(f"429 rate-limited; sleeping {wait}s")
+                    time.sleep(wait)
+                    continue
+                if 400 <= resp.status_code < 500:
+                    # Permanent (bad payload / auth / too large) — do not retry.
+                    raise PermanentUploadError(
+                        f"HTTP {resp.status_code}: {resp.text[:500]}"
+                    )
+                last_error = f"HTTP {resp.status_code}: {resp.text[:300]}"
+            except PermanentUploadError:
+                raise
+            except requests.RequestException as e:
+                last_error = f"network: {e}"
+            if attempt < _HTTP_MAX_RETRIES:
+                time.sleep(self._backoff(attempt))
+        raise TransientUploadError(
+            f"upload failed after {_HTTP_MAX_RETRIES} attempts: {last_error}"
+        )
+
+    def upload_status(self, upload_id: str) -> dict | None:
+        url = f"{self.base}/api/worker-uploads/documents/{upload_id}/"
+        resp = self.session.get(url, timeout=60, verify=self._verify)
+        if resp.status_code == 200:
+            return resp.json()
+        return None
+
+    def backlog_count(self) -> int:
+        """PENDING + PROCESSING uploads for this token (drives backpressure)."""
+        total = 0
+        for st in ("PENDING", "PROCESSING"):
+            url = f"{self.base}/api/worker-uploads/documents/list/?status={st}&page_size=1"
+            try:
+                resp = self.session.get(url, timeout=30, verify=self._verify)
+                if resp.status_code == 200:
+                    total += int(resp.json().get("count", 0))
+            except requests.RequestException:
+                # Treat polling failure as "no backpressure signal" — better to
+                # keep moving than to stall the whole run on a flaky status call.
+                return 0
+        return total
+
+
+class PermanentUploadError(Exception):
+    pass
+
+
+class TransientUploadError(Exception):
+    pass
+
+
+# ======================================================================
+# Embedder client (vector-embedder microservice)
+# ======================================================================
+
+
+class EmbedderClient:
+    """Thin HTTP client for the vector-embedder microservice."""
+
+    def __init__(self, service_url: str, api_key: str | None, batch_size: int):
+        self.base = service_url.rstrip("/")
+        self.session = requests.Session()
+        if api_key:
+            self.session.headers["X-API-Key"] = api_key
+        self.batch_size = batch_size
+
+    def embed_text(self, text: str) -> list[float] | None:
+        if not text or not text.strip():
+            return None
+        resp = self.session.post(
+            f"{self.base}/embeddings", json={"text": text}, timeout=30
+        )
+        resp.raise_for_status()
+        return self._coerce_vector(resp.json().get("embeddings"))
+
+    @staticmethod
+    def _coerce_vector(vec) -> list[float] | None:
+        """Accept either a 1-D vector or a 2-D ``[[...]]`` single-row response."""
+        if not isinstance(vec, list) or not vec:
+            return None
+        if isinstance(vec[0], list):  # 2-D (batch-shaped) single response
+            inner = vec[0]
+            return inner if inner else None
+        return vec
+
+    def embed_batch(self, texts: list[str]) -> list[list[float] | None]:
+        """Embed a list of texts (sub-batched). Empty texts map to None."""
+        out: list[list[float] | None] = [None] * len(texts)
+        # indices with non-empty text
+        idxs = [i for i, t in enumerate(texts) if t and t.strip()]
+        for start in range(0, len(idxs), self.batch_size):
+            chunk_idxs = idxs[start : start + self.batch_size]
+            chunk_texts = [texts[i] for i in chunk_idxs]
+            resp = self.session.post(
+                f"{self.base}/embeddings/batch",
+                json={"texts": chunk_texts},
+                timeout=120,
+            )
+            resp.raise_for_status()
+            vecs = resp.json().get("embeddings")
+            if not isinstance(vecs, list):
+                continue
+            for local_i, vec in enumerate(vecs):
+                # The batch endpoint wraps each row one level deeper than the
+                # single endpoint (per-item shape is ``[[...floats...]]``), so
+                # coerce each row down to a flat numeric vector.
+                coerced = self._coerce_vector(vec)
+                if coerced is not None:
+                    out[chunk_idxs[local_i]] = coerced
+        return out
+
+
+# ======================================================================
+# Parser wrapper (lazy Django + DoclingParser singleton)
+# ======================================================================
+
+
+class _Parser:
+    """Lazily-initialised, thread-safe singleton wrapper around DoclingParser."""
+
+    def __init__(self) -> None:
+        self._parser = None
+        self._build_translation_layer = None
+        self._default_embedder_path = None
+        self._lock = threading.Lock()
+
+    def _ensure(self) -> None:
+        if self._parser is not None:
+            return
+        with self._lock:
+            if self._parser is not None:
+                return
+            # Ensure the OpenContracts repo root is importable. When this file is
+            # run directly (``python .../oc_remote_ingest.py``) sys.path[0] is the
+            # script's own directory, so ``config`` / ``opencontractserver`` are
+            # not importable until we add the repo root (this file lives at
+            # ``<root>/scripts/remote_ingest/oc_remote_ingest.py``).
+            repo_root = str(Path(__file__).resolve().parents[2])
+            if repo_root not in sys.path:
+                sys.path.insert(0, repo_root)
+
+            os.environ.setdefault(
+                "DJANGO_SETTINGS_MODULE", "config.settings.remote_worker"
+            )
+            import django
+
+            django.setup()
+            from plasmapdf.models.PdfDataLayer import build_translation_layer
+
+            from opencontractserver.pipeline.parsers.docling_parser_rest import (
+                DoclingParser,
+            )
+
+            try:
+                from opencontractserver.pipeline.utils import get_default_embedder_path
+
+                self._default_embedder_path = get_default_embedder_path()
+            except Exception:
+                self._default_embedder_path = (
+                    "opencontractserver.pipeline.embedders."
+                    "sent_transformer_microservice.MicroserviceEmbedder"
+                )
+
+            self._build_translation_layer = build_translation_layer
+            self._parser = DoclingParser()
+
+            # Pipeline component settings (incl. the Docling service URL) are
+            # normally sourced from the PipelineSettings DB table — the
+            # ``env_var`` declared on each setting only SEEDS that table via
+            # ``migrate_pipeline_settings``, it is not read at runtime. The
+            # remote worker runs WITHOUT that DB, so the parser comes up with
+            # dataclass defaults (service_url=""). Backfill the Docling knobs
+            # from the environment so the worker is configured purely via env,
+            # mirroring how the in-cluster parser is seeded from the same vars.
+            self._backfill_parser_settings_from_env()
+
+            if not self._parser.service_url:
+                raise RuntimeError(
+                    "DOCLING_PARSER_SERVICE_URL must be set so the remote worker "
+                    "can reach the Docling microservice."
+                )
+            logger.info(
+                f"DoclingParser ready (service={self._parser.service_url!r}, "
+                f"extract_images={self._parser.extract_images}, "
+                f"embedder_path={self._default_embedder_path})"
+            )
+
+    def _backfill_parser_settings_from_env(self) -> None:
+        """Override DoclingParser instance settings from DOCLING_* env vars.
+
+        Only applied when the value is present in the environment, so a worker
+        that sets nothing inherits the same defaults the in-cluster parser uses.
+        """
+
+        def _set(attr: str, env_var: str, cast) -> None:
+            raw = os.environ.get(env_var)
+            if raw is None or raw == "":
+                return
+            try:
+                setattr(self._parser, attr, cast(raw))
+            except (ValueError, TypeError):
+                logger.warning(f"Ignoring invalid {env_var}={raw!r}")
+
+        def _as_bool(v: str) -> bool:
+            return v.strip().lower() in ("1", "true", "yes", "on")
+
+        _set("service_url", "DOCLING_PARSER_SERVICE_URL", str)
+        _set("request_timeout", "DOCLING_PARSER_TIMEOUT", int)
+        _set("extract_images", "DOCLING_EXTRACT_IMAGES", _as_bool)
+        _set("image_format", "DOCLING_IMAGE_FORMAT", str)
+        _set("image_quality", "DOCLING_IMAGE_QUALITY", int)
+        _set("image_dpi", "DOCLING_IMAGE_DPI", int)
+        _set("min_image_width", "DOCLING_MIN_IMAGE_WIDTH", int)
+        _set("min_image_height", "DOCLING_MIN_IMAGE_HEIGHT", int)
+        _set("max_pages_per_chunk", "DOCLING_MAX_PAGES_PER_CHUNK", int)
+        _set("min_pages_for_chunking", "DOCLING_MIN_PAGES_FOR_CHUNKING", int)
+        _set("max_concurrent_chunks", "DOCLING_MAX_CONCURRENT_CHUNKS", int)
+        _set("chunk_overlap", "DOCLING_CHUNK_OVERLAP", int)
+
+    def ensure_ready(self) -> None:
+        """Eagerly set up Django + the parser (used to fail fast on config errors
+        and to make ``config`` / ``opencontractserver`` importable before
+        enrichers are loaded)."""
+        self._ensure()
+
+    @property
+    def default_embedder_path(self) -> str:
+        self._ensure()
+        return self._default_embedder_path
+
+    def parse(self, pdf_bytes: bytes) -> dict:
+        self._ensure()
+        result = self._parser.parse_pdf_bytes(pdf_bytes, user_id=0, doc_id=0)
+        if result is None:
+            raise RuntimeError("parser returned no result")
+        return result
+
+    def text_from_pawls(self, pawls_pages: list) -> str:
+        self._ensure()
+        if not pawls_pages:
+            return ""
+        return self._build_translation_layer(pawls_pages).doc_text
+
+
+# ======================================================================
+# Payload construction
+# ======================================================================
+
+# Mirror save_parsed_data's structural-label definitions so the target
+# auto-creates any labels the parser emitted with identical presentation.
+_TOKEN_LABEL = "TOKEN_LABEL"
+_RELATIONSHIP_LABEL = "RELATIONSHIP_LABEL"
+_DOC_TYPE_LABEL = "DOC_TYPE_LABEL"
+
+
+def _build_metadata(
+    *,
+    title: str,
+    export: dict,
+    content: str,
+    embedder_path: str,
+    embeddings: dict | None,
+    target_folder_path: str | None,
+    overlay: MetadataOverlay | None = None,
+) -> dict:
+    labelled_text = export.get("labelled_text", []) or []
+    relationships = export.get("relationships", []) or []
+    doc_label_names = list(export.get("doc_labels", []) or [])
+
+    # text_labels: token-annotation labels + relationship labels. _prepare_labels
+    # on the server merges these into one lookup used by BOTH import_annotations
+    # and import_relationships, so relationship labels must live here too.
+    text_labels: dict[str, dict] = {}
+    for ann in labelled_text:
+        name = ann.get("annotationLabel")
+        if name and name not in text_labels:
+            text_labels[name] = {
+                "label_type": ann.get("annotation_type") or _TOKEN_LABEL,
+                "color": "grey",
+                "description": "Parser Structural Label",
+                "icon": "expand",
+                "text": name,
+                "read_only": True,
+            }
+    for rel in relationships:
+        name = rel.get("relationshipLabel")
+        if name and name not in text_labels:
+            text_labels[name] = {
+                "label_type": _RELATIONSHIP_LABEL,
+                "color": "grey",
+                "description": "Parser Relationship Label",
+                "icon": "share-alt",
+                "text": name,
+                "read_only": True,
+            }
+
+    doc_labels_definitions: dict[str, dict] = {
+        name: {
+            "label_type": _DOC_TYPE_LABEL,
+            "color": "grey",
+            "description": "Parser Document Label",
+            "icon": "tag",
+            "text": name,
+            "read_only": True,
+        }
+        for name in doc_label_names
+    }
+
+    custom_meta: dict = {}
+    description = export.get("description", "") or ""
+    if overlay is not None:
+        # Enricher-supplied label definitions WIN over the generic parser
+        # defaults so injected annotations/labels carry their intended
+        # presentation (color/icon/description).
+        text_labels.update(overlay.text_label_defs)
+        doc_labels_definitions.update(overlay.doc_label_defs)
+        if overlay.title:
+            title = overlay.title
+        if overlay.description:
+            description = overlay.description
+        custom_meta = overlay.custom_meta or {}
+
+    metadata: dict = {
+        "title": title,
+        "description": description,
+        "content": content,
+        "page_count": export.get("page_count")
+        or len(export.get("pawls_file_content", [])),
+        "file_type": export.get("file_type", "application/pdf") or "application/pdf",
+        "pawls_file_content": export.get("pawls_file_content", []),
+        "labelled_text": labelled_text,
+        "relationships": relationships,
+        "doc_labels": doc_label_names,
+        "text_labels": text_labels,
+        "doc_labels_definitions": doc_labels_definitions,
+        "parser_name": "Docling Parser (REST)",
+        "parser_version": "1.0",
+    }
+    if target_folder_path:
+        metadata["target_folder_path"] = target_folder_path
+    if embeddings:
+        metadata["embeddings"] = embeddings
+    if custom_meta:
+        metadata["custom_meta"] = custom_meta
+    if overlay is not None and overlay.metadata:
+        metadata["metadata"] = overlay.metadata
+    return metadata
+
+
+def _compute_embeddings(
+    *,
+    embedder: EmbedderClient,
+    embedder_path: str,
+    content: str,
+    labelled_text: list,
+) -> dict | None:
+    """Compute the doc-level + per-annotation embeddings the server would store."""
+    doc_vec = embedder.embed_text(content)
+
+    # Annotation embeddings keyed by the annotation's stable export ``id``
+    # (the same id the worker-upload path maps to the new DB pk).
+    ann_ids: list = []
+    ann_texts: list[str] = []
+    for ann in labelled_text:
+        ann_id = ann.get("id")
+        raw = ann.get("rawText") or ""
+        if ann_id is not None and raw.strip():
+            ann_ids.append(ann_id)
+            ann_texts.append(raw)
+
+    annotation_embeddings: dict[str, list[float]] = {}
+    if ann_texts:
+        vecs = embedder.embed_batch(ann_texts)
+        for ann_id, vec in zip(ann_ids, vecs):
+            if vec is not None:
+                annotation_embeddings[str(ann_id)] = vec
+
+    if doc_vec is None and not annotation_embeddings:
+        return None
+
+    payload: dict = {"embedder_path": embedder_path}
+    if doc_vec is not None:
+        payload["document_embedding"] = doc_vec
+    if annotation_embeddings:
+        payload["annotation_embeddings"] = annotation_embeddings
+    return payload
+
+
+# ======================================================================
+# Scanning
+# ======================================================================
+
+
+def _sha256(path: str) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as fh:
+        for block in iter(lambda: fh.read(1 << 20), b""):
+            h.update(block)
+    return h.hexdigest()
+
+
+def _scan(root: str, extensions: tuple[str, ...]):
+    root_path = Path(root).resolve()
+    for path in sorted(root_path.rglob("*")):
+        if not path.is_file():
+            continue
+        if path.suffix.lower() not in extensions:
+            continue
+        rel = path.relative_to(root_path).as_posix()
+        yield rel, str(path)
+
+
+# ======================================================================
+# Subcommands
+# ======================================================================
+
+
+def cmd_plan(cfg: Config) -> int:
+    ledger = Ledger(cfg.ledger_path)
+    ledger.set_meta("root_dir", str(Path(cfg.root_dir).resolve()))
+    if cfg.corpus_id:
+        ledger.set_meta("corpus_id", cfg.corpus_id)
+    now = time.time()
+    added = scanned = 0
+    for rel, abs_path in _scan(cfg.root_dir, cfg.extensions):
+        scanned += 1
+        size = os.path.getsize(abs_path)
+        # sha256 is recorded for provenance/dedup; cheap enough at plan time.
+        if ledger.upsert_doc(rel, abs_path, size, _sha256(abs_path), now):
+            added += 1
+        if cfg.limit and added >= cfg.limit:
+            logger.info(f"reached --limit {cfg.limit}; stopping scan")
+            break
+        if scanned % 500 == 0:
+            logger.info(f"planned {scanned} files ({added} new)…")
+    logger.info(f"plan complete: scanned={scanned}, new={added}")
+    _print_status(ledger, None)
+    return 0
+
+
+def _process_one(
+    cfg: Config,
+    parser: _Parser,
+    embedder: EmbedderClient | None,
+    client: TargetClient,
+    row: sqlite3.Row,
+    enrichers: list | None = None,
+) -> tuple[str, bool, str]:
+    """Parse + (enrich) + embed + upload one document. Returns (rel_path, ok, message)."""
+    rel_path = row["rel_path"]
+    abs_path = row["abs_path"]
+    try:
+        with open(abs_path, "rb") as fh:
+            pdf_bytes = fh.read()
+
+        export = parser.parse(pdf_bytes)
+        pawls = export.get("pawls_file_content", []) or []
+
+        # Rebuild the text layer the same way the server's save_parsed_data does
+        # (PAWLs translation), falling back to the parser-reported content.
+        content = parser.text_from_pawls(pawls) or (export.get("content") or "")
+        if not content.strip():
+            return (rel_path, False, "empty content/text layer (would be unsearchable)")
+
+        # Pre-processing / enrichment stage: calculate + inject extra metadata
+        # and annotations BEFORE embedding (so injected annotations get embedded)
+        # and BEFORE building the payload. A validation failure fails the doc.
+        overlay = None
+        if enrichers:
+            from enrichers import (  # local import: needs Django path set up
+                EnricherContext,
+                apply_enrichment,
+                run_enrichers,
+                validate_enrichment,
+            )
+
+            ctx = EnricherContext(
+                rel_path=rel_path, abs_path=abs_path, export=export, content=content
+            )
+            enrichment = run_enrichers(enrichers, ctx)
+            if not enrichment.is_empty():
+                errors = validate_enrichment(export, enrichment)
+                if errors:
+                    return (
+                        rel_path,
+                        False,
+                        "enrichment invalid: " + "; ".join(errors[:5]),
+                    )
+                overlay = apply_enrichment(export, enrichment)
+
+        embeddings = None
+        if cfg.embeddings and embedder is not None:
+            # Compute over the (possibly enriched) labelled_text so injected
+            # annotations are embedded too.
+            embeddings = _compute_embeddings(
+                embedder=embedder,
+                embedder_path=parser.default_embedder_path,
+                content=content,
+                labelled_text=export.get("labelled_text", []) or [],
+            )
+
+        target_folder_path = None
+        if cfg.target_folder_from_tree:
+            parent = PurePosixPath(rel_path).parent.as_posix()
+            target_folder_path = None if parent in (".", "") else parent
+
+        title = PurePosixPath(rel_path).name
+        metadata = _build_metadata(
+            title=title,
+            export=export,
+            content=content,
+            embedder_path=parser.default_embedder_path,
+            embeddings=embeddings,
+            target_folder_path=target_folder_path,
+            overlay=overlay,
+        )
+
+        upload_id = client.upload(abs_path, metadata)
+        page_count = metadata["page_count"]
+        return (rel_path, True, f"{upload_id}|{page_count}")
+    except PermanentUploadError as e:
+        return (rel_path, False, f"permanent: {e}")
+    except Exception as e:  # noqa: BLE001 — surface any parse/embed/upload failure
+        return (rel_path, False, str(e))
+
+
+def cmd_run(cfg: Config) -> int:
+    ledger = Ledger(cfg.ledger_path)
+    parser = _Parser()
+    # Set up Django + the parser eagerly so config errors (missing service URL,
+    # broken enricher import) surface before we start churning documents.
+    parser.ensure_ready()
+
+    enrichers: list = []
+    if cfg.enrichers:
+        from enrichers import load_enrichers
+
+        enrichers = load_enrichers(cfg.enrichers)
+        logger.info(
+            f"loaded {len(enrichers)} enricher(s): "
+            + ", ".join(name for name, _ in enrichers)
+        )
+
+    embedder = None
+    if cfg.embeddings:
+        embedder = EmbedderClient(
+            os.environ.get(
+                "EMBEDDINGS_MICROSERVICE_URL", "http://vector-embedder:8000"
+            ),
+            os.environ.get("VECTOR_EMBEDDER_API_KEY") or None,
+            DEFAULT_EMBED_BATCH,
+        )
+    client = TargetClient(cfg)
+
+    todo = ledger.claimable()
+    if not todo:
+        logger.info("nothing to do — run `plan` first or everything is done.")
+        _print_status(ledger, client)
+        return 0
+
+    logger.info(
+        f"run: {len(todo)} docs to process with {cfg.max_workers} workers "
+        f"(embeddings={'on' if cfg.embeddings else 'off'}, "
+        f"enrichers={len(enrichers)})"
+    )
+
+    # Backpressure gate shared by all workers.
+    pause_event = threading.Event()
+    pause_event.set()  # set == "go"
+    governor_state = {"last_poll": 0.0, "stop": False}
+    gov_lock = threading.Lock()
+
+    def maybe_poll_backpressure() -> None:
+        if cfg.queue_high <= 0:
+            return
+        with gov_lock:
+            now = time.time()
+            if now - governor_state["last_poll"] < 15:
+                return
+            governor_state["last_poll"] = now
+        backlog = client.backlog_count()
+        if backlog > cfg.queue_high and pause_event.is_set():
+            logger.info(f"backpressure: backlog={backlog} > {cfg.queue_high}; pausing")
+            pause_event.clear()
+        elif backlog <= cfg.queue_low and not pause_event.is_set():
+            logger.info(f"backpressure: backlog={backlog} <= {cfg.queue_low}; resuming")
+            pause_event.set()
+
+    done = {"ok": 0, "fail": 0}
+    done_lock = threading.Lock()
+
+    def worker(row: sqlite3.Row) -> None:
+        # Wait while paused (re-poll periodically to unblock).
+        while not pause_event.wait(timeout=10):
+            maybe_poll_backpressure()
+        maybe_poll_backpressure()
+        rel, ok, msg = _process_one(cfg, parser, embedder, client, row, enrichers)
+        now = time.time()
+        if ok:
+            upload_id, _, page_count = msg.partition("|")
+            ledger.mark_uploaded(rel, upload_id, int(page_count or 0), now)
+            with done_lock:
+                done["ok"] += 1
+                n = done["ok"] + done["fail"]
+            logger.info(f"[{n}/{len(todo)}] uploaded {rel} -> {upload_id}")
+        else:
+            ledger.mark_failed(rel, msg, cfg.max_attempts)
+            with done_lock:
+                done["fail"] += 1
+                n = done["ok"] + done["fail"]
+            logger.warning(f"[{n}/{len(todo)}] FAILED {rel}: {msg}")
+
+    with ThreadPoolExecutor(max_workers=cfg.max_workers) as pool:
+        futures = [pool.submit(worker, row) for row in todo]
+        for fut in as_completed(futures):
+            exc = fut.exception()
+            if exc is not None:
+                logger.error(f"worker crashed: {exc}")
+
+    logger.info(f"run complete: uploaded={done['ok']}, failed={done['fail']}")
+    _print_status(ledger, client)
+    return 0 if done["fail"] == 0 else 1
+
+
+def cmd_verify(cfg: Config) -> int:
+    ledger = Ledger(cfg.ledger_path)
+    client = TargetClient(cfg)
+    pending = ledger.uploaded_unconfirmed()
+    logger.info(f"verify: polling {len(pending)} uploaded docs for terminal status")
+    confirmed = failed = still = 0
+    now = time.time()
+    for row in pending:
+        status = client.upload_status(row["upload_id"])
+        if status is None:
+            still += 1
+            continue
+        st = status.get("status")
+        if st == "COMPLETED":
+            ledger.mark_completed(row["rel_path"], now)
+            confirmed += 1
+        elif st == "FAILED":
+            ledger.mark_failed(
+                row["rel_path"],
+                f"server: {status.get('error_message', 'failed')}",
+                cfg.max_attempts,
+            )
+            failed += 1
+        else:
+            still += 1
+    logger.info(
+        f"verify complete: confirmed={confirmed}, failed={failed}, still-processing={still}"
+    )
+    _print_status(ledger, client)
+    return 0
+
+
+def cmd_status(cfg: Config) -> int:
+    ledger = Ledger(cfg.ledger_path)
+    client = None
+    if cfg.target_url and cfg.worker_token:
+        client = TargetClient(cfg)
+    _print_status(ledger, client)
+    return 0
+
+
+def _print_status(ledger: Ledger, client: TargetClient | None) -> None:
+    counts = ledger.status_counts()
+    total = sum(counts.values())
+    print("\n── Ledger ──")
+    print(f"  root_dir : {ledger.get_meta('root_dir')}")
+    print(f"  corpus   : {ledger.get_meta('corpus_id')}")
+    print(f"  total    : {total}")
+    for st in (PENDING, UPLOADED, COMPLETED, FAILED, PARKED):
+        if counts.get(st):
+            print(f"  {st:<9}: {counts[st]}")
+    if client is not None:
+        try:
+            print("\n── Target worker-upload backlog ──")
+            print(f"  PENDING+PROCESSING : {client.backlog_count()}")
+        except Exception as e:  # noqa: BLE001
+            print(f"  (could not reach target: {e})")
+    print("")
+
+
+# ======================================================================
+# CLI
+# ======================================================================
+
+
+def _build_config(args: argparse.Namespace) -> Config:
+    target_url = args.target_url or os.environ.get("OC_TARGET_URL", "")
+    worker_token = args.worker_token or os.environ.get("OC_WORKER_TOKEN", "")
+    corpus_id = args.corpus_id or os.environ.get("OC_CORPUS_ID")
+    extensions = tuple(
+        e if e.startswith(".") else f".{e}"
+        for e in (args.extensions or DEFAULT_EXTENSIONS).lower().split(",")
+    )
+    # Enrichers: --enricher (repeatable) plus comma-separated OC_ENRICHERS env.
+    enrichers = list(args.enricher or [])
+    enrichers += [s for s in os.environ.get("OC_ENRICHERS", "").split(",") if s.strip()]
+    return Config(
+        target_url=target_url,
+        worker_token=worker_token,
+        corpus_id=corpus_id,
+        root_dir=args.root_dir or "",
+        ledger_path=args.ledger,
+        extensions=extensions,
+        max_workers=args.max_workers,
+        max_attempts=args.max_attempts,
+        queue_high=args.queue_high,
+        queue_low=args.queue_low,
+        embeddings=not args.no_embeddings,
+        target_folder_from_tree=not args.flat,
+        verify_tls=not args.insecure,
+        limit=args.limit,
+        enrichers=enrichers,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        prog="oc_remote_ingest",
+        description="Remote parse + worker-upload driver for OpenContracts.",
+    )
+    p.add_argument(
+        "--ledger", default="oc_remote_ingest.sqlite3", help="SQLite ledger path"
+    )
+    p.add_argument("--target-url", help="Target OC base URL (env OC_TARGET_URL)")
+    p.add_argument("--worker-token", help="WorkerKey token (env OC_WORKER_TOKEN)")
+    p.add_argument("--corpus-id", help="Corpus id (informational; env OC_CORPUS_ID)")
+    p.add_argument("--root-dir", help="Root directory of PDFs (for plan/run)")
+    p.add_argument("--extensions", help="Comma-separated extensions (default .pdf)")
+    p.add_argument("--max-workers", type=int, default=DEFAULT_MAX_WORKERS)
+    p.add_argument("--max-attempts", type=int, default=DEFAULT_MAX_ATTEMPTS)
+    p.add_argument("--queue-high", type=int, default=DEFAULT_QUEUE_HIGH)
+    p.add_argument("--queue-low", type=int, default=DEFAULT_QUEUE_LOW)
+    p.add_argument(
+        "--no-embeddings",
+        action="store_true",
+        help="Skip remote embedding; let the server embed",
+    )
+    p.add_argument(
+        "--flat",
+        action="store_true",
+        help="Do not mirror the directory tree into corpus folders",
+    )
+    p.add_argument(
+        "--limit",
+        type=int,
+        default=0,
+        help="Cap the number of docs recorded at plan time (0 = no cap)",
+    )
+    p.add_argument(
+        "--insecure",
+        action="store_true",
+        help="Disable TLS verification (testing only)",
+    )
+    p.add_argument(
+        "--enricher",
+        action="append",
+        metavar="MODULE:CALLABLE",
+        help=(
+            "Pre-processing enricher to calc + inject metadata/annotations "
+            "(repeatable; also OC_ENRICHERS, comma-separated). "
+            "E.g. example_enrichers:effective_date_annotations"
+        ),
+    )
+    p.add_argument("-v", "--verbose", action="store_true")
+    p.add_argument("command", choices=["plan", "run", "verify", "status"])
+    args = p.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    cfg = _build_config(args)
+
+    if args.command in ("run", "verify") and (
+        not cfg.target_url or not cfg.worker_token
+    ):
+        p.error(
+            "run/verify require --target-url and --worker-token (or OC_TARGET_URL/OC_WORKER_TOKEN)"
+        )
+    if args.command in ("plan", "run") and not cfg.root_dir:
+        p.error("plan/run require --root-dir")
+
+    return {
+        "plan": cmd_plan,
+        "run": cmd_run,
+        "verify": cmd_verify,
+        "status": cmd_status,
+    }[args.command](cfg)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/remote_ingest/remote_worker.yml
+++ b/scripts/remote_ingest/remote_worker.yml
@@ -1,0 +1,83 @@
+# ===========================================================================
+# OpenContracts remote-ingest worker bundle
+# ===========================================================================
+# Run the FULL ingestion pipeline (Docling parse + embeddings) on a beefy
+# off-cluster host and stream faithful, fully-processed documents to a target
+# OpenContracts instance via the worker-upload REST API. No database, no
+# inbound ports, no access to the target's Postgres — just outbound HTTPS to
+# the target's /api/worker-uploads/ endpoint with a corpus-scoped token.
+#
+# This bundle runs the SAME Docling microservice and the SAME embedder image
+# the server uses, and the worker driver imports the SAME DoclingParser code,
+# so the PAWLs token layer, structural annotations and embeddings are identical
+# to an in-cluster ingestion (faithful by construction).
+#
+# ---------------------------------------------------------------------------
+# Quick start (a remote host with Docker + this repo cloned):
+#
+#   export OC_TARGET_URL=https://opencontracts.example.com
+#   export OC_WORKER_TOKEN=<token from `manage.py mint_worker_token` on the server>
+#   export OC_DATA_DIR=/data/pdfs           # directory tree of PDFs to ingest
+#   export VECTOR_EMBEDDER_API_KEY=change-me # must match the embedder's API_KEY
+#
+#   cd scripts/remote_ingest
+#   docker compose -f remote_worker.yml up -d --build docling-parser vector-embedder
+#   docker compose -f remote_worker.yml run --rm worker plan
+#   docker compose -f remote_worker.yml run --rm worker run --max-workers 8
+#   docker compose -f remote_worker.yml run --rm worker verify
+#
+# The ledger is persisted in a named volume, so `run` is fully resumable —
+# re-run it after an interruption and it skips finished documents.
+# ===========================================================================
+name: oc-remote-worker
+
+volumes:
+  oc_remote_ledger: {}
+
+services:
+  # The exact Docling microservice image the server uses — identical
+  # tokenisation, so PAWLs token indices match an in-cluster parse.
+  docling-parser:
+    image: jscrudato/docsling-local
+    restart: unless-stopped
+
+  # The exact vector-embedder image the server uses — identical 384-dim
+  # embeddings over identical inputs.
+  vector-embedder:
+    image: ghcr.io/jsv4/vectorembeddermicroservice:latest
+    restart: unless-stopped
+    environment:
+      PORT: 8000
+      # Must match VECTOR_EMBEDDER_API_KEY passed to the worker below.
+      API_KEY: ${VECTOR_EMBEDDER_API_KEY:-}
+
+  # The worker driver. Built from the OpenContracts repo so it runs the real
+  # parser code. Invoked on demand via `docker compose run --rm worker <cmd>`.
+  worker:
+    build:
+      # Repo root is two levels up from scripts/remote_ingest/.
+      context: ../..
+      dockerfile: ./compose/local/django/Dockerfile
+      cache_from:
+        - type=registry,ref=ghcr.io/open-source-legal/opencontracts/django-local-cache:main
+    image: opencontractserver_local_django
+    entrypoint: ["/app/scripts/remote_ingest/worker-entrypoint.sh"]
+    depends_on:
+      - docling-parser
+      - vector-embedder
+    environment:
+      DJANGO_SETTINGS_MODULE: config.settings.remote_worker
+      DOCLING_PARSER_SERVICE_URL: http://docling-parser:8000/parse/
+      EMBEDDINGS_MICROSERVICE_URL: http://vector-embedder:8000
+      VECTOR_EMBEDDER_API_KEY: ${VECTOR_EMBEDDER_API_KEY:-}
+      # Target instance + corpus-scoped token (set on the host before running).
+      OC_TARGET_URL: ${OC_TARGET_URL:?set OC_TARGET_URL to your OpenContracts host}
+      OC_WORKER_TOKEN: ${OC_WORKER_TOKEN:?set OC_WORKER_TOKEN (see manage.py mint_worker_token)}
+      OC_CORPUS_ID: ${OC_CORPUS_ID:-}
+      # Optional Docling tuning (defaults match the server):
+      DOCLING_MAX_CONCURRENT_CHUNKS: ${DOCLING_MAX_CONCURRENT_CHUNKS:-3}
+    volumes:
+      - ../..:/app
+      - ${OC_DATA_DIR:?set OC_DATA_DIR to the directory tree of PDFs to ingest}:/data:ro
+      - oc_remote_ledger:/ledger
+    working_dir: /app

--- a/scripts/remote_ingest/worker-entrypoint.sh
+++ b/scripts/remote_ingest/worker-entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Entrypoint for the remote-ingest worker container.
+#
+# Prepends the fixed in-container paths (ledger + mounted PDF root) to every
+# invocation, so the user only types the subcommand + tuning flags, e.g.:
+#
+#   docker compose -f remote_worker.yml run --rm worker plan
+#   docker compose -f remote_worker.yml run --rm worker run --max-workers 8
+#   docker compose -f remote_worker.yml run --rm worker verify
+#   docker compose -f remote_worker.yml run --rm worker status
+#
+# Target URL + token come from the environment (OC_TARGET_URL / OC_WORKER_TOKEN).
+set -o errexit
+set -o nounset
+
+exec python /app/scripts/remote_ingest/oc_remote_ingest.py \
+    --ledger /ledger/ledger.sqlite3 \
+    --root-dir /data \
+    "$@"


### PR DESCRIPTION
## What & why

Adds a turnkey way to run the **full OpenContracts ingestion pipeline** (Docling
parse + embeddings) on **off-cluster hardware** and stream fully-processed,
faithfully-mirrored documents into a corpus via the worker-upload REST API.
Built for the "I have spare workstations and a 100k–1M document corpus to
populate" problem: the expensive parsing/enrichment runs on *your* hardware, and
the target instance just ingests the finished artifacts.

**Faithful by construction** — the remote worker runs the *same* Docling
microservice and the *same* `DoclingParser` code the server runs, and embeds
against the *same* vector-embedder, so the PAWLs token layer, structural
annotations and embeddings are identical to an in-cluster ingestion. The worker
needs **no database access** to the target — only outbound HTTPS to
`/api/worker-uploads/`.

## How it relates to existing upload methods

| | `scripts/bulk_import` (existing) | `scripts/remote_ingest` (this PR) |
|---|---|---|
| Ships | raw PDFs (ZIP) | fully-processed documents |
| Who parses + embeds | the **server** | the **remote worker** |
| Offloads compute? | no | **yes** |
| Pre-processing hook | — | yes (calc + inject metadata/annotations) |

## What's in it

**Driver + bundle (`scripts/remote_ingest/`)**
- `oc_remote_ingest.py` — resumable per-document driver (SQLite ledger;
  `plan`/`run`/`verify`/`status`; thread-pool concurrency; backpressure against
  the target's worker-upload backlog; bounded retry honouring `429 Retry-After`).
- `remote_worker.yml` + `worker-entrypoint.sh` — docling-parser + vector-embedder
  + worker bundle the remote host brings up in a few commands.
- `enrichers.py` + `example_enrichers.py` — pluggable **pre-processing stage**.
  Enrichers (`EnricherContext -> Enrichment`) calculate + inject **typed corpus
  metadata** (Column/Datacell — the document-metadata grid), freeform
  `custom_meta`, doc-type labels, **token annotations** (faithful
  `annotation_json` built by `ctx.find_token_matches` / `ctx.token_annotation`),
  and relationships *before* embed+upload. `validate_enrichment` fails a buggy
  enricher's document loudly rather than shipping a broken annotation.

**Server-side**
- `BaseChunkedParser.parse_pdf_bytes()` — database-free parse entry point;
  `_parse_document_impl` now delegates to it (behaviour unchanged).
- `mint_worker_token` management command — one-command corpus-scoped token mint.
- **Worker-upload fidelity**: materialise `StructuralAnnotationSet` + subtree
  groups, regenerate the thumbnail, and suppress redundant server-side
  re-embedding when the worker ships embeddings (shared
  `utils/structural_sets.py`).
- **Worker-upload metadata**: accepts `custom_meta` (`Document.custom_meta`) and
  **typed metadata** via `MetadataService.upsert_document_metadata`
  (Column/Datacell) — the document-metadata system (successor to the old metadata
  annotations).
- `config/settings/remote_worker.py` — lean DB-free settings for the worker.

## Testing

- New `test_remote_ingest_enrichers.py` (token anchoring, `annotation_json`
  shape, enrichment merge/validation, typed-metadata fields, example enrichers).
- Extended `test_worker_uploads.py` (structural set, thumbnail, embedding
  ownership, `custom_meta`, injected annotations, typed-metadata datacells) and
  `test_chunked_parser.py` (`parse_pdf_bytes`). Full worker-upload + chunked
  parser + enrichers suites green; black/isort/flake8/mypy clean.
- Smoke-tested end to end against a second local stack with real Fort Worth
  contract PDFs: documents land COMPLETED with faithful PAWLs + content +
  StructuralAnnotationSet + doc/annotation embeddings + thumbnail, plus injected
  `DETECTED_DATE` annotations and typed metadata datacells (Contract Number,
  Effective Date, Contract Type, …).

## Docs

`docs/upload_methods/remote_ingest_worker.md` (wired into the mkdocs nav +
upload-methods index, cross-linked from `worker_uploads.md`), plus the
`scripts/remote_ingest/README.md` flag reference. Changes recorded as
`changelog.d/` fragments.
