### PR TITLE
Auto-detecting hardware-accelerated parser + embedder images (Intel XPU/NPU · CUDA · ROCm)

### DIFF
--- a/changelog.d/accelerated-local-images.added.md
+++ b/changelog.d/accelerated-local-images.added.md
@@ -1,0 +1,27 @@
+- **Hardware-accelerated, auto-detecting parser + embedder images** for local /
+  remote-worker deployments (`compose/accelerated/`). Each image picks the best
+  compute device available at startup (CUDA · ROCm · Intel XPU · Intel NPU via
+  OpenVINO · CPU) and falls back to CPU, so the same image "just works" on
+  whatever host it lands on:
+  - `compose/accelerated/accel_detect.py` — runtime hardware probe + device
+    routing; `entrypoint.sh` applies it. Docling → torch device (cuda/xpu/cpu);
+    embedder → OpenVINO (NPU preferred, then GPU) or torch, falling back to CPU.
+  - `embedder/` — OpenVINO-backed sentence-transformers image with a static-shape
+    **NPU engine** (`ov_npu.py`) whose output is numerically identical to the
+    reference (mean cosine 1.0). The accelerator *family* for the torch fallback
+    is a build-arg (`ACCEL=auto|cpu|xpu|cuda|rocm`).
+  - `docling/` — Docling image rebuilt on the chosen torch wheel
+    (`ACCEL=`), with an integrated-GPU `mem_get_info` compatibility shim
+    (`sitecustomize.py`).
+  - `accel.override.yml` — compose override that swaps both services into
+    `local.yml` with GPU/NPU device passthrough.
+  - `compose/accelerated/bench_parse.py` — measure the real Docling GPU-vs-CPU
+    speedup on a given host.
+  - `scripts/remote_ingest/remote_worker.accel.yml` — opt-in GPU override for the
+    remote-ingest worker bundle, so the off-cluster workstation runs parse +
+    embed on its GPU.
+  Measured on an Intel Lunar Lake reference host: the embedder runs ~11× (NPU) /
+  ~15× (iGPU) faster than the CPU service with identical output; Docling on the
+  *integrated* GPU is a wash (~1.05×) — a discrete GPU (NVIDIA/AMD/Intel Arc
+  Battlemage) is the right target for parser acceleration, so benchmark per host
+  rather than assuming. See `compose/accelerated/README.md`.

--- a/compose/accelerated/README.md
+++ b/compose/accelerated/README.md
@@ -1,0 +1,188 @@
+# Hardware-accelerated parser + embedder (Intel XPU/NPU · CUDA · ROCm)
+
+Locally-built, **auto-detecting** replacements for the `docling-parser` and
+`vector-embedder` microservices. Each image picks the best compute device
+available at startup and **falls back to CPU**, so the same image "just works"
+on whatever host it lands on.
+
+Measured on the Intel **Lunar Lake** reference host (Core Ultra 7 258V, Arc 140V
+iGPU + NPU):
+
+| Service | Best device | Measured | Verdict |
+|---|---|---|---|
+| `vector-embedder` | Intel **NPU** (OpenVINO) | **~11×** vs CPU (GPU variant **~15×**), output identical to reference | **Deploy it.** Embeddings run per-annotation (high volume) and are batched — the iGPU/NPU is a clean win. |
+| `docling-parser` | Intel iGPU (XPU) | **~1.05× (a wash)** + ~338 s kernel cold-start | **Keep on CPU here.** Docling is batch-1 CV inference; the *integrated* GPU's per-inference overhead cancels the compute gain. |
+
+> **The Docling "wash" is iGPU-specific, NOT a general result.** A small,
+> shared-memory integrated GPU doesn't help batch-1 detection/table inference. On
+> a **discrete** GPU Docling accelerates a lot — Docling's own technical report
+> (arXiv:2408.09869, NVIDIA L4) measures **14× layout, 8× EasyOCR, 4.3× table**,
+> and the docs report **~5–6× end-to-end** (RTX 5090). Discrete AMD via ROCm
+> shows batch-1 CV gains too (AMD's ROCm blog: 3.5× ResNet-152, 2.3× ViT at
+> batch=1 on Instinct MI210 with `torch.compile` reduce-overhead). Levers on a
+> real GPU: raise Docling's `layout_batch_size` / `ocr_batch_size` (default 4 →
+> e.g. 64) to amortize per-inference overhead; OCR is the dominant cost (~60%)
+> and the biggest GPU win. Caveats: GPU OCR under ROCm is the weak link (Docling
+> docs: only RapidOCR+torch is "known to work" on GPU — EasyOCR-on-ROCm is
+> unvalidated), and the table stage is not GPU-batched. **Build for your
+> accelerator (`ACCEL=cuda`/`rocm`) and run the parse benchmark to get the real
+> number** (see "Benchmarking your host"). Don't extrapolate the iGPU result.
+
+The embedder prefers the NPU so that — on the rare host where Docling *does*
+benefit from the iGPU — the two services run on separate engines without
+contending.
+
+## Why two images, not one
+
+A single image cannot contain CUDA **and** ROCm **and** XPU torch — they are
+mutually-exclusive `torch` wheels. So the **accelerator family** is chosen at
+*build* time with `--build-arg ACCEL=`; the **device within that family** is
+auto-selected at *run* time and degrades to CPU. This mirrors how PyTorch / vLLM
+ship per-accelerator images.
+
+```
+ACCEL=auto|cpu  -> CPU torch     (embedder still gets Intel GPU/NPU via OpenVINO)
+ACCEL=xpu       -> Intel-GPU torch
+ACCEL=cuda      -> NVIDIA torch
+ACCEL=rocm      -> AMD torch
+```
+
+The **embedder** always bundles OpenVINO, so every embedder variant supports
+Intel GPU/NPU + CPU regardless of `ACCEL` — `ACCEL` only governs its (rarely
+used) torch fallback path. The **docling** image is torch-only (docling has no
+OpenVINO path), so its `ACCEL` directly selects the GPU it uses.
+
+## Auto-detection
+
+`accel_detect.py` probes the runtime and routes:
+
+| Host | Embedder | Docling |
+|---|---|---|
+| Intel (NPU+GPU) | `openvino:NPU` | `xpu` |
+| Intel (GPU only) | `openvino:GPU` | `xpu` |
+| NVIDIA | `torch:cuda` | `cuda` |
+| AMD (ROCm) | `torch:cuda` | `cuda` |
+| Apple | `torch:mps` | `mps` |
+| none | `openvino:CPU` / `torch:cpu` | `cpu` |
+
+The container `entrypoint.sh` runs the detector, exports the device env, then
+execs the service. Override with `EMBED_ACCEL` / `DOCLING_ACCEL`
+(`auto` | `cpu` | `xpu` | `cuda` | `rocm`, or for the embedder a fully-qualified
+`openvino:GPU` / `openvino:NPU` / `torch:xpu`).
+
+Inspect a host's routing without running a service:
+
+```bash
+docker run --rm --device /dev/dri --device /dev/accel/accel0 \
+  --group-add "$(stat -c '%g' /dev/dri/renderD128)" \
+  oc-embedder:auto python3 /opt/accel/accel_detect.py
+```
+
+## The NPU embedder (static-shape engine)
+
+The Intel NPU requires a **fully static** compute graph; sentence-transformers'
+dynamic `encode()` won't compile on it. `ov_npu.py` loads the pre-exported
+OpenVINO IR, reshapes it to a fixed `[batch, seq]`, compiles on the NPU, and
+reimplements encode (fixed-length tokenize → infer → mean-pool → L2-normalize).
+Output is **numerically identical** to the sentence-transformers reference
+(verified mean cosine = `1.00000`). Tunable via `NPU_BATCH` (default 32) /
+`NPU_SEQ_LEN` (default 128).
+
+## Best target: a discrete Intel Arc (Battlemage) workstation GPU
+
+The iGPU result above is the *floor*. A **discrete Intel Arc Pro B-series**
+(Battlemage / Xe2 — e.g. Arc Pro B70: 32 Xe2 cores, 256 XMX engines, 32 GB GDDR6
+@ 608 GB/s, 367 INT8 TOPS) is the same architecture this stack already targets,
+but with dedicated VRAM and ~10× the compute — exactly what flips Docling out of
+the iGPU "wash" into the discrete-GPU regime, and a great host for the
+[remote-ingest worker](../../scripts/remote_ingest/README.md). Both services use
+`ACCEL=xpu` here (discrete Arc has **no NPU**, so the embedder routes to
+`openvino:GPU` — the 32 GB VRAM easily hosts both services on one card; with
+several cards, dedicate or scale out). Then **benchmark it** — don't trust the
+iGPU numbers:
+
+```bash
+export RENDER_GID=$(stat -c '%g' /dev/dri/renderD128)
+OC_DOCLING_ACCEL=xpu OC_EMBED_ACCEL=auto \
+  docker compose -f local.yml -f compose/accelerated/accel.override.yml build \
+      docling-parser vector-embedder
+# parser GPU-vs-CPU on the real hardware:
+docker build --build-arg ACCEL=xpu -f compose/accelerated/docling/Dockerfile -t oc-docling:xpu compose/accelerated
+docker run -d --name dl-gpu -p 8014:8000 --device /dev/dri --group-add "$RENDER_GID" oc-docling:xpu
+docker run -d --name dl-cpu -p 8015:8000 -e DOCLING_ACCEL=cpu oc-docling:xpu
+python compose/accelerated/bench_parse.py sample.pdf --gpu-port 8014 --cpu-port 8015
+```
+
+Worth A/B-testing on the B-series: OpenVINO **INT8** for the embedder (the XMX
+engines do 367 INT8 TOPS) and a higher Docling `layout_batch_size`/`ocr_batch_size`
+to amortize per-page overhead across the big VRAM.
+
+## Usage
+
+```bash
+# Render-group GID is host-specific — set it once:
+export RENDER_GID=$(stat -c '%g' /dev/dri/renderD128)
+
+# Build the accelerated images (Intel default: docling=xpu, embedder=auto):
+docker compose -f local.yml -f compose/accelerated/accel.override.yml build \
+    docling-parser vector-embedder
+
+# Run the stack with the override merged on top:
+docker compose -f local.yml -f compose/accelerated/accel.override.yml up
+```
+
+For NVIDIA build with `OC_DOCLING_ACCEL=cuda OC_EMBED_ACCEL=cuda` and pass GPUs
+via the nvidia runtime instead of `/dev/dri`; for AMD use `ACCEL=rocm` and pass
+`/dev/kfd` + `/dev/dri`.
+
+## Benchmarking your host (don't extrapolate the iGPU numbers)
+
+Whether the GPU helps **Docling** depends entirely on the hardware — measure it.
+On a discrete AMD GPU (ROCm):
+
+```bash
+# build the ROCm docling image + a CPU baseline of the same image
+docker build --build-arg ACCEL=rocm -f compose/accelerated/docling/Dockerfile -t oc-docling:rocm compose/accelerated
+
+docker run -d --name dl-gpu -p 8014:8000 \
+    --device /dev/kfd --device /dev/dri --group-add video --group-add render \
+    --security-opt seccomp=unconfined oc-docling:rocm
+docker run -d --name dl-cpu -p 8015:8000 -e DOCLING_ACCEL=cpu oc-docling:rocm
+
+# confirm the GPU was selected, then time a real parse vs CPU
+docker logs dl-gpu | grep -i "device"
+python compose/accelerated/bench_parse.py some-sample.pdf --gpu-port 8014 --cpu-port 8015
+```
+
+On NVIDIA, build `ACCEL=cuda` and run with `--gpus all` (no `/dev/dri`). The
+detector prints the chosen device in the container log on startup; `bench_parse.py`
+reports the steady-state speedup and the one-time warmup separately. (If the GPU
+is an `HSA_OVERRIDE_GFX_VERSION` case, set that env on the container — see ROCm
+docs for your gfx target.)
+
+## Files
+
+Both Dockerfiles use **this directory** as their build context (`-f
+{docling,embedder}/Dockerfile`), so the detector + entrypoint are a single shared
+source — no per-image duplication.
+
+| File | Purpose |
+|---|---|
+| `accel_detect.py` | hardware probe + device routing (shared by both images) |
+| `entrypoint.sh` | runs the detector, exports device env, execs the service (shared) |
+| `bench_parse.py` | benchmark a running docling-parser's `/parse/` on your hardware |
+| `embedder/Dockerfile` | OpenVINO base + sentence-transformers + torch (by `ACCEL`); pre-exports the OV IR |
+| `embedder/ov_npu.py` | static-shape NPU embedding engine (drop-in `.encode()`) |
+| `embedder/{embeddings,main}.py` | the embedder service (vendored, with the device-select load path) |
+| `docling/Dockerfile` | docling image + Intel GPU runtime + torch wheel (by `ACCEL`) |
+| `docling/sitecustomize.py` | torch+XPU integrated-GPU `mem_get_info` shim (auto-imported) |
+| `accel.override.yml` | compose override that swaps both services into `local.yml` with device passthrough |
+
+## Validated on the reference host
+
+* OpenVINO sees `['CPU','GPU','NPU']` in-container with `/dev/dri` + `/dev/accel`
+  + render group (no privileged mode).
+* Embedder auto-detect → NPU: **127.6 texts/s** HTTP vs **11.5** on the
+  production CPU embedder (~11×); GPU variant **168 texts/s** (~15×).
+* `torch 2.6.0+xpu` in the docling image: `xpu available: True` (Intel Graphics);
+  `decide_device(auto) -> xpu`.

--- a/compose/accelerated/accel.override.yml
+++ b/compose/accelerated/accel.override.yml
@@ -1,0 +1,62 @@
+# Intel-accelerator (and CUDA/ROCm) override for the parser + embedder services.
+#
+# Swaps the docling-parser and vector-embedder for locally-built, auto-detecting
+# accelerated images and passes the GPU/NPU device nodes through. The images
+# detect the best available device at startup and fall back to CPU, so this same
+# override is safe on a host with no accelerator.
+#
+# On the Lunar Lake reference host (MEASURED — see README.md):
+#   * vector-embedder -> Intel NPU (OpenVINO)   ~11x (GPU variant ~15x). The real
+#                        win: embeddings run per-annotation (high volume), batched.
+#   * docling-parser  -> DEFAULTS TO CPU. The integrated GPU is a WASH for docling
+#                        (~1.05x, batch-1 CV inference) and adds a ~338s kernel
+#                        JIT cold-start. The XPU/CUDA docling image only pays off
+#                        on a DISCRETE GPU (e.g. set OC_DOCLING_ACCEL=cuda on an
+#                        NVIDIA host). Scale CPU parsing with more replicas instead.
+#
+# Usage (compose merges this on top of local.yml):
+#   # one-time: build the accelerated images for your accelerator family
+#   docker compose -f local.yml -f compose/accelerated/accel.override.yml build \
+#       docling-parser vector-embedder
+#   # then bring the stack up as usual with both files:
+#   docker compose -f local.yml -f compose/accelerated/accel.override.yml up
+#
+# Pick the torch wheel family with ACCEL via the env vars OC_DOCLING_ACCEL /
+# OC_EMBED_ACCEL (auto|cpu|xpu|cuda|rocm). Defaults: docling=cpu, embedder=auto.
+#
+# Device access (no privileged mode):
+#   * Intel GPU/NPU: /dev/dri + /dev/accel + the host's render group GID.
+#     The render GID is host-specific; set it once:  export RENDER_GID=$(stat -c '%g' /dev/dri/renderD128)
+#   * NVIDIA: add `deploy.resources.reservations.devices` / the nvidia runtime instead.
+#   * AMD ROCm: pass /dev/kfd + /dev/dri.
+
+services:
+  docling-parser:
+    image: oc-docling:${OC_DOCLING_ACCEL:-xpu}
+    build:
+      context: ./compose/accelerated
+      dockerfile: docling/Dockerfile
+      args:
+        ACCEL: ${OC_DOCLING_ACCEL:-xpu}
+    devices:
+      - /dev/dri:/dev/dri
+    group_add:
+      - "${RENDER_GID:-993}"     # = $(stat -c '%g' /dev/dri/renderD128); host-specific
+    environment:
+      DOCLING_ACCEL: auto         # entrypoint auto-selects xpu/cuda/cpu at start
+
+  vector-embedder:
+    image: oc-embedder:${OC_EMBED_ACCEL:-auto}
+    build:
+      context: ./compose/accelerated
+      dockerfile: embedder/Dockerfile
+      args:
+        ACCEL: ${OC_EMBED_ACCEL:-auto}
+    devices:
+      - /dev/dri:/dev/dri
+      - /dev/accel/accel0:/dev/accel/accel0   # NPU (Intel) — embedder's preferred engine
+    group_add:
+      - "${RENDER_GID:-993}"
+    environment:
+      EMBED_ACCEL: auto           # entrypoint auto-selects NPU>GPU>xpu>cpu at start
+      VECTOR_EMBEDDER_API_KEY: ${VECTOR_EMBEDDER_API_KEY:-abc123}

--- a/compose/accelerated/accel_detect.py
+++ b/compose/accelerated/accel_detect.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""
+Runtime accelerator detection for the OpenContracts local-processing images.
+
+Probes the hardware/runtime actually visible inside the container and picks the
+best available compute device, falling back to CPU. Used by BOTH the embedder
+and the docling parser so one image "just works" on whatever host it lands on:
+
+  * NVIDIA GPU   (CUDA)        -> torch device "cuda"
+  * AMD GPU      (ROCm/HIP)    -> torch device "cuda"  (ROCm torch exposes HIP as the "cuda" device)
+  * Intel GPU    (Arc/Xe XPU)  -> torch device "xpu"   OR OpenVINO device "GPU"
+  * Intel NPU    (AI Boost)    -> OpenVINO device "NPU"
+  * Apple MPS                  -> torch device "mps"
+  * none                       -> "cpu"
+
+A single image can only carry ONE torch wheel (cuda XOR rocm XOR xpu XOR cpu),
+chosen at build time via the ACCEL build-arg. This detector reports what is
+USABLE given the installed runtime, so the service routes correctly and degrades
+to CPU instead of crashing when the expected accelerator is absent.
+
+CLI:
+    python accel_detect.py            # human-readable report
+    python accel_detect.py --export   # emit shell `export VAR=...` lines for an entrypoint
+    python accel_detect.py --json      # machine-readable
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sys
+
+
+def _torch():
+    try:
+        import torch  # noqa
+
+        return torch
+    except Exception:
+        return None
+
+
+def detect() -> dict:
+    """Return a dict describing the best torch + OpenVINO devices available."""
+    info: dict = {
+        "torch_backend": None,  # cuda | rocm | xpu | mps | cpu | None(no torch)
+        "torch_device": "cpu",  # value to pass to torch .to()/SentenceTransformer
+        "torch_version": None,
+        "ov_devices": [],  # OpenVINO devices: subset of CPU/GPU/NPU
+        "ov_accel_device": None,  # best non-CPU OpenVINO device (GPU>NPU) or None
+        "gpu_vendor": None,  # nvidia | amd | intel | apple | None
+    }
+
+    # --- torch backend ---
+    torch = _torch()
+    if torch is not None:
+        info["torch_version"] = torch.__version__
+        try:
+            if torch.cuda.is_available():
+                # ROCm builds report through the cuda API too; tell them apart
+                # via torch.version.hip.
+                is_rocm = bool(getattr(torch.version, "hip", None))
+                info["torch_backend"] = "rocm" if is_rocm else "cuda"
+                info["torch_device"] = "cuda"
+                info["gpu_vendor"] = "amd" if is_rocm else "nvidia"
+            elif hasattr(torch, "xpu") and torch.xpu.is_available():
+                info["torch_backend"] = "xpu"
+                info["torch_device"] = "xpu"
+                info["gpu_vendor"] = "intel"
+            elif (
+                getattr(torch.backends, "mps", None)
+                and torch.backends.mps.is_available()
+            ):
+                info["torch_backend"] = "mps"
+                info["torch_device"] = "mps"
+                info["gpu_vendor"] = "apple"
+            else:
+                info["torch_backend"] = "cpu"
+        except Exception:
+            info["torch_backend"] = "cpu"
+
+    # --- OpenVINO devices (Intel CPU/GPU/NPU) ---
+    try:
+        import openvino as ov  # noqa
+
+        devs = ov.Core().available_devices
+        info["ov_devices"] = list(devs)
+        # Prefer GPU over NPU for batched throughput.
+        for d in ("GPU", "NPU"):
+            if any(x == d or x.startswith(d + ".") for x in devs):
+                info["ov_accel_device"] = d
+                if info["gpu_vendor"] is None and d == "GPU":
+                    info["gpu_vendor"] = "intel"
+                break
+    except Exception:
+        pass
+
+    return info
+
+
+def choose_embedder(info: dict, prefer: str = "auto") -> tuple[str, str]:
+    """Pick (backend, device) for the embedder.
+
+    backend: "torch" or "openvino"; device: torch device or OV device name.
+
+    Policy (prefer="auto") — "embedder uses OpenVINO if available, else XPU":
+      NVIDIA/AMD GPU via torch                                     (non-Intel hosts)
+      > Intel NPU via OpenVINO    (PREFERRED on Intel: a SEPARATE engine from the
+                                   iGPU, so the embedder never contends with the
+                                   Docling parser which runs on the iGPU/XPU)
+      > Intel GPU via OpenVINO    (if no NPU)
+      > Intel GPU via torch-XPU   (if OpenVINO somehow unavailable)
+      > Apple MPS > CPU.
+    Override with EMBED_ACCEL, e.g. "openvino:GPU", "openvino:NPU", "torch:xpu",
+    "cpu".
+    """
+    if prefer and prefer != "auto":
+        if ":" in prefer:  # explicit "backend:device"
+            b, d = prefer.split(":", 1)
+            return b, d
+        if prefer == "cpu":
+            return "torch", "cpu"
+
+    ov = info.get("ov_devices", [])
+    has_npu = any(x == "NPU" or x.startswith("NPU.") for x in ov)
+    has_gpu = any(x == "GPU" or x.startswith("GPU.") for x in ov)
+    tb = info.get("torch_backend")
+
+    if tb in ("cuda", "rocm"):  # NVIDIA/AMD: torch is the only path
+        return "torch", "cuda"
+    if has_npu:  # Intel: NPU first (separate from iGPU)
+        return "openvino", "NPU"
+    if has_gpu:
+        return "openvino", "GPU"
+    if tb == "xpu":  # OpenVINO absent but torch sees the iGPU
+        return "torch", "xpu"
+    if tb == "mps":
+        return "torch", "mps"
+    if "CPU" in ov:
+        return "openvino", "CPU"
+    return "torch", "cpu"
+
+
+def choose_docling(info: dict, prefer: str = "auto") -> str:
+    """Pick the DOCLING_ACCELERATOR_DEVICE (docling uses torch only).
+
+    Returns one of: cuda | xpu | mps | cpu. (docling has no OpenVINO path.)
+    """
+    if prefer and prefer != "auto":
+        return prefer
+    tb = info.get("torch_backend")
+    if tb in ("cuda", "rocm"):
+        return "cuda"
+    if tb == "xpu":
+        return "xpu"
+    if tb == "mps":
+        return "mps"
+    return "cpu"
+
+
+def _device_files() -> dict:
+    """Raw device-node presence, useful for diagnostics."""
+    return {
+        "nvidia": os.path.exists("/dev/nvidiactl") or bool(shutil.which("nvidia-smi")),
+        "amd_kfd": os.path.exists("/dev/kfd"),
+        "dri_render": os.path.exists("/dev/dri/renderD128"),
+        "intel_npu": os.path.exists("/dev/accel/accel0"),
+    }
+
+
+def main(argv: list[str]) -> int:
+    prefer_emb = os.getenv("EMBED_ACCEL", "auto")
+    prefer_doc = os.getenv("DOCLING_ACCEL", "auto")
+    info = detect()
+    eb, ed = choose_embedder(info, prefer_emb)
+    dd = choose_docling(info, prefer_doc)
+    payload = {
+        **info,
+        "devices": _device_files(),
+        "embedder_backend": eb,
+        "embedder_device": ed,
+        "docling_device": dd,
+    }
+
+    if "--json" in argv:
+        print(json.dumps(payload, indent=2))
+    elif "--export" in argv:
+        # Shell-sourceable: an entrypoint does `eval "$(accel_detect.py --export)"`
+        print(f"export EMBED_BACKEND={eb}")
+        print(f"export EMBED_DEVICE={ed}")
+        print(f"export DOCLING_ACCELERATOR_DEVICE={dd}")
+    else:
+        print("=== accelerator detection ===")
+        print(f" gpu_vendor      : {info['gpu_vendor']}")
+        print(
+            f" torch           : {info['torch_version']} (backend={info['torch_backend']})"
+        )
+        print(f" openvino devices: {info['ov_devices']}")
+        print(f" device nodes    : {_device_files()}")
+        print(f" -> embedder     : backend={eb} device={ed}")
+        print(f" -> docling      : device={dd}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/compose/accelerated/bench_parse.py
+++ b/compose/accelerated/bench_parse.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""
+Benchmark a running docling-parser's /parse/ endpoint on a sample PDF.
+
+Use it to measure the REAL accelerator speedup on YOUR hardware — the iGPU
+result in the README does not generalize to discrete GPUs, so measure.
+
+    # start the accelerated parser (e.g. ROCm on an AMD box):
+    #   docker build --build-arg ACCEL=rocm -t oc-docling:rocm compose/accelerated/docling
+    #   docker run -d --name dl-gpu -p 8014:8000 \
+    #     --device /dev/kfd --device /dev/dri --group-add video \
+    #     oc-docling:rocm
+    # start a CPU baseline of the SAME image:
+    #   docker run -d --name dl-cpu -p 8015:8000 -e DOCLING_ACCEL=cpu oc-docling:rocm
+
+    python bench_parse.py path/to/sample.pdf --gpu-port 8014 --cpu-port 8015
+
+Prints per-service warmup + steady-state parse time and the speedup. The first
+parse on a GPU includes one-time model load / kernel compile — reported as
+"warmup" separately from the steady-state average.
+"""
+
+import argparse
+import base64
+import json
+import sys
+import time
+import urllib.request
+
+
+def parse_once(port: int, payload: bytes, timeout: int = 1200) -> float:
+    req = urllib.request.Request(
+        f"http://localhost:{port}/parse/",
+        data=payload,
+        headers={"Content-Type": "application/json"},
+    )
+    t = time.time()
+    resp = urllib.request.urlopen(req, timeout=timeout)
+    resp.read()
+    return time.time() - t
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("pdf")
+    ap.add_argument("--gpu-port", type=int, default=8014)
+    ap.add_argument("--cpu-port", type=int, default=8015)
+    ap.add_argument("--runs", type=int, default=3)
+    args = ap.parse_args()
+
+    pdf = open(args.pdf, "rb").read()
+    payload = json.dumps(
+        {
+            "filename": "bench.pdf",
+            "pdf_base64": base64.b64encode(pdf).decode(),
+            "force_ocr": False,
+            "roll_up_groups": True,
+            "llm_enhanced_hierarchy": False,
+        }
+    ).encode()
+
+    print(f"PDF: {args.pdf} ({len(pdf)} bytes), {args.runs} timed runs each\n")
+    res = {}
+    for name, port in [("GPU", args.gpu_port), ("CPU", args.cpu_port)]:
+        try:
+            warm = parse_once(port, payload)
+            runs = [parse_once(port, payload) for _ in range(args.runs)]
+            avg = sum(runs) / len(runs)
+            res[name] = avg
+            print(
+                f"{name:4} warmup={warm:7.1f}s  steady avg={avg:6.2f}s  "
+                f"runs={[round(x, 2) for x in runs]}"
+            )
+        except Exception as e:  # noqa: BLE001
+            print(f"{name:4} FAILED: {str(e)[:160]}")
+
+    if "GPU" in res and "CPU" in res and res["GPU"] > 0:
+        print(f"\n=> GPU steady-state speedup: {res['CPU'] / res['GPU']:.2f}x")
+        print("   (factor in the one-time GPU warmup for short-lived containers)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/compose/accelerated/docling/Dockerfile
+++ b/compose/accelerated/docling/Dockerfile
@@ -1,0 +1,66 @@
+# OpenContracts Docling parser — auto-accelerated, "just works" local image.
+#
+# Starts FROM the working docling image (docling + deps + pre-baked models) and
+# (1) adds the Intel Arc GPU userspace runtime, (2) swaps torch for the wheel of
+# the chosen accelerator family, (3) auto-selects the device at RUNTIME.
+#
+# Docling 2.67's decide_device("auto") already picks cuda > xpu > mps > cpu from
+# whatever torch supports — so once the right torch wheel is installed, docling
+# auto-accelerates. The torch FAMILY is a build-arg (wheels are exclusive):
+#   ACCEL=auto|cpu -> CPU torch
+#   ACCEL=xpu      -> Intel-GPU torch (+ Intel GPU runtime libs)   [proven here]
+#   ACCEL=cuda     -> NVIDIA torch
+#   ACCEL=rocm     -> AMD torch
+#
+# Build: docker build --build-arg ACCEL=xpu -t oc-docling:xpu .
+# Run  : docker run --device /dev/dri --group-add "$(stat -c '%g' /dev/dri/renderD128)" ...
+#        (--gpus all for CUDA; --device /dev/kfd --device /dev/dri for ROCm)
+FROM jscrudato/docsling-local
+USER root
+
+ARG ACCEL=auto
+
+# Intel GPU compute runtime (only needed for ACCEL=xpu, but cheap + harmless
+# otherwise). gnupg provides `gpg` (the base lacks it -> the earlier exit 127).
+RUN set -eux; \
+    if [ "${ACCEL}" = "xpu" ] || [ "${ACCEL}" = "auto" ]; then \
+      apt-get update; \
+      apt-get install -y --no-install-recommends gnupg wget ca-certificates; \
+      wget -qO- https://repositories.intel.com/gpu/intel-graphics.key \
+        | gpg --dearmor -o /usr/share/keyrings/intel-graphics.gpg; \
+      echo "deb [arch=amd64 signed-by=/usr/share/keyrings/intel-graphics.gpg] https://repositories.intel.com/gpu/ubuntu jammy client" \
+        > /etc/apt/sources.list.d/intel-gpu-jammy.list; \
+      apt-get update; \
+      apt-get install -y --no-install-recommends \
+        libze-intel-gpu1 libze1 intel-opencl-icd; \
+      rm -rf /var/lib/apt/lists/*; \
+    fi
+
+# Swap torch for the chosen accelerator wheel (force over the base's cu124 wheel).
+RUN set -eux; \
+    case "${ACCEL}" in \
+      cuda)  IDX="https://download.pytorch.org/whl/cu124" ;; \
+      rocm)  IDX="https://download.pytorch.org/whl/rocm6.2" ;; \
+      xpu)   IDX="https://download.pytorch.org/whl/xpu" ;; \
+      *)     IDX="https://download.pytorch.org/whl/cpu" ;; \
+    esac; \
+    echo "ACCEL=${ACCEL} -> torch index ${IDX}"; \
+    pip install --no-cache-dir --force-reinstall \
+      torch==2.6.0 torchvision==0.21.0 --index-url "${IDX}"
+
+# Detector + entrypoint (shared, single source at the build-context root).
+COPY accel_detect.py /opt/accel/accel_detect.py
+COPY entrypoint.sh /opt/accel/entrypoint.sh
+RUN chmod +x /opt/accel/entrypoint.sh
+
+# torch+XPU iGPU compatibility shim (auto-imported via PYTHONPATH). Fixes
+# transformers' mem_get_info warmup crash on integrated GPUs (Lunar Lake).
+COPY docling/sitecustomize.py /opt/accel/sitecustomize.py
+ENV PYTHONPATH=/opt/accel
+
+ENV DOCLING_ACCEL=auto \
+    OMP_NUM_THREADS=4
+
+EXPOSE 8000
+ENTRYPOINT ["/opt/accel/entrypoint.sh"]
+CMD ["python3", "-m", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/compose/accelerated/docling/sitecustomize.py
+++ b/compose/accelerated/docling/sitecustomize.py
@@ -1,0 +1,33 @@
+"""
+Transparent compatibility shim for torch+XPU on Intel INTEGRATED GPUs.
+
+Auto-imported by CPython at startup (any sitecustomize on the path runs). On
+Lunar Lake (and other iGPUs), the GPU driver does not expose the SYCL
+``ext_intel_free_memory`` aspect, so ``torch.xpu.mem_get_info()`` raises. The
+HuggingFace ``transformers`` model-load warmup (``caching_allocator_warmup``)
+calls it unconditionally, which crashes docling's model loading on XPU even
+though XPU compute itself works fine.
+
+This shim wraps ``torch.xpu.mem_get_info`` to return a benign large value when
+the underlying call raises, so model-load warmup succeeds and inference proceeds
+on the iGPU. It is a no-op on discrete Arc GPUs (which DO report free memory) and
+on non-XPU builds.
+"""
+
+try:  # never let the shim break interpreter startup
+    import torch
+
+    if hasattr(torch, "xpu") and hasattr(torch.xpu, "mem_get_info"):
+        _orig_mem_get_info = torch.xpu.mem_get_info
+
+        def _safe_mem_get_info(device=None):
+            try:
+                return _orig_mem_get_info(device)
+            except Exception:
+                # (free, total) — 8 GiB is a harmless stand-in; transformers
+                # only uses it to size an allocation hint.
+                return (8 * 1024**3, 8 * 1024**3)
+
+        torch.xpu.mem_get_info = _safe_mem_get_info
+except Exception:
+    pass

--- a/compose/accelerated/embedder/Dockerfile
+++ b/compose/accelerated/embedder/Dockerfile
@@ -1,0 +1,66 @@
+# OpenContracts vector embedder — auto-accelerated, "just works" local image.
+#
+# ONE image picks the best device available at RUNTIME (CUDA / ROCm / Intel
+# XPU+OpenVINO / NPU / CPU) and falls back to CPU. The accelerator FAMILY for the
+# torch wheel is chosen at BUILD time via --build-arg ACCEL=... because torch's
+# cuda/rocm/xpu/cpu wheels are mutually exclusive. OpenVINO is ALWAYS present, so
+# every variant supports Intel GPU/NPU + CPU regardless of ACCEL.
+#
+#   ACCEL=auto|cpu  -> CPU torch  (+ OpenVINO Intel GPU/NPU/CPU)        [default]
+#   ACCEL=xpu       -> Intel-GPU torch (+ OpenVINO)
+#   ACCEL=cuda      -> NVIDIA torch (+ OpenVINO Intel/CPU)
+#   ACCEL=rocm      -> AMD torch    (+ OpenVINO Intel/CPU)
+#
+# Build:  docker build --build-arg ACCEL=auto -t oc-embedder:auto .
+# Run  :  docker run --device /dev/dri --group-add "$(stat -c '%g' /dev/dri/renderD128)" ...
+#         (add --gpus all for CUDA; --device /dev/kfd --device /dev/dri for ROCm)
+FROM openvino/ubuntu24_runtime:latest
+USER root
+WORKDIR /app
+
+ARG ACCEL=auto
+
+# Service deps + OpenVINO-backed sentence-transformers (covers Intel GPU/NPU/CPU).
+RUN pip install --no-cache-dir \
+      flask gunicorn numpy "Pillow>=10" python-decouple requests \
+      "sentence-transformers[openvino]>=3"
+
+# Select the torch wheel for the chosen accelerator family. CPU is the safe
+# default; the others pull vendor wheels that bundle their own runtime.
+RUN set -eux; \
+    case "${ACCEL}" in \
+      cuda)  IDX="https://download.pytorch.org/whl/cu124" ;; \
+      rocm)  IDX="https://download.pytorch.org/whl/rocm6.2" ;; \
+      xpu)   IDX="https://download.pytorch.org/whl/xpu" ;; \
+      *)     IDX="https://download.pytorch.org/whl/cpu" ;; \
+    esac; \
+    echo "ACCEL=${ACCEL} -> torch index ${IDX}"; \
+    pip install --no-cache-dir --force-reinstall torch --index-url "${IDX}"
+
+ENV EMBEDDING_MODEL=multi-qa-MiniLM-L6-cos-v1 \
+    TOKENIZER_MODEL=sentence-transformers/multi-qa-MiniLM-L6-cos-v1 \
+    HF_HOME=/models/hf
+
+# Pre-export the model to OpenVINO IR at BUILD time (CPU; no device needed) so
+# the torch->IR export + weight download are baked in, not paid on every boot.
+RUN python3 -c "import os; from sentence_transformers import SentenceTransformer; \
+m=SentenceTransformer(os.environ['EMBEDDING_MODEL'], backend='openvino'); \
+m.save_pretrained('/models/ov-embedder'); print('exported OpenVINO IR')"
+
+# Detector + entrypoint (shared, single source at the build-context root).
+COPY accel_detect.py /opt/accel/accel_detect.py
+COPY entrypoint.sh /opt/accel/entrypoint.sh
+RUN chmod +x /opt/accel/entrypoint.sh
+
+COPY embedder/embeddings.py embedder/main.py embedder/ov_npu.py /app/
+
+ENV OV_MODEL_DIR=/models/ov-embedder \
+    EMBED_ACCEL=auto \
+    PORT=8000 \
+    GUNICORN_WORKERS=1 \
+    HF_HUB_OFFLINE=1 \
+    TRANSFORMERS_OFFLINE=1
+
+EXPOSE 8000
+ENTRYPOINT ["/opt/accel/entrypoint.sh"]
+CMD ["sh", "-c", "exec gunicorn --bind :${PORT} --workers ${GUNICORN_WORKERS} --threads 1 --timeout 0 main:app"]

--- a/compose/accelerated/embedder/embeddings.py
+++ b/compose/accelerated/embedder/embeddings.py
@@ -1,0 +1,255 @@
+import base64
+import io
+import os
+
+import numpy as np
+from PIL import Image
+from sentence_transformers import SentenceTransformer
+from transformers import AutoTokenizer
+
+# Load configuration (defaults unchanged for backward compatibility)
+EMBEDDING_MODEL = os.getenv("EMBEDDING_MODEL", "multi-qa-MiniLM-L6-cos-v1")
+TOKENIZER_MODEL = os.getenv(
+    "TOKENIZER_MODEL", "sentence-transformers/multi-qa-MiniLM-L6-cos-v1"
+)
+MAX_BATCH_SIZE = int(os.getenv("MAX_BATCH_SIZE", "8"))  # Chunks per encode() call
+MAX_IMAGE_SIZE = int(os.getenv("MAX_IMAGE_SIZE", "10485760"))  # 10MB default
+
+print(f"Loading embedding model: {EMBEDDING_MODEL}")
+
+# Auto-accelerated inference. The container entrypoint runs accel_detect.py and
+# exports EMBED_BACKEND + EMBED_DEVICE for the best device available (CUDA / ROCm
+# / Intel-XPU / Intel-GPU+NPU via OpenVINO / CPU). Both default to the CPU torch
+# path so a bare `import` (e.g. tests, no entrypoint) still works unchanged.
+#   EMBED_BACKEND=openvino  EMBED_DEVICE=GPU|NPU|CPU  -> OpenVINO (Intel)
+#   EMBED_BACKEND=torch     EMBED_DEVICE=cuda|xpu|mps|cpu -> torch
+# OV_MODEL_DIR points at a pre-exported OpenVINO IR baked into the image so the
+# torch->IR export is not paid on boot. backend="openvino" carries the model's
+# mean-pooling + L2-normalize, so output matches torch (FP16 cosine > 0.999).
+EMBED_BACKEND = os.getenv("EMBED_BACKEND", "torch").lower()
+EMBED_DEVICE = os.getenv("EMBED_DEVICE", "cpu")
+OV_MODEL_DIR = os.getenv("OV_MODEL_DIR", "").strip()
+
+
+NPU_BATCH = int(os.getenv("NPU_BATCH", "32"))
+NPU_SEQ_LEN = int(os.getenv("NPU_SEQ_LEN", "128"))
+
+
+def _load_model():
+    if EMBED_BACKEND == "openvino":
+        src = OV_MODEL_DIR or EMBEDDING_MODEL
+        if EMBED_DEVICE.upper().startswith("NPU"):
+            # The NPU needs a fully-static graph; ST's dynamic encode() won't
+            # compile on it. Use the static-shape engine (output verified
+            # identical to ST, mean cosine 1.0). Runs on a SEPARATE accelerator
+            # from the iGPU, so it doesn't contend with the Docling parser.
+            from ov_npu import NpuEmbedder
+
+            m = NpuEmbedder(
+                src, device=EMBED_DEVICE, batch=NPU_BATCH, seq_len=NPU_SEQ_LEN
+            )
+            print(
+                f"OpenVINO NPU engine ready ({EMBED_DEVICE}, batch={NPU_BATCH}, seq={NPU_SEQ_LEN})"
+            )
+            return m
+        # GPU/CPU: ST's dynamic OpenVINO path (carries pooling + normalize). The
+        # OV device goes in model_kwargs; the ST `device` is the torch device for
+        # the cheap pooling modules (keep cpu — "GPU" is not a torch device).
+        m = SentenceTransformer(
+            src,
+            backend="openvino",
+            device="cpu",
+            model_kwargs={"device": EMBED_DEVICE},
+        )
+        print(f"OpenVINO backend ready on device={EMBED_DEVICE} (source={src})")
+        return m
+    m = SentenceTransformer(EMBEDDING_MODEL, device=EMBED_DEVICE)
+    print(f"torch backend ready on device={EMBED_DEVICE}")
+    return m
+
+
+try:
+    model = _load_model()
+except Exception as exc:  # hardware/driver dependent — never fail to start
+    print(
+        f"{EMBED_BACKEND}/{EMBED_DEVICE} unavailable ({exc}); falling back to torch+cpu"
+    )
+    model = SentenceTransformer(EMBEDDING_MODEL, device="cpu")
+
+
+def _check_image_support():
+    """Check if model supports image encoding."""
+    try:
+        dummy = Image.new("RGB", (224, 224))
+        model.encode(dummy)
+        return True
+    except Exception:
+        return False
+
+
+SUPPORTS_IMAGES = _check_image_support()
+print(f"Image embedding support: {SUPPORTS_IMAGES}")
+
+# Load tokenizer only for text-only models (needed for chunking)
+# CLIP models don't need chunking - they handle text directly
+tokenizer = None
+if TOKENIZER_MODEL and not SUPPORTS_IMAGES:
+    print(f"Loading tokenizer: {TOKENIZER_MODEL}")
+    tokenizer = AutoTokenizer.from_pretrained(TOKENIZER_MODEL)
+
+
+def decode_image(image_base64: str) -> Image.Image:
+    """Decode base64 image string to PIL Image."""
+    image_bytes = base64.b64decode(image_base64)
+    if len(image_bytes) > MAX_IMAGE_SIZE:
+        raise ValueError(f"Image exceeds maximum size of {MAX_IMAGE_SIZE} bytes")
+    return Image.open(io.BytesIO(image_bytes)).convert("RGB")
+
+
+def embed_image(image_base64: str) -> np.ndarray:
+    """Generate embedding for a base64-encoded image."""
+    if not SUPPORTS_IMAGES:
+        raise NotImplementedError("Current model does not support image embeddings")
+    image = decode_image(image_base64)
+    embedding = model.encode(image)
+    return embedding.reshape(1, -1)
+
+
+def embed_images_batch(images_base64: list[str]) -> list[np.ndarray]:
+    """Generate embeddings for multiple images."""
+    if not SUPPORTS_IMAGES:
+        raise NotImplementedError("Current model does not support image embeddings")
+    images = [decode_image(img) for img in images_base64]
+    embeddings = model.encode(images)
+    return [emb.reshape(1, -1) for emb in embeddings]
+
+
+def chunk_by_transformers_tokens(
+    content: str, max_token_length: int = 512, transformer_id: str = None
+) -> list[str]:
+    """
+    Tokenizes a long string and splits it into substrings based on a specified maximum token length.
+
+    Parameters:
+    - content (str): The input text to be tokenized.
+    - transformer_id (str): Model name for SentenceTransformer.
+                            If None, uses the cached module-level tokenizer.
+    - max_token_length (int): The maximum length for each chunk of tokens.
+
+    Returns:
+    - List[str]: List of substrings, each specified max tokens or fewer tokens.
+    """
+    # Use cached tokenizer if using default model, otherwise load specified one
+    if transformer_id is None or transformer_id == TOKENIZER_MODEL:
+        tok = tokenizer
+    else:
+        tok = AutoTokenizer.from_pretrained(transformer_id)
+
+    if tok is None:
+        # No tokenizer available (CLIP model) - return text as single chunk
+        return [content]
+
+    tokens = tok.tokenize(content)
+
+    # Split the tokens into chunks
+    tokenized_chunks = [
+        tokens[i : i + max_token_length]
+        for i in range(0, len(tokens), max_token_length)
+    ]
+    chunk_lengths = [len(" ".join(chunk)) for chunk in tokenized_chunks]
+
+    chunks = []
+    next_start = 0
+    for index, length in enumerate(chunk_lengths):
+
+        if index == len(chunk_lengths) - 1:
+            chunk = content[next_start:]
+        else:
+            chunk = content[next_start : next_start + length]
+            next_start += length
+
+        if len(chunk) == 0 or chunk is None:
+            print("Skipping empty chunk!")
+            continue
+
+        chunks.append(chunk)
+
+    return chunks
+
+
+def embed_text(text: str) -> np.ndarray:
+    """Generate embedding for text."""
+    # CLIP models: encode directly (no chunking needed, handles up to 77 tokens)
+    # Text-only models: use chunking as before
+    if SUPPORTS_IMAGES:
+        # CLIP model - direct encoding (text truncated to ~77 tokens by model)
+        embedding = model.encode(text)
+        return embedding.reshape(1, -1)
+    else:
+        # Text-only model - use chunking
+        return _embed_text_chunked(text)
+
+
+def _embed_text_chunked(text: str) -> np.ndarray:
+    """Embed text with chunking (for text-only models)."""
+    window = 512  # Use full model capacity
+
+    chunks = chunk_by_transformers_tokens(text, max_token_length=window)
+    print(f"Initial chunk length: {len(chunks)}")
+
+    # Limit to 5 chunks - benchmarks show 4-5 chunks optimal for throughput
+    # while still capturing document semantics
+    chunks = chunks[:5]
+    print(f"\tFinal chunk length following truncation: {len(chunks)}")
+
+    embeddings = model.encode(chunks)
+    avg_embedding: np.ndarray = np.mean(embeddings, axis=0, keepdims=True)
+    return avg_embedding
+
+
+def embed_texts_batch(texts: list[str], max_batch_size: int = None) -> list[np.ndarray]:
+    """
+    Embed multiple texts efficiently by batching model.encode() calls.
+
+    Parameters:
+    - texts: List of texts to embed
+    - max_batch_size: Maximum chunks to encode in single model.encode() call.
+                      Defaults to MAX_BATCH_SIZE env var (default 8).
+
+    Returns:
+    - List of embedding arrays, one per input text
+    """
+    # CLIP models: encode directly without chunking
+    if SUPPORTS_IMAGES:
+        embeddings = model.encode(texts)
+        return [emb.reshape(1, -1) for emb in embeddings]
+
+    # Text-only models: use chunking
+    if max_batch_size is None:
+        max_batch_size = MAX_BATCH_SIZE
+    window = 512  # Use full model capacity
+    all_chunks = []
+    chunk_boundaries = []  # Track which chunks belong to which text
+
+    # Chunk all texts
+    for text in texts:
+        chunks = chunk_by_transformers_tokens(text, max_token_length=window)
+        chunks = chunks[:5]  # Same limit as embed_text
+        chunk_boundaries.append((len(all_chunks), len(all_chunks) + len(chunks)))
+        all_chunks.extend(chunks)
+
+    # Encode all chunks in batches
+    all_embeddings = []
+    for i in range(0, len(all_chunks), max_batch_size):
+        batch = all_chunks[i : i + max_batch_size]
+        batch_embeddings = model.encode(batch)
+        all_embeddings.extend(batch_embeddings)
+
+    # Average embeddings for each text
+    results = []
+    for start, end in chunk_boundaries:
+        text_embeddings = np.array(all_embeddings[start:end])
+        avg_embedding = np.mean(text_embeddings, axis=0, keepdims=True)
+        results.append(avg_embedding)
+
+    return results

--- a/compose/accelerated/embedder/main.py
+++ b/compose/accelerated/embedder/main.py
@@ -1,0 +1,209 @@
+import os
+
+from decouple import config
+from embeddings import (
+    SUPPORTS_IMAGES,
+    embed_image,
+    embed_images_batch,
+    embed_text,
+    embed_texts_batch,
+)
+from flask import Flask, jsonify, request
+
+app = Flask(__name__)
+
+# Health check endpoints (no auth required)
+EMBEDDING_MODEL = os.getenv("EMBEDDING_MODEL", "multi-qa-MiniLM-L6-cos-v1")
+
+
+@app.route("/health", methods=["GET"])
+def health():
+    """Liveness probe - returns 200 if server is running."""
+    return jsonify({"status": "ok"}), 200
+
+
+@app.route("/health/ready", methods=["GET"])
+def health_ready():
+    """Readiness probe - confirms model backend is initialized."""
+    import embeddings
+
+    # Check for model/backend - works with both old (model) and new (backend) versions
+    is_ready = (
+        getattr(embeddings, "backend", None) is not None
+        or getattr(embeddings, "model", None) is not None
+    )
+
+    if not is_ready:
+        return jsonify({"status": "not_ready", "error": "Model not loaded"}), 503
+    return (
+        jsonify(
+            {
+                "status": "ready",
+                "model": EMBEDDING_MODEL,
+                "supports_images": SUPPORTS_IMAGES,
+            }
+        ),
+        200,
+    )
+
+
+API_KEY = config("VECTOR_EMBEDDER_API_KEY", default="abc123")
+MAX_TEXTS_PER_BATCH = config("MAX_TEXTS_PER_BATCH", default=100, cast=int)
+MAX_IMAGES_PER_BATCH = config("MAX_IMAGES_PER_BATCH", default=20, cast=int)
+
+
+@app.route("/embeddings", methods=["POST"])
+def generate_embeddings():
+    api_key = request.headers.get("X-API-Key")
+    if api_key != API_KEY:
+        return jsonify({"error": "Invalid API key"}), 401
+
+    text = request.json.get("text")
+    if not text:
+        return jsonify({"error": "Text is required"}), 400
+
+    embeddings = embed_text(text)
+    return jsonify({"embeddings": embeddings.tolist()}), 200
+
+
+@app.route("/embeddings/batch", methods=["POST"])
+def generate_embeddings_batch():
+    """
+    Batch endpoint for embedding multiple texts efficiently.
+
+    Request body:
+    {
+        "texts": ["text1", "text2", ...]
+    }
+
+    Response:
+    {
+        "embeddings": [[...], [...], ...]
+    }
+    """
+    api_key = request.headers.get("X-API-Key")
+    if api_key != API_KEY:
+        return jsonify({"error": "Invalid API key"}), 401
+
+    texts = request.json.get("texts")
+    if not texts:
+        return jsonify({"error": "texts array is required"}), 400
+
+    if not isinstance(texts, list):
+        return jsonify({"error": "texts must be an array"}), 400
+
+    if len(texts) == 0:
+        return jsonify({"error": "texts array cannot be empty"}), 400
+
+    if len(texts) > MAX_TEXTS_PER_BATCH:
+        error_msg = (
+            f"Batch size {len(texts)} exceeds maximum of {MAX_TEXTS_PER_BATCH} texts "
+            "per request. Split into multiple requests."
+        )
+        return jsonify({"error": error_msg}), 400
+
+    # Filter out empty texts
+    valid_texts = [t for t in texts if t and isinstance(t, str)]
+    if len(valid_texts) != len(texts):
+        return jsonify({"error": "All texts must be non-empty strings"}), 400
+
+    embeddings_list = embed_texts_batch(valid_texts)
+    return jsonify({"embeddings": [emb.tolist() for emb in embeddings_list]}), 200
+
+
+@app.route("/embeddings/image", methods=["POST"])
+def generate_image_embedding():
+    """
+    Generate embedding for a single image.
+
+    Request body:
+    {
+        "image": "<base64-encoded-image>"
+    }
+
+    Response:
+    {
+        "embeddings": [[0.1, -0.2, ...]]
+    }
+    """
+    api_key = request.headers.get("X-API-Key")
+    if api_key != API_KEY:
+        return jsonify({"error": "Invalid API key"}), 401
+
+    if not SUPPORTS_IMAGES:
+        return (
+            jsonify({"error": "Image embeddings not supported by current model"}),
+            501,
+        )
+
+    image_base64 = request.json.get("image")
+    if not image_base64:
+        return jsonify({"error": "image (base64) is required"}), 400
+
+    try:
+        embeddings = embed_image(image_base64)
+        return jsonify({"embeddings": embeddings.tolist()}), 200
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
+    except Exception as e:
+        return jsonify({"error": f"Failed to process image: {str(e)}"}), 400
+
+
+@app.route("/embeddings/image/batch", methods=["POST"])
+def generate_image_embeddings_batch():
+    """
+    Generate embeddings for multiple images.
+
+    Request body:
+    {
+        "images": ["<base64-img1>", "<base64-img2>", ...]
+    }
+
+    Response:
+    {
+        "embeddings": [[[...]], [[...]], ...]
+    }
+    """
+    api_key = request.headers.get("X-API-Key")
+    if api_key != API_KEY:
+        return jsonify({"error": "Invalid API key"}), 401
+
+    if not SUPPORTS_IMAGES:
+        return (
+            jsonify({"error": "Image embeddings not supported by current model"}),
+            501,
+        )
+
+    images = request.json.get("images")
+    if not images:
+        return jsonify({"error": "images array is required"}), 400
+
+    if not isinstance(images, list):
+        return jsonify({"error": "images must be an array"}), 400
+
+    if len(images) == 0:
+        return jsonify({"error": "images array cannot be empty"}), 400
+
+    if len(images) > MAX_IMAGES_PER_BATCH:
+        error_msg = (
+            f"Batch size {len(images)} exceeds maximum of {MAX_IMAGES_PER_BATCH} images "
+            "per request. Split into multiple requests."
+        )
+        return jsonify({"error": error_msg}), 400
+
+    # Validate all images are non-empty strings
+    valid_images = [img for img in images if img and isinstance(img, str)]
+    if len(valid_images) != len(images):
+        return jsonify({"error": "All images must be non-empty base64 strings"}), 400
+
+    try:
+        embeddings_list = embed_images_batch(valid_images)
+        return jsonify({"embeddings": [emb.tolist() for emb in embeddings_list]}), 200
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
+    except Exception as e:
+        return jsonify({"error": f"Failed to process images: {str(e)}"}), 400
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5001)

--- a/compose/accelerated/embedder/ov_npu.py
+++ b/compose/accelerated/embedder/ov_npu.py
@@ -1,0 +1,120 @@
+"""
+Static-shape OpenVINO NPU embedding engine for the OpenContracts embedder.
+
+The Intel NPU (AI Boost) requires a FULLY STATIC compute graph — sentence-
+transformers' high-level ``encode()`` exports a dynamic-shape model the NPU
+compiler rejects ("Upper bounds are not specified"). This module loads the
+pre-exported OpenVINO IR, reshapes it to a fixed ``[batch, seq]``, compiles it
+on the NPU, and reimplements the encode path (fixed-length tokenize -> infer ->
+mean-pool -> L2-normalize). The output is numerically identical to the sentence-
+transformers reference (verified mean cosine = 1.00000).
+
+Why the NPU at all: it is a SEPARATE accelerator from the iGPU, so the embedder
+can run here while the Docling parser saturates the iGPU (XPU) — no contention.
+
+Exposes a drop-in ``.encode()`` compatible with the subset of the
+SentenceTransformer API the embedder service uses (list[str] -> np.ndarray
+[N, dim], or a single str -> np.ndarray [dim]).
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+
+import numpy as np
+import openvino as ov
+from transformers import AutoTokenizer
+
+
+def _find_ir_xml(model_dir: str) -> str:
+    """Locate the openvino_model.xml inside a sentence-transformers OV export."""
+    for cand in (
+        os.path.join(model_dir, "openvino", "openvino_model.xml"),
+        os.path.join(model_dir, "openvino_model.xml"),
+    ):
+        if os.path.exists(cand):
+            return cand
+    hits = glob.glob(
+        os.path.join(model_dir, "**", "openvino_model.xml"), recursive=True
+    )
+    if not hits:
+        raise FileNotFoundError(f"No openvino_model.xml under {model_dir}")
+    return hits[0]
+
+
+class NpuEmbedder:
+    """Static-shape OpenVINO NPU (or any OV device) sentence embedder."""
+
+    def __init__(
+        self,
+        model_dir: str,
+        device: str = "NPU",
+        batch: int = 32,
+        seq_len: int = 128,
+    ):
+        self.device = device
+        self.batch = batch
+        self.seq_len = seq_len
+        self.tokenizer = AutoTokenizer.from_pretrained(model_dir)
+
+        core = ov.Core()
+        ir = core.read_model(_find_ir_xml(model_dir))
+        # Static [batch, seq] for every input (input_ids / attention_mask /
+        # token_type_ids). This is what makes the NPU compiler accept the graph.
+        ir.reshape({i.get_any_name(): [batch, seq_len] for i in ir.inputs})
+        cfg = {"PERFORMANCE_HINT": "THROUGHPUT"}
+        self.compiled = core.compile_model(ir, device, cfg)
+        self.input_names = [i.get_any_name() for i in ir.inputs]
+        self._req = self.compiled.create_infer_request()
+
+    # -- pooling matches sentence-transformers multi-qa-MiniLM (mean + L2) --
+    @staticmethod
+    def _mean_pool_normalize(last_hidden: np.ndarray, mask: np.ndarray) -> np.ndarray:
+        m = mask[..., None].astype("float32")
+        summed = (last_hidden * m).sum(axis=1)
+        counts = np.clip(m.sum(axis=1), 1e-9, None)
+        v = summed / counts
+        norm = np.linalg.norm(v, axis=1, keepdims=True)
+        return v / np.clip(norm, 1e-12, None)
+
+    def _infer_fixed_batch(self, enc: dict) -> np.ndarray:
+        feeds = {n: enc[n] for n in self.input_names if n in enc}
+        out = self._req.infer(feeds)
+        last_hidden = list(out.values())[0]
+        return self._mean_pool_normalize(last_hidden, enc["attention_mask"])
+
+    def encode(self, sentences, batch_size: int | None = None, **_kwargs) -> np.ndarray:
+        """Drop-in for SentenceTransformer.encode for the text path.
+
+        Accepts a str or list[str]; returns np.ndarray of shape [dim] (single)
+        or [N, dim] (list). ``batch_size`` is ignored — the NPU batch is fixed at
+        compile time; inputs are processed in fixed ``self.batch`` chunks, with
+        the final partial chunk padded up to the static batch and sliced back.
+        """
+        single = isinstance(sentences, str)
+        texts = [sentences] if single else list(sentences)
+        if not texts:
+            return np.zeros((0, self.compiled.outputs[0].shape[-1]), dtype="float32")
+
+        results: list[np.ndarray] = []
+        B = self.batch
+        for start in range(0, len(texts), B):
+            chunk = texts[start : start + B]
+            pad_n = B - len(chunk)
+            if pad_n:
+                chunk = chunk + [""] * pad_n  # pad batch up to static size
+            enc = self.tokenizer(
+                chunk,
+                padding="max_length",
+                truncation=True,
+                max_length=self.seq_len,
+                return_tensors="np",
+            )
+            emb = self._infer_fixed_batch(enc)
+            if pad_n:
+                emb = emb[: B - pad_n]  # drop padded rows
+            results.append(emb)
+
+        out = np.concatenate(results, axis=0)
+        return out[0] if single else out

--- a/compose/accelerated/entrypoint.sh
+++ b/compose/accelerated/entrypoint.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Auto-detect the best available accelerator, export the service's device env,
+# then exec the real service command. Idempotent + CPU-safe: if no accelerator
+# is visible (or detection fails), the service runs on CPU.
+#
+# Honor explicit overrides: set EMBED_ACCEL / DOCLING_ACCEL to force a choice
+# (e.g. EMBED_ACCEL=openvino:NPU, DOCLING_ACCEL=cpu). "auto" (default) detects.
+set -euo pipefail
+
+DETECT="${ACCEL_DETECT:-/opt/accel/accel_detect.py}"
+
+if [ -f "$DETECT" ]; then
+    echo "[entrypoint] detecting accelerators..."
+    python3 "$DETECT" || true            # human-readable report to logs
+    # Apply the detector's choice unless the caller pinned the values already.
+    if eval "$(python3 "$DETECT" --export 2>/dev/null)"; then
+        echo "[entrypoint] EMBED_BACKEND=${EMBED_BACKEND:-} EMBED_DEVICE=${EMBED_DEVICE:-} DOCLING_ACCELERATOR_DEVICE=${DOCLING_ACCELERATOR_DEVICE:-}"
+    else
+        echo "[entrypoint] detection failed; using CPU defaults" >&2
+    fi
+else
+    echo "[entrypoint] no detector at $DETECT; using preset env" >&2
+fi
+
+exec "$@"

--- a/scripts/remote_ingest/README.md
+++ b/scripts/remote_ingest/README.md
@@ -90,6 +90,31 @@ That's it. The directory tree under `OC_DATA_DIR` is mirrored into the corpus's
 folder structure (each PDF's path becomes its folder path). `run` is resumable —
 if it's interrupted, just run it again; finished documents are skipped.
 
+### GPU acceleration (recommended on beefy workstations)
+
+The slow step is the Docling parse. If the host has a GPU, merge the
+`remote_worker.accel.yml` override to run the parser + embedder on it — this is
+the whole point of "beefy workstations sitting around". It swaps in the
+auto-detecting [accelerated images](../../compose/accelerated/README.md) and
+passes the GPU through (auto-selects the device, falls back to CPU):
+
+```bash
+export RENDER_GID=$(stat -c '%g' /dev/dri/renderD128)   # Intel/AMD; host-specific
+docker compose -f remote_worker.yml -f remote_worker.accel.yml build \
+    docling-parser vector-embedder
+docker compose -f remote_worker.yml -f remote_worker.accel.yml up -d \
+    docling-parser vector-embedder
+docker compose -f remote_worker.yml -f remote_worker.accel.yml run --rm worker run --max-workers 8
+```
+
+A **discrete Intel Arc Pro B-series** (Battlemage, e.g. Arc Pro B70 — 32 GB, 256
+XMX engines) is an ideal target: defaults (`OC_DOCLING_ACCEL=xpu`,
+`OC_EMBED_ACCEL=auto`) run Docling on the GPU and the embedder on OpenVINO.
+NVIDIA: `OC_DOCLING_ACCEL=cuda OC_EMBED_ACCEL=cuda` + the nvidia runtime. AMD:
+`ACCEL=rocm` + `/dev/kfd`. **Benchmark Docling on YOUR GPU**
+(`compose/accelerated/bench_parse.py`) — the speedup is hardware-specific (a
+discrete GPU helps a lot; a weak integrated GPU may not).
+
 ---
 
 ## Subcommands

--- a/scripts/remote_ingest/remote_worker.accel.yml
+++ b/scripts/remote_ingest/remote_worker.accel.yml
@@ -1,0 +1,67 @@
+# ===========================================================================
+# GPU-acceleration override for the remote-ingest worker bundle.
+# ===========================================================================
+# Swaps the stock docling-parser + vector-embedder for the locally-built,
+# auto-detecting accelerated images (see compose/accelerated/) and passes the
+# GPU/NPU device nodes through. This is what makes the remote-ingest worker run
+# the parse + embed on the beefy workstation's GPU instead of its CPU.
+#
+# Merge it ON TOP of remote_worker.yml — it is OPT-IN because the device
+# passthrough requires the GPU to be present (a CPU-only host should NOT use it;
+# the stock bundle already runs on CPU):
+#
+#   export OC_TARGET_URL=...  OC_WORKER_TOKEN=...  OC_DATA_DIR=/data/pdfs
+#   export VECTOR_EMBEDDER_API_KEY=change-me
+#   export RENDER_GID=$(stat -c '%g' /dev/dri/renderD128)   # host-specific
+#
+#   cd scripts/remote_ingest
+#   docker compose -f remote_worker.yml -f remote_worker.accel.yml build \
+#       docling-parser vector-embedder
+#   docker compose -f remote_worker.yml -f remote_worker.accel.yml up -d \
+#       docling-parser vector-embedder
+#   docker compose -f remote_worker.yml -f remote_worker.accel.yml run --rm worker plan
+#   docker compose -f remote_worker.yml -f remote_worker.accel.yml run --rm worker run --max-workers 8
+#
+# Accelerator family (torch wheel) is chosen per-host via env. Defaults target
+# Intel (discrete Arc / Battlemage, e.g. Arc Pro B70 — the recommended target):
+#   OC_DOCLING_ACCEL : auto|cpu|xpu|cuda|rocm   (default: xpu)
+#   OC_EMBED_ACCEL   : auto|cpu|xpu|cuda|rocm   (default: auto; embedder also uses
+#                      OpenVINO so on Intel it routes NPU>GPU automatically)
+#
+# NVIDIA: set OC_DOCLING_ACCEL=cuda OC_EMBED_ACCEL=cuda and replace the `devices`
+#   blocks below with the nvidia runtime (`deploy.resources...devices` / `--gpus all`).
+# AMD ROCm: set ACCEL=rocm and pass `/dev/kfd` + `/dev/dri` + `--group-add video`.
+# ===========================================================================
+
+services:
+  docling-parser:
+    image: oc-docling:${OC_DOCLING_ACCEL:-xpu}
+    build:
+      context: ../../compose/accelerated
+      dockerfile: docling/Dockerfile
+      args:
+        ACCEL: ${OC_DOCLING_ACCEL:-xpu}
+    devices:
+      - /dev/dri:/dev/dri
+    group_add:
+      - "${RENDER_GID:-993}"   # = $(stat -c '%g' /dev/dri/renderD128); host-specific
+    environment:
+      DOCLING_ACCEL: auto      # entrypoint auto-selects xpu/cuda/cpu at start
+
+  vector-embedder:
+    image: oc-embedder:${OC_EMBED_ACCEL:-auto}
+    build:
+      context: ../../compose/accelerated
+      dockerfile: embedder/Dockerfile
+      args:
+        ACCEL: ${OC_EMBED_ACCEL:-auto}
+    devices:
+      - /dev/dri:/dev/dri
+      # NPU only exists on Intel SoCs (e.g. Lunar Lake), not on discrete Arc.
+      # Harmless to omit on a discrete-GPU box; uncomment if the host has an NPU:
+      # - /dev/accel/accel0:/dev/accel/accel0
+    group_add:
+      - "${RENDER_GID:-993}"
+    environment:
+      EMBED_ACCEL: auto        # entrypoint auto-selects NPU>GPU>xpu>cpu at start
+      VECTOR_EMBEDDER_API_KEY: ${VECTOR_EMBEDDER_API_KEY:-}


### PR DESCRIPTION
> **Stacked on #2065** (the remote-ingest worker). The base branch is
> `feature/remote-ingest-worker` because this work edits remote-ingest files
> (`scripts/remote_ingest/`). After #2065 merges, retarget this PR to `main`.

## What & why

Locally-built, **auto-detecting** replacements for the `docling-parser` and
`vector-embedder` microservices that pick the best compute device at startup
(**CUDA · ROCm · Intel XPU · Intel NPU via OpenVINO · CPU**) and fall back to CPU
— so the same image "just works" on whatever host it lands on. Targets the beefy
off-cluster workstations the remote-ingest worker is built for.

A single image can't hold CUDA + ROCm + XPU torch (mutually-exclusive wheels), so
the accelerator *family* is a build-arg (`ACCEL=auto|cpu|xpu|cuda|rocm`); the
*device within it* is auto-selected at runtime and degrades to CPU.

## Contents (`compose/accelerated/`)

- **`accel_detect.py` + `entrypoint.sh`** — shared runtime hardware probe + device
  routing. Docling → torch `cuda/xpu/cpu`; embedder → OpenVINO (NPU preferred, to
  keep off the iGPU the parser uses, then GPU) or torch.
- **`embedder/`** — OpenVINO sentence-transformers image. `ov_npu.py` is a
  static-shape NPU engine (the NPU needs a fully-static graph the high-level
  `encode()` won't compile); its output is numerically identical to the reference
  (mean cosine 1.0).
- **`docling/`** — Docling rebuilt on the chosen torch wheel + an integrated-GPU
  `torch.xpu.mem_get_info` compatibility shim (`sitecustomize.py`) that fixes a
  transformers warmup crash on iGPUs.
- **`accel.override.yml`** — compose override that swaps both services into
  `local.yml` with GPU/NPU device passthrough.
- **`bench_parse.py`** — measure the real Docling GPU-vs-CPU speedup per host.
- **`scripts/remote_ingest/remote_worker.accel.yml`** — opt-in GPU override for the
  remote-ingest worker bundle.

Both Dockerfiles share one build context, so the detector + entrypoint are a
single source, not per-image copies.

## Measured (Intel Lunar Lake reference host)

- **Embedder: ~11× (NPU) / ~15× (iGPU)** vs the CPU service, output byte-identical.
  The real win — embeddings run per-annotation, batched.
- **Docling on the *integrated* GPU: a wash (~1.05×)** with a large kernel
  cold-start → the parser defaults to CPU there. A **discrete** GPU (NVIDIA, AMD
  ROCm, or Intel Arc Battlemage e.g. Arc Pro B70) is the right target for parser
  acceleration — Docling's own report shows 14× layout / 8× OCR / ~5–6×
  end-to-end on discrete GPUs. **Benchmark per host** (`bench_parse.py`) rather
  than assuming. Details in `compose/accelerated/README.md`.