### PR TITLE
Validate crawl_authorities tool bounds

### DIFF
--- a/opencontractserver/enrichment/constants.py
+++ b/opencontractserver/enrichment/constants.py
@@ -92,6 +92,11 @@ CRAWL_DEFAULT_PER_JURISDICTION_CAP = 15  # max ingests per (jurisdiction) per ru
 CRAWL_DEFAULT_TOKEN_BUDGET = (
     2_000_000  # cumulative est. tokens (text len / 4) before stop
 )
+# Upper bounds for caller-controlled crawl runs exposed through analyzer/tool APIs.
+CRAWL_MAX_DEPTH = 5
+CRAWL_MAX_AUTHORITIES = CRAWL_DEFAULT_MAX_AUTHORITIES
+CRAWL_MAX_PER_JURISDICTION_CAP = CRAWL_DEFAULT_PER_JURISDICTION_CAP
+CRAWL_MAX_TOKEN_BUDGET = CRAWL_DEFAULT_TOKEN_BUDGET
 # Punctuation stripped from the tail of a captured defined term
 # (e.g. (the "Notes," ...) -> "Notes").
 TRAILING_PUNCT = ",.;:"

--- a/opencontractserver/llms/tools/core_tools/corpus_references.py
+++ b/opencontractserver/llms/tools/core_tools/corpus_references.py
@@ -320,7 +320,11 @@ def crawl_authorities(
     return CrawlAuthoritiesService.crawl(
         creator_id=creator_id,
         corpus_id=corpus_id,
-        **bounds,
+        max_depth=bounds["max_depth"],
+        min_demand=bounds["min_demand"],
+        max_authorities=bounds["max_authorities"],
+        per_jurisdiction_cap=bounds["per_jurisdiction_cap"],
+        token_budget=bounds["token_budget"],
     )
 
 

--- a/opencontractserver/llms/tools/core_tools/corpus_references.py
+++ b/opencontractserver/llms/tools/core_tools/corpus_references.py
@@ -12,6 +12,52 @@ from opencontractserver.enrichment import constants as C
 from ._helpers import _db_sync_to_async
 
 
+def _validate_crawl_bound(name: str, value: int, *, minimum: int, maximum: int) -> int:
+    """Validate caller-controlled crawl bounds before reaching the shared queue."""
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ValueError(f"{name} must be an integer")
+    if value < minimum or value > maximum:
+        raise ValueError(f"{name} must be between {minimum} and {maximum}")
+    return value
+
+
+def _validated_crawl_bounds(
+    *,
+    max_depth: int,
+    min_demand: int,
+    max_authorities: int,
+    per_jurisdiction_cap: int,
+    token_budget: int,
+) -> dict[str, int]:
+    """Enforce safe ranges for the approval-gated crawl_authorities tool."""
+    return {
+        "max_depth": _validate_crawl_bound(
+            "max_depth", max_depth, minimum=0, maximum=C.CRAWL_MAX_DEPTH
+        ),
+        "min_demand": _validate_crawl_bound(
+            "min_demand", min_demand, minimum=0, maximum=1_000_000
+        ),
+        "max_authorities": _validate_crawl_bound(
+            "max_authorities",
+            max_authorities,
+            minimum=1,
+            maximum=C.CRAWL_MAX_AUTHORITIES,
+        ),
+        "per_jurisdiction_cap": _validate_crawl_bound(
+            "per_jurisdiction_cap",
+            per_jurisdiction_cap,
+            minimum=1,
+            maximum=C.CRAWL_MAX_PER_JURISDICTION_CAP,
+        ),
+        "token_budget": _validate_crawl_bound(
+            "token_budget",
+            token_budget,
+            minimum=1,
+            maximum=C.CRAWL_MAX_TOKEN_BUDGET,
+        ),
+    }
+
+
 def scan_corpus_references(
     *,
     corpus_id: int,
@@ -264,14 +310,17 @@ def crawl_authorities(
         CrawlAuthoritiesService,
     )
 
-    return CrawlAuthoritiesService.crawl(
-        creator_id=creator_id,
-        corpus_id=corpus_id,
+    bounds = _validated_crawl_bounds(
         max_depth=max_depth,
         min_demand=min_demand,
         max_authorities=max_authorities,
         per_jurisdiction_cap=per_jurisdiction_cap,
         token_budget=token_budget,
+    )
+    return CrawlAuthoritiesService.crawl(
+        creator_id=creator_id,
+        corpus_id=corpus_id,
+        **bounds,
     )
 
 

--- a/opencontractserver/llms/tools/tool_registry.py
+++ b/opencontractserver/llms/tools/tool_registry.py
@@ -472,7 +472,7 @@ AVAILABLE_TOOLS: tuple[ToolDefinition, ...] = (
         parameters=(
             (
                 "max_depth",
-                "Authority-to-authority hops past the cited seeds (default 2)",
+                "Authority-to-authority hops past the cited seeds (0-5; default 2)",
                 False,
             ),
             (
@@ -482,17 +482,17 @@ AVAILABLE_TOOLS: tuple[ToolDefinition, ...] = (
             ),
             (
                 "max_authorities",
-                "Hard cap on authorities ingested this run (default 50)",
+                "Hard cap on authorities ingested this run (1-50; default 50)",
                 False,
             ),
             (
                 "per_jurisdiction_cap",
-                "Max authorities ingested per jurisdiction per run",
+                "Max authorities ingested per jurisdiction per run (1-15)",
                 False,
             ),
             (
                 "token_budget",
-                "Approx token budget before the crawl stops",
+                "Approx token budget before the crawl stops (1-2000000)",
                 False,
             ),
         ),

--- a/opencontractserver/tasks/corpus_analysis_tasks.py
+++ b/opencontractserver/tasks/corpus_analysis_tasks.py
@@ -86,7 +86,7 @@ def corpus_reference_enrichment(
             "max_depth": {
                 "type": "integer",
                 "minimum": 0,
-                "maximum": 5,
+                "maximum": C.CRAWL_MAX_DEPTH,
                 "default": C.CRAWL_DEFAULT_MAX_DEPTH,
             },
             "min_demand": {
@@ -102,11 +102,13 @@ def corpus_reference_enrichment(
             "per_jurisdiction_cap": {
                 "type": "integer",
                 "minimum": 1,
+                "maximum": C.CRAWL_MAX_PER_JURISDICTION_CAP,
                 "default": C.CRAWL_DEFAULT_PER_JURISDICTION_CAP,
             },
             "token_budget": {
                 "type": "integer",
-                "minimum": 0,
+                "minimum": 1,
+                "maximum": C.CRAWL_MAX_TOKEN_BUDGET,
                 "default": C.CRAWL_DEFAULT_TOKEN_BUDGET,
             },
             "make_public": {"type": "boolean", "default": True},

--- a/opencontractserver/tests/test_enrichment_tools.py
+++ b/opencontractserver/tests/test_enrichment_tools.py
@@ -1,9 +1,9 @@
 """Tool-registry + tool-function tests for corpus reference enrichment."""
 
-from django.contrib.auth import get_user_model
-from django.core.files.base import ContentFile
 from unittest.mock import patch
 
+from django.contrib.auth import get_user_model
+from django.core.files.base import ContentFile
 from django.test import TestCase
 
 from opencontractserver.annotations.models import Annotation, CorpusReference

--- a/opencontractserver/tests/test_enrichment_tools.py
+++ b/opencontractserver/tests/test_enrichment_tools.py
@@ -2,6 +2,8 @@
 
 from django.contrib.auth import get_user_model
 from django.core.files.base import ContentFile
+from unittest.mock import patch
+
 from django.test import TestCase
 
 from opencontractserver.annotations.models import Annotation, CorpusReference
@@ -439,6 +441,60 @@ class CrawlAuthoritiesToolRegistryTests(TestCase):
         from opencontractserver.llms.tools.core_tools import (  # noqa: F401
             acrawl_authorities,
             crawl_authorities,
+        )
+
+    def test_crawl_authorities_rejects_unsafe_bounds(self):
+        from opencontractserver.llms.tools.core_tools.corpus_references import (
+            crawl_authorities,
+        )
+
+        with patch(
+            "opencontractserver.enrichment.services.crawl_authorities_service."
+            "CrawlAuthoritiesService.crawl"
+        ) as crawl:
+            with self.assertRaises(ValueError):
+                crawl_authorities(
+                    creator_id=1,
+                    corpus_id=1,
+                    per_jurisdiction_cap=0,
+                )
+            with self.assertRaises(ValueError):
+                crawl_authorities(creator_id=1, corpus_id=1, token_budget=0)
+            with self.assertRaises(ValueError):
+                crawl_authorities(
+                    creator_id=1,
+                    corpus_id=1,
+                    max_authorities=1_000_000,
+                )
+
+        crawl.assert_not_called()
+
+    def test_crawl_authorities_forwards_valid_bounds(self):
+        from opencontractserver.llms.tools.core_tools.corpus_references import (
+            crawl_authorities,
+        )
+
+        with patch(
+            "opencontractserver.enrichment.services.crawl_authorities_service."
+            "CrawlAuthoritiesService.crawl",
+            return_value={"ok": True},
+        ) as crawl:
+            out = crawl_authorities(
+                creator_id=1,
+                corpus_id=2,
+                per_jurisdiction_cap=1,
+                token_budget=1,
+            )
+
+        assert out == {"ok": True}
+        crawl.assert_called_once_with(
+            creator_id=1,
+            corpus_id=2,
+            max_depth=2,
+            min_demand=2,
+            max_authorities=50,
+            per_jurisdiction_cap=1,
+            token_budget=1,
         )
 
     def test_crawl_authorities_in_function_registry(self):


### PR DESCRIPTION
### Motivation
- The agent-facing `crawl_authorities` tool forwarded `per_jurisdiction_cap` and `token_budget` directly to the shared crawl service without range validation, allowing zero/invalid values to park the global frontier or disable quotas and enabling a denial-of-service/queue tampering vector.

### Description
- Add explicit safe maxima constants (`CRAWL_MAX_DEPTH`, `CRAWL_MAX_AUTHORITIES`, `CRAWL_MAX_PER_JURISDICTION_CAP`, `CRAWL_MAX_TOKEN_BUDGET`) in `opencontractserver/enrichment/constants.py` to centralize caller-controlled bounds.
- Add `_validate_crawl_bound` and `_validated_crawl_bounds` to `opencontractserver/llms/tools/core_tools/corpus_references.py` and enforce these checks before forwarding args to `CrawlAuthoritiesService.crawl` so non-integer, out-of-range, or zero/negative values are rejected.
- Update the analyzer input schema in `opencontractserver/tasks/corpus_analysis_tasks.py` to reference the new maxima and require `token_budget >= 1` and `per_jurisdiction_cap >= 1` to match the tool validation.
- Update the `crawl_authorities` parameter descriptions in `opencontractserver/llms/tools/tool_registry.py` to document the enforced safe ranges, and add unit tests in `opencontractserver/tests/test_enrichment_tools.py` that assert unsafe bounds raise `ValueError` and valid bounds are forwarded to the crawl service (tests patch the crawl call).

### Testing
- Ran `python -m compileall` over the modified modules which succeeded without syntax errors.
- Attempted `pytest opencontractserver/tests/test_enrichment_tools.py::CrawlAuthoritiesToolRegistryTests -q` but the run failed in this environment due to a missing test dependency: `ModuleNotFoundError: No module named 'django'`.
- The added unit tests patch `CrawlAuthoritiesService.crawl` and are intended to run in the repository CI or a developer environment with Django installed; they verify unsafe inputs are rejected and valid inputs are forwarded to the service.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a41a9c7cfd883288df73a0de438a471)