### PR TITLE
Corpus-home follow-ups: null-title crash + dead Artifact.is_public surface

### DIFF
--- a/changelog.d/2095-corpus-home-followups.fixed.md
+++ b/changelog.d/2095-corpus-home-followups.fixed.md
@@ -1,0 +1,12 @@
+- **Fixed a null-title crash in the corpus-home Collection Overview panel.**
+  `IntelligencePanel.tsx`'s documents-index sort comparator
+  (`frontend/src/components/corpuses/CorpusHome/intelligence/IntelligencePanel.tsx`)
+  called `a.title.localeCompare(b.title)` directly. `Document.title` is
+  `CharField(null=True, blank=True)` (`opencontractserver/documents/models.py`),
+  so a document with a `null` title (mid-ingest, or a parser that never set
+  one) threw a `TypeError` and crashed the entire panel for that corpus. The
+  render path already guarded with `doc.title || "Untitled document"`; the
+  comparator now applies the same `(a.title || "").localeCompare(b.title || "")`
+  guard. Added a regression test to `frontend/tests/IntelligencePanel.ct.tsx`
+  that mounts the panel with a null-titled document and asserts it renders
+  (rather than throwing) with the "Untitled document" fallback. (#2095)

--- a/changelog.d/2095-corpus-home-followups.removed.md
+++ b/changelog.d/2095-corpus-home-followups.removed.md
@@ -1,0 +1,31 @@
+- **Removed the dead `Artifact.is_public` override surface (docstring/behavior
+  mismatch flagged in a post-merge review of #2077).** The `Artifact` model's
+  docstring (`opencontractserver/corpuses/models.py`) claimed visibility was
+  "corpus-as-gate OR `is_public`", but no read path ever implemented the
+  `is_public` branch: `ArtifactService._corpus_readable`
+  (`opencontractserver/corpuses/services/artifact_service.py`) — the sole gate
+  used by `get_by_slug`, `list_for_corpus`, `update_captions`, `set_image` —
+  checks only the source corpus's visibility. `ArtifactService.create`'s
+  `is_public: bool = True` parameter was passed straight to
+  `Artifact.objects.create(...)` but never consulted by anything, and the
+  `CreateArtifact` GraphQL mutation didn't even expose it as an argument.
+  Not exploitable (the code was already more restrictive than documented,
+  never less), but a footgun: a future change that "fixed" the code to match
+  the documented OR-semantic would have silently reopened an IDOR (a
+  public-flagged artifact on a private corpus leaking that corpus's data to
+  anyone with the artifact's slug). Removed the `is_public` parameter from
+  `ArtifactService.create` and its `Artifact.objects.create(...)` kwarg, the
+  `is_public` field from `ArtifactType` (`config/graphql/corpus_types.py`) and
+  `_artifact_to_type` (`config/graphql/corpus_queries.py`), and the `isPublic`
+  field from the `ArtifactNode` interface/queries in
+  `frontend/src/graphql/queries.ts` (fetched but never branched on by any
+  component). Corrected the three docstrings that repeated the OR-semantic
+  claim to state the actual corpus-as-gate-ONLY behavior. Note: the
+  `is_public` *column* itself is inherited from `BaseOCModel` (every
+  BaseOCModel subclass — Document, Corpus, Annotation, etc. — has its own copy
+  via abstract-base inheritance) and is used generically by
+  `BaseVisibilityManager`/`visible_to_user()` elsewhere in the system; dropping
+  it from the database would require decoupling `Artifact` from `BaseOCModel`
+  entirely, which is out of scope here, so the column stays present but is no
+  longer read, set, or documented as meaningful for `Artifact` specifically. No
+  migration was needed. (#2095)

--- a/config/graphql/corpus_mutations.py
+++ b/config/graphql/corpus_mutations.py
@@ -1755,8 +1755,9 @@ class CreateArtifact(graphene.Mutation):
     """Create a shareable poster (Artifact) of a corpus from a template.
 
     READ-gated on the corpus (you can make a poster of any collection you can
-    see); the artifact is public by default so its ``/a/<slug>`` link is
-    shareable, but its data still only renders to viewers who can read the
+    see): its ``/a/<slug>`` link is shareable to anyone who can read the
+    source corpus (corpus-as-gate ONLY — there is no per-artifact visibility
+    override), and its data still only renders to viewers who can read the
     corpus. ``template`` is validated against the service's registry.
     """
 

--- a/config/graphql/corpus_queries.py
+++ b/config/graphql/corpus_queries.py
@@ -99,7 +99,6 @@ def _artifact_to_type(a: Any) -> "ArtifactType":
         corpus_id=to_global_id("CorpusType", a.corpus_id),
         corpus_slug=a.corpus.slug if a.corpus_id else None,
         creator_slug=getattr(a.creator, "slug", None) if a.creator_id else None,
-        is_public=a.is_public,
         image_url=(a.image.url if a.image else None),
         created=a.created,
     )

--- a/config/graphql/corpus_types.py
+++ b/config/graphql/corpus_types.py
@@ -1091,7 +1091,6 @@ class ArtifactType(graphene.ObjectType):
     corpus_id = graphene.ID(required=True)
     corpus_slug = graphene.String()
     creator_slug = graphene.String()
-    is_public = graphene.Boolean()
     image_url = graphene.String()
     created = graphene.DateTime()
 

--- a/frontend/src/components/corpuses/CorpusHome/intelligence/IntelligencePanel.tsx
+++ b/frontend/src/components/corpuses/CorpusHome/intelligence/IntelligencePanel.tsx
@@ -347,7 +347,9 @@ export const IntelligencePanel: React.FC<IntelligencePanelProps> = ({
       (data?.documents?.edges ?? [])
         .map((e) => e.node)
         .sort(
-          (a, b) => a.title.localeCompare(b.title) || a.id.localeCompare(b.id)
+          (a, b) =>
+            (a.title || "").localeCompare(b.title || "") ||
+            a.id.localeCompare(b.id)
         ),
     [data]
   );

--- a/frontend/src/graphql/queries.ts
+++ b/frontend/src/graphql/queries.ts
@@ -392,7 +392,6 @@ export interface ArtifactNode {
   config?: Record<string, unknown> | null;
   corpusId: string;
   corpusSlug?: string | null;
-  isPublic?: boolean | null;
   imageUrl?: string | null;
 }
 
@@ -415,7 +414,6 @@ export const GET_ARTIFACT_BY_SLUG = gql`
       config
       corpusId
       corpusSlug
-      isPublic
       imageUrl
     }
   }

--- a/frontend/tests/ArtifactPosterRoute.ct.tsx
+++ b/frontend/tests/ArtifactPosterRoute.ct.tsx
@@ -47,7 +47,6 @@ const beeswarmArtifact = {
   config: { noun: "contracts" },
   corpusId: CORPUS_ID,
   corpusSlug: "acme",
-  isPublic: true,
   imageUrl: null,
 };
 

--- a/frontend/tests/IntelligencePanel.ct.tsx
+++ b/frontend/tests/IntelligencePanel.ct.tsx
@@ -32,7 +32,7 @@ const CORPUS_ID = "Q29ycHVzVHlwZTox";
 
 interface DocSeed {
   id: string;
-  title: string;
+  title: string | null;
   description?: string;
   pageCount?: number;
 }
@@ -400,6 +400,44 @@ test.describe("IntelligencePanel", () => {
     await entry.focus();
     await entry.press("Enter");
     await expect(page.locator(PANEL)).toBeVisible();
+
+    await component.unmount();
+  });
+
+  test("sorts and renders documents with a null title without crashing", async ({
+    mount,
+    page,
+  }) => {
+    // Document.title is nullable on the backend (CharField(null=True)), so the
+    // GraphQL field can come back null — e.g. mid-ingest, or a parser that
+    // never set one. The client-side sort comparator must not call
+    // .localeCompare() directly on a null title, or it throws and takes down
+    // the whole panel for the corpus.
+    const docs: DocSeed[] = [
+      { id: "Doc1", title: "Zeta Agreement", pageCount: 5 },
+      { id: "Doc2", title: null, pageCount: 2 },
+      { id: "Doc3", title: "Alpha Agreement", pageCount: 1 },
+    ];
+
+    const component = await mount(
+      <MemoryRouter>
+        <MockedProvider
+          mocks={[docsMock(docs, 3), governanceMock(0), setupStatusSilentMock]}
+          addTypename={false}
+        >
+          <IntelligencePanel corpusId={CORPUS_ID} />
+        </MockedProvider>
+      </MemoryRouter>
+    );
+
+    // The panel must render (not crash) and show all three entries, with the
+    // null-title document falling back to the same placeholder used for
+    // empty-string titles.
+    await expect(page.locator(PANEL)).toBeVisible({ timeout: 10000 });
+    await expect(page.locator(ENTRY)).toHaveCount(3);
+    await expect(page.locator(PANEL)).toContainText("Untitled document");
+    await expect(page.locator(PANEL)).toContainText("Zeta Agreement");
+    await expect(page.locator(PANEL)).toContainText("Alpha Agreement");
 
     await component.unmount();
   });

--- a/opencontractserver/corpuses/models.py
+++ b/opencontractserver/corpuses/models.py
@@ -2617,9 +2617,9 @@ class Artifact(BaseOCModel):
 
     Templates carry no per-corpus logic — the corpus + the caption/config fields
     are the only per-artifact state, so the same template generalises to any
-    collection whose data supports it. Visibility is corpus-as-gate (the source
-    corpus must be READ-visible) OR ``is_public``; managed by ``ArtifactService``,
-    so no per-object guardian tables are needed.
+    collection whose data supports it. Visibility is corpus-as-gate ONLY (the
+    source corpus must be READ-visible); managed by ``ArtifactService``, so no
+    per-object guardian tables are needed.
     """
 
     corpus = django.db.models.ForeignKey(
@@ -2651,6 +2651,16 @@ class Artifact(BaseOCModel):
     # requires an authenticated user (``ArtifactService.create`` rejects
     # anonymous callers). A non-null creator is the DB-level backstop against
     # anonymous writes.
+    #
+    # NOTE: the inherited ``BaseOCModel.is_public`` column is NOT used for
+    # Artifact access control (issue #2095) — every read path
+    # (``ArtifactService._corpus_readable``) checks the *corpus's* visibility
+    # directly and never branches on this field. It cannot be dropped from
+    # this model without decoupling ``Artifact`` from ``BaseOCModel`` (every
+    # BaseOCModel subclass gets its own copy of the field via abstract-base
+    # inheritance, so it is not Artifact-specific plumbing), so it stays
+    # present but inert; application code (service / GraphQL / frontend) does
+    # not read or set it.
 
     class Meta:
         indexes = [

--- a/opencontractserver/corpuses/services/artifact_service.py
+++ b/opencontractserver/corpuses/services/artifact_service.py
@@ -173,7 +173,6 @@ class ArtifactService(BaseService):
         subtitle: str = "",
         byline: str = "",
         config: dict | None = None,
-        is_public: bool = True,
         request: Any = None,
     ) -> Artifact | None:
         """Create an artifact for a corpus the caller can read.
@@ -181,8 +180,9 @@ class ArtifactService(BaseService):
         Requires an **authenticated** creator — anonymous users may *view* a
         public corpus's posters but may not mint new ones (no anonymous DB
         writes). Gated at READ on top of that (you can make a poster of any
-        collection you can see); the artifact is public by default so its
-        ``/a/<slug>`` link is shareable, but its data still only renders to
+        collection you can see): its ``/a/<slug>`` link is shareable to anyone
+        who can read the source corpus (corpus-as-gate ONLY — there is no
+        per-artifact visibility override), and its data still only renders to
         viewers who can read the corpus.
         """
         if not getattr(user, "is_authenticated", False):
@@ -199,7 +199,6 @@ class ArtifactService(BaseService):
             subtitle=subtitle or "",
             byline=byline or "",
             config=config or {},
-            is_public=is_public,
             creator=user,
         )
         # Refetch with corpus/creator prefetched: the CreateArtifact mutation


### PR DESCRIPTION
## Summary

Two independent, small fixes from a post-merge review of #2077 (corpus-home editorial redesign), per #2095.

**1. Crash risk: null-title sort in `IntelligencePanel.tsx`**

`frontend/src/components/corpuses/CorpusHome/intelligence/IntelligencePanel.tsx`'s documents-index sort comparator called `a.title.localeCompare(b.title)` directly. `Document.title` is `CharField(null=True, blank=True)` (`opencontractserver/documents/models.py`), so a document with a `null` title (mid-ingest, or a parser that never set one) threw a `TypeError` and crashed the entire Collection Overview panel for that whole corpus. The render path already guards with `doc.title || "Untitled document"`; the sort comparator now applies the same guard:

```ts
.sort((a, b) => (a.title || "").localeCompare(b.title || "") || a.id.localeCompare(b.id))
```

Added a regression test to `frontend/tests/IntelligencePanel.ct.tsx` ("sorts and renders documents with a null title without crashing") that mounts the panel with a null-titled document among others and asserts the panel renders without throwing, with "Untitled document" shown for that row.

**2. Dead `Artifact.is_public` field (docstring/behavior mismatch)**

The `Artifact` model's docstring claimed visibility was "corpus-as-gate (the source corpus must be READ-visible) OR `is_public`" — but no read path ever implemented the OR-`is_public` branch. Every visibility check gates purely on corpus-as-gate (`ArtifactService._corpus_readable`), and the `CreateArtifact` GraphQL mutation never even exposed `is_public` as an argument (it was always `True`, silently). Not exploitable today (the code was already more restrictive than documented, never less), but a footgun: a future change that "fixed" the code to match the documented OR-semantic would silently reopen an IDOR (a public-flagged artifact on a private corpus leaking that corpus's data to anyone with the artifact's slug).

**Decision: removed the dead surface** rather than wiring `is_public` into a real per-artifact override — grepped the whole repo (backend services/tests/GraphQL, frontend queries/components) and found zero live consumers of `Artifact.is_public` for access control, and no frontend UI branches on the field at all (it was fetched but never read). No open issues/PRs signal a near-term want for per-artifact visibility overrides. This matches the repo's "no dead code" / YAGNI conventions.

Changes:
- Removed `is_public` parameter from `ArtifactService.create` and its `Artifact.objects.create(...)` kwarg (`opencontractserver/corpuses/services/artifact_service.py`).
- Removed `is_public` field from `ArtifactType` (`config/graphql/corpus_types.py`) and from `_artifact_to_type` (`config/graphql/corpus_queries.py`).
- Removed `isPublic` from the `ArtifactNode` interface/query in `frontend/src/graphql/queries.ts` and from the test mock in `frontend/tests/ArtifactPosterRoute.ct.tsx`.
- Corrected the three docstrings that repeated the stale OR-semantic claim (`Artifact` model, `ArtifactService.create`, `CreateArtifact` mutation) to state the actual corpus-as-gate-ONLY behavior.

**Important finding for reviewers:** the underlying `is_public` *database column* is inherited from `BaseOCModel` (every `BaseOCModel` subclass — `Document`, `Corpus`, `Annotation`, etc. — gets its own copy of this field via abstract-base inheritance, and it's used generically by `BaseVisibilityManager`/`visible_to_user()` elsewhere in the codebase). It is **not** Artifact-specific plumbing, so it cannot be cleanly dropped from just the `Artifact` table without decoupling `Artifact` from `BaseOCModel` entirely — an unrelated, much larger refactor that's out of scope here. No migration was needed; `python manage.py makemigrations --check` confirms no pending schema changes. The column stays present in the `artifacts` table but is no longer read, set, or documented as meaningful for `Artifact` specifically (see the new NOTE comment on the model).

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `yarn test:ct --reporter=list -g "IntelligencePanel"` — 9/9 passed (including the new null-title regression test)
- [x] `yarn test:ct --reporter=list -g "ArtifactPosterRoute"` — 4/4 passed
- [x] `yarn lint` — clean
- [x] `docker compose -f test.yml run --rm --no-deps django pytest opencontractserver/tests/test_artifact_service.py -n 4 --dist loadscope --create-db` — 25/25 passed
- [x] `docker compose -f test.yml run --rm --no-deps django python manage.py makemigrations --check --dry-run` — "No changes detected"
- [x] `docker compose -f test.yml run --rm --no-deps django python manage.py check` — no issues (covers the `opencontracts.E001` service-layer check)
- [x] `docker compose -f test.yml run --rm --no-deps django pytest opencontractserver/tests/architecture/test_graphql_service_layer.py opencontractserver/tests/architecture/test_frontend_graphql_documents.py -n 4 --dist loadscope` — 91/91 passed (confirms the frontend GraphQL query edits still validate against the live schema)
- [x] `pre-commit run --all-files` (backend files) — black/isort/flake8/mypy/pyupgrade all clean

Closes #2095