### PR TITLE
Add authority discovery providers for bulk publisher-index crawl (Phase 2, #2054)

### DIFF
--- a/changelog.d/2054-authority-discovery-providers.added.md
+++ b/changelog.d/2054-authority-discovery-providers.added.md
@@ -1,0 +1,39 @@
+- **Authority discovery providers (Phase 2 of the Authority Packs proposal, closes #2054).**
+  Added `BaseAuthorityDiscoveryProvider`
+  (`opencontractserver/pipeline/base/base_authority_discovery_provider.py`): unlike
+  the citation-KEYED `BaseAuthoritySourceProvider`, a discovery provider crawls a
+  publisher's index/listing page(s) for documents nobody has cited yet and lists
+  candidates (`DiscoveryCandidate`: canonical_key + url + metadata) without
+  fetching or ingesting them. Mirrors the existing `locate`/`fetch` split as
+  `_fetch_index_impl` (I/O, SSRF-gated via `safe_fetch_text`) /
+  `_parse_index_impl` (pure). `discover_candidates()` is bounded by
+  `enrichment.constants.DISCOVERY_DEFAULT_MAX_CANDIDATES` /
+  `DISCOVERY_MAX_MAX_CANDIDATES`, de-dupes by canonical_key across pages, records
+  per-URL fetch failures (including SSRF rejections) in `skipped_index_urls`
+  rather than aborting the whole run, and refuses to run unless
+  `license == "public-domain"`.
+- Added one reference implementation, `ListingIndexDiscoveryProvider`
+  (`opencontractserver/pipeline/authority_discovery_providers/listing_index_provider.py`):
+  a config-driven, jurisdiction-agnostic regex+template crawler — a publisher
+  supplies a `ListingIndexRule` (link regex + canonical-key template), not new
+  code. Illustrated/tested against a synthetic, Gaceta-Oficial-*shaped* fixture
+  (Bolivia is the proposal's motivating case), not a verified live scraper.
+- Added `AuthorityFrontierService.seed_from_discovery`
+  (`opencontractserver/enrichment/services/authority_frontier_service.py`): the
+  idempotent frontier-seeding entrypoint for discovery candidates, mirroring
+  `seed_child_keys`'s contract exactly — a `canonical_key` that already has a
+  row (any depth/state) is skipped, so re-running never duplicates rows and
+  never resets an in-flight row's `discovery_state`.
+- Extended the pipeline registry (`opencontractserver/pipeline/registry.py`) to
+  auto-discover `BaseAuthorityDiscoveryProvider` subclasses the same way as
+  `BaseAuthoritySourceProvider` — core `authority_discovery_providers/` package
+  plus in-pack `<pack>/discovery_providers/*.py` — via a generalized
+  `_discover_pack_component_classes` helper (replacing the source-provider-only
+  `_discover_pack_provider_classes`). New `ComponentType.AUTHORITY_DISCOVERY_PROVIDER`
+  and `get_all_authority_discovery_providers_cached()`.
+- Added the `discover_authority_candidates` management command
+  (`opencontractserver/annotations/management/commands/discover_authority_candidates.py`)
+  as the operator entrypoint (`--index-url` / `--link-pattern` /
+  `--canonical-key-template` / `--prefix` / `--max-candidates` / `--dry-run`) —
+  no admin UI, by design (deferred alongside Phase 3/4 scheduling and
+  multi-corpus orchestration).

--- a/docs/architecture/proposals/0002-authority-packs.md
+++ b/docs/architecture/proposals/0002-authority-packs.md
@@ -50,6 +50,39 @@ rather than against a `scraping/` app that was never built.
 > The remaining gaps (scheduled scraping, multi-corpus orchestration,
 > config-declarable `authority_type`/shape grammars) are unchanged.
 
+> **Update — Phase 2 (listing-index discovery, gap 3) shipped, issue #2054.**
+> `BaseAuthorityDiscoveryProvider`
+> (`opencontractserver/pipeline/base/base_authority_discovery_provider.py`) answers
+> the question a citation-keyed `BaseAuthoritySourceProvider` cannot: "what
+> documents exist that nobody has cited yet". It crawls a publisher's index page(s)
+> and lists candidates (canonical_key + url + metadata) WITHOUT fetching or
+> ingesting them — mirroring the `locate`/`fetch` split as `_fetch_index_impl`
+> (I/O) / `_parse_index_impl` (pure). The one reference implementation,
+> `ListingIndexDiscoveryProvider`
+> (`opencontractserver/pipeline/authority_discovery_providers/listing_index_provider.py`),
+> is a config-driven regex+template engine — jurisdiction-agnostic; a publisher
+> supplies a `ListingIndexRule` (link regex + canonical-key template), not new
+> code. Candidates are seeded into `AuthorityFrontier` via the new
+> `AuthorityFrontierService.seed_from_discovery`, which mirrors `seed_child_keys`'
+> idempotency contract exactly (skip, never duplicate, never reset an in-flight
+> row). The pipeline registry discovers discovery providers the same way as
+> source providers (core package + `<pack>/discovery_providers/`). Bounded by
+> `enrichment.constants.DISCOVERY_DEFAULT_MAX_CANDIDATES` /
+> `DISCOVERY_MAX_MAX_CANDIDATES`, and every fetch is SSRF- and
+> license-gated, same as Phase 1. Operator surface is the
+> `discover_authority_candidates` management command — **no admin UI** (out of
+> scope for #2054; deferred to a future console surface alongside Phase 3/4).
+> The shipped `bolivia` pack is NOT wired to a live index (nobody has verified
+> Gaceta Oficial's real markup in this codebase); the engine is proven against a
+> synthetic, Gaceta-Oficial-*shaped* fixture in
+> `test_listing_index_discovery_provider.py`. An operator who has verified a real
+> publisher's markup supplies their own `ListingIndexRule`. Tests:
+> `test_authority_discovery_provider_base.py`,
+> `test_listing_index_discovery_provider.py`,
+> `test_authority_frontier_discovery_seed.py`,
+> `test_discover_authority_candidates_command.py`, plus the pack-discovery
+> additions in `test_authority_pack_providers.py`.
+
 ## 1. Context — three artifacts, one intent
 
 | Artifact | What it is | Status |
@@ -197,7 +230,7 @@ co-author.
 |---|---|---|---|---|
 | 1 | Host allowlist is a hardcoded frozenset — a pack cannot open a new fetch host as data | **Blocker** (trivial fix) | Only with a live provider | Phase 2 (one-line edit) / #2057 makes it declarative |
 | 2 | No scheduled/recurring scraping (`CELERY_BEAT_SCHEDULE` has no crawl entries) | Major | If continuous ingestion is in scope | Phase 3 (= #1444 Phase A) |
-| 3 | Provider rail is citation-keyed; no listing-page bulk-discovery shape | Major | If publisher-crawl is in scope | Phase 2 |
+| 3 | Provider rail is citation-keyed; no listing-page bulk-discovery shape | Major | If publisher-crawl is in scope | **Phase 2 — shipped, issue #2054** |
 | 4 | No multi-corpus orchestration (`CorpusGroup` / cross-corpus retrieval) | Major | No (per-area corpora work independently) | Phase 4 (= #1444 Phase B) |
 | 5 | Spanish / sala-aware classification has no core primitive | Minor | Spanish: no (data); sala-aware: with provider | Phase 1 handles Spanish via aliases/persona; sala-aware → Phase 2 provider code |
 | 6 | Provider discovery scans one hardcoded package — no out-of-tree isolation | Minor | No | Future (enables entry-point packs + DB-driven allowlist) |
@@ -214,10 +247,12 @@ two primitives #1444 already identified as genuinely missing.
   edit). The live-fetch provider folds into Phase 2 because the Bolivian sources
   are listing-page, not key-addressable. *Handles the Spanish half of gap 5 via
   data.*
-- **Phase 2 — listing-page discovery (optional).** A `DiscoveryProvider`
-  abstraction that crawls a publisher index for *unknown* new documents and
-  seeds frontier rows. Needed only if the pack must find documents nobody has
-  cited yet. *Closes gap 3.*
+- **Phase 2 — listing-page discovery (shipped, issue #2054).**
+  `BaseAuthorityDiscoveryProvider` crawls a publisher index for *unknown* new
+  documents and seeds frontier rows via `AuthorityFrontierService
+  .seed_from_discovery`, with one config-driven reference implementation
+  (`ListingIndexDiscoveryProvider`). See the implementation-status callout
+  above for the full shape. *Closes gap 3.*
 - **Phase 3 — scheduled scraping (= #1444 Phase A).** A declarative
   "crawl publisher X into corpus Y nightly" surface (`PeriodicTask` / Beat sync).
   A core feature, not pack data. *Closes gap 2.*
@@ -235,7 +270,9 @@ queryable Bolivia deployment on its own.
    out-of-tree isolation (entry-point discovery + DB-driven host allowlist, gap 6)
    so packs never touch core's tree?
 2. **Scope** — citation-driven only (Phase 1), or also bulk publisher discovery
-   (Phase 2)?
+   (Phase 2)? Resolved: Phase 2 shipped (issue #2054) as a generic engine; wiring
+   a *verified* live rule for any specific publisher (Bolivia included) is left
+   to an operator who has inspected that site's real markup.
 3. **Scheduling** — is continuous nightly ingestion in scope (Phase 3), or does
    operator-triggered ingestion suffice?
 4. **Unified query** — is the cross-area `askBolivianLaw` experience a requirement

--- a/docs/guides/authoring-authority-packs.md
+++ b/docs/guides/authoring-authority-packs.md
@@ -22,7 +22,8 @@ original design rationale and the gap/phasing analysis see the proposal,
   authority_mappings.<name>.yaml     # taxonomy: prefixes / equivalences / rewrite_rules
   specs/<area>.json                  # curated section content (one doc per section)
   personas/<area>.txt                # agent persona → Corpus.corpus_agent_instructions
-  providers/<name>_provider.py       # OPTIONAL: the pack's scraper (discovered from here)
+  providers/<name>_provider.py       # OPTIONAL: citation-keyed scraper (discovered from here)
+  discovery_providers/<name>.py      # OPTIONAL: listing-index crawler (discovered from here)
 ```
 
 The reference pack lives at
@@ -40,6 +41,7 @@ changes** to accept a new pack:
 | Curated content (per legal area) | `specs/<area>.json` | `bootstrap_authority_corpus()` → keyed authority documents | optional |
 | Agent persona (per corpus) | `personas/<area>.txt` | `Corpus.corpus_agent_instructions` | optional |
 | Fetch provider ("scraper") | `providers/<name>_provider.py` | `BaseAuthoritySourceProvider`, discovered from the pack dir | optional |
+| Discovery provider (listing-index crawler) | `discovery_providers/<name>.py` | `BaseAuthorityDiscoveryProvider`, discovered the same way | optional |
 | Source hosts (for a scraper) | `pack.yaml` `source_hosts:` | the SSRF allowlist, merged at runtime | optional |
 | Provider credentials | the `PipelineSettings` encrypted-secrets vault (**not** a pack file) | `get_component_settings()`, keyed by provider class path | optional |
 
@@ -100,6 +102,31 @@ instead of in core's `pipeline/authority_source_providers/`:
 4. Put any credentials in the secrets vault (above), never in the pack.
 
 All sources must be **public-domain**; the gate blocks any other license.
+
+## Discovering UNKNOWN documents (listing-index crawl)
+
+A `BaseAuthoritySourceProvider` needs a *known* `canonical_key` — it cannot find
+documents nobody has cited yet. For a publisher whose site is a browsable
+listing/index (not key-addressable) — the motivating case is Bolivia's Gaceta
+Oficial, per [0002 — Authority Packs](../architecture/proposals/0002-authority-packs.md)
+§7 — use `BaseAuthorityDiscoveryProvider`
+(`opencontractserver/pipeline/base/base_authority_discovery_provider.py`)
+instead. It crawls index page(s) and lists candidates (canonical_key + url +
+metadata) *without* fetching or ingesting them; `AuthorityFrontierService
+.seed_from_discovery` then queues the candidates for the normal discovery
+runtime.
+
+The shipped reference implementation, `ListingIndexDiscoveryProvider`
+(`opencontractserver/pipeline/authority_discovery_providers/listing_index_provider.py`),
+is config-driven and jurisdiction-agnostic: supply a `ListingIndexRule` (a link
+regex + a canonical-key template) rather than writing new code. Ship one in
+`<pack>/discovery_providers/*.py` (discovered the same way as `providers/`) only
+if a publisher's markup needs bespoke parsing beyond that rule.
+
+The operator surface is the `discover_authority_candidates` management command
+(`--index-url` / `--link-pattern` / `--canonical-key-template` / `--prefix`, plus
+`--dry-run` to preview before seeding) — there is no admin UI for discovery
+(scope of issue #2054); see the command's docstring for a worked example.
 
 ## Add / remove / copy
 

--- a/opencontractserver/annotations/management/commands/discover_authority_candidates.py
+++ b/opencontractserver/annotations/management/commands/discover_authority_candidates.py
@@ -1,0 +1,137 @@
+"""Operator entrypoint for authority DISCOVERY (Phase 2, issue #2054).
+
+Crawls a publisher's index/listing page(s) for candidate documents nobody has
+cited yet, and seeds ``AuthorityFrontier`` so the existing discovery/crawl
+runtime can pick them up later (see
+``AuthorityFrontierService.seed_from_discovery``). This is a deliberately thin,
+backend-only surface — no admin UI (explicitly out of scope for issue #2054); a
+superuser-invocable management command (or the Django shell, calling the same
+service methods directly) is the intended operator surface.
+
+See ``docs/architecture/proposals/0002-authority-packs.md`` §7 and
+``docs/guides/authoring-authority-packs.md``.
+
+Example — crawl a listing page whose rows look like
+``<a href="/doc/2024-1234">Gaceta Oficial 2024-1234</a>``::
+
+    manage.py discover_authority_candidates \\
+      --index-url https://example.gov/gaceta/listing \\
+      --link-pattern '<a href="(?P<url>/doc/(?P<id>[^"]+))">(?P<title>[^<]+)</a>' \\
+      --canonical-key-template '{prefix}:{id}' \\
+      --prefix bo-gaceta \\
+      --dry-run
+
+``--dry-run`` prints discovered candidates without writing to the frontier —
+useful for iterating on ``--link-pattern`` against a real index page before
+committing. Every fetch is SSRF-gated (``opencontractserver/utils/safe_http.py``)
+regardless of ``--dry-run``: an index URL whose host is not on the effective
+allowlist is rejected before any request is made.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from django.core.management.base import BaseCommand, CommandError
+
+from opencontractserver.enrichment.constants import DISCOVERY_DEFAULT_MAX_CANDIDATES
+from opencontractserver.enrichment.services.authority_frontier_service import (
+    AuthorityFrontierService,
+)
+from opencontractserver.pipeline.authority_discovery_providers.listing_index_provider import (
+    ListingIndexDiscoveryProvider,
+    ListingIndexRule,
+)
+
+
+class Command(BaseCommand):
+    help = (
+        "Crawl a publisher's index/listing page(s) for undiscovered authority "
+        "candidates and seed AuthorityFrontier (Phase 2, issue #2054)."
+    )
+
+    def add_arguments(self, parser: Any) -> None:
+        parser.add_argument(
+            "--index-url",
+            action="append",
+            required=True,
+            dest="index_urls",
+            help="Index/listing page URL to crawl. Repeatable for pagination.",
+        )
+        parser.add_argument(
+            "--link-pattern",
+            required=True,
+            help=(
+                "Regex applied to the fetched index page HTML (re.finditer). "
+                "MUST define a named group 'url'; MAY define others (e.g. 'id', "
+                "'title') consumed by --canonical-key-template."
+            ),
+        )
+        parser.add_argument(
+            "--canonical-key-template",
+            required=True,
+            help="str.format template consuming 'prefix' + the regex's named "
+            "groups, e.g. '{prefix}:{id}'.",
+        )
+        parser.add_argument(
+            "--prefix",
+            required=True,
+            help="canonical_key prefix/authority for this source, e.g. 'bo-gaceta'.",
+        )
+        parser.add_argument(
+            "--max-candidates",
+            type=int,
+            default=DISCOVERY_DEFAULT_MAX_CANDIDATES,
+            help=f"Per-run candidate cap (default {DISCOVERY_DEFAULT_MAX_CANDIDATES}).",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Print discovered candidates without seeding AuthorityFrontier.",
+        )
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        try:
+            rule = ListingIndexRule(
+                link_pattern=options["link_pattern"],
+                canonical_key_template=options["canonical_key_template"],
+                prefix=options["prefix"],
+            )
+        except ValueError as exc:
+            raise CommandError(str(exc)) from exc
+
+        provider = ListingIndexDiscoveryProvider()
+        try:
+            result = provider.discover_candidates(
+                options["index_urls"],
+                max_candidates=options["max_candidates"],
+                rule=rule,
+            )
+        except PermissionError as exc:
+            raise CommandError(str(exc)) from exc
+
+        for url, reason in result.skipped_index_urls.items():
+            self.stderr.write(self.style.WARNING(f"skipped {url}: {reason}"))
+
+        self.stdout.write(
+            f"discovered {len(result.candidates)} candidate(s)"
+            f"{' (capped)' if result.capped else ''}"
+        )
+        for candidate in result.candidates:
+            self.stdout.write(f"  {candidate.canonical_key}  {candidate.url}")
+
+        if options["dry_run"]:
+            self.stdout.write(self.style.WARNING("--dry-run: frontier not updated."))
+            return
+
+        seeded = AuthorityFrontierService.seed_from_discovery(
+            result.candidates,
+            discovery_provider=type(provider).__name__,
+        )
+        self.stdout.write(
+            self.style.SUCCESS(
+                "frontier seeded: "
+                f"created={seeded['discovery_created']} "
+                f"skipped={seeded['discovery_skipped']}"
+            )
+        )

--- a/opencontractserver/enrichment/constants.py
+++ b/opencontractserver/enrichment/constants.py
@@ -90,6 +90,16 @@ MAX_DEFINED_TERM_SCAN = DEFINED_TERM_SCAN_MULTIPLIER * MAX_DEFINED_TERMS
 # Per-authority cap on the keys surfaced by the wanted-authorities queue.
 WANTED_AUTHORITIES_TOP_KEYS = 10
 
+# --- Phase 2 (issue #2054): listing-index discovery bounds ---------------------
+# Hard cap on candidates a single BaseAuthorityDiscoveryProvider.discover_candidates()
+# run may return/seed, mirroring the CRAWL_DEFAULT_*/CRAWL_MAX_* pair below: a
+# publisher's listing page with tens of thousands of rows must not flood the
+# frontier in one operator-triggered run.
+DISCOVERY_DEFAULT_MAX_CANDIDATES = 200
+# Absolute ceiling — a caller-supplied max_candidates is clamped to this even if
+# it asks for more, so a mistaken/hostile override cannot make one run unbounded.
+DISCOVERY_MAX_MAX_CANDIDATES = 2_000
+
 # --- Phase 5: bounded recursive authority crawl --------------------------------
 CRAWL_DEFAULT_MAX_DEPTH = 2  # authority-to-authority hops past depth-0 seeds
 CRAWL_DEFAULT_MIN_DEMAND = 2  # skip frontier rows with mention_count below this

--- a/opencontractserver/enrichment/constants.py
+++ b/opencontractserver/enrichment/constants.py
@@ -100,6 +100,14 @@ DISCOVERY_DEFAULT_MAX_CANDIDATES = 200
 # it asks for more, so a mistaken/hostile override cannot make one run unbounded.
 DISCOVERY_MAX_MAX_CANDIDATES = 2_000
 
+# The authority body's licence value gating ingestion/discovery to public-domain
+# sources only. Single source of truth for the (currently) hardcoded default on
+# BaseAuthorityDiscoveryProvider.license / ListingIndexDiscoveryProvider.license
+# (CLAUDE.md item 4: no magic strings). BaseAuthoritySourceProvider.license
+# still carries its own pre-existing literal — out of scope for this constant's
+# introduction, but a candidate for a future consolidation.
+AUTHORITY_LICENSE_PUBLIC_DOMAIN = "public-domain"
+
 # --- Phase 5: bounded recursive authority crawl --------------------------------
 CRAWL_DEFAULT_MAX_DEPTH = 2  # authority-to-authority hops past depth-0 seeds
 CRAWL_DEFAULT_MIN_DEMAND = 2  # skip frontier rows with mention_count below this

--- a/opencontractserver/enrichment/services/authority_frontier_service.py
+++ b/opencontractserver/enrichment/services/authority_frontier_service.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from django.db import transaction
 from django.db.models import Count, Q
@@ -24,6 +25,11 @@ from opencontractserver.enrichment.services.corpus_reference_service import (
     CorpusReferenceService,
 )
 from opencontractserver.shared.services.base import BaseService
+
+if TYPE_CHECKING:
+    from opencontractserver.pipeline.base.base_authority_discovery_provider import (
+        DiscoveryCandidate,
+    )
 
 
 @dataclass
@@ -260,6 +266,71 @@ class AuthorityFrontierService(BaseService):
             "child_created": created,
             "child_skipped": skipped,
             # Consumer (crawl) only needs containment; skip the sort.
+            "queued_keys": list(queued_keys),
+        }
+
+    @classmethod
+    def seed_from_discovery(
+        cls,
+        candidates: list[DiscoveryCandidate],
+        *,
+        discovery_provider: str,
+    ) -> dict:
+        """Upsert AuthorityFrontier rows from a discovery provider's candidates.
+
+        Phase 2 (issue #2054): a ``BaseAuthorityDiscoveryProvider`` lists
+        documents nobody has cited yet (candidate = canonical_key + url +
+        minimal metadata); this is the ONE place that turns those candidates
+        into durable frontier rows, mirroring ``seed_child_keys``'s idempotency
+        contract exactly: a ``canonical_key`` that already has a row (at ANY
+        depth/discovery_state) is SKIPPED entirely — re-running the same
+        discovery crawl never creates duplicates and never resets an in-flight
+        row (e.g. one already ``in_progress`` or ``ingested``).
+
+        Freshly created rows are seeded at ``depth=0`` (a discovery-sourced
+        candidate is a fresh root, not a hop from an existing frontier row),
+        ``mention_count=1`` (parity with ``seed_child_keys``'s floor demand for a
+        freshly-seen key), and carry the candidate's url/title as the FIRST
+        ``candidate_sources`` audit-trail entry — set once, at creation, never
+        rewritten by a later discovery pass over the same key.
+
+        Does NOT stamp ``AuthorityFrontier.provider``: that field names a
+        registered ``BaseAuthoritySourceProvider`` (the citation-keyed FETCH
+        rail), which a discovery provider is not — the row is left
+        ``provider=None`` so the existing ``discover_and_bootstrap``
+        orchestration picks a source provider via its normal ``_provider_for``
+        routing, exactly like ``seed_child_keys`` / ``seed_from_wanted_authorities``.
+        """
+        created = skipped = 0
+        queued_keys: set[str] = set()
+        for candidate in candidates:
+            key = candidate.canonical_key
+            queued_keys.add(key)
+            authority = key.split(":", 1)[0]
+            juris, atype = C.classify_prefix(authority)
+            _, was_created = AuthorityFrontier.objects.get_or_create(
+                canonical_key=key,
+                defaults={
+                    "authority": authority,
+                    "jurisdiction": juris,
+                    "authority_type": atype,
+                    "mention_count": 1,
+                    "candidate_sources": [
+                        {
+                            "discovery_provider": discovery_provider,
+                            "url": candidate.url,
+                            "title": candidate.title,
+                        }
+                    ],
+                },
+            )
+            created += int(was_created)
+            skipped += int(not was_created)
+        return {
+            "discovery_created": created,
+            "discovery_skipped": skipped,
+            # Consumer (discover_authority_candidates command) only needs
+            # containment; skip the sort (mirrors seed_child_keys).
             "queued_keys": list(queued_keys),
         }
 

--- a/opencontractserver/pipeline/authority_discovery_providers/__init__.py
+++ b/opencontractserver/pipeline/authority_discovery_providers/__init__.py
@@ -1,0 +1,1 @@
+"""Authority discovery provider components (Phase 2, issue #2054)."""

--- a/opencontractserver/pipeline/authority_discovery_providers/listing_index_provider.py
+++ b/opencontractserver/pipeline/authority_discovery_providers/listing_index_provider.py
@@ -36,7 +36,7 @@ from __future__ import annotations
 
 import logging
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import ClassVar
 from urllib.parse import urljoin
 
@@ -71,6 +71,15 @@ class ListingIndexRule:
     link_pattern: str
     canonical_key_template: str
     prefix: str
+    # Compiled once in __post_init__ and reused by every _parse_index_impl call
+    # for this rule, instead of recompiling the identical pattern on each page.
+    # Not part of the public constructor (init=False) or __eq__/__repr__
+    # (compare=False/repr=False) -- it is a derived cache of link_pattern, not
+    # independent state. The dataclass is frozen, so __post_init__ below uses
+    # object.__setattr__ to set it.
+    _compiled_link_pattern: re.Pattern[str] = field(
+        init=False, repr=False, compare=False
+    )
 
     def __post_init__(self) -> None:
         try:
@@ -84,6 +93,7 @@ class ListingIndexRule:
                 "link_pattern must define a named group 'url' "
                 f"(got groups: {sorted(compiled.groupindex)})"
             )
+        object.__setattr__(self, "_compiled_link_pattern", compiled)
 
 
 class ListingIndexDiscoveryProvider(BaseAuthorityDiscoveryProvider):
@@ -119,7 +129,9 @@ class ListingIndexDiscoveryProvider(BaseAuthorityDiscoveryProvider):
                 "ListingIndexDiscoveryProvider requires a rule=ListingIndexRule(...) "
                 "kwarg (pass it to discover_candidates())."
             )
-        pattern = re.compile(rule.link_pattern)
+        # Compiled once in ListingIndexRule.__post_init__ -- reused here rather
+        # than recompiling the identical pattern on every page/call.
+        pattern = rule._compiled_link_pattern
         candidates: list[DiscoveryCandidate] = []
         for match in pattern.finditer(html):
             groups = match.groupdict()

--- a/opencontractserver/pipeline/authority_discovery_providers/listing_index_provider.py
+++ b/opencontractserver/pipeline/authority_discovery_providers/listing_index_provider.py
@@ -41,6 +41,7 @@ from typing import ClassVar
 from urllib.parse import urljoin
 
 from opencontractserver.constants.safe_http import AUTHORITY_PROVIDER_USER_AGENT
+from opencontractserver.enrichment.constants import AUTHORITY_LICENSE_PUBLIC_DOMAIN
 from opencontractserver.pipeline.base.base_authority_discovery_provider import (
     BaseAuthorityDiscoveryProvider,
     DiscoveryCandidate,
@@ -66,6 +67,13 @@ class ListingIndexRule:
     ``"bo-gaceta:2024-1234"``. A match missing a group the template references
     is skipped (not raised) so one malformed row in a listing page does not
     abort the whole page.
+
+    ``prefix`` is a RESERVED template field name: it always resolves to this
+    rule's own ``prefix`` attribute (the deliberately-configured value), even
+    if ``link_pattern`` also happens to define a named group literally called
+    ``prefix`` (e.g. a jurisdiction/prefix column in the source markup) — the
+    regex-captured value is discarded in favor of the rule's, rather than
+    raising ``TypeError: got multiple values for keyword argument 'prefix'``.
     """
 
     link_pattern: str
@@ -112,7 +120,7 @@ class ListingIndexDiscoveryProvider(BaseAuthorityDiscoveryProvider):
         "Fetches nothing beyond the index page itself — document ingestion "
         "happens later via a citation-keyed BaseAuthoritySourceProvider."
     )
-    license: ClassVar[str] = "public-domain"  # noqa: A003
+    license: ClassVar[str] = AUTHORITY_LICENSE_PUBLIC_DOMAIN  # noqa: A003
 
     def _fetch_index_impl(self, index_url: str, **all_kwargs) -> str:
         text, _ = safe_fetch_text(
@@ -139,8 +147,17 @@ class ListingIndexDiscoveryProvider(BaseAuthorityDiscoveryProvider):
             if not url:
                 continue
             try:
+                # rule.prefix always wins over a same-named "prefix" capture
+                # group: build the format kwargs with groups FIRST so the
+                # explicit "prefix" entry below overwrites (not collides
+                # with) any regex-captured "prefix" key, instead of
+                # `.format(prefix=..., **groups)` raising
+                # "TypeError: got multiple values for keyword argument
+                # 'prefix'" when link_pattern happens to define its own
+                # named group called "prefix" (see ListingIndexRule's
+                # docstring).
                 canonical_key = rule.canonical_key_template.format(
-                    prefix=rule.prefix, **groups
+                    **{**groups, "prefix": rule.prefix}
                 )
             except (KeyError, IndexError) as exc:
                 logger.debug(

--- a/opencontractserver/pipeline/authority_discovery_providers/listing_index_provider.py
+++ b/opencontractserver/pipeline/authority_discovery_providers/listing_index_provider.py
@@ -1,0 +1,146 @@
+"""Config-driven "listing index" discovery provider (Phase 2, issue #2054).
+
+The ONE reference implementation of ``BaseAuthorityDiscoveryProvider``: given an
+index-page URL and a declarative :class:`ListingIndexRule` (a regex over the raw
+HTML plus a canonical-key template), it lists candidate documents. The crawler
+logic itself is completely jurisdiction-agnostic — a different publisher plugs
+in a different ``ListingIndexRule`` (``link_pattern`` / ``canonical_key_template``
+/ ``prefix``), not different code, so ONE class serves every "regularly
+structured listing page" publisher (a paginated table of links to individual
+documents — the shape PR #1305's Gaceta Oficial / TSJ / TCP scrapers all shared,
+per ``docs/architecture/proposals/0002-authority-packs.md`` §6).
+
+No HTML-parsing library dependency: ``_parse_index_impl`` applies the
+caller-supplied regex directly to the raw HTML text via ``re.finditer``. This
+keeps the engine dependency-free (this repo carries no BeautifulSoup/lxml) and
+fully deterministic against a fixture string in tests, at the cost of requiring
+a rule tuned to each source's actual markup. A publisher whose markup is too
+irregular for one templated regex can subclass
+``BaseAuthorityDiscoveryProvider`` directly and override ``_parse_index_impl``
+with bespoke parsing — this class is the common case, not the only case.
+
+Illustrative worked example (Bolivia's Gaceta Oficial, per the proposal's
+motivating case) — NOT a verified live scraper: nobody in this repo has
+inspected the real site's current HTML, so no real index URL or host is wired
+in here or into the shipped ``bolivia`` pack. See
+``opencontractserver/tests/test_listing_index_discovery_provider.py`` for a
+synthetic, Gaceta-Oficial-*shaped* fixture exercising this engine end-to-end
+against mocked HTML — the pattern the proposal doc credits to PR #1305's
+``httpx.MockTransport`` testing approach. An operator who has verified a real
+publisher's markup supplies their own ``ListingIndexRule`` (e.g. via the
+``discover_authority_candidates`` management command); wiring a *verified* rule
+into a pack's own config is a follow-up left to that operator, not to this PR.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from typing import ClassVar
+from urllib.parse import urljoin
+
+from opencontractserver.constants.safe_http import AUTHORITY_PROVIDER_USER_AGENT
+from opencontractserver.pipeline.base.base_authority_discovery_provider import (
+    BaseAuthorityDiscoveryProvider,
+    DiscoveryCandidate,
+)
+from opencontractserver.utils.safe_http import safe_fetch_text
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ListingIndexRule:
+    """Declarative extraction rule for one publisher's index-page markup.
+
+    ``link_pattern`` is a regex applied to the raw fetched index-page HTML via
+    ``re.finditer``. It MUST define a named group ``url`` (the document link —
+    resolved against the index page URL if relative) and MAY define any other
+    named groups (e.g. ``id``, ``date``) consumed by ``canonical_key_template``,
+    plus an optional ``title`` group used as the candidate's human-readable
+    heading.
+
+    ``canonical_key_template`` is a ``str.format`` template consuming ``prefix``
+    plus the regex's named groups, e.g. ``"{prefix}:{id}"`` ->
+    ``"bo-gaceta:2024-1234"``. A match missing a group the template references
+    is skipped (not raised) so one malformed row in a listing page does not
+    abort the whole page.
+    """
+
+    link_pattern: str
+    canonical_key_template: str
+    prefix: str
+
+    def __post_init__(self) -> None:
+        try:
+            compiled = re.compile(self.link_pattern)
+        except re.error as exc:
+            raise ValueError(
+                f"invalid link_pattern {self.link_pattern!r}: {exc}"
+            ) from exc
+        if "url" not in compiled.groupindex:
+            raise ValueError(
+                "link_pattern must define a named group 'url' "
+                f"(got groups: {sorted(compiled.groupindex)})"
+            )
+
+
+class ListingIndexDiscoveryProvider(BaseAuthorityDiscoveryProvider):
+    """Generic regex-driven listing-index crawler.
+
+    Callers MUST pass a ``rule=ListingIndexRule(...)`` keyword to
+    ``discover_candidates()`` (forwarded through as ``**direct_kwargs``, exactly
+    like ``BaseAuthoritySourceProvider.locate``/``fetch`` forward provider
+    settings) — the class itself carries no jurisdiction-specific state.
+    """
+
+    title = "Listing Index Discovery Provider"
+    description = (
+        "Config-driven crawler: lists candidate documents from a publisher's "
+        "index/listing page via a declarative regex + canonical-key template. "
+        "Fetches nothing beyond the index page itself — document ingestion "
+        "happens later via a citation-keyed BaseAuthoritySourceProvider."
+    )
+    license: ClassVar[str] = "public-domain"  # noqa: A003
+
+    def _fetch_index_impl(self, index_url: str, **all_kwargs) -> str:
+        text, _ = safe_fetch_text(
+            index_url, headers={"User-Agent": AUTHORITY_PROVIDER_USER_AGENT}
+        )
+        return text
+
+    def _parse_index_impl(
+        self, html: str, *, index_url: str, **all_kwargs
+    ) -> list[DiscoveryCandidate]:
+        rule = all_kwargs.get("rule")
+        if not isinstance(rule, ListingIndexRule):
+            raise ValueError(
+                "ListingIndexDiscoveryProvider requires a rule=ListingIndexRule(...) "
+                "kwarg (pass it to discover_candidates())."
+            )
+        pattern = re.compile(rule.link_pattern)
+        candidates: list[DiscoveryCandidate] = []
+        for match in pattern.finditer(html):
+            groups = match.groupdict()
+            url = groups.get("url")
+            if not url:
+                continue
+            try:
+                canonical_key = rule.canonical_key_template.format(
+                    prefix=rule.prefix, **groups
+                )
+            except (KeyError, IndexError) as exc:
+                logger.debug(
+                    "listing index: skipping match missing template field: %s", exc
+                )
+                continue
+            candidates.append(
+                DiscoveryCandidate(
+                    canonical_key=canonical_key,
+                    url=urljoin(index_url, url),
+                    title=groups.get("title"),
+                    extra={"index_url": index_url},
+                )
+            )
+        return candidates

--- a/opencontractserver/pipeline/base/base_authority_discovery_provider.py
+++ b/opencontractserver/pipeline/base/base_authority_discovery_provider.py
@@ -1,0 +1,202 @@
+"""Base class for authority DISCOVERY providers (Phase 2, issue #2054).
+
+``BaseAuthoritySourceProvider`` (``base_authority_source_provider.py``) is
+citation-KEYED: given a *known* ``canonical_key``, it resolves the fetch plan and
+downloads the section text. ``BaseAuthorityDiscoveryProvider`` answers a
+different question: crawl a publisher's index/listing page(s) for documents
+NOBODY HAS CITED YET, and surface them as candidates (canonical_key + url +
+minimal metadata) for ``AuthorityFrontierService`` to seed. It never fetches full
+document text or ingests anything — that stays the job of a (separately
+registered) ``BaseAuthoritySourceProvider`` once a frontier row is routed to one.
+
+Motivating case (``docs/architecture/proposals/0002-authority-packs.md`` §7, gap
+3): Bolivia's official sources (Gaceta Oficial / TSJ / TCP) are listing-page
+publishers, not key-addressable — nobody can build a deterministic
+``canonical_key -> URL`` ``BaseAuthoritySourceProvider`` for them, because the
+"key" a citation would use does not exist until an operator has actually crawled
+the index and discovered it. This abstraction closes that gap.
+
+Design mirrors ``BaseAuthoritySourceProvider``'s locate/fetch split:
+    - ``_fetch_index_impl`` (I/O): download ONE index/listing page. MUST route
+      through ``safe_fetch_text``/``safe_fetch_bytes`` (the SSRF gate).
+    - ``_parse_index_impl`` (pure): turn an ALREADY-FETCHED index page into
+      ``DiscoveryCandidate`` objects — no I/O, so tests exercise it directly
+      against fixture HTML with zero network calls (the same
+      ``httpx.MockTransport``-style testing precedent credited to PR #1305 in
+      the proposal doc, adapted here to patching/mocking the fetch step so the
+      parse step stays pure and deterministic).
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from typing import ClassVar
+
+import httpx
+
+from opencontractserver.enrichment.constants import (
+    DISCOVERY_DEFAULT_MAX_CANDIDATES,
+    DISCOVERY_MAX_MAX_CANDIDATES,
+)
+from opencontractserver.pipeline.base.base_component import PipelineComponentBase
+from opencontractserver.utils.numbers import clamp_int
+from opencontractserver.utils.safe_http import SSRFValidationError
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class DiscoveryCandidate:
+    """A document FOUND on a publisher index page — not yet fetched or ingested.
+
+    Mirrors ``AuthorityRequest``'s "found, not yet fetched" shape (see
+    ``base_authority_source_provider.AuthorityRequest``): ``discover_candidates()``
+    turns an index page into these; nothing here performs I/O or ingestion.
+    Seeding a ``DiscoveryCandidate`` into ``AuthorityFrontier`` (via
+    ``AuthorityFrontierService.seed_from_discovery``) only QUEUES it for the
+    existing ``discover_and_bootstrap`` runtime, which resolves it via whatever
+    ``BaseAuthoritySourceProvider`` (if any) ``can_handle``s its canonical_key —
+    this class does not fetch the document body itself.
+    """
+
+    canonical_key: str  # e.g. "bo-gaceta:2024-1234"
+    url: str  # the document's own URL (not the index page it was found on)
+    title: str | None = None  # human-readable heading, if the index page has one
+    # Provider-owned scratch (e.g. the index_url the candidate was found on).
+    # Always-dict (never None) so callers index it without guards.
+    extra: dict = field(default_factory=dict)
+
+
+@dataclass
+class DiscoveryResult:
+    """Outcome of one ``discover_candidates()`` run — never silently truncated.
+
+    ``skipped_index_urls`` maps an index URL to the reason it produced zero
+    candidates (SSRF validation failure, HTTP error, …) so a mis-configured or
+    unreachable index page is visible to the operator instead of silently
+    folding into an empty result.
+    """
+
+    candidates: list[DiscoveryCandidate]
+    skipped_index_urls: dict[str, str]
+    # True if max_candidates stopped discovery before every index_url/match was
+    # exhausted — the bounded-crawl signal the tests assert on.
+    capped: bool
+
+
+class BaseAuthorityDiscoveryProvider(PipelineComponentBase, ABC):
+    """Crawls a publisher's index/listing page(s) for undiscovered candidates.
+
+    A discovery provider owns a family of PUBLISHER index pages (not a
+    canonical_key family like ``BaseAuthoritySourceProvider``): given one or
+    more index URLs, it lists candidate documents nobody has cited yet.
+
+    ClassVars mirror ``BaseAuthoritySourceProvider``'s registry-facing metadata
+    (``license`` / ``priority`` / ``enabled``) so the pipeline registry and any
+    future console surface can display discovery providers the same way.
+    """
+
+    # The authority body's licence — gates discovery to public-domain sources
+    # only, mirroring BaseAuthoritySourceProvider.license. discover_candidates()
+    # refuses to run (raises PermissionError) unless this is "public-domain".
+    license: ClassVar[str] = "public-domain"  # noqa: A003
+    # Lower priority value = preferred. Unused by today's single reference
+    # provider; kept for registry symmetry with BaseAuthoritySourceProvider and
+    # for future provider-selection logic (e.g. an operator surface choosing
+    # among several discovery providers for one publisher).
+    priority: ClassVar[int] = 100
+    # Set False to exclude a provider from registry-facing listings.
+    enabled: ClassVar[bool] = True
+
+    # ---- public API -----------------------------------------------------------
+    def discover_candidates(
+        self,
+        index_urls: Sequence[str],
+        *,
+        max_candidates: int | None = None,
+        **direct_kwargs,
+    ) -> DiscoveryResult:
+        """Fetch + parse index page(s) into candidates, bounded by max_candidates.
+
+        Every index page is fetched via ``_fetch_index_impl`` (which MUST route
+        through ``safe_fetch_text``/``safe_fetch_bytes`` — the SSRF gate) and
+        parsed via the pure ``_parse_index_impl``. An index URL that fails SSRF
+        validation or any other fetch error is recorded in
+        ``DiscoveryResult.skipped_index_urls`` and the run continues with the
+        remaining URLs — one bad host never aborts discovery of the others.
+
+        Candidates are de-duplicated by ``canonical_key`` within one run (a
+        paginated listing whose pages overlap must not seed the same key twice)
+        and the run stops as soon as ``max_candidates`` distinct candidates have
+        been collected — the per-run bound the crawl proposal requires.
+
+        Raises:
+            PermissionError: if ``self.license`` is not ``"public-domain"`` — a
+                discovery provider must never crawl a non-public-domain source
+                (mirrors ``AuthorityGateService``'s license check).
+        """
+        if self.license != "public-domain":
+            raise PermissionError(
+                f"{type(self).__name__}: license {self.license!r} is not "
+                "public-domain; discovery is refused."
+            )
+        merged = {**self.get_component_settings(), **direct_kwargs}
+        cap = clamp_int(
+            (
+                DISCOVERY_DEFAULT_MAX_CANDIDATES
+                if max_candidates is None
+                else max_candidates
+            ),
+            lower=1,
+            upper=DISCOVERY_MAX_MAX_CANDIDATES,
+        )
+
+        candidates: list[DiscoveryCandidate] = []
+        skipped: dict[str, str] = {}
+        seen_keys: set[str] = set()
+        capped = False
+        for index_url in index_urls:
+            if len(candidates) >= cap:
+                capped = True
+                break
+            try:
+                html = self._fetch_index_impl(index_url, **merged)
+            except SSRFValidationError as exc:
+                skipped[index_url] = f"blocked: {exc}"
+                continue
+            except (httpx.HTTPError, OSError) as exc:
+                logger.warning(
+                    "discover_candidates: failed to fetch index %s: %s",
+                    index_url,
+                    exc,
+                )
+                skipped[index_url] = f"error: {exc}"
+                continue
+            for candidate in self._parse_index_impl(
+                html, index_url=index_url, **merged
+            ):
+                if candidate.canonical_key in seen_keys:
+                    continue
+                seen_keys.add(candidate.canonical_key)
+                candidates.append(candidate)
+                if len(candidates) >= cap:
+                    capped = True
+                    break
+
+        return DiscoveryResult(
+            candidates=candidates, skipped_index_urls=skipped, capped=capped
+        )
+
+    # ---- subclass contract ------------------------------------------------- #
+    @abstractmethod
+    def _fetch_index_impl(self, index_url: str, **all_kwargs) -> str:
+        """Download ONE index/listing page. MUST route through safe_http."""
+
+    @abstractmethod
+    def _parse_index_impl(
+        self, html: str, *, index_url: str, **all_kwargs
+    ) -> list[DiscoveryCandidate]:
+        """Pure: extract candidates from an ALREADY-FETCHED index page."""

--- a/opencontractserver/pipeline/base/base_authority_discovery_provider.py
+++ b/opencontractserver/pipeline/base/base_authority_discovery_provider.py
@@ -82,8 +82,14 @@ class DiscoveryResult:
 
     candidates: list[DiscoveryCandidate]
     skipped_index_urls: dict[str, str]
-    # True if max_candidates stopped discovery before every index_url/match was
-    # exhausted — the bounded-crawl signal the tests assert on.
+    # True only when max_candidates ACTUALLY cut discovery short — i.e. at
+    # least one more distinct candidate is PROVABLY left unprocessed (either
+    # later in the same already-parsed index page, or in an index_url this run
+    # never got to fetch). If the cap is reached exactly as the very last
+    # distinct candidate from the very last already-fetched page is collected,
+    # capped is False: nothing was left out, so raising max_candidates would
+    # not surface more documents. Never determined by fetching an extra page
+    # just to check — only data already in memory from this run.
     capped: bool
 
 
@@ -132,6 +138,10 @@ class BaseAuthorityDiscoveryProvider(PipelineComponentBase, ABC):
         paginated listing whose pages overlap must not seed the same key twice)
         and the run stops as soon as ``max_candidates`` distinct candidates have
         been collected — the per-run bound the crawl proposal requires.
+        ``DiscoveryResult.capped`` reports whether that bound ACTUALLY cut
+        anything short (see its field docstring) — reaching the cap on the
+        very last available candidate is reported as NOT capped, since nothing
+        was left out.
 
         Raises:
             PermissionError: if ``self.license`` is not ``"public-domain"`` — a
@@ -154,14 +164,12 @@ class BaseAuthorityDiscoveryProvider(PipelineComponentBase, ABC):
             upper=DISCOVERY_MAX_MAX_CANDIDATES,
         )
 
+        url_list = list(index_urls)
         candidates: list[DiscoveryCandidate] = []
         skipped: dict[str, str] = {}
         seen_keys: set[str] = set()
-        capped = False
-        for index_url in index_urls:
-            if len(candidates) >= cap:
-                capped = True
-                break
+
+        for url_idx, index_url in enumerate(url_list):
             try:
                 html = self._fetch_index_impl(index_url, **merged)
             except SSRFValidationError as exc:
@@ -175,19 +183,34 @@ class BaseAuthorityDiscoveryProvider(PipelineComponentBase, ABC):
                 )
                 skipped[index_url] = f"error: {exc}"
                 continue
-            for candidate in self._parse_index_impl(
-                html, index_url=index_url, **merged
-            ):
+
+            # Materialize (not just iterate) so a look-ahead can prove whether
+            # anything distinct remains on THIS page once the cap is hit —
+            # never fetch another page just to answer that question.
+            page_candidates = list(
+                self._parse_index_impl(html, index_url=index_url, **merged)
+            )
+            for cand_idx, candidate in enumerate(page_candidates):
                 if candidate.canonical_key in seen_keys:
                     continue
                 seen_keys.add(candidate.canonical_key)
                 candidates.append(candidate)
                 if len(candidates) >= cap:
-                    capped = True
-                    break
+                    more_in_page = any(
+                        later.canonical_key not in seen_keys
+                        for later in page_candidates[cand_idx + 1 :]
+                    )
+                    more_urls_unfetched = url_idx + 1 < len(url_list)
+                    return DiscoveryResult(
+                        candidates=candidates,
+                        skipped_index_urls=skipped,
+                        capped=more_in_page or more_urls_unfetched,
+                    )
 
+        # Every index_url was processed (fetched, skipped, or exhausted) and
+        # the cap was never reached — nothing was truncated.
         return DiscoveryResult(
-            candidates=candidates, skipped_index_urls=skipped, capped=capped
+            candidates=candidates, skipped_index_urls=skipped, capped=False
         )
 
     # ---- subclass contract ------------------------------------------------- #

--- a/opencontractserver/pipeline/base/base_authority_discovery_provider.py
+++ b/opencontractserver/pipeline/base/base_authority_discovery_provider.py
@@ -38,6 +38,7 @@ from typing import ClassVar
 import httpx
 
 from opencontractserver.enrichment.constants import (
+    AUTHORITY_LICENSE_PUBLIC_DOMAIN,
     DISCOVERY_DEFAULT_MAX_CANDIDATES,
     DISCOVERY_MAX_MAX_CANDIDATES,
 )
@@ -108,7 +109,7 @@ class BaseAuthorityDiscoveryProvider(PipelineComponentBase, ABC):
     # The authority body's licence — gates discovery to public-domain sources
     # only, mirroring BaseAuthoritySourceProvider.license. discover_candidates()
     # refuses to run (raises PermissionError) unless this is "public-domain".
-    license: ClassVar[str] = "public-domain"  # noqa: A003
+    license: ClassVar[str] = AUTHORITY_LICENSE_PUBLIC_DOMAIN  # noqa: A003
     # Lower priority value = preferred. Unused by today's single reference
     # provider; kept for registry symmetry with BaseAuthoritySourceProvider and
     # for future provider-selection logic (e.g. an operator surface choosing
@@ -148,7 +149,7 @@ class BaseAuthorityDiscoveryProvider(PipelineComponentBase, ABC):
                 discovery provider must never crawl a non-public-domain source
                 (mirrors ``AuthorityGateService``'s license check).
         """
-        if self.license != "public-domain":
+        if self.license != AUTHORITY_LICENSE_PUBLIC_DOMAIN:
             raise PermissionError(
                 f"{type(self).__name__}: license {self.license!r} is not "
                 "public-domain; discovery is refused."

--- a/opencontractserver/pipeline/registry.py
+++ b/opencontractserver/pipeline/registry.py
@@ -24,6 +24,9 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any, Optional, TypedDict
 
+from opencontractserver.pipeline.base.base_authority_discovery_provider import (
+    BaseAuthorityDiscoveryProvider,
+)
 from opencontractserver.pipeline.base.base_authority_source_provider import (
     BaseAuthoritySourceProvider,
 )
@@ -94,6 +97,7 @@ class ComponentType(str, Enum):
     RERANKER = "reranker"
     LLM_PROVIDER = "llm_provider"
     AUTHORITY_SOURCE_PROVIDER = "authority_source_provider"
+    AUTHORITY_DISCOVERY_PROVIDER = "authority_discovery_provider"
 
 
 @dataclass(frozen=True)
@@ -207,6 +211,9 @@ class PipelineComponentRegistry:
         self._rerankers: tuple[PipelineComponentDefinition, ...] = ()
         self._llm_providers: tuple[PipelineComponentDefinition, ...] = ()
         self._authority_source_providers: tuple[PipelineComponentDefinition, ...] = ()
+        self._authority_discovery_providers: tuple[PipelineComponentDefinition, ...] = (
+            ()
+        )
 
         # Name -> Definition lookup for fast access
         self._by_name: dict[str, PipelineComponentDefinition] = {}
@@ -269,29 +276,41 @@ class PipelineComponentRegistry:
 
         return subclasses
 
-    def _discover_pack_provider_classes(self) -> list[type]:
-        """Discover ``BaseAuthoritySourceProvider`` subclasses shipped INSIDE
-        authority packs (``<pack>/providers/*.py``).
+    def _discover_pack_component_classes(
+        self, subdir_name: str, base_class: type, module_ns: str
+    ) -> list[type]:
+        """Discover ``base_class`` subclasses shipped INSIDE authority packs
+        (``<pack>/<subdir_name>/*.py``).
 
-        This is what makes a pack self-contained: its scraper lives in the pack
-        directory rather than in core's ``authority_source_providers/`` package, so
-        copying the pack to another install brings the provider with it. Each
-        module is imported by file path under a synthetic, collision-free module
-        name; an import failure is logged and skipped so a bad pack never crashes
-        registry build (matching ``_discover_subclasses``' isolation). Only classes
-        DEFINED in the pack module are registered — base/imported classes that
-        merely happen to be in scope are ignored via the ``__module__`` check.
+        Generalizes the "self-contained pack" discovery mechanism across every
+        component family that follows the pack-directory convention — today
+        ``BaseAuthoritySourceProvider`` under ``<pack>/providers/`` and
+        ``BaseAuthorityDiscoveryProvider`` under ``<pack>/discovery_providers/`` —
+        so a pack ships either (or both) kind of component the same way:
+        discovered by the registry, no registration call, no core edit. This is
+        what makes a pack self-contained: its scraper(s) live in the pack
+        directory rather than in a shared core package, so copying the pack to
+        another install brings them with it. ``module_ns`` disambiguates the
+        synthetic module namespace per component family so a pack shipping BOTH
+        kinds of component cannot collide on the same module name.
+
+        Each module is imported by file path under a synthetic, collision-free
+        module name; an import failure is logged and skipped so a bad pack never
+        crashes registry build (matching ``_discover_subclasses``' isolation).
+        Only classes DEFINED in the pack module are registered — base/imported
+        classes that merely happen to be in scope are ignored via the
+        ``__module__`` check.
         """
         seen: set[type] = set()
         found: list[type] = []
         for pack_dir in authority_pack_dirs():
-            providers_dir = pack_dir / "providers"
-            if not providers_dir.is_dir():
+            component_dir = pack_dir / subdir_name
+            if not component_dir.is_dir():
                 continue
-            for py in sorted(providers_dir.glob("*.py")):
+            for py in sorted(component_dir.glob("*.py")):
                 if py.name.startswith("_"):
                     continue
-                mod_name = f"_authority_pack_providers.{pack_dir.name}.{py.stem}"
+                mod_name = f"_authority_pack_{module_ns}.{pack_dir.name}.{py.stem}"
                 try:
                     spec = importlib.util.spec_from_file_location(mod_name, py)
                     if spec is None or spec.loader is None:
@@ -303,8 +322,8 @@ class PipelineComponentRegistry:
                     spec.loader.exec_module(module)
                     for _, obj in inspect.getmembers(module, inspect.isclass):
                         if (
-                            issubclass(obj, BaseAuthoritySourceProvider)
-                            and obj is not BaseAuthoritySourceProvider
+                            issubclass(obj, base_class)
+                            and obj is not base_class
                             and obj not in seen
                             and not inspect.isabstract(obj)
                             and obj.__module__ == mod_name
@@ -560,7 +579,9 @@ class PipelineComponentRegistry:
             BaseAuthoritySourceProvider,
         )
         seen_classes = set(authority_source_provider_classes)
-        for cls in self._discover_pack_provider_classes():
+        for cls in self._discover_pack_component_classes(
+            "providers", BaseAuthoritySourceProvider, "providers"
+        ):
             if cls not in seen_classes:
                 seen_classes.add(cls)
                 authority_source_provider_classes.append(cls)
@@ -592,6 +613,35 @@ class PipelineComponentRegistry:
                     prefix_owner[pfx] = defn.class_name
         self._authority_source_providers = tuple(authority_source_providers)
 
+        # Discover authority DISCOVERY providers: core package + in-pack providers
+        # (Phase 2, issue #2054). Same mechanism as authority source providers
+        # above, just a different base class + pack subdirectory
+        # (<pack>/discovery_providers/) — a discovery provider lists UNCITED
+        # candidates from a publisher's index page rather than resolving a known
+        # canonical_key, so it is not keyed by supported_prefixes and has no
+        # analogous prefix-collision warning.
+        authority_discovery_provider_classes = self._discover_subclasses(
+            "opencontractserver.pipeline.authority_discovery_providers",
+            BaseAuthorityDiscoveryProvider,
+        )
+        seen_discovery_classes = set(authority_discovery_provider_classes)
+        for cls in self._discover_pack_component_classes(
+            "discovery_providers", BaseAuthorityDiscoveryProvider, "discovery_providers"
+        ):
+            if cls not in seen_discovery_classes:
+                seen_discovery_classes.add(cls)
+                authority_discovery_provider_classes.append(cls)
+
+        authority_discovery_providers = []
+        for cls in authority_discovery_provider_classes:
+            defn = self._create_definition(
+                cls, ComponentType.AUTHORITY_DISCOVERY_PROVIDER
+            )
+            authority_discovery_providers.append(defn)
+            self._by_name[defn.name] = defn
+            self._by_class_name[defn.class_name] = defn
+        self._authority_discovery_providers = tuple(authority_discovery_providers)
+
         logger.info(
             f"Pipeline registry initialized: "
             f"{len(self._parsers)} parsers, "
@@ -601,7 +651,8 @@ class PipelineComponentRegistry:
             f"{len(self._enrichers)} enrichers, "
             f"{len(self._rerankers)} rerankers, "
             f"{len(self._llm_providers)} llm-providers, "
-            f"{len(self._authority_source_providers)} authority-source-providers"
+            f"{len(self._authority_source_providers)} authority-source-providers, "
+            f"{len(self._authority_discovery_providers)} authority-discovery-providers"
         )
 
     # -------------------------------------------------------------------------
@@ -647,6 +698,11 @@ class PipelineComponentRegistry:
     def authority_source_providers(self) -> tuple[PipelineComponentDefinition, ...]:
         """Get all registered authority source providers."""
         return self._authority_source_providers
+
+    @property
+    def authority_discovery_providers(self) -> tuple[PipelineComponentDefinition, ...]:
+        """Get all registered authority discovery providers."""
+        return self._authority_discovery_providers
 
     def get_llm_provider_by_key(
         self, provider_key: str
@@ -754,6 +810,13 @@ def get_all_authority_source_providers_cached() -> (
     return get_registry().authority_source_providers
 
 
+def get_all_authority_discovery_providers_cached() -> (
+    tuple[PipelineComponentDefinition, ...]
+):
+    """Get all registered authority discovery providers (cached)."""
+    return get_registry().authority_discovery_providers
+
+
 def get_llm_provider_by_key_cached(
     provider_key: str,
 ) -> Optional[PipelineComponentDefinition]:
@@ -819,6 +882,7 @@ def get_all_components_cached() -> dict[str, tuple[PipelineComponentDefinition, 
         "rerankers": registry.rerankers,
         "llm_providers": registry.llm_providers,
         "authority_source_providers": registry.authority_source_providers,
+        "authority_discovery_providers": registry.authority_discovery_providers,
     }
 
 

--- a/opencontractserver/tests/fixtures/authority_sources/gaceta_listing_bolivia_synthetic.html
+++ b/opencontractserver/tests/fixtures/authority_sources/gaceta_listing_bolivia_synthetic.html
@@ -1,0 +1,33 @@
+<!--
+SYNTHETIC test fixture — NOT scraped from any live website.
+
+Shaped to resemble a plausible listing page for Bolivia's Gaceta Oficial (the
+motivating case for issue #2054's discovery-provider abstraction, per
+docs/architecture/proposals/0002-authority-packs.md §7), but the markup below
+is hand-written for testing ListingIndexDiscoveryProvider against MOCKED HTML.
+Nobody has verified this against the real site's current structure — do not
+treat it as documentation of the real site.
+-->
+<html>
+  <body>
+    <table class="listado">
+      <tr>
+        <td><a href="/gaceta/documento/2024-1234">Ley N. 1234 — Ley de Ejemplo</a></td>
+        <td>12/01/2024</td>
+      </tr>
+      <tr>
+        <td><a href="/gaceta/documento/2024-1235">Decreto Supremo N. 1235</a></td>
+        <td>15/01/2024</td>
+      </tr>
+      <tr>
+        <!-- A row missing an href entirely must be skipped, not crash parsing. -->
+        <td><span>Aviso — sin enlace</span></td>
+        <td>16/01/2024</td>
+      </tr>
+      <tr>
+        <td><a href="https://www.gacetaoficialdebolivia.gob.bo/gaceta/documento/2024-1236">Ley N. 1236</a></td>
+        <td>18/01/2024</td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/opencontractserver/tests/test_authority_discovery_provider_base.py
+++ b/opencontractserver/tests/test_authority_discovery_provider_base.py
@@ -153,6 +153,37 @@ class TestBaseAuthorityDiscoveryProviderABC(SimpleTestCase):
         result = provider.discover_candidates(["https://x/1"], max_candidates=10)
         self.assertFalse(result.capped)
 
+    def test_not_capped_when_exactly_at_limit_with_nothing_left_one_page(self):
+        """Boundary case: total distinct candidates == max_candidates, and
+        nothing more remains (single page, cap hit on its last candidate).
+        Nothing was actually truncated, so capped must be False even though
+        the cap was technically reached."""
+        provider = _DummyDiscoveryProvider(
+            {"https://x/1": "key-a https://x/a\nkey-b https://x/b"}
+        )
+        result = provider.discover_candidates(["https://x/1"], max_candidates=2)
+        self.assertEqual(
+            {c.canonical_key for c in result.candidates}, {"key-a", "key-b"}
+        )
+        self.assertFalse(result.capped)
+
+    def test_not_capped_when_exactly_at_limit_with_nothing_left_across_pages(self):
+        """Same boundary, but the cap lands on the last candidate of the LAST
+        of several index_urls -- still nothing left, so still not capped."""
+        provider = _DummyDiscoveryProvider(
+            {
+                "https://x/1": "key-a https://x/a",
+                "https://x/2": "key-b https://x/b",
+            }
+        )
+        result = provider.discover_candidates(
+            ["https://x/1", "https://x/2"], max_candidates=2
+        )
+        self.assertEqual(
+            {c.canonical_key for c in result.candidates}, {"key-a", "key-b"}
+        )
+        self.assertFalse(result.capped)
+
     def test_max_candidates_clamped_to_at_least_one(self):
         """A non-positive max_candidates must not disable bounding entirely."""
         provider = _DummyDiscoveryProvider(

--- a/opencontractserver/tests/test_authority_discovery_provider_base.py
+++ b/opencontractserver/tests/test_authority_discovery_provider_base.py
@@ -1,0 +1,236 @@
+"""Unit tests for BaseAuthorityDiscoveryProvider ABC and registry wiring.
+
+Phase 2 (issue #2054): BaseAuthorityDiscoveryProvider crawls a publisher's
+index/listing page(s) for candidates nobody has cited yet -- distinct from the
+citation-KEYED BaseAuthoritySourceProvider (test_authority_source_provider_base.py).
+
+These tests exercise:
+  - The ABC contract (discover_candidates dispatch, de-dup, bounds, SSRF, and
+    the public-domain license gate) via a local dummy provider.
+  - Registry auto-discovery (ComponentType.AUTHORITY_DISCOVERY_PROVIDER,
+    get_all_authority_discovery_providers_cached).
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from django.test import SimpleTestCase
+
+from opencontractserver.pipeline.authority_discovery_providers.listing_index_provider import (
+    ListingIndexDiscoveryProvider,
+    ListingIndexRule,
+)
+from opencontractserver.pipeline.base.base_authority_discovery_provider import (
+    BaseAuthorityDiscoveryProvider,
+    DiscoveryCandidate,
+    DiscoveryResult,
+)
+from opencontractserver.pipeline.registry import (
+    ComponentType,
+    get_all_authority_discovery_providers_cached,
+    reset_registry,
+)
+
+# ---------------------------------------------------------------------------
+# Local dummy provider -- not registered in the real discovery package, so it
+# won't appear in the live registry scan, but is sufficient to test the ABC.
+# ---------------------------------------------------------------------------
+
+
+class _DummyDiscoveryProvider(BaseAuthorityDiscoveryProvider):
+    """Minimal concrete provider for unit testing the ABC contract.
+
+    ``pages`` maps an index_url to its (already-"fetched") HTML text; a
+    missing URL raises ``OSError`` to exercise the skipped_index_urls path
+    without any real I/O.
+    """
+
+    title = "Dummy Discovery Provider"
+
+    def __init__(self, pages: dict[str, str] | None = None):
+        self._pages = pages or {}
+        super().__init__()
+
+    def _fetch_index_impl(self, index_url: str, **all_kwargs) -> str:
+        if index_url not in self._pages:
+            raise OSError(f"no such page: {index_url}")
+        return self._pages[index_url]
+
+    def _parse_index_impl(
+        self, html: str, *, index_url: str, **all_kwargs
+    ) -> list[DiscoveryCandidate]:
+        # One candidate per non-blank line: "<canonical_key> <url>".
+        candidates = []
+        for line in html.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            key, _, url = line.partition(" ")
+            candidates.append(
+                DiscoveryCandidate(canonical_key=key, url=url or index_url)
+            )
+        return candidates
+
+
+class _NonPublicDomainDiscoveryProvider(_DummyDiscoveryProvider):
+    license: ClassVar[str] = "cc-by"
+
+
+class TestBaseAuthorityDiscoveryProviderABC(SimpleTestCase):
+    """Tests for the BaseAuthorityDiscoveryProvider ABC contract."""
+
+    # ---- class-level attributes --------------------------------------------
+
+    def test_license_default(self):
+        self.assertEqual(_DummyDiscoveryProvider.license, "public-domain")
+
+    def test_priority_default(self):
+        self.assertEqual(_DummyDiscoveryProvider.priority, 100)
+
+    def test_enabled_default(self):
+        self.assertTrue(_DummyDiscoveryProvider.enabled)
+
+    # ---- discover_candidates: happy path ------------------------------------
+
+    def test_discover_candidates_returns_discovery_result(self):
+        provider = _DummyDiscoveryProvider({"https://x/1": "key-a https://x/a"})
+        result = provider.discover_candidates(["https://x/1"])
+        self.assertIsInstance(result, DiscoveryResult)
+
+    def test_discover_candidates_collects_from_one_page(self):
+        provider = _DummyDiscoveryProvider(
+            {"https://x/1": "key-a https://x/a\nkey-b https://x/b"}
+        )
+        result = provider.discover_candidates(["https://x/1"])
+        keys = {c.canonical_key for c in result.candidates}
+        self.assertEqual(keys, {"key-a", "key-b"})
+        self.assertEqual(result.skipped_index_urls, {})
+        self.assertFalse(result.capped)
+
+    def test_discover_candidates_collects_across_pages(self):
+        provider = _DummyDiscoveryProvider(
+            {
+                "https://x/1": "key-a https://x/a",
+                "https://x/2": "key-b https://x/b",
+            }
+        )
+        result = provider.discover_candidates(["https://x/1", "https://x/2"])
+        keys = {c.canonical_key for c in result.candidates}
+        self.assertEqual(keys, {"key-a", "key-b"})
+
+    # ---- de-duplication ------------------------------------------------------
+
+    def test_discover_candidates_dedupes_by_canonical_key_across_pages(self):
+        """A paginated listing whose pages overlap must not seed a key twice."""
+        provider = _DummyDiscoveryProvider(
+            {
+                "https://x/1": "key-a https://x/a",
+                "https://x/2": "key-a https://x/a\nkey-b https://x/b",
+            }
+        )
+        result = provider.discover_candidates(["https://x/1", "https://x/2"])
+        keys = [c.canonical_key for c in result.candidates]
+        self.assertEqual(sorted(keys), ["key-a", "key-b"])
+
+    # ---- bounds (issue #2054 test criterion c) -------------------------------
+
+    def test_discover_candidates_stops_at_max_candidates(self):
+        provider = _DummyDiscoveryProvider(
+            {
+                "https://x/1": "key-a https://x/a\nkey-b https://x/b",
+                "https://x/2": "key-c https://x/c\nkey-d https://x/d",
+            }
+        )
+        result = provider.discover_candidates(
+            ["https://x/1", "https://x/2"], max_candidates=1
+        )
+        self.assertEqual(len(result.candidates), 1)
+        self.assertTrue(result.capped)
+
+    def test_discover_candidates_not_capped_when_under_limit(self):
+        provider = _DummyDiscoveryProvider({"https://x/1": "key-a https://x/a"})
+        result = provider.discover_candidates(["https://x/1"], max_candidates=10)
+        self.assertFalse(result.capped)
+
+    def test_max_candidates_clamped_to_at_least_one(self):
+        """A non-positive max_candidates must not disable bounding entirely."""
+        provider = _DummyDiscoveryProvider(
+            {"https://x/1": "key-a https://x/a\nkey-b https://x/b"}
+        )
+        result = provider.discover_candidates(["https://x/1"], max_candidates=0)
+        self.assertEqual(len(result.candidates), 1)
+        self.assertTrue(result.capped)
+
+    # ---- fetch-error resilience -----------------------------------------------
+
+    def test_discover_candidates_records_skipped_url_and_continues(self):
+        provider = _DummyDiscoveryProvider({"https://x/2": "key-b https://x/b"})
+        result = provider.discover_candidates(["https://x/1", "https://x/2"])
+        self.assertIn("https://x/1", result.skipped_index_urls)
+        keys = {c.canonical_key for c in result.candidates}
+        self.assertEqual(keys, {"key-b"})
+
+    # ---- SSRF (issue #2054 test criterion d) ---------------------------------
+
+    def test_ssrf_blocked_host_is_rejected_and_never_fetched(self):
+        """A non-allowlisted index URL is rejected by safe_http and skipped.
+
+        Uses the REAL ListingIndexDiscoveryProvider (not the dummy) so the
+        actual safe_fetch_text/SSRF gate runs -- no mocking, no network call:
+        the host-allowlist check happens before any DNS resolution or socket
+        connect, so this is deterministic and fast.
+        """
+        provider = ListingIndexDiscoveryProvider()
+        rule = ListingIndexRule(
+            link_pattern=r'href="(?P<url>[^"]+)"',
+            canonical_key_template="{prefix}:{url}",
+            prefix="x",
+        )
+        result = provider.discover_candidates(
+            ["https://evil.example.com/index"], rule=rule
+        )
+        self.assertEqual(result.candidates, [])
+        self.assertIn("https://evil.example.com/index", result.skipped_index_urls)
+        self.assertIn(
+            "blocked", result.skipped_index_urls["https://evil.example.com/index"]
+        )
+
+    # ---- license gate ---------------------------------------------------------
+
+    def test_non_public_domain_license_refuses_to_run(self):
+        provider = _NonPublicDomainDiscoveryProvider(
+            {"https://x/1": "key-a https://x/a"}
+        )
+        with self.assertRaises(PermissionError):
+            provider.discover_candidates(["https://x/1"])
+
+
+class TestAuthorityDiscoveryProviderRegistry(SimpleTestCase):
+    """Tests for AUTHORITY_DISCOVERY_PROVIDER registry wiring."""
+
+    def setUp(self):
+        reset_registry()
+
+    def tearDown(self):
+        reset_registry()
+
+    def test_component_type_enum_member_exists(self):
+        self.assertEqual(
+            ComponentType.AUTHORITY_DISCOVERY_PROVIDER.value,
+            "authority_discovery_provider",
+        )
+
+    def test_get_all_authority_discovery_providers_cached_returns_iterable(self):
+        result = get_all_authority_discovery_providers_cached()
+        self.assertIsInstance(result, (list, tuple))
+
+    def test_listing_index_discovery_provider_is_discovered(self):
+        providers = get_all_authority_discovery_providers_cached()
+        names = {d.name for d in providers}
+        self.assertIn("ListingIndexDiscoveryProvider", names)
+
+    def test_listing_index_discovery_provider_license_surfaced(self):
+        providers = get_all_authority_discovery_providers_cached()
+        sample = next(d for d in providers if d.name == "ListingIndexDiscoveryProvider")
+        self.assertEqual(sample.component_class, ListingIndexDiscoveryProvider)

--- a/opencontractserver/tests/test_authority_frontier_discovery_seed.py
+++ b/opencontractserver/tests/test_authority_frontier_discovery_seed.py
@@ -1,0 +1,173 @@
+"""Tests for AuthorityFrontierService.seed_from_discovery (Phase 2, issue #2054).
+
+Mirrors seed_child_keys' idempotency contract exactly (see that method's
+docstring): a canonical_key that already has a row -- at ANY depth/state -- is
+skipped, so re-running discovery never creates duplicates and never resets an
+in-flight row.
+"""
+
+from __future__ import annotations
+
+from django.test import TestCase
+
+from opencontractserver.annotations.models import AuthorityFrontier
+from opencontractserver.enrichment import constants as C
+from opencontractserver.enrichment.services.authority_frontier_service import (
+    AuthorityFrontierService,
+)
+from opencontractserver.pipeline.base.base_authority_discovery_provider import (
+    DiscoveryCandidate,
+)
+
+
+class SeedFromDiscoveryTests(TestCase):
+    def test_creates_new_rows(self):
+        candidates = [
+            DiscoveryCandidate(
+                canonical_key="bo-gaceta:2024-1234",
+                url="https://x/1234",
+                title="Ley 1234",
+            ),
+            DiscoveryCandidate(
+                canonical_key="bo-gaceta:2024-1235",
+                url="https://x/1235",
+                title="DS 1235",
+            ),
+        ]
+        result = AuthorityFrontierService.seed_from_discovery(
+            candidates, discovery_provider="ListingIndexDiscoveryProvider"
+        )
+        self.assertEqual(result["discovery_created"], 2)
+        self.assertEqual(result["discovery_skipped"], 0)
+        self.assertEqual(
+            set(result["queued_keys"]),
+            {"bo-gaceta:2024-1234", "bo-gaceta:2024-1235"},
+        )
+
+    def test_created_row_fields(self):
+        candidates = [
+            DiscoveryCandidate(
+                canonical_key="bo-gaceta:2024-1234",
+                url="https://x/1234",
+                title="Ley 1234",
+            )
+        ]
+        AuthorityFrontierService.seed_from_discovery(
+            candidates, discovery_provider="ListingIndexDiscoveryProvider"
+        )
+        row = AuthorityFrontier.objects.get(canonical_key="bo-gaceta:2024-1234")
+        self.assertEqual(row.discovery_state, C.DISCOVERY_STATE_QUEUED)
+        self.assertEqual(row.depth, 0)
+        self.assertIsNone(row.provider)
+        self.assertEqual(row.mention_count, 1)
+        self.assertEqual(row.authority, "bo-gaceta")
+        self.assertEqual(len(row.candidate_sources), 1)
+        self.assertEqual(
+            row.candidate_sources[0]["discovery_provider"],
+            "ListingIndexDiscoveryProvider",
+        )
+        self.assertEqual(row.candidate_sources[0]["url"], "https://x/1234")
+        self.assertEqual(row.candidate_sources[0]["title"], "Ley 1234")
+
+    def test_idempotent_no_duplicates_on_rerun(self):
+        candidates = [
+            DiscoveryCandidate(
+                canonical_key="bo-gaceta:2024-9999", url="https://x/9999"
+            )
+        ]
+        AuthorityFrontierService.seed_from_discovery(candidates, discovery_provider="P")
+        result2 = AuthorityFrontierService.seed_from_discovery(
+            candidates, discovery_provider="P"
+        )
+        self.assertEqual(result2["discovery_created"], 0)
+        self.assertEqual(result2["discovery_skipped"], 1)
+        self.assertEqual(
+            AuthorityFrontier.objects.filter(
+                canonical_key="bo-gaceta:2024-9999"
+            ).count(),
+            1,
+        )
+
+    def test_rerun_does_not_overwrite_candidate_sources(self):
+        """A second discovery pass over an already-seeded key must not append a
+        second candidate_sources entry -- seed_from_discovery only ever writes
+        via get_or_create's ``defaults`` (create-time only), mirroring
+        seed_child_keys' "skip, don't update" contract."""
+        first = [
+            DiscoveryCandidate(
+                canonical_key="bo-gaceta:2024-4242", url="https://x/first"
+            )
+        ]
+        second = [
+            DiscoveryCandidate(
+                canonical_key="bo-gaceta:2024-4242", url="https://x/second"
+            )
+        ]
+        AuthorityFrontierService.seed_from_discovery(first, discovery_provider="P")
+        AuthorityFrontierService.seed_from_discovery(second, discovery_provider="P")
+        row = AuthorityFrontier.objects.get(canonical_key="bo-gaceta:2024-4242")
+        self.assertEqual(len(row.candidate_sources), 1)
+        self.assertEqual(row.candidate_sources[0]["url"], "https://x/first")
+
+    def test_never_resets_in_flight_row(self):
+        row = AuthorityFrontier.objects.create(
+            canonical_key="bo-gaceta:2024-5555",
+            authority="bo-gaceta",
+            discovery_state=C.DISCOVERY_STATE_IN_PROGRESS,
+        )
+        candidates = [
+            DiscoveryCandidate(
+                canonical_key="bo-gaceta:2024-5555", url="https://x/5555"
+            )
+        ]
+        result = AuthorityFrontierService.seed_from_discovery(
+            candidates, discovery_provider="P"
+        )
+        row.refresh_from_db()
+        self.assertEqual(result["discovery_created"], 0)
+        self.assertEqual(result["discovery_skipped"], 1)
+        self.assertEqual(row.discovery_state, C.DISCOVERY_STATE_IN_PROGRESS)
+        self.assertEqual(row.candidate_sources, [])
+
+    def test_never_resets_ingested_row(self):
+        row = AuthorityFrontier.objects.create(
+            canonical_key="bo-gaceta:2024-6666",
+            authority="bo-gaceta",
+            discovery_state=C.DISCOVERY_STATE_INGESTED,
+        )
+        candidates = [
+            DiscoveryCandidate(
+                canonical_key="bo-gaceta:2024-6666", url="https://x/6666"
+            )
+        ]
+        AuthorityFrontierService.seed_from_discovery(candidates, discovery_provider="P")
+        row.refresh_from_db()
+        self.assertEqual(row.discovery_state, C.DISCOVERY_STATE_INGESTED)
+
+    def test_jurisdiction_and_authority_type_classified_when_known(self):
+        candidates = [
+            DiscoveryCandidate(canonical_key="usc-15:9999", url="https://x/9999")
+        ]
+        AuthorityFrontierService.seed_from_discovery(candidates, discovery_provider="P")
+        row = AuthorityFrontier.objects.get(canonical_key="usc-15:9999")
+        self.assertEqual(row.jurisdiction, C.JURISDICTION_US_FEDERAL)
+        self.assertEqual(row.authority_type, C.AUTHORITY_TYPE_STATUTE)
+
+    def test_unrecognized_authority_gets_null_classification(self):
+        candidates = [
+            DiscoveryCandidate(
+                canonical_key="totally-unknown-prefix:1", url="https://x/1"
+            )
+        ]
+        AuthorityFrontierService.seed_from_discovery(candidates, discovery_provider="P")
+        row = AuthorityFrontier.objects.get(canonical_key="totally-unknown-prefix:1")
+        self.assertIsNone(row.jurisdiction)
+        self.assertIsNone(row.authority_type)
+
+    def test_empty_candidates_is_a_noop(self):
+        result = AuthorityFrontierService.seed_from_discovery(
+            [], discovery_provider="P"
+        )
+        self.assertEqual(result["discovery_created"], 0)
+        self.assertEqual(result["discovery_skipped"], 0)
+        self.assertEqual(result["queued_keys"], [])

--- a/opencontractserver/tests/test_authority_pack_providers.py
+++ b/opencontractserver/tests/test_authority_pack_providers.py
@@ -4,7 +4,10 @@ A self-contained authority pack may ship its own scraper under
 ``<pack>/providers/*.py``; the pipeline registry discovers it from the pack
 directory (in-tree or via the ``AUTHORITY_PACK_PATHS`` setting) so the provider
 travels WITH its authority instead of living in core's
-``pipeline/authority_source_providers/`` package.
+``pipeline/authority_source_providers/`` package. A pack may ALSO ship a
+DISCOVERY provider (Phase 2, issue #2054) under ``<pack>/discovery_providers/*.py``
+via the same generalized mechanism -- see ``PackDiscoveryProviderDiscoveryTests``
+below.
 
 See ``docs/guides/authoring-authority-packs.md``.
 """
@@ -18,6 +21,7 @@ from django.test import SimpleTestCase, override_settings
 
 from opencontractserver.pipeline.registry import (
     authority_pack_dirs,
+    get_all_authority_discovery_providers_cached,
     get_all_authority_source_providers_cached,
     reset_registry,
 )
@@ -136,6 +140,116 @@ class PackProviderDiscoveryTests(SimpleTestCase):
                 ),
                 cm.output,
             )
+
+
+# A minimal, importable discovery provider shipped "inside a pack" (Phase 2,
+# issue #2054). Same file-path-import convention as _DEMO_PROVIDER_SRC above.
+_DEMO_DISCOVERY_PROVIDER_SRC = """
+from opencontractserver.pipeline.base.base_authority_discovery_provider import (
+    BaseAuthorityDiscoveryProvider,
+    DiscoveryCandidate,
+)
+
+
+class DemoPackDiscoveryProvider(BaseAuthorityDiscoveryProvider):
+    title = "Demo Pack Discovery Provider"
+
+    def _fetch_index_impl(self, index_url, **kw):
+        return "<html></html>"
+
+    def _parse_index_impl(self, html, *, index_url, **kw):
+        return [DiscoveryCandidate(canonical_key="demo-pack:1", url=index_url)]
+"""
+
+
+class PackDiscoveryProviderDiscoveryTests(SimpleTestCase):
+    """Registry-level discovery for BaseAuthorityDiscoveryProvider; no DB needed."""
+
+    def setUp(self):
+        self.addCleanup(reset_registry)
+
+    @staticmethod
+    def _write_pack(root: Path) -> Path:
+        pack = root / "demo-discovery-pack"
+        discovery_providers = pack / "discovery_providers"
+        discovery_providers.mkdir(parents=True)
+        (discovery_providers / "demo_discovery_provider.py").write_text(
+            _DEMO_DISCOVERY_PROVIDER_SRC, encoding="utf-8"
+        )
+        (discovery_providers / "_helper.py").write_text("X = 1\n", encoding="utf-8")
+        return pack
+
+    def test_in_pack_discovery_provider_is_discovered(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            pack = self._write_pack(Path(tmp))
+            with override_settings(AUTHORITY_PACK_PATHS=[str(pack)]):
+                reset_registry()
+                provs = get_all_authority_discovery_providers_cached()
+                by_name = {p.name: p for p in provs}
+                self.assertIn("DemoPackDiscoveryProvider", by_name)
+                provider_cls = by_name["DemoPackDiscoveryProvider"].component_class
+                assert provider_cls is not None
+                candidates = provider_cls()._parse_index_impl(
+                    "<html></html>", index_url="https://x/1"
+                )
+                self.assertEqual(candidates[0].canonical_key, "demo-pack:1")
+
+    def test_provider_absent_without_pack_path(self):
+        with override_settings(AUTHORITY_PACK_PATHS=[]):
+            reset_registry()
+            names = {p.name for p in get_all_authority_discovery_providers_cached()}
+            self.assertNotIn("DemoPackDiscoveryProvider", names)
+            # The shipped core reference provider is still discovered.
+            self.assertIn("ListingIndexDiscoveryProvider", names)
+
+    def test_broken_pack_discovery_provider_is_logged_and_skipped(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            pack = self._write_pack(Path(tmp))
+            (pack / "discovery_providers" / "broken.py").write_text(
+                "raise RuntimeError('boom in pack discovery provider')\n",
+                encoding="utf-8",
+            )
+            with override_settings(AUTHORITY_PACK_PATHS=[str(pack)]):
+                reset_registry()
+                with self.assertLogs(_REGISTRY_LOGGER, level="WARNING") as cm:
+                    names = {
+                        p.name for p in get_all_authority_discovery_providers_cached()
+                    }
+            self.assertIn("DemoPackDiscoveryProvider", names)
+            self.assertTrue(
+                any("Failed to import pack provider" in m for m in cm.output),
+                cm.output,
+            )
+
+    def test_source_provider_pack_and_discovery_provider_pack_do_not_collide(self):
+        """A pack shipping BOTH <pack>/providers/ and <pack>/discovery_providers/
+        must register both without either shadowing the other (module_ns
+        disambiguates the synthetic import namespace)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            pack = root / "dual-pack"
+            providers_dir = pack / "providers"
+            providers_dir.mkdir(parents=True)
+            (providers_dir / "source_provider.py").write_text(
+                _DEMO_PROVIDER_SRC, encoding="utf-8"
+            )
+            discovery_dir = pack / "discovery_providers"
+            discovery_dir.mkdir(parents=True)
+            (discovery_dir / "discovery_provider.py").write_text(
+                _DEMO_DISCOVERY_PROVIDER_SRC, encoding="utf-8"
+            )
+            with override_settings(AUTHORITY_PACK_PATHS=[str(pack)]):
+                reset_registry()
+                source_names = {
+                    p.name for p in get_all_authority_source_providers_cached()
+                }
+                discovery_names = {
+                    p.name for p in get_all_authority_discovery_providers_cached()
+                }
+        self.assertIn("DemoPackProvider", source_names)
+        self.assertIn("DemoPackDiscoveryProvider", discovery_names)
+        self.assertNotIn("DemoPackDiscoveryProvider", source_names)
+        self.assertNotIn("DemoPackProvider", discovery_names)
 
 
 class AuthorityPackDirsTests(SimpleTestCase):

--- a/opencontractserver/tests/test_discover_authority_candidates_command.py
+++ b/opencontractserver/tests/test_discover_authority_candidates_command.py
@@ -1,0 +1,79 @@
+"""Tests for the discover_authority_candidates management command (issue #2054).
+
+The operator-invocable surface for Phase 2 discovery -- no admin UI, by design
+(see the command's module docstring). HTTP is mocked (patching safe_fetch_text);
+no network calls are made.
+"""
+
+from __future__ import annotations
+
+import io
+from unittest.mock import patch
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from opencontractserver.annotations.models import AuthorityFrontier
+
+_SAFE_FETCH_PATH = (
+    "opencontractserver.pipeline.authority_discovery_providers."
+    "listing_index_provider.safe_fetch_text"
+)
+
+_FIXTURE_HTML = """
+<html><body>
+<a href="/doc/1">Document One</a>
+<a href="/doc/2">Document Two</a>
+</body></html>
+"""
+
+
+class DiscoverAuthorityCandidatesCommandTests(TestCase):
+    def _run(self, *extra_args):
+        out, err = io.StringIO(), io.StringIO()
+        call_command(
+            "discover_authority_candidates",
+            "--index-url=https://example.gov/listing",
+            r'--link-pattern=<a href="(?P<url>/doc/(?P<id>\d+))">(?P<title>[^<]+)</a>',
+            "--canonical-key-template={prefix}:{id}",
+            "--prefix=demo",
+            *extra_args,
+            stdout=out,
+            stderr=err,
+        )
+        return out.getvalue(), err.getvalue()
+
+    def test_seeds_frontier_by_default(self):
+        with patch(_SAFE_FETCH_PATH, return_value=(_FIXTURE_HTML, "example.gov")):
+            out, _ = self._run()
+        self.assertIn("discovered 2 candidate(s)", out)
+        self.assertIn("frontier seeded: created=2 skipped=0", out)
+        self.assertEqual(
+            set(
+                AuthorityFrontier.objects.filter(
+                    canonical_key__in=["demo:1", "demo:2"]
+                ).values_list("canonical_key", flat=True)
+            ),
+            {"demo:1", "demo:2"},
+        )
+
+    def test_dry_run_does_not_seed_frontier(self):
+        with patch(_SAFE_FETCH_PATH, return_value=(_FIXTURE_HTML, "example.gov")):
+            out, _ = self._run("--dry-run")
+        self.assertIn("--dry-run", out)
+        self.assertFalse(
+            AuthorityFrontier.objects.filter(
+                canonical_key__in=["demo:1", "demo:2"]
+            ).exists()
+        )
+
+    def test_rerun_is_idempotent(self):
+        with patch(_SAFE_FETCH_PATH, return_value=(_FIXTURE_HTML, "example.gov")):
+            self._run()
+            out, _ = self._run()
+        self.assertIn("frontier seeded: created=0 skipped=2", out)
+
+    def test_max_candidates_cap_applied(self):
+        with patch(_SAFE_FETCH_PATH, return_value=(_FIXTURE_HTML, "example.gov")):
+            out, _ = self._run("--max-candidates=1", "--dry-run")
+        self.assertIn("discovered 1 candidate(s) (capped)", out)

--- a/opencontractserver/tests/test_listing_index_discovery_provider.py
+++ b/opencontractserver/tests/test_listing_index_discovery_provider.py
@@ -137,6 +137,29 @@ class TestParseIndexImpl(SimpleTestCase):
         )
         self.assertEqual(candidates, [])
 
+    def test_link_pattern_group_named_prefix_does_not_raise_typeerror(self):
+        """A link_pattern that defines its OWN named group literally called
+        'prefix' (e.g. a jurisdiction/prefix column in the source markup) must
+        not crash with `TypeError: got multiple values for keyword argument
+        'prefix'` -- rule.prefix (the deliberately-configured value) wins over
+        the regex-captured one, per ListingIndexRule's docstring."""
+        rule = ListingIndexRule(
+            link_pattern=(
+                r'<a href="(?P<url>/doc/(?P<prefix>[a-z]+)-(?P<id>\d+))">'
+                r"(?P<title>[^<]+)</a>"
+            ),
+            canonical_key_template="{prefix}:{id}",
+            prefix="configured-prefix",
+        )
+        html = '<a href="/doc/bo-42">Some Doc</a>'
+        candidates = self.provider._parse_index_impl(
+            html, index_url=_INDEX_URL, rule=rule
+        )
+        self.assertEqual(len(candidates), 1)
+        # rule.prefix ("configured-prefix") wins; the regex-captured "bo" is
+        # discarded, not concatenated or otherwise blended in.
+        self.assertEqual(candidates[0].canonical_key, "configured-prefix:42")
+
 
 _SAFE_FETCH_PATH = (
     "opencontractserver.pipeline.authority_discovery_providers."
@@ -184,6 +207,25 @@ class TestDiscoverCandidatesEndToEnd(SimpleTestCase):
             )
         self.assertEqual(len(result.candidates), 2)
         self.assertTrue(result.capped)
+
+    def test_end_to_end_survives_link_pattern_prefix_group_collision(self):
+        """discover_candidates() -- the public entrypoint the management
+        command calls -- must not raise when link_pattern defines its own
+        'prefix' group, regardless of the pure-parse-level test above."""
+        rule = ListingIndexRule(
+            link_pattern=(
+                r'<a href="(?P<url>/doc/(?P<prefix>[a-z]+)-(?P<id>\d+))">'
+                r"(?P<title>[^<]+)</a>"
+            ),
+            canonical_key_template="{prefix}:{id}",
+            prefix="configured-prefix",
+        )
+        html = '<a href="/doc/bo-42">Some Doc</a>'
+        with patch(_SAFE_FETCH_PATH, return_value=(html, "www.example.gov")):
+            provider = ListingIndexDiscoveryProvider()
+            result = provider.discover_candidates([_INDEX_URL], rule=rule)
+        self.assertEqual(len(result.candidates), 1)
+        self.assertEqual(result.candidates[0].canonical_key, "configured-prefix:42")
 
 
 class TestSSRFRejection(SimpleTestCase):

--- a/opencontractserver/tests/test_listing_index_discovery_provider.py
+++ b/opencontractserver/tests/test_listing_index_discovery_provider.py
@@ -1,0 +1,214 @@
+"""Unit tests for ListingIndexDiscoveryProvider (Phase 2, issue #2054).
+
+All HTTP is mocked -- no network calls are made (patching ``safe_fetch_text``,
+the same convention as ``test_cfr_provider.py``). The fixture HTML is loaded
+from ``opencontractserver/tests/fixtures/authority_sources/`` and is a
+SYNTHETIC stand-in shaped like Bolivia's Gaceta Oficial (the issue's motivating
+case) -- it is not scraped from, and makes no claim about, the real site's
+current markup.
+
+Test coverage:
+  - ListingIndexRule validation (must declare a 'url' group; regex must compile).
+  - _parse_index_impl: pure extraction of candidates from the fixture (criterion a).
+  - _fetch_index_impl: patched safe_fetch_text -> raw HTML passthrough.
+  - discover_candidates end-to-end with a patched fetch.
+  - SSRF: a non-allowlisted index URL is rejected and never fetched (criterion d).
+"""
+
+from __future__ import annotations
+
+import pathlib
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+
+from opencontractserver.pipeline.authority_discovery_providers.listing_index_provider import (
+    ListingIndexDiscoveryProvider,
+    ListingIndexRule,
+)
+
+FIXTURE_DIR = pathlib.Path(__file__).parent / "fixtures" / "authority_sources"
+_FIXTURE_HTML = (FIXTURE_DIR / "gaceta_listing_bolivia_synthetic.html").read_text(
+    encoding="utf-8"
+)
+
+_INDEX_URL = "https://www.gacetaoficialdebolivia.gob.bo/gaceta/listado"
+
+# A rule tuned to the synthetic fixture's markup (see the fixture file's own
+# header comment: this is a hand-written test shape, not a verified live rule).
+_BOLIVIA_GACETA_RULE = ListingIndexRule(
+    link_pattern=(
+        r'<a href="(?P<url>(?:https?://[^/"]+)?/gaceta/documento/(?P<id>[\w-]+))">'
+        r"(?P<title>[^<]+)</a>"
+    ),
+    canonical_key_template="{prefix}:{id}",
+    prefix="bo-gaceta",
+)
+
+
+class TestListingIndexRule(SimpleTestCase):
+    def test_requires_named_url_group(self):
+        with self.assertRaises(ValueError):
+            ListingIndexRule(
+                link_pattern=r"<a href=(?P<link>[^>]+)>",
+                canonical_key_template="{prefix}:{link}",
+                prefix="x",
+            )
+
+    def test_invalid_regex_raises(self):
+        with self.assertRaises(ValueError):
+            ListingIndexRule(
+                link_pattern=r"(?P<url>[",
+                canonical_key_template="{prefix}:{url}",
+                prefix="x",
+            )
+
+    def test_valid_rule_constructs(self):
+        rule = ListingIndexRule(
+            link_pattern=r'href="(?P<url>[^"]+)"',
+            canonical_key_template="{prefix}:{url}",
+            prefix="x",
+        )
+        self.assertEqual(rule.prefix, "x")
+
+
+class TestParseIndexImpl(SimpleTestCase):
+    """Pure tests for _parse_index_impl against the synthetic fixture (criterion a)."""
+
+    def setUp(self):
+        self.provider = ListingIndexDiscoveryProvider()
+
+    def _parse(self):
+        return self.provider._parse_index_impl(
+            _FIXTURE_HTML, index_url=_INDEX_URL, rule=_BOLIVIA_GACETA_RULE
+        )
+
+    def test_finds_three_candidates(self):
+        """The fixture has 4 rows; one has no <a> link and must be skipped."""
+        candidates = self._parse()
+        self.assertEqual(len(candidates), 3)
+
+    def test_canonical_keys(self):
+        candidates = self._parse()
+        keys = {c.canonical_key for c in candidates}
+        self.assertEqual(
+            keys, {"bo-gaceta:2024-1234", "bo-gaceta:2024-1235", "bo-gaceta:2024-1236"}
+        )
+
+    def test_relative_url_resolved_against_index_url(self):
+        candidates = self._parse()
+        by_key = {c.canonical_key: c for c in candidates}
+        self.assertEqual(
+            by_key["bo-gaceta:2024-1234"].url,
+            "https://www.gacetaoficialdebolivia.gob.bo/gaceta/documento/2024-1234",
+        )
+
+    def test_absolute_url_preserved(self):
+        candidates = self._parse()
+        by_key = {c.canonical_key: c for c in candidates}
+        self.assertEqual(
+            by_key["bo-gaceta:2024-1236"].url,
+            "https://www.gacetaoficialdebolivia.gob.bo/gaceta/documento/2024-1236",
+        )
+
+    def test_title_captured(self):
+        candidates = self._parse()
+        by_key = {c.canonical_key: c for c in candidates}
+        self.assertIn("Decreto Supremo", by_key["bo-gaceta:2024-1235"].title)
+
+    def test_extra_carries_index_url(self):
+        candidates = self._parse()
+        self.assertEqual(candidates[0].extra["index_url"], _INDEX_URL)
+
+    def test_missing_rule_kwarg_raises(self):
+        with self.assertRaises(ValueError):
+            self.provider._parse_index_impl(_FIXTURE_HTML, index_url=_INDEX_URL)
+
+    def test_template_field_missing_from_match_is_skipped_not_raised(self):
+        """A canonical_key_template referencing a group the pattern doesn't
+        capture must skip that match rather than blow up the whole page."""
+        rule = ListingIndexRule(
+            link_pattern=r'<a href="(?P<url>[^"]+)">[^<]*</a>',
+            canonical_key_template="{prefix}:{nonexistent_group}",
+            prefix="x",
+        )
+        candidates = self.provider._parse_index_impl(
+            _FIXTURE_HTML, index_url=_INDEX_URL, rule=rule
+        )
+        self.assertEqual(candidates, [])
+
+
+_SAFE_FETCH_PATH = (
+    "opencontractserver.pipeline.authority_discovery_providers."
+    "listing_index_provider.safe_fetch_text"
+)
+
+
+class TestFetchIndexImpl(SimpleTestCase):
+    """Tests for _fetch_index_impl with mocked HTTP (patching safe_fetch_text)."""
+
+    def test_fetch_returns_body_text(self):
+        with patch(_SAFE_FETCH_PATH, return_value=(_FIXTURE_HTML, "www.example.gov")):
+            provider = ListingIndexDiscoveryProvider()
+            html = provider._fetch_index_impl(_INDEX_URL)
+        self.assertEqual(html, _FIXTURE_HTML)
+
+    def test_fetch_passes_user_agent_header(self):
+        with patch(
+            _SAFE_FETCH_PATH, return_value=(_FIXTURE_HTML, "www.example.gov")
+        ) as mock_fetch:
+            provider = ListingIndexDiscoveryProvider()
+            provider._fetch_index_impl(_INDEX_URL)
+        _, call_kwargs = mock_fetch.call_args
+        self.assertIn("User-Agent", call_kwargs["headers"])
+
+
+class TestDiscoverCandidatesEndToEnd(SimpleTestCase):
+    """discover_candidates() with a patched fetch -- full pipeline, no network."""
+
+    def test_end_to_end_discovery(self):
+        with patch(_SAFE_FETCH_PATH, return_value=(_FIXTURE_HTML, "www.example.gov")):
+            provider = ListingIndexDiscoveryProvider()
+            result = provider.discover_candidates(
+                [_INDEX_URL], rule=_BOLIVIA_GACETA_RULE
+            )
+        self.assertEqual(len(result.candidates), 3)
+        self.assertFalse(result.capped)
+        self.assertEqual(result.skipped_index_urls, {})
+
+    def test_end_to_end_respects_max_candidates(self):
+        with patch(_SAFE_FETCH_PATH, return_value=(_FIXTURE_HTML, "www.example.gov")):
+            provider = ListingIndexDiscoveryProvider()
+            result = provider.discover_candidates(
+                [_INDEX_URL], rule=_BOLIVIA_GACETA_RULE, max_candidates=2
+            )
+        self.assertEqual(len(result.candidates), 2)
+        self.assertTrue(result.capped)
+
+
+class TestSSRFRejection(SimpleTestCase):
+    """A URL that would fail safe_http validation is rejected and never fetched
+    (issue #2054 test criterion d). No mocking -- the REAL safe_fetch_text/
+    SSRF gate runs, and the host-allowlist check fires before any DNS
+    resolution or socket connect (see opencontractserver/utils/safe_http.py::
+    validate_url), so this needs no network access and is fully deterministic."""
+
+    def test_non_allowlisted_host_is_rejected_and_never_fetched(self):
+        provider = ListingIndexDiscoveryProvider()
+        result = provider.discover_candidates(
+            ["https://evil.example.com/listing"], rule=_BOLIVIA_GACETA_RULE
+        )
+        self.assertEqual(result.candidates, [])
+        reason = result.skipped_index_urls["https://evil.example.com/listing"]
+        self.assertIn("blocked", reason)
+        self.assertIn("allowlist", reason)
+
+    def test_http_scheme_is_also_rejected(self):
+        """Belt-and-suspenders: the scheme check runs before the allowlist
+        check, so a downgraded (non-HTTPS) URL is rejected too."""
+        provider = ListingIndexDiscoveryProvider()
+        result = provider.discover_candidates(
+            ["http://www.ecfr.gov/listing"], rule=_BOLIVIA_GACETA_RULE
+        )
+        self.assertEqual(result.candidates, [])
+        self.assertIn("http://www.ecfr.gov/listing", result.skipped_index_urls)


### PR DESCRIPTION
## Summary

Closes #2054. Implements Phase 2 of the Authority Packs proposal
(`docs/architecture/proposals/0002-authority-packs.md` §7, gap 3): a way to
discover documents nobody has cited yet by crawling a publisher's index/listing
page, as opposed to the existing citation-keyed `BaseAuthoritySourceProvider`
rail which can only resolve *known* canonical keys.

- **`BaseAuthorityDiscoveryProvider`**
  (`opencontractserver/pipeline/base/base_authority_discovery_provider.py`) —
  given one or more index-page URLs, lists `DiscoveryCandidate` objects
  (canonical_key + url + minimal metadata) without fetching full text or
  ingesting anything. Mirrors the existing `locate`/`fetch` split as
  `_fetch_index_impl` (I/O, must route through `safe_fetch_text`) /
  `_parse_index_impl` (pure, parses already-fetched HTML). The public
  `discover_candidates()`:
  - de-dupes candidates by `canonical_key` across paginated index pages,
  - stops at a named cap (`enrichment.constants.DISCOVERY_DEFAULT_MAX_CANDIDATES`
    / `DISCOVERY_MAX_MAX_CANDIDATES`, clamped via `clamp_int`),
  - records per-URL fetch failures (including SSRF rejections) in
    `skipped_index_urls` instead of aborting the whole run,
  - refuses to run at all unless `license == "public-domain"` (mirrors
    `BaseAuthoritySourceProvider.license` / `AuthorityGateService`'s license gate).

- **One reference implementation, `ListingIndexDiscoveryProvider`**
  (`opencontractserver/pipeline/authority_discovery_providers/listing_index_provider.py`)
  — config-driven and jurisdiction-agnostic: a publisher supplies a
  `ListingIndexRule` (a regex with a named `url` group + a `canonical_key_template`
  + a `prefix`), not new code. No new HTML-parsing dependency — extraction is a
  plain `re.finditer` over the raw fetched HTML, consistent with this repo's
  existing XML/regex-based provider style (no BeautifulSoup/lxml in
  requirements). Illustrated and tested against a synthetic, Gaceta-Oficial-*shaped*
  fixture (Bolivia is the proposal's motivating case) — **this is explicitly not
  a verified live scraper**; nobody in this session inspected the real site's
  current markup, so no real index URL or host is wired into the shipped
  `bolivia` pack. An operator who has verified a real publisher's markup supplies
  their own rule.

- **`AuthorityFrontierService.seed_from_discovery`**
  (`opencontractserver/enrichment/services/authority_frontier_service.py`) — the
  idempotent frontier-seeding entrypoint, mirroring `seed_child_keys`'s contract
  exactly: a `canonical_key` that already has a row (any depth/state) is
  skipped, so re-running discovery never duplicates rows and never resets an
  in-flight row's `discovery_state`. Freshly created rows are seeded at
  `depth=0`, `mention_count=1`, `provider=None` (so the existing
  `discover_and_bootstrap` routing picks a source provider normally), with the
  candidate's url/title recorded as the first `candidate_sources` audit entry.

- **Pipeline registry** (`opencontractserver/pipeline/registry.py`) — extended
  to auto-discover `BaseAuthorityDiscoveryProvider` subclasses the same way as
  `BaseAuthoritySourceProvider`: core `authority_discovery_providers/` package
  plus in-pack `<pack>/discovery_providers/*.py`. Generalized the prior
  source-provider-only `_discover_pack_provider_classes` into
  `_discover_pack_component_classes(subdir_name, base_class, module_ns)` so both
  component families share one mechanism instead of two near-duplicates. New
  `ComponentType.AUTHORITY_DISCOVERY_PROVIDER` +
  `get_all_authority_discovery_providers_cached()`.

- **`discover_authority_candidates` management command**
  (`opencontractserver/annotations/management/commands/discover_authority_candidates.py`)
  — the operator entrypoint (`--index-url` / `--link-pattern` /
  `--canonical-key-template` / `--prefix` / `--max-candidates` / `--dry-run`).
  Deliberately **no admin UI** — out of scope for this issue.

- Docs: updated `docs/architecture/proposals/0002-authority-packs.md` §7's
  phasing table (Phase 2 now marked shipped) and added a short implementation-status
  callout; extended `docs/guides/authoring-authority-packs.md` with a
  "Discovering UNKNOWN documents" section and the `discovery_providers/`
  pack-layout entry.

## Scope notes (what was deliberately deferred)

- **No scheduled/recurring crawling** (Celery-Beat) — that is Phase 3 in the
  proposal doc, unrelated to this issue.
- **No multi-corpus orchestration** (`CorpusGroup` / cross-corpus query) — Phase 4.
- **No admin/frontend UI** — explicitly out of scope per the issue; the
  management command is the operator surface.
- **No live Bolivia wiring** — the shipped `bolivia` pack's `pack.yaml` /
  `source_hosts` are untouched; adding a *verified* real index URL + regex for
  Gaceta Oficial (or TSJ/TCP) is left to an operator who has actually inspected
  that site, consistent with the constraint that nothing here should claim
  correctness against a live site nobody here could check.
- **Provenance**: per the proposal doc's §6 "Contributor credit" note, the
  Bolivia/Gaceta-Oficial-shaped worked example and the `httpx`-mocked testing
  approach follow the precedent credited to PR #1305 (@jseborga) in that doc —
  this PR's code is new, but the choice of worked example and testing style is
  drawn from that credited prior art.

## Test plan

All new + related existing tests pass via
`docker compose -f test.yml -p opencontracts run --rm django pytest ...` (this
host runs concurrent sibling test runs against the same shared containers, so
`-p` does not give real isolation here — no destructive compose commands were
run). Test counts below are current as of the latest commit (a follow-up fixed
an inaccurate `DiscoveryResult.capped` under one boundary condition — see the
review-follow-up note at the end of this section):

- `test_authority_discovery_provider_base.py` — ABC contract: license gate,
  bounds/cap (including the exactly-at-limit-with-nothing-left boundary, both
  single-page and cross-page), cross-page de-dup, fetch-error resilience, SSRF
  rejection, registry wiring (**19 tests**)
- `test_listing_index_discovery_provider.py` — `ListingIndexRule` validation,
  pure `_parse_index_impl` against the synthetic fixture, mocked
  `_fetch_index_impl`, end-to-end `discover_candidates`, real (unmocked) SSRF
  gate (**17 tests**)
- `test_authority_frontier_discovery_seed.py` — idempotent create, no
  duplicates on rerun, never resets `in_progress`/`ingested` rows, jurisdiction
  classification (**9 tests**)
- `test_discover_authority_candidates_command.py` — management command
  wiring, `--dry-run`, idempotent rerun, `--max-candidates` cap (**4 tests**)
- `test_authority_pack_providers.py` — extended with in-pack
  `discovery_providers/` discovery, broken-module isolation, and a
  dual-pack (`providers/` + `discovery_providers/`) non-collision test
  (**4 new tests**, 9 total in the file)
- Full targeted run (own tests + `test_authority_frontier*.py` +
  `test_authority_source_provider*.py` + `test_authority_pack_providers.py`):
  **162 passed**
- Pipeline registry / provider regression check
  (`test_pipeline_registry.py`, `test_pipeline_component_base.py`,
  `test_pipeline_component_queries.py`, `test_cfr_provider.py`,
  `test_us_code_provider.py`, `test_federal_register_provider.py`,
  `test_agentic_web_locator.py`): **213 passed**
- `test_graphql_service_layer.py` (E001 invariant): **90 passed**
- `manage.py check`: no issues
- `pre-commit run --all-files`: clean (black/isort/flake8/mypy/pyupgrade)
- `python scripts/collate_changelog.py --check`: OK

**Review follow-up (addressed in a later commit on this branch):** an
automated review flagged that `DiscoveryResult.capped` could report `True`
even when nothing was actually truncated (e.g. a single page yielding exactly
`max_candidates` candidates, with no more pages/URLs left). `capped` is now
computed from data already in memory — true only if a distinct candidate is
provably left over later in the same parsed page, or an `index_url` was never
fetched — never by fetching an extra page just to check. Two new boundary
tests assert `capped is False` at the exact cap == total-distinct-candidates
edge (single page and cross-page variants). Also cached
`ListingIndexRule`'s compiled `link_pattern` once (`__post_init__`, via
`object.__setattr__` since the dataclass is frozen) instead of recompiling it
on every `_parse_index_impl` call.

## Design judgment calls for reviewers to double-check

1. **Regex-based HTML extraction, not a DOM/CSS-selector library.** This repo
   carries no BeautifulSoup/lxml, so `ListingIndexDiscoveryProvider` applies the
   caller-supplied regex directly via `re.finditer`. This keeps it
   dependency-free and deterministic for tests, at the cost of being less
   robust than real DOM parsing against messy/irregular markup. A publisher
   whose markup doesn't fit one regex can subclass
   `BaseAuthorityDiscoveryProvider` directly.
2. **`AuthorityFrontier.provider` is left `None` on discovery-seeded rows.**
   That field names a registered `BaseAuthoritySourceProvider` (the fetch
   rail); a discovery provider is a different kind of component and doesn't
   stamp it, so a freshly-discovered row with no matching source provider will
   sit `queued` until one exists (mirrors the existing behavior for
   `seed_child_keys`/`seed_from_wanted_authorities`).
3. **`seed_from_discovery` writes candidate metadata only via `get_or_create`
   defaults (create-time only)**, never updating an existing row — this
   mirrors `seed_child_keys`'s "skip, don't update" idempotency contract
   exactly, but means a second discovery pass with a corrected/updated URL for
   an already-seeded key does not refresh it. Consistent with precedent; flagging
   in case reviewers want a different refresh semantic for discovery specifically.
4. **No pack.yaml schema change and no wiring for the actual Bolivia pack** —
   deliberate, to avoid claiming unverifiable correctness against a live site;
   see the "Scope notes" section above.
