### PR TITLE
Add dedicated bulk embeddings pool for ingest

### DIFF
--- a/changelog.d/bulk-embeddings-pool.added.md
+++ b/changelog.d/bulk-embeddings-pool.added.md
@@ -1,0 +1,12 @@
+- **Separate "bulk" embeddings microservice pool for ingest.** Added the
+  `EMBEDDINGS_MICROSERVICE_URL_BULK` setting (`config/settings/base.py`, next to
+  `EMBEDDINGS_MICROSERVICE_URL`), defaulting to `EMBEDDINGS_MICROSERVICE_URL` so
+  single-pool deployments are unaffected. The Celery ingest tasks in
+  `opencontractserver/tasks/embeddings_task.py` now thread this bulk URL into
+  the embedder's existing call-time `embeddings_microservice_url` override kwarg
+  via a new optional `service_url_override` parameter on `_create_text_embedding`,
+  `_create_embedding_for_annotation`, `_batch_embed_text_annotations`, and
+  `_apply_dual_embedding_strategy` (plus `_embed_relationship`). Query/search
+  call sites are unchanged — they keep reading `EMBEDDINGS_MICROSERVICE_URL` (the
+  always-warm pod), so search latency is fully isolated from batch ingest load.
+  No change to the embedder client, base class, or any search resolver.

--- a/changelog.d/bulk-embeddings-pool.added.md
+++ b/changelog.d/bulk-embeddings-pool.added.md
@@ -1,7 +1,8 @@
 - **Separate "bulk" embeddings microservice pool for ingest.** Added the
   `EMBEDDINGS_MICROSERVICE_URL_BULK` setting (`config/settings/base.py`, next to
-  `EMBEDDINGS_MICROSERVICE_URL`), defaulting to `EMBEDDINGS_MICROSERVICE_URL` so
-  single-pool deployments are unaffected. The Celery ingest tasks in
+  `EMBEDDINGS_MICROSERVICE_URL`). It is opt-in and defaults to unset (`None`), so
+  single-pool deployments keep using `EMBEDDINGS_MICROSERVICE_URL` unchanged. The
+  Celery ingest tasks in
   `opencontractserver/tasks/embeddings_task.py` now thread this bulk URL into
   the embedder's existing call-time `embeddings_microservice_url` override kwarg
   via a new optional `service_url_override` parameter on `_create_text_embedding`,

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -1175,11 +1175,10 @@ EMBEDDINGS_MICROSERVICE_URL = env(
 # affected. Batch ingest (the Celery tasks in
 # opencontractserver/tasks/embeddings_task.py) routes through this bulk pool
 # instead, which can scale to zero / cold-start under load without touching the
-# query path. Defaults to EMBEDDINGS_MICROSERVICE_URL so single-pool
-# deployments need no extra configuration.
-EMBEDDINGS_MICROSERVICE_URL_BULK = env(
-    "EMBEDDINGS_MICROSERVICE_URL_BULK", default=EMBEDDINGS_MICROSERVICE_URL
-)
+# query path. Opt-in: when unset (the default) it is ``None`` and ingest stays
+# on the embedder's configured URL (EMBEDDINGS_MICROSERVICE_URL) exactly as
+# before — set it only to split ingest onto a separate pool.
+EMBEDDINGS_MICROSERVICE_URL_BULK = env("EMBEDDINGS_MICROSERVICE_URL_BULK", default=None)
 VECTOR_EMBEDDER_API_KEY = env("VECTOR_EMBEDDER_API_KEY", default="")
 # CLIP embedder configuration (768-dimensional vectors)
 CLIP_EMBEDDER_URL = env("CLIP_EMBEDDER_URL", default="http://vector-embedder:8000")

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -1170,6 +1170,16 @@ DEFAULT_PERMISSIONS_GROUP = "Public Objects Access"
 EMBEDDINGS_MICROSERVICE_URL = env(
     "EMBEDDINGS_MICROSERVICE_URL", default="http://vector-embedder:8000"
 )
+# Ingest ("bulk") embeddings pool. Query call sites keep reading
+# EMBEDDINGS_MICROSERVICE_URL (the always-warm pod) so search latency is never
+# affected. Batch ingest (the Celery tasks in
+# opencontractserver/tasks/embeddings_task.py) routes through this bulk pool
+# instead, which can scale to zero / cold-start under load without touching the
+# query path. Defaults to EMBEDDINGS_MICROSERVICE_URL so single-pool
+# deployments need no extra configuration.
+EMBEDDINGS_MICROSERVICE_URL_BULK = env(
+    "EMBEDDINGS_MICROSERVICE_URL_BULK", default=EMBEDDINGS_MICROSERVICE_URL
+)
 VECTOR_EMBEDDER_API_KEY = env("VECTOR_EMBEDDER_API_KEY", default="")
 # CLIP embedder configuration (768-dimensional vectors)
 CLIP_EMBEDDER_URL = env("CLIP_EMBEDDER_URL", default="http://vector-embedder:8000")

--- a/docs/deployment/performance_tuning.md
+++ b/docs/deployment/performance_tuning.md
@@ -118,6 +118,32 @@ A process-wide singleton session gives us:
 are permanent failures that should surface as `EmbeddingClientError`
 immediately, not waste retry budget.
 
+#### Separate "bulk" embeddings pool for ingest
+
+Search queries embed one short string and need a *warm* microservice pod
+(cold starts add seconds to every query). Batch ingest embeds thousands of
+strings and is happy to hit an autoscaled / scale-to-zero pool. Serving both
+from the same URL forces a compromise. The `EMBEDDINGS_MICROSERVICE_URL_BULK`
+setting (`config/settings/base.py`, defaults to `EMBEDDINGS_MICROSERVICE_URL`)
+lets operators point ingest at a dedicated bulk pool while query call sites
+stay on the always-warm pod — search latency is then fully isolated from
+ingest load.
+
+The mechanism reuses the embedder's *existing* call-time override kwarg
+(`embeddings_microservice_url`, read in
+`MicroserviceEmbedder._get_service_config`) rather than touching the embedder
+client or base class. The ingest Celery tasks in
+`opencontractserver/tasks/embeddings_task.py` resolve the bulk URL via
+`_bulk_embeddings_service_url()` and thread it through an optional
+`service_url_override` parameter on the four ingest leaves
+(`_create_text_embedding`, `_create_embedding_for_annotation`,
+`_batch_embed_text_annotations`, `_apply_dual_embedding_strategy`, plus
+`_embed_relationship`). When unset, `service_url_override` is `None` and no
+override kwarg is passed, so the embedder stays on its configured URL and
+default behavior is unchanged. The multimodal *image* pool is intentionally
+left on its own URL (`CLIP_EMBEDDER_URL` / `QWEN_EMBEDDER_URL`) — the bulk
+setting is text-only.
+
 ### Annotation-creation changes
 
 #### `import_annotations` uses `bulk_create` + dispatched batch task

--- a/docs/deployment/performance_tuning.md
+++ b/docs/deployment/performance_tuning.md
@@ -124,10 +124,11 @@ Search queries embed one short string and need a *warm* microservice pod
 (cold starts add seconds to every query). Batch ingest embeds thousands of
 strings and is happy to hit an autoscaled / scale-to-zero pool. Serving both
 from the same URL forces a compromise. The `EMBEDDINGS_MICROSERVICE_URL_BULK`
-setting (`config/settings/base.py`, defaults to `EMBEDDINGS_MICROSERVICE_URL`)
-lets operators point ingest at a dedicated bulk pool while query call sites
-stay on the always-warm pod — search latency is then fully isolated from
-ingest load.
+setting (`config/settings/base.py`, opt-in — defaults to unset/`None`) lets
+operators point ingest at a dedicated bulk pool while query call sites stay on
+the always-warm pod — search latency is then fully isolated from ingest load.
+When unset, ingest stays on `EMBEDDINGS_MICROSERVICE_URL` exactly as before and
+no override kwarg is threaded at all.
 
 The mechanism reuses the embedder's *existing* call-time override kwarg
 (`embeddings_microservice_url`, read in

--- a/docs/sample_env_files/backend/local/.django
+++ b/docs/sample_env_files/backend/local/.django
@@ -48,6 +48,10 @@ OPENAI_MODEL=gpt-4o
 # Microservice URLs
 # ------------------------------------------------------------------------------
 EMBEDDINGS_MICROSERVICE_URL=http://vector-embedder:8000
+# Optional: dedicated "bulk" embeddings pool for ingest. Only batch ingest
+# (embedding Celery tasks) routes here; query call sites stay on
+# EMBEDDINGS_MICROSERVICE_URL. Defaults to EMBEDDINGS_MICROSERVICE_URL when unset.
+# EMBEDDINGS_MICROSERVICE_URL_BULK=http://vector-embedder-bulk:8000
 DOCLING_PARSER_SERVICE_URL=http://docling-parser:8000/parse/
 
 # Docling

--- a/docs/sample_env_files/backend/local/.django
+++ b/docs/sample_env_files/backend/local/.django
@@ -50,7 +50,8 @@ OPENAI_MODEL=gpt-4o
 EMBEDDINGS_MICROSERVICE_URL=http://vector-embedder:8000
 # Optional: dedicated "bulk" embeddings pool for ingest. Only batch ingest
 # (embedding Celery tasks) routes here; query call sites stay on
-# EMBEDDINGS_MICROSERVICE_URL. Defaults to EMBEDDINGS_MICROSERVICE_URL when unset.
+# EMBEDDINGS_MICROSERVICE_URL. Opt-in: when unset, ingest uses
+# EMBEDDINGS_MICROSERVICE_URL exactly as before.
 # EMBEDDINGS_MICROSERVICE_URL_BULK=http://vector-embedder-bulk:8000
 DOCLING_PARSER_SERVICE_URL=http://docling-parser:8000/parse/
 

--- a/docs/sample_env_files/backend/production/.django
+++ b/docs/sample_env_files/backend/production/.django
@@ -69,8 +69,8 @@ EMBEDDINGS_MICROSERVICE_URL=http://vector-embedder:8000
 # Optional: dedicated "bulk" embeddings pool for ingest (document/annotation
 # embedding Celery tasks). Query call sites keep using EMBEDDINGS_MICROSERVICE_URL
 # (the always-warm pod); only batch ingest routes here, so a cold-starting /
-# autoscaled bulk pool never affects search latency. Defaults to
-# EMBEDDINGS_MICROSERVICE_URL when unset.
+# autoscaled bulk pool never affects search latency. Opt-in: when unset, ingest
+# uses EMBEDDINGS_MICROSERVICE_URL exactly as before.
 # EMBEDDINGS_MICROSERVICE_URL_BULK=http://vector-embedder-bulk:8000
 DOCLING_PARSER_SERVICE_URL=http://docling-parser:8000/parse/
 

--- a/docs/sample_env_files/backend/production/.django
+++ b/docs/sample_env_files/backend/production/.django
@@ -66,6 +66,12 @@ AUTH0_M2M_MANAGEMENT_GRANT_TYPE=client_credentials
 # bare metal, or managed service deployments, replace with the actual URLs.
 # ------------------------------------------------------------------------------
 EMBEDDINGS_MICROSERVICE_URL=http://vector-embedder:8000
+# Optional: dedicated "bulk" embeddings pool for ingest (document/annotation
+# embedding Celery tasks). Query call sites keep using EMBEDDINGS_MICROSERVICE_URL
+# (the always-warm pod); only batch ingest routes here, so a cold-starting /
+# autoscaled bulk pool never affects search latency. Defaults to
+# EMBEDDINGS_MICROSERVICE_URL when unset.
+# EMBEDDINGS_MICROSERVICE_URL_BULK=http://vector-embedder-bulk:8000
 DOCLING_PARSER_SERVICE_URL=http://docling-parser:8000/parse/
 
 # Docling

--- a/opencontractserver/tasks/embeddings_task.py
+++ b/opencontractserver/tasks/embeddings_task.py
@@ -1,7 +1,7 @@
 import functools
 import logging
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from typing import Any, Optional, Protocol, TypeVar, Union, cast
+from typing import Any, Callable, Optional, TypeVar, Union, cast
 
 import requests
 from celery import shared_task
@@ -54,10 +54,10 @@ def _bulk_embeddings_service_url() -> Optional[str]:
     """Resolve the ingest ("bulk") embeddings-pool URL from settings.
 
     Read at call time (not import time) so ``override_settings`` in tests and
-    runtime reconfiguration both take effect. Returns ``None`` when unset, which
-    leaves ingest on the embedder's configured URL. The setting defaults to
-    ``EMBEDDINGS_MICROSERVICE_URL`` (see ``config/settings/base.py``), so
-    single-pool deployments are unaffected.
+    runtime reconfiguration both take effect. The setting is opt-in and defaults
+    to ``None`` (see ``config/settings/base.py``); when unset this returns
+    ``None`` and no override kwarg is threaded, leaving ingest on the embedder's
+    configured URL (``EMBEDDINGS_MICROSERVICE_URL``) exactly as before.
     """
     return getattr(settings, "EMBEDDINGS_MICROSERVICE_URL_BULK", None)
 
@@ -77,25 +77,6 @@ def _service_url_override_kwargs(service_url_override: Optional[str]) -> dict[st
     if not service_url_override:
         return {}
     return {"embeddings_microservice_url": service_url_override}
-
-
-class _EmbedFunc(Protocol):
-    """Call shape shared by every ``embed_func`` handed to the dual strategy.
-
-    Accepts the ``(obj, embedder, embedder_path)`` positional triple plus an
-    optional ``service_url_override`` keyword. The strategy only forwards the
-    keyword when a bulk URL is set, so closures written against the original
-    three-argument contract keep working.
-    """
-
-    def __call__(
-        self,
-        obj: Any,
-        embedder: "BaseEmbedder",
-        embedder_path: str,
-        *,
-        service_url_override: Optional[str] = ...,
-    ) -> bool: ...
 
 
 def _create_text_embedding(
@@ -273,7 +254,7 @@ def _apply_dual_embedding_strategy(
     corpus_id: Optional[int],
     obj_type: str,
     obj_id: int,
-    embed_func: _EmbedFunc,
+    embed_func: Callable[..., bool],
     service_url_override: Optional[str] = None,
 ) -> None:
     """
@@ -307,6 +288,14 @@ def _apply_dual_embedding_strategy(
     # Only thread the override keyword when a bulk URL is set, so ``embed_func``
     # closures written against the original ``(obj, embedder, path)`` contract
     # keep working unchanged.
+    #
+    # NOTE: the override is forwarded to BOTH the default-embedder pass and the
+    # corpus-preferred-embedder pass below. Today only one MicroserviceEmbedder
+    # class reads ``embeddings_microservice_url``, so a corpus embedder either
+    # ignores it (hosted / multimodal) or is the same microservice family — the
+    # bulk URL is always the right target. If a second microservice-embedder
+    # variant with its own dedicated pool is ever added, revisit this so a
+    # corpus's ingest isn't silently redirected to the default bulk pool.
     embed_extra: dict[str, str] = (
         {"service_url_override": service_url_override} if service_url_override else {}
     )
@@ -533,7 +522,7 @@ def calculate_embedding_for_annotation_text(
         corpus_id=int(effective_corpus_id) if effective_corpus_id else None,
         obj_type="annotation",
         obj_id=annotation.id,
-        embed_func=cast(_EmbedFunc, _create_embedding_for_annotation),
+        embed_func=_create_embedding_for_annotation,
         service_url_override=_bulk_embeddings_service_url(),
     )
 
@@ -979,7 +968,7 @@ def calculate_embeddings_for_annotation_batch(
                     ),
                     obj_type="annotation",
                     obj_id=annotation.id,
-                    embed_func=cast(_EmbedFunc, _create_embedding_for_annotation),
+                    embed_func=_create_embedding_for_annotation,
                     service_url_override=bulk_service_url,
                 )
                 result["succeeded"] += 1

--- a/opencontractserver/tasks/embeddings_task.py
+++ b/opencontractserver/tasks/embeddings_task.py
@@ -1,11 +1,12 @@
 import functools
 import logging
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from typing import Any, Callable, Optional, TypeVar, Union, cast
+from typing import Any, Optional, Protocol, TypeVar, Union, cast
 
 import requests
 from celery import shared_task
 from celery.utils.log import get_task_logger
+from django.conf import settings
 from django.contrib.auth import get_user_model
 
 from opencontractserver.annotations.models import Annotation, Note, Relationship
@@ -35,6 +36,68 @@ logger = get_task_logger(__name__)
 logger.setLevel(logging.DEBUG)
 
 
+# --------------------------------------------------------------------------- #
+# Bulk-ingest embeddings pool routing
+# --------------------------------------------------------------------------- #
+#
+# Ingest (the Celery tasks in this module) routes embedding calls through a
+# dedicated "bulk" microservice pool so that batch ingest load never competes
+# with — or cold-starts — the always-warm query pod that search call sites use
+# via ``settings.EMBEDDINGS_MICROSERVICE_URL``. The redirect reuses the
+# embedder's *existing* call-time override kwarg (``embeddings_microservice_url``,
+# read in ``MicroserviceEmbedder._get_service_config``) rather than
+# reconstructing the embedder or touching the base class — see
+# ``docs/deployment/performance_tuning.md``.
+
+
+def _bulk_embeddings_service_url() -> Optional[str]:
+    """Resolve the ingest ("bulk") embeddings-pool URL from settings.
+
+    Read at call time (not import time) so ``override_settings`` in tests and
+    runtime reconfiguration both take effect. Returns ``None`` when unset, which
+    leaves ingest on the embedder's configured URL. The setting defaults to
+    ``EMBEDDINGS_MICROSERVICE_URL`` (see ``config/settings/base.py``), so
+    single-pool deployments are unaffected.
+    """
+    return getattr(settings, "EMBEDDINGS_MICROSERVICE_URL_BULK", None)
+
+
+def _service_url_override_kwargs(service_url_override: Optional[str]) -> dict[str, str]:
+    """Translate a ``service_url_override`` into the embedder's call-time URL kwarg.
+
+    The text microservice embedder reads ``embeddings_microservice_url`` from its
+    per-call kwargs, overriding the settings-derived value. Threading the bulk
+    URL this way keeps the embedder client and base class untouched; embedders
+    that don't read this kwarg (hosted providers, multimodal image pools) simply
+    ignore it.
+
+    Returns an empty dict when no override is supplied, leaving the embedder on
+    its configured URL so default (query-pod) behavior is unchanged.
+    """
+    if not service_url_override:
+        return {}
+    return {"embeddings_microservice_url": service_url_override}
+
+
+class _EmbedFunc(Protocol):
+    """Call shape shared by every ``embed_func`` handed to the dual strategy.
+
+    Accepts the ``(obj, embedder, embedder_path)`` positional triple plus an
+    optional ``service_url_override`` keyword. The strategy only forwards the
+    keyword when a bulk URL is set, so closures written against the original
+    three-argument contract keep working.
+    """
+
+    def __call__(
+        self,
+        obj: Any,
+        embedder: "BaseEmbedder",
+        embedder_path: str,
+        *,
+        service_url_override: Optional[str] = ...,
+    ) -> bool: ...
+
+
 def _create_text_embedding(
     obj: HasEmbeddingMixin,
     embedder: BaseEmbedder,
@@ -42,6 +105,7 @@ def _create_text_embedding(
     text: str,
     obj_type: str,
     obj_id: int,
+    service_url_override: Optional[str] = None,
 ) -> bool:
     """
     Helper to create a text embedding for any object with HasEmbeddingMixin.
@@ -53,6 +117,9 @@ def _create_text_embedding(
         text: The text to embed
         obj_type: Type name for logging (e.g., "document", "note")
         obj_id: Object ID for logging
+        service_url_override: Optional embeddings-microservice URL that routes
+            this call to the bulk ingest pool instead of the embedder's
+            configured (query-pod) URL. ``None`` leaves the embedder unchanged.
 
     Returns:
         True if embedding was created successfully, False otherwise
@@ -66,7 +133,9 @@ def _create_text_embedding(
         f"with embedder {embedder_path} (text length={len(text)})"
     )
 
-    vector = embedder.embed_text(text)
+    vector = embedder.embed_text(
+        text, **_service_url_override_kwargs(service_url_override)
+    )
 
     if vector is None:
         logger.error(
@@ -92,6 +161,8 @@ def _create_embedding_for_annotation(
     annotation: Annotation,
     embedder: BaseEmbedder,
     embedder_path: str,
+    *,
+    service_url_override: Optional[str] = None,
 ) -> bool:
     """
     Helper to create a single embedding for an annotation.
@@ -103,6 +174,10 @@ def _create_embedding_for_annotation(
         annotation: The annotation to embed
         embedder: The embedder instance to use
         embedder_path: Path identifier for the embedder
+        service_url_override: Optional embeddings-microservice URL routing the
+            text path to the bulk ingest pool. Only the text branches honor it;
+            multimodal image embedding keeps its own (multimodal) pool since the
+            bulk setting is text-only.
 
     Returns:
         True if embedding was created successfully, False otherwise
@@ -161,6 +236,7 @@ def _create_embedding_for_annotation(
                 annotation.raw_text or "",
                 "annotation",
                 annotation.id,
+                service_url_override=service_url_override,
             )
     # Standard text-only embedding (annotation is either text-only, or
     # contains images that the embedder cannot handle and will drop).
@@ -178,6 +254,7 @@ def _create_embedding_for_annotation(
         annotation.raw_text or "",
         "annotation",
         annotation.id,
+        service_url_override=service_url_override,
     )
 
 
@@ -196,7 +273,8 @@ def _apply_dual_embedding_strategy(
     corpus_id: Optional[int],
     obj_type: str,
     obj_id: int,
-    embed_func: Callable[[_EmbeddableT, BaseEmbedder, str], bool],
+    embed_func: _EmbedFunc,
+    service_url_override: Optional[str] = None,
 ) -> None:
     """
     Apply the dual embedding strategy to any embeddable object.
@@ -212,6 +290,11 @@ def _apply_dual_embedding_strategy(
         obj_type: Type name for logging (e.g., "document", "annotation")
         obj_id: Object ID for logging
         embed_func: Function to call for creating embeddings (handles modality specifics)
+        service_url_override: Optional embeddings-microservice URL forwarded to
+            ``embed_func`` (both the default and corpus-specific passes) so ingest
+            routes through the bulk pool. Forwarded only when set, keeping the
+            original three-argument ``embed_func`` contract intact for callers
+            that don't need it.
 
     Raises:
         EmbeddingGenerationError: If the default embedding fails (triggers Celery retry).
@@ -220,6 +303,13 @@ def _apply_dual_embedding_strategy(
     if not text.strip():
         logger.info(f"{obj_type.capitalize()} {obj_id} has no text to embed.")
         return
+
+    # Only thread the override keyword when a bulk URL is set, so ``embed_func``
+    # closures written against the original ``(obj, embedder, path)`` contract
+    # keep working unchanged.
+    embed_extra: dict[str, str] = (
+        {"service_url_override": service_url_override} if service_url_override else {}
+    )
 
     # 1. Always create DEFAULT_EMBEDDER embedding (for global search)
     default_embedder_path = get_default_embedder_path()
@@ -236,7 +326,7 @@ def _apply_dual_embedding_strategy(
         if default_embedder_class:
             default_embedder = default_embedder_class()
             default_embedding_succeeded = embed_func(
-                obj, default_embedder, default_embedder_path
+                obj, default_embedder, default_embedder_path, **embed_extra
             )
             if not default_embedding_succeeded:
                 default_embedding_error = "Embedder returned None or failed to store"
@@ -266,7 +356,7 @@ def _apply_dual_embedding_strategy(
                     )
                     corpus_embedder = corpus_embedder_class()
                     corpus_succeeded = embed_func(
-                        obj, corpus_embedder, corpus_embedder_path
+                        obj, corpus_embedder, corpus_embedder_path, **embed_extra
                     )
                     if not corpus_succeeded:
                         logger.warning(
@@ -331,9 +421,15 @@ def calculate_embedding_for_doc_text(
             text = ""
 
         # Create embed function for documents (text-only)
-        def doc_embed_func(obj, embedder, embedder_path):
+        def doc_embed_func(obj, embedder, embedder_path, *, service_url_override=None):
             return _create_text_embedding(
-                obj, embedder, embedder_path, text, "document", doc.id
+                obj,
+                embedder,
+                embedder_path,
+                text,
+                "document",
+                doc.id,
+                service_url_override=service_url_override,
             )
 
         _apply_dual_embedding_strategy(
@@ -343,6 +439,7 @@ def calculate_embedding_for_doc_text(
             obj_type="document",
             obj_id=doc.id,
             embed_func=doc_embed_func,
+            service_url_override=_bulk_embeddings_service_url(),
         )
 
     except Exception as e:
@@ -406,7 +503,10 @@ def calculate_embedding_for_annotation_text(
             )
             embedder = embedder_class()
             succeeded = _create_embedding_for_annotation(
-                annotation, embedder, embedder_path
+                annotation,
+                embedder,
+                embedder_path,
+                service_url_override=_bulk_embeddings_service_url(),
             )
             if not succeeded:
                 raise EmbeddingGenerationError(
@@ -433,10 +533,8 @@ def calculate_embedding_for_annotation_text(
         corpus_id=int(effective_corpus_id) if effective_corpus_id else None,
         obj_type="annotation",
         obj_id=annotation.id,
-        embed_func=cast(
-            "Callable[[HasEmbeddingMixin, BaseEmbedder, str], bool]",
-            _create_embedding_for_annotation,
-        ),
+        embed_func=cast(_EmbedFunc, _create_embedding_for_annotation),
+        service_url_override=_bulk_embeddings_service_url(),
     )
 
 
@@ -446,6 +544,7 @@ def _batch_embed_text_annotations(
     embedder_path: str,
     api_batch_size: int,
     result: dict,
+    service_url_override: Optional[str] = None,
 ) -> None:
     """
     Embed a list of text-only annotations using batched API calls.
@@ -473,6 +572,9 @@ def _batch_embed_text_annotations(
         embedder_path: Embedder path string stored alongside the vector.
         api_batch_size: Max texts per ``embed_texts_batch`` call.
         result: Mutable summary dict (keys: succeeded, failed, skipped, errors).
+        service_url_override: Optional embeddings-microservice URL that routes
+            every ``embed_texts_batch`` sub-batch to the bulk ingest pool.
+            ``None`` leaves the embedder on its configured URL.
     """
     # Build (annotation, text) tuples, filtering out empties
     items: list[tuple[Annotation, str]] = []
@@ -527,9 +629,11 @@ def _batch_embed_text_annotations(
     )
     logger.info(log_prefix)
 
+    batch_override_kwargs = _service_url_override_kwargs(service_url_override)
+
     def _embed_one(chunk):
         texts_only = [text for _, text in chunk]
-        return chunk, embedder.embed_texts_batch(texts_only)
+        return chunk, embedder.embed_texts_batch(texts_only, **batch_override_kwargs)
 
     # Map future -> chunk index for logging/sub-batch numbering.
     #
@@ -728,6 +832,10 @@ def calculate_embeddings_for_annotation_batch(
     if not annotation_ids:
         return result
 
+    # Ingest routes every embedder call through the bulk pool (see
+    # ``_bulk_embeddings_service_url``); resolved once for the whole batch.
+    bulk_service_url = _bulk_embeddings_service_url()
+
     logger.info(
         f"Processing batch of {len(annotation_ids)} annotations "
         f"(corpus_id={corpus_id}, embedder_path={embedder_path})"
@@ -805,6 +913,7 @@ def calculate_embeddings_for_annotation_batch(
                     embedder_path,
                     api_batch_size,
                     result,
+                    service_url_override=bulk_service_url,
                 )
             except ValueError as e:
                 # Programming error (e.g., batch size misconfiguration).
@@ -833,7 +942,10 @@ def calculate_embeddings_for_annotation_batch(
         for annot in multimodal_annots:
             try:
                 succeeded = _create_embedding_for_annotation(
-                    annot, embedder, embedder_path
+                    annot,
+                    embedder,
+                    embedder_path,
+                    service_url_override=bulk_service_url,
                 )
                 if succeeded:
                     result["succeeded"] += 1
@@ -867,10 +979,8 @@ def calculate_embeddings_for_annotation_batch(
                     ),
                     obj_type="annotation",
                     obj_id=annotation.id,
-                    embed_func=cast(
-                        "Callable[[HasEmbeddingMixin, BaseEmbedder, str], bool]",
-                        _create_embedding_for_annotation,
-                    ),
+                    embed_func=cast(_EmbedFunc, _create_embedding_for_annotation),
+                    service_url_override=bulk_service_url,
                 )
                 result["succeeded"] += 1
             except Exception as e:
@@ -920,9 +1030,15 @@ def calculate_embedding_for_note_text(
         effective_corpus_id = corpus_id or (note.corpus_id if note.corpus else None)
 
         # Create embed function for notes (text-only)
-        def note_embed_func(obj, embedder, embedder_path):
+        def note_embed_func(obj, embedder, embedder_path, *, service_url_override=None):
             return _create_text_embedding(
-                obj, embedder, embedder_path, text, "note", note.id
+                obj,
+                embedder,
+                embedder_path,
+                text,
+                "note",
+                note.id,
+                service_url_override=service_url_override,
             )
 
         _apply_dual_embedding_strategy(
@@ -932,6 +1048,7 @@ def calculate_embedding_for_note_text(
             obj_type="note",
             obj_id=note.id,
             embed_func=note_embed_func,
+            service_url_override=_bulk_embeddings_service_url(),
         )
 
     except Exception as e:
@@ -952,6 +1069,7 @@ def _embed_relationship(
     embedder_path: str,
     *,
     precomputed_text: str | None = None,
+    service_url_override: Optional[str] = None,
 ) -> bool:
     """Embed a single Relationship using ``synthesize_relationship_block_text``.
 
@@ -964,6 +1082,9 @@ def _embed_relationship(
     would re-synthesize the block text on every embedder pass
     (default + corpus-preferred), which is wasted work when batches
     grow.
+
+    ``service_url_override`` routes the embedder call to the bulk ingest
+    pool; ``None`` leaves the embedder on its configured URL.
     """
     text = (
         precomputed_text
@@ -984,7 +1105,9 @@ def _embed_relationship(
         embedder_path,
         len(text),
     )
-    vector = embedder.embed_text(text)
+    vector = embedder.embed_text(
+        text, **_service_url_override_kwargs(service_url_override)
+    )
     if vector is None:
         logger.error(
             "Embedder %s returned None for relationship %s",
@@ -1069,6 +1192,10 @@ def calculate_embeddings_for_relationship_batch(
     if not relationship_ids:
         return result
 
+    # Ingest routes every embedder call through the bulk pool (see
+    # ``_bulk_embeddings_service_url``); resolved once for the whole batch.
+    bulk_service_url = _bulk_embeddings_service_url()
+
     logger.info(
         "Embedding batch of %s relationships (corpus_id=%s, embedder_path=%s)",
         len(relationship_ids),
@@ -1106,7 +1233,12 @@ def calculate_embeddings_for_relationship_batch(
                 result["skipped"] += 1
                 continue
             try:
-                if _embed_relationship(rel, explicit_embedder, embedder_path):
+                if _embed_relationship(
+                    rel,
+                    explicit_embedder,
+                    embedder_path,
+                    service_url_override=bulk_service_url,
+                ):
                     result["succeeded"] += 1
                 else:
                     result["failed"] += 1
@@ -1147,6 +1279,7 @@ def calculate_embeddings_for_relationship_batch(
                 embed_func=functools.partial(
                     _embed_relationship, precomputed_text=rel_text
                 ),
+                service_url_override=bulk_service_url,
             )
             result["succeeded"] += 1
         except Exception as e:

--- a/opencontractserver/tasks/embeddings_task.py
+++ b/opencontractserver/tasks/embeddings_task.py
@@ -1216,6 +1216,13 @@ def calculate_embeddings_for_relationship_batch(
             result["failed"] = len(relationship_ids)
             return result
 
+        # Thread the bulk pool only when configured, so the default (unset)
+        # call keeps the original ``_embed_relationship(rel, embedder, path)``
+        # shape — the same conditional-forwarding pattern used for ``embed_extra``
+        # in ``_apply_dual_embedding_strategy``.
+        rel_override_kwargs = (
+            {"service_url_override": bulk_service_url} if bulk_service_url else {}
+        )
         for rid in relationship_ids:
             rel = rel_map.get(rid)
             if rel is None:
@@ -1223,10 +1230,7 @@ def calculate_embeddings_for_relationship_batch(
                 continue
             try:
                 if _embed_relationship(
-                    rel,
-                    explicit_embedder,
-                    embedder_path,
-                    service_url_override=bulk_service_url,
+                    rel, explicit_embedder, embedder_path, **rel_override_kwargs
                 ):
                     result["succeeded"] += 1
                 else:

--- a/opencontractserver/tests/test_batch_embedding.py
+++ b/opencontractserver/tests/test_batch_embedding.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock, patch
 
 import numpy as np
 import requests
+from django.test import override_settings
 
 from opencontractserver.constants.document_processing import (
     MICROSERVICE_EMBEDDER_MAX_BATCH_SIZE,
@@ -941,8 +942,6 @@ class TestCalculateEmbeddingsForAnnotationBatch(unittest.TestCase):
         End-to-end check that the entry point resolves the bulk setting and
         threads it through to the embedder's per-call override kwarg.
         """
-        from django.test import override_settings
-
         captured: dict = {}
 
         class RecordingEmbedder(DummyEmbedder384):

--- a/opencontractserver/tests/test_batch_embedding.py
+++ b/opencontractserver/tests/test_batch_embedding.py
@@ -303,6 +303,59 @@ class TestBatchEmbedTextAnnotations(unittest.TestCase):
 
         self.assertEqual(result["succeeded"], 6)
 
+    def test_service_url_override_threaded_to_embedder(self):
+        """service_url_override is forwarded as the embeddings_microservice_url kwarg.
+
+        This is how ingest routes to the bulk pool without touching the
+        embedder client or base class (issue: bulk embeddings pool).
+        """
+        captured: dict = {}
+
+        class RecordingEmbedder(DummyEmbedder384):
+            def embed_texts_batch(self, texts, **kw):
+                captured.update(kw)
+                return [[0.1] * self.vector_size for _ in texts]
+
+        annots = [_make_mock_annotation(1, "hello")]
+        result = self._make_result()
+
+        _batch_embed_text_annotations(
+            annots,
+            RecordingEmbedder(),
+            "test.RecordingEmbedder",
+            50,
+            result,
+            service_url_override="http://bulk-pool:8000",
+        )
+
+        self.assertEqual(result["succeeded"], 1)
+        self.assertEqual(
+            captured.get("embeddings_microservice_url"), "http://bulk-pool:8000"
+        )
+
+    def test_no_service_url_override_passes_no_url_kwarg(self):
+        """Default (no override) leaves the embedder on its configured URL.
+
+        No ``embeddings_microservice_url`` kwarg leaks to the embedder, so
+        query-pod behavior is unchanged when the bulk setting is absent.
+        """
+        captured: dict = {"kw": None}
+
+        class RecordingEmbedder(DummyEmbedder384):
+            def embed_texts_batch(self, texts, **kw):
+                captured["kw"] = kw
+                return [[0.1] * self.vector_size for _ in texts]
+
+        annots = [_make_mock_annotation(1, "hello")]
+        result = self._make_result()
+
+        _batch_embed_text_annotations(
+            annots, RecordingEmbedder(), "test.RecordingEmbedder", 50, result
+        )
+
+        self.assertEqual(result["succeeded"], 1)
+        self.assertEqual(captured["kw"], {})
+
     def test_batch_api_failure(self):
         """When embed_texts_batch raises, all annotations in that chunk fail."""
         annots = [_make_mock_annotation(i, f"Text {i}") for i in range(3)]
@@ -877,6 +930,45 @@ class TestCalculateEmbeddingsForAnnotationBatch(unittest.TestCase):
         self.assertEqual(result["skipped"], 0)
         for annot in annots:
             annot.add_embedding.assert_called_once()
+
+    @patch("opencontractserver.tasks.embeddings_task.get_component_by_name")
+    @patch("opencontractserver.tasks.embeddings_task.Annotation")
+    def test_bulk_url_from_settings_threaded_to_embedder(
+        self, mock_ann_cls, mock_get_component
+    ):
+        """The batch task reads EMBEDDINGS_MICROSERVICE_URL_BULK and routes ingest there.
+
+        End-to-end check that the entry point resolves the bulk setting and
+        threads it through to the embedder's per-call override kwarg.
+        """
+        from django.test import override_settings
+
+        captured: dict = {}
+
+        class RecordingEmbedder(DummyEmbedder384):
+            def embed_texts_batch(self, texts, **kw):
+                captured.update(kw)
+                return [[0.1] * self.vector_size for _ in texts]
+
+        annots = [
+            _make_mock_annotation(1, "Hello world"),
+            _make_mock_annotation(2, "Second text"),
+        ]
+        mock_ann_cls.objects = self._mock_objects(annots)
+        mock_get_component.return_value = RecordingEmbedder
+
+        with override_settings(
+            EMBEDDINGS_MICROSERVICE_URL_BULK="http://bulk-pool:8000"
+        ):
+            result = calculate_embeddings_for_annotation_batch(
+                annotation_ids=[1, 2],
+                embedder_path="test.RecordingEmbedder",
+            )
+
+        self.assertEqual(result["succeeded"], 2)
+        self.assertEqual(
+            captured.get("embeddings_microservice_url"), "http://bulk-pool:8000"
+        )
 
     @patch("opencontractserver.tasks.embeddings_task.get_component_by_name")
     def test_batch_path_empty_ids(self, mock_get_component):

--- a/opencontractserver/tests/test_embeddings_task.py
+++ b/opencontractserver/tests/test_embeddings_task.py
@@ -1754,6 +1754,44 @@ class TestCalculateEmbeddingsForRelationshipBatch(unittest.TestCase):
         self.assertEqual(len(result["errors"]), 1)
 
 
+class TestBulkPoolHelpers(unittest.TestCase):
+    """Direct unit tests for the bulk-pool routing helpers."""
+
+    def test_service_url_override_kwargs_none_returns_empty(self):
+        from opencontractserver.tasks.embeddings_task import (
+            _service_url_override_kwargs,
+        )
+
+        self.assertEqual(_service_url_override_kwargs(None), {})
+        self.assertEqual(_service_url_override_kwargs(""), {})
+
+    def test_service_url_override_kwargs_maps_to_embedder_kwarg(self):
+        from opencontractserver.tasks.embeddings_task import (
+            _service_url_override_kwargs,
+        )
+
+        self.assertEqual(
+            _service_url_override_kwargs("http://bulk-pool:8000"),
+            {"embeddings_microservice_url": "http://bulk-pool:8000"},
+        )
+
+    @override_settings(EMBEDDINGS_MICROSERVICE_URL_BULK="http://bulk-pool:8000")
+    def test_bulk_service_url_resolves_from_settings(self):
+        from opencontractserver.tasks.embeddings_task import (
+            _bulk_embeddings_service_url,
+        )
+
+        self.assertEqual(_bulk_embeddings_service_url(), "http://bulk-pool:8000")
+
+    @override_settings(EMBEDDINGS_MICROSERVICE_URL_BULK=None)
+    def test_bulk_service_url_none_when_unset(self):
+        from opencontractserver.tasks.embeddings_task import (
+            _bulk_embeddings_service_url,
+        )
+
+        self.assertIsNone(_bulk_embeddings_service_url())
+
+
 class TestBulkEmbeddingsPoolRouting(unittest.TestCase):
     """Ingest tasks route embedder calls through EMBEDDINGS_MICROSERVICE_URL_BULK.
 

--- a/opencontractserver/tests/test_embeddings_task.py
+++ b/opencontractserver/tests/test_embeddings_task.py
@@ -2,6 +2,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from django.contrib.auth import get_user_model
+from django.test import override_settings
 
 from opencontractserver.annotations.models import Annotation, Note
 from opencontractserver.pipeline.base.embedder import BaseEmbedder
@@ -1751,6 +1752,144 @@ class TestCalculateEmbeddingsForRelationshipBatch(unittest.TestCase):
         self.assertEqual(result["succeeded"], 1)
         self.assertEqual(result["failed"], 1)
         self.assertEqual(len(result["errors"]), 1)
+
+
+class TestBulkEmbeddingsPoolRouting(unittest.TestCase):
+    """Ingest tasks route embedder calls through EMBEDDINGS_MICROSERVICE_URL_BULK.
+
+    Complements the batch-annotation coverage in test_batch_embedding.py by
+    asserting the bulk-pool override reaches the embedder for the document,
+    note, and relationship entry points, which all funnel through
+    ``_apply_dual_embedding_strategy`` / ``_service_url_override_kwargs``.
+    """
+
+    class _RecordingEmbedder:
+        """Captures the kwargs passed to ``embed_text`` (shared across tests)."""
+
+        def __init__(self):
+            self.captured: dict = {}
+
+        def embed_text(self, text, **kw):
+            self.captured.update(kw)
+            return [0.1, 0.2]
+
+    @override_settings(EMBEDDINGS_MICROSERVICE_URL_BULK="http://bulk-pool:8000")
+    @patch("opencontractserver.tasks.embeddings_task.get_default_embedder_path")
+    @patch("opencontractserver.tasks.embeddings_task.get_default_embedder")
+    @patch("opencontractserver.tasks.embeddings_task.read_field_file_text")
+    @patch("opencontractserver.tasks.embeddings_task.Document")
+    def test_doc_text_task_threads_bulk_url(
+        self, mock_doc_cls, mock_read, mock_get_default, mock_get_path
+    ):
+        from opencontractserver.tasks.embeddings_task import (
+            calculate_embedding_for_doc_text,
+        )
+
+        embedder = self._RecordingEmbedder()
+        mock_get_default.return_value = lambda: embedder
+        mock_get_path.return_value = "default.path"
+        mock_read.return_value = "hello world"
+
+        mock_doc = MagicMock()
+        mock_doc.id = 1
+        mock_doc.txt_extract_file.name = "doc.txt"
+        mock_doc_cls.objects.get.return_value = mock_doc
+
+        calculate_embedding_for_doc_text(doc_id=1)
+
+        self.assertEqual(
+            embedder.captured.get("embeddings_microservice_url"),
+            "http://bulk-pool:8000",
+        )
+
+    @override_settings(EMBEDDINGS_MICROSERVICE_URL_BULK="http://bulk-pool:8000")
+    @patch("opencontractserver.tasks.embeddings_task.get_default_embedder_path")
+    @patch("opencontractserver.tasks.embeddings_task.get_default_embedder")
+    @patch("opencontractserver.tasks.embeddings_task.Note")
+    def test_note_text_task_threads_bulk_url(
+        self, mock_note_cls, mock_get_default, mock_get_path
+    ):
+        from opencontractserver.tasks.embeddings_task import (
+            calculate_embedding_for_note_text,
+        )
+
+        embedder = self._RecordingEmbedder()
+        mock_get_default.return_value = lambda: embedder
+        mock_get_path.return_value = "default.path"
+
+        mock_note = MagicMock()
+        mock_note.id = 1
+        mock_note.content = "note text"
+        mock_note.corpus = None
+        mock_note_cls.objects.get.return_value = mock_note
+
+        calculate_embedding_for_note_text(note_id=1)
+
+        self.assertEqual(
+            embedder.captured.get("embeddings_microservice_url"),
+            "http://bulk-pool:8000",
+        )
+
+    @override_settings(EMBEDDINGS_MICROSERVICE_URL_BULK="http://bulk-pool:8000")
+    @patch("opencontractserver.tasks.embeddings_task.get_component_by_name")
+    @patch("opencontractserver.tasks.embeddings_task.Relationship")
+    def test_relationship_batch_task_threads_bulk_url(
+        self, mock_rel_cls, mock_get_component
+    ):
+        from opencontractserver.tasks.embeddings_task import (
+            calculate_embeddings_for_relationship_batch,
+        )
+
+        embedder = self._RecordingEmbedder()
+        mock_get_component.return_value = lambda: embedder
+
+        mock_rel = MagicMock()
+        mock_rel.pk = 1
+        mock_rel.id = 1
+        mock_rel.add_embedding.return_value = MagicMock(pk=9)
+        mock_rel_cls.objects.filter.return_value = [mock_rel]
+
+        with patch(
+            "opencontractserver.tasks.embeddings_task."
+            "synthesize_relationship_block_text",
+            return_value="relationship text",
+        ):
+            result = calculate_embeddings_for_relationship_batch(
+                relationship_ids=[1], embedder_path="test.RecordingEmbedder"
+            )
+
+        self.assertEqual(result["succeeded"], 1)
+        self.assertEqual(
+            embedder.captured.get("embeddings_microservice_url"),
+            "http://bulk-pool:8000",
+        )
+
+    @patch("opencontractserver.tasks.embeddings_task.get_default_embedder_path")
+    @patch("opencontractserver.tasks.embeddings_task.get_default_embedder")
+    @patch("opencontractserver.tasks.embeddings_task.read_field_file_text")
+    @patch("opencontractserver.tasks.embeddings_task.Document")
+    def test_doc_text_task_without_bulk_setting_passes_no_url_kwarg(
+        self, mock_doc_cls, mock_read, mock_get_default, mock_get_path
+    ):
+        """With the bulk setting unset (default), no override kwarg leaks."""
+        from opencontractserver.tasks.embeddings_task import (
+            calculate_embedding_for_doc_text,
+        )
+
+        embedder = self._RecordingEmbedder()
+        mock_get_default.return_value = lambda: embedder
+        mock_get_path.return_value = "default.path"
+        mock_read.return_value = "hello world"
+
+        mock_doc = MagicMock()
+        mock_doc.id = 1
+        mock_doc.txt_extract_file.name = "doc.txt"
+        mock_doc_cls.objects.get.return_value = mock_doc
+
+        with override_settings(EMBEDDINGS_MICROSERVICE_URL_BULK=None):
+            calculate_embedding_for_doc_text(doc_id=1)
+
+        self.assertNotIn("embeddings_microservice_url", embedder.captured)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Ingest embedding tasks and search queries currently share a single embeddings
microservice URL (`EMBEDDINGS_MICROSERVICE_URL`). That forces a compromise: a
pool sized for latency-sensitive **search queries** (needs to stay warm) also
absorbs the load of **batch ingest** (thousands of embeddings, happy to hit an
autoscaled / scale-to-zero pool), and vice versa.

This PR lets operators point ingest at a separate **bulk** pool while query call
sites stay on the always-warm pod, fully isolating search latency from ingest
load — with **no change to the embedder client, base class, or any search
resolver**.

## Changes

1. **New setting** — `EMBEDDINGS_MICROSERVICE_URL_BULK` in
   `config/settings/base.py` (next to `EMBEDDINGS_MICROSERVICE_URL`), defaulting
   to `EMBEDDINGS_MICROSERVICE_URL` so single-pool deployments need no config.
   Query call sites are untouched and stay warm automatically.

2. **Ingest routing** — the Celery tasks in
   `opencontractserver/tasks/embeddings_task.py` resolve the bulk URL via a new
   `_bulk_embeddings_service_url()` helper and thread it through an optional
   `service_url_override` parameter added to the four ingest leaves —
   `_create_text_embedding`, `_create_embedding_for_annotation`,
   `_batch_embed_text_annotations`, `_apply_dual_embedding_strategy` — plus
   `_embed_relationship`. The override is translated into the embedder's
   **existing** call-time `embeddings_microservice_url` kwarg (read by
   `MicroserviceEmbedder._get_service_config`), so no embedder/base-class change
   is required. Embedders that don't read that kwarg (hosted providers, the
   multimodal image pool) simply ignore it.

3. **Backwards compatible by construction** — when the override is `None`
   (the default, and any direct/legacy caller), **no** URL kwarg is passed and
   behavior is byte-identical to before. The dual-embedding strategy only
   forwards the keyword to `embed_func` when a bulk URL is set, so the original
   three-argument `embed_func` contract keeps working.

4. **Multimodal image pool left alone** — the bulk setting is text-only; image
   embedding keeps its own `CLIP_EMBEDDER_URL` / `QWEN_EMBEDDER_URL` pool.

### Deployment note

Rebuild/redeploy the Django image so Celery workers pick up the new code and
setting. Set `EMBEDDINGS_MICROSERVICE_URL_BULK` in the environment to point
ingest at the bulk pool; leaving it unset keeps the current single-pool
behavior.

## Tests

`opencontractserver/tests/test_batch_embedding.py` gains regression tests
verifying:
- `_batch_embed_text_annotations` forwards `service_url_override` as
  `embeddings_microservice_url`, and passes **no** URL kwarg when unset.
- The full `calculate_embeddings_for_annotation_batch` task reads
  `EMBEDDINGS_MICROSERVICE_URL_BULK` (via `override_settings`) and routes ingest
  to it end-to-end.

## Docs / changelog

- `docs/deployment/performance_tuning.md` — new "Separate bulk embeddings pool
  for ingest" section.
- Sample env files updated with the new (commented, optional) variable.
- Changelog fragment `changelog.d/bulk-embeddings-pool.added.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RSJewSJz3p4sqancvmoQ8E)_