### PR TITLE
Pipeline settings: add reranker GUI + fix runtime/validation gaps

### DIFF
--- a/changelog.d/pipeline-agent-llm-chat.fixed.md
+++ b/changelog.d/pipeline-agent-llm-chat.fixed.md
@@ -1,0 +1,13 @@
+- **Interactive chat now honors `AgentConfiguration.preferred_llm` (the
+  per-agent model override).** `config/websocket/consumers/unified_agent_conversation.py`
+  `_initialize_agent` built the agent-factory kwargs without
+  `agent_preferred_llm`, so the WebSocket chat path silently fell back to the
+  corpus / install-wide default model even when the selected agent pinned a
+  model — diverging from the Celery (`opencontractserver/tasks/agent_tasks.py`)
+  and delegation (`opencontractserver/llms/tools/delegation_tools.py`) paths,
+  which already thread it. Now the consumer passes
+  `agent_kwargs["agent_preferred_llm"] = self.agent_config.preferred_llm` (when
+  set) into `agents.for_document`/`for_corpus`, which the factory treats as the
+  top-of-chain override. Regression tests:
+  `UnifiedAgentConsumerAgentLlmTestCase` in
+  `opencontractserver/tests/websocket/test_unified_agent_consumer.py`.

--- a/changelog.d/pipeline-mapping-typecheck.fixed.md
+++ b/changelog.d/pipeline-mapping-typecheck.fixed.md
@@ -1,0 +1,11 @@
+- **`updatePipelineSettings` now rejects cross-stage component assignments.**
+  `validate_component_mapping` (`config/graphql/pipeline_settings_mutations.py`)
+  only checked registry membership, so a raw GraphQL call could assign e.g. a
+  parser class as a `preferred_thumbnailers`/`preferred_embedders`/`preferred_parsers`
+  entry. Registry membership is insufficient: the wrong component type has no
+  `.generate_thumbnail` / `.embed_text` and blows up at ingest with an
+  `AttributeError`, marking every affected document FAILED. The validator now
+  takes an expected `ComponentType` and rejects the mismatch up front (mirroring
+  the stricter guard already applied to `default_file_converter`). The GUI
+  dropdowns can never produce this, but the API previously accepted it. Test:
+  `test_update_preferred_thumbnailer_rejects_wrong_component_type`.

--- a/changelog.d/pipeline-reranker-gui.added.md
+++ b/changelog.d/pipeline-reranker-gui.added.md
@@ -1,0 +1,16 @@
+- **Admin GUI control for the install-wide post-retrieval reranker
+  (`PipelineSettings.default_reranker`).** The backend has persisted, validated,
+  cache-busted and *read* this setting at runtime for reranking
+  (`opencontractserver/llms/vector_stores/core_vector_stores.py`
+  `_get_reranker`), but the admin Pipeline Configuration surface never exposed
+  it — `GET_PIPELINE_SETTINGS`/`UPDATE_PIPELINE_SETTINGS` omitted the field and
+  there was no widget, so an operator could only change it via a raw GraphQL
+  call or DB edit. Added a "Default Reranker" picker to
+  `frontend/src/components/admin/system_settings/FiletypeDefaults.tsx` (mirroring
+  the File Converter / Default LLM rows; empty = reranking disabled), wired
+  `defaultReranker` through `graphql.ts` (query + `UPDATE`/`RESET` mutations) and
+  surfaced the registered rerankers via a new `pipelineComponents.rerankers`
+  selection. Also filled in the previously-omitted `defaultLlm`/`defaultReranker`
+  fields on the `UPDATE`/`RESET` mutation return selections. Verified end-to-end
+  against a live stack (set → persisted to DB → revert). Covered by
+  `frontend/tests/system-settings-flows.ct.tsx`.

--- a/changelog.d/pipeline-tool-secret-leak.fixed.md
+++ b/changelog.d/pipeline-tool-secret-leak.fixed.md
@@ -1,0 +1,12 @@
+- **`components_with_secrets` no longer leaks agent-tool secret keys.** Component
+  secrets and agent-tool secrets (e.g. `tool:web_search`) share one encrypted
+  store on `PipelineSettings`. The GraphQL resolver and the
+  update/reset/component-secret mutations built the component list from raw
+  `get_secrets().keys()`, so `tool:`-prefixed keys leaked into the admin
+  Component Library's per-component secret indicators. Added
+  `PipelineSettings.get_components_with_secrets()`
+  (`opencontractserver/documents/models.py`) — the inverse of
+  `get_tools_with_secrets()` — and routed `config/graphql/pipeline_queries.py`
+  and the four mutation return sites through it. Tests:
+  `test_get_components_with_secrets_excludes_tool_keys`,
+  `test_pipeline_settings_query_excludes_tool_secret_keys`.

--- a/config/graphql/pipeline_queries.py
+++ b/config/graphql/pipeline_queries.py
@@ -305,7 +305,7 @@ class PipelineQueryMixin:
         settings_instance = PipelineSettings.get_instance()
 
         # Get list of components that have secrets (don't expose actual secrets)
-        components_with_secrets = list(settings_instance.get_secrets().keys())
+        components_with_secrets = settings_instance.get_components_with_secrets()
 
         return PipelineSettingsType(
             preferred_parsers=settings_instance.preferred_parsers or {},

--- a/config/graphql/pipeline_settings_mutations.py
+++ b/config/graphql/pipeline_settings_mutations.py
@@ -76,7 +76,7 @@ def validate_mime_type(mime_type: str) -> Optional[str]:
 
 
 def validate_component_mapping(
-    mapping: dict, registry, component_type: str
+    mapping: dict, registry, component_type: str, expected_type=None
 ) -> Optional[str]:
     """
     Validate a mapping of MIME types to component paths.
@@ -85,6 +85,12 @@ def validate_component_mapping(
         mapping: Dict mapping MIME types to component class paths
         registry: Pipeline component registry for validation
         component_type: Type name for error messages (e.g., "Parser")
+        expected_type: When provided (a ``ComponentType``), require each mapped
+            component to actually BE that stage. Registry membership alone is
+            insufficient — assigning e.g. a parser class as a thumbnailer passes
+            the membership check but blows up at ingest with an ``AttributeError``
+            on ``.generate_thumbnail`` and marks every affected document FAILED.
+            Mirrors the stricter guard already applied to ``default_file_converter``.
 
     Returns:
         Error message if invalid, None if valid
@@ -104,8 +110,17 @@ def validate_component_mapping(
             return error
 
         # Validate component exists in registry
-        if not registry.get_by_class_name(component_path):
+        component_def = registry.get_by_class_name(component_path)
+        if not component_def:
             return f"{component_type} '{component_path}' not found in registry"
+
+        # Validate the component is the RIGHT KIND for this stage.
+        if expected_type is not None and component_def.component_type != expected_type:
+            return (
+                f"Component '{component_path}' is a "
+                f"{component_def.component_type.value}, not a "
+                f"{component_type.lower()}."
+            )
 
     return None
 
@@ -305,7 +320,7 @@ class UpdatePipelineSettingsMutation(graphene.Mutation):
         Security: Only superusers can update these settings.
         """
         from opencontractserver.documents.models import PipelineSettings
-        from opencontractserver.pipeline.registry import get_registry
+        from opencontractserver.pipeline.registry import ComponentType, get_registry
 
         user = info.context.user
 
@@ -324,7 +339,7 @@ class UpdatePipelineSettingsMutation(graphene.Mutation):
             # Validate and apply preferred_parsers
             if preferred_parsers is not None:
                 error = validate_component_mapping(
-                    preferred_parsers, registry, "Parser"
+                    preferred_parsers, registry, "Parser", ComponentType.PARSER
                 ) or validate_json_field_size(preferred_parsers, "preferred_parsers")
                 if error:
                     return UpdatePipelineSettingsMutation(
@@ -335,7 +350,7 @@ class UpdatePipelineSettingsMutation(graphene.Mutation):
             # Validate and apply preferred_embedders
             if preferred_embedders is not None:
                 error = validate_component_mapping(
-                    preferred_embedders, registry, "Embedder"
+                    preferred_embedders, registry, "Embedder", ComponentType.EMBEDDER
                 ) or validate_json_field_size(
                     preferred_embedders, "preferred_embedders"
                 )
@@ -348,7 +363,10 @@ class UpdatePipelineSettingsMutation(graphene.Mutation):
             # Validate and apply preferred_thumbnailers
             if preferred_thumbnailers is not None:
                 error = validate_component_mapping(
-                    preferred_thumbnailers, registry, "Thumbnailer"
+                    preferred_thumbnailers,
+                    registry,
+                    "Thumbnailer",
+                    ComponentType.THUMBNAILER,
                 ) or validate_json_field_size(
                     preferred_thumbnailers, "preferred_thumbnailers"
                 )
@@ -733,8 +751,8 @@ class UpdatePipelineSettingsMutation(graphene.Mutation):
                     or "",
                     default_llm=settings_instance.default_llm or "",
                     enabled_components=settings_instance.enabled_components or [],
-                    components_with_secrets=list(
-                        settings_instance.get_secrets().keys()
+                    components_with_secrets=(
+                        settings_instance.get_components_with_secrets()
                     ),
                     modified=settings_instance.modified,
                     modified_by=settings_instance.modified_by,
@@ -841,8 +859,8 @@ class ResetPipelineSettingsMutation(graphene.Mutation):
                     or "",
                     default_llm=settings_instance.default_llm or "",
                     enabled_components=[],
-                    components_with_secrets=list(
-                        settings_instance.get_secrets().keys()
+                    components_with_secrets=(
+                        settings_instance.get_components_with_secrets()
                     ),
                     modified=settings_instance.modified,
                     modified_by=settings_instance.modified_by,
@@ -958,9 +976,9 @@ class UpdateComponentSecretsMutation(graphene.Mutation):
             settings_instance.modified_by = user
             settings_instance.save()
 
-            # Return list of components that have secrets (don't return actual secrets)
-            all_secrets = settings_instance.get_secrets()
-            components_with_secrets = list(all_secrets.keys())
+            # Return list of components that have secrets (don't return actual
+            # secrets). Excludes tool: keys, which are tracked separately.
+            components_with_secrets = settings_instance.get_components_with_secrets()
 
             logger.info(
                 "Secrets updated for component '%s' by %s (keys=%s, merge=%s)",
@@ -1276,9 +1294,8 @@ class DeleteComponentSecretsMutation(graphene.Mutation):
             settings_instance.modified_by = user
             settings_instance.save()
 
-            # Return updated list of components with secrets
-            all_secrets = settings_instance.get_secrets()
-            components_with_secrets = list(all_secrets.keys())
+            # Return updated list of components with secrets (excludes tool: keys).
+            components_with_secrets = settings_instance.get_components_with_secrets()
 
             logger.info(
                 f"Secrets deleted for component '{component_path}' by {user.username}"

--- a/config/websocket/consumers/unified_agent_conversation.py
+++ b/config/websocket/consumers/unified_agent_conversation.py
@@ -653,6 +653,17 @@ class UnifiedAgentConsumer(AuthHandshakeMixin, AsyncWebsocketConsumer):
             # This will be a future enhancement. For now, the default instructions apply.
             pass
 
+        # Thread the per-agent LLM override (``AgentConfiguration.preferred_llm``)
+        # into the factory so interactive chat honors it. Without this the
+        # interactive WebSocket path silently falls back to the corpus/install
+        # default model, diverging from the Celery (agent_tasks.py) and
+        # delegation (delegation_tools.py) paths, which both pass
+        # ``agent_preferred_llm=``. The factory treats this as the top-of-chain
+        # override that wins over ``Corpus.preferred_llm`` and the install
+        # default (see api.for_document/for_corpus and agent_factory).
+        if self.agent_config and self.agent_config.preferred_llm:
+            agent_kwargs["agent_preferred_llm"] = self.agent_config.preferred_llm
+
         if extra_tools:
             agent_kwargs["tools"] = list(extra_tools)
 

--- a/frontend/src/components/admin/SystemSettings.tsx
+++ b/frontend/src/components/admin/SystemSettings.tsx
@@ -153,6 +153,9 @@ export const SystemSettings: React.FC = () => {
     useState("");
   const [showDefaultLlmModal, setShowDefaultLlmModal] = useState(false);
   const [defaultLlmValue, setDefaultLlmValue] = useState("");
+  const [showDefaultRerankerModal, setShowDefaultRerankerModal] =
+    useState(false);
+  const [defaultRerankerValue, setDefaultRerankerValue] = useState("");
   const [showDeleteSecretsConfirm, setShowDeleteSecretsConfirm] =
     useState(false);
   const [deleteSecretsPath, setDeleteSecretsPath] = useState("");
@@ -300,8 +303,19 @@ export const SystemSettings: React.FC = () => {
       (comp): comp is PipelineComponentType & { className: string } =>
         Boolean(comp?.className)
     );
+    const rerankers = (components?.rerankers || []).filter(
+      (comp): comp is PipelineComponentType & { className: string } =>
+        Boolean(comp?.className)
+    );
 
-    return { parsers, embedders, thumbnailers, llmProviders, fileConverters };
+    return {
+      parsers,
+      embedders,
+      thumbnailers,
+      llmProviders,
+      fileConverters,
+      rerankers,
+    };
   }, [components]);
 
   const componentByClassName = useMemo(() => {
@@ -638,6 +652,23 @@ export const SystemSettings: React.FC = () => {
     setShowDefaultLlmModal(false);
   }, [defaultLlmValue, updateSettings]);
 
+  // Handle default reranker. Empty string DISABLES second-stage reranking
+  // (the backend treats "" as "reranking off"), so we always send the string
+  // value — never null (null means "leave unchanged").
+  const handleEditDefaultReranker = useCallback(() => {
+    setDefaultRerankerValue(settings?.defaultReranker || "");
+    setShowDefaultRerankerModal(true);
+  }, [settings]);
+
+  const handleSaveDefaultReranker = useCallback(() => {
+    updateSettings({
+      variables: {
+        defaultReranker: defaultRerankerValue.trim(),
+      },
+    });
+    setShowDefaultRerankerModal(false);
+  }, [defaultRerankerValue, updateSettings]);
+
   // Format date
   const formatDate = useCallback((dateStr: string | null | undefined) => {
     if (!dateStr) return "Never";
@@ -695,11 +726,13 @@ export const SystemSettings: React.FC = () => {
       defaultEmbedder: settings?.defaultEmbedder || "",
       defaultFileConverter: settings?.defaultFileConverter || "",
       defaultLlm: settings?.defaultLlm || "",
+      defaultReranker: settings?.defaultReranker || "",
       updating,
       onAssign: handleAssign,
       onEditDefaultEmbedder: handleEditDefaultEmbedder,
       onEditDefaultFileConverter: handleEditDefaultFileConverter,
       onEditDefaultLlm: handleEditDefaultLlm,
+      onEditDefaultReranker: handleEditDefaultReranker,
     }),
     [
       componentsByStage,
@@ -712,11 +745,13 @@ export const SystemSettings: React.FC = () => {
       settings?.defaultEmbedder,
       settings?.defaultFileConverter,
       settings?.defaultLlm,
+      settings?.defaultReranker,
       updating,
       handleAssign,
       handleEditDefaultEmbedder,
       handleEditDefaultFileConverter,
       handleEditDefaultLlm,
+      handleEditDefaultReranker,
     ]
   );
 
@@ -1248,6 +1283,109 @@ export const SystemSettings: React.FC = () => {
           <Button
             variant="primary"
             onClick={handleSaveDefaultLlm}
+            loading={updating}
+          >
+            <Save style={{ width: 16, height: 16, marginRight: 8 }} />
+            Save
+          </Button>
+        </ModalFooter>
+      </Modal>
+
+      {/* Default Reranker Modal */}
+      <Modal
+        open={showDefaultRerankerModal}
+        onClose={() => setShowDefaultRerankerModal(false)}
+        size="md"
+      >
+        <ModalHeader
+          title="Edit Default Reranker"
+          onClose={() => setShowDefaultRerankerModal(false)}
+        />
+        <ModalBody>
+          <FormField>
+            <FormLabel>Reranker Class Path</FormLabel>
+            <Input
+              id="default-reranker"
+              value={defaultRerankerValue}
+              onChange={(e) => setDefaultRerankerValue(e.target.value)}
+              placeholder="e.g., opencontractserver.pipeline.rerankers.cross_encoder_reranker.CrossEncoderReranker"
+              fullWidth
+            />
+            <FormHelperText>
+              Applied as a second-stage reorder over vector / hybrid search
+              results across all corpora. Leave empty to disable reranking
+              (first-stage retrieval results are returned as-is).
+            </FormHelperText>
+          </FormField>
+          <div style={{ marginTop: "1rem" }}>
+            <FormLabel>Available Rerankers:</FormLabel>
+            <div
+              style={{
+                padding: "0.75rem",
+                fontSize: "0.875rem",
+                cursor: "pointer",
+                borderRadius: "8px",
+                marginBottom: "0.5rem",
+                background:
+                  defaultRerankerValue === ""
+                    ? "#e0e7ff"
+                    : OS_LEGAL_COLORS.surfaceHover,
+                border: `1px solid ${
+                  defaultRerankerValue === ""
+                    ? "#6366f1"
+                    : OS_LEGAL_COLORS.border
+                }`,
+              }}
+              onClick={() => setDefaultRerankerValue("")}
+            >
+              <strong>None (reranking disabled)</strong>
+            </div>
+            {componentsByStage.rerankers.map((r) => (
+              <div
+                key={r.className}
+                style={{
+                  padding: "0.75rem",
+                  fontSize: "0.875rem",
+                  cursor: "pointer",
+                  borderRadius: "8px",
+                  marginBottom: "0.5rem",
+                  background:
+                    defaultRerankerValue === r.className
+                      ? "#e0e7ff"
+                      : OS_LEGAL_COLORS.surfaceHover,
+                  border: `1px solid ${
+                    defaultRerankerValue === r.className
+                      ? "#6366f1"
+                      : OS_LEGAL_COLORS.border
+                  }`,
+                }}
+                onClick={() => setDefaultRerankerValue(r.className)}
+              >
+                <strong>{r.title || r.name}</strong>
+                <div
+                  style={{
+                    fontSize: "0.75rem",
+                    color: OS_LEGAL_COLORS.textSecondary,
+                    fontFamily: "monospace",
+                    marginTop: "0.25rem",
+                  }}
+                >
+                  {r.className}
+                </div>
+              </div>
+            ))}
+          </div>
+        </ModalBody>
+        <ModalFooter>
+          <Button
+            variant="secondary"
+            onClick={() => setShowDefaultRerankerModal(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            onClick={handleSaveDefaultReranker}
             loading={updating}
           >
             <Save style={{ width: 16, height: 16, marginRight: 8 }} />

--- a/frontend/src/components/admin/system_settings/FiletypeDefaults.tsx
+++ b/frontend/src/components/admin/system_settings/FiletypeDefaults.tsx
@@ -7,6 +7,7 @@ import {
   Settings,
   Bot,
   FileOutput,
+  ListOrdered,
 } from "lucide-react";
 import {
   PipelineComponentType,
@@ -52,6 +53,7 @@ interface FiletypeDefaultsProps {
   defaultEmbedder: string;
   defaultFileConverter: string;
   defaultLlm: string;
+  defaultReranker: string;
   updating: boolean;
   onAssign: (
     stage: "parsers" | "embedders" | "thumbnailers",
@@ -61,6 +63,7 @@ interface FiletypeDefaultsProps {
   onEditDefaultEmbedder: () => void;
   onEditDefaultFileConverter: () => void;
   onEditDefaultLlm: () => void;
+  onEditDefaultReranker: () => void;
 }
 
 // ============================================================================
@@ -89,11 +92,13 @@ export const FiletypeDefaults = memo<FiletypeDefaultsProps>(
     defaultEmbedder,
     defaultFileConverter,
     defaultLlm,
+    defaultReranker,
     updating,
     onAssign,
     onEditDefaultEmbedder,
     onEditDefaultFileConverter,
     onEditDefaultLlm,
+    onEditDefaultReranker,
   }) => {
     // Build a lookup from stage key to its preferred mapping
     const preferredByStage = useMemo(
@@ -320,6 +325,39 @@ export const FiletypeDefaults = memo<FiletypeDefaultsProps>(
                   size="sm"
                   data-testid="edit-default-llm"
                   onClick={onEditDefaultLlm}
+                >
+                  Edit
+                </Button>
+              </DefaultEmbedderDisplay>
+            </div>
+          </FiletypeRow>
+
+          {/* Default Reranker row. Not file-type-scoped: a single install-wide
+              post-retrieval reranker applied to vector / hybrid search results
+              across corpora. Empty = reranking disabled (first-stage retrieval
+              results are returned as-is). */}
+          <FiletypeRow>
+            <FiletypeLabel>
+              <ListOrdered />
+              Default Reranker
+            </FiletypeLabel>
+            <div style={{ gridColumn: "2 / -1" }}>
+              <DefaultEmbedderDisplay>
+                {defaultReranker ? (
+                  <DefaultEmbedderInfo>
+                    <ComponentName>
+                      {getComponentDisplayName(defaultReranker)}
+                    </ComponentName>
+                    <DefaultEmbedderPath>{defaultReranker}</DefaultEmbedderPath>
+                  </DefaultEmbedderInfo>
+                ) : (
+                  <EmptyValue>Disabled (no reranking)</EmptyValue>
+                )}
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  data-testid="edit-default-reranker"
+                  onClick={onEditDefaultReranker}
                 >
                   Edit
                 </Button>

--- a/frontend/src/components/admin/system_settings/graphql.ts
+++ b/frontend/src/components/admin/system_settings/graphql.ts
@@ -36,6 +36,7 @@ export const GET_PIPELINE_SETTINGS = gql`
       defaultEmbedder
       defaultFileConverter
       defaultLlm
+      defaultReranker
       componentsWithSecrets
       enabledComponents
       modified
@@ -148,6 +149,24 @@ export const GET_PIPELINE_COMPONENTS = gql`
         }
         enabled
       }
+      rerankers {
+        name
+        title
+        description
+        className
+        settingsSchema {
+          name
+          settingType
+          pythonType
+          required
+          description
+          default
+          envVar
+          hasValue
+          currentValue
+        }
+        enabled
+      }
     }
   }
 `;
@@ -162,6 +181,7 @@ export const UPDATE_PIPELINE_SETTINGS = gql`
     $defaultEmbedder: String
     $defaultFileConverter: String
     $defaultLlm: String
+    $defaultReranker: String
     $enabledComponents: [String]
   ) {
     updatePipelineSettings(
@@ -173,6 +193,7 @@ export const UPDATE_PIPELINE_SETTINGS = gql`
       defaultEmbedder: $defaultEmbedder
       defaultFileConverter: $defaultFileConverter
       defaultLlm: $defaultLlm
+      defaultReranker: $defaultReranker
       enabledComponents: $enabledComponents
     ) {
       ok
@@ -185,6 +206,8 @@ export const UPDATE_PIPELINE_SETTINGS = gql`
         componentSettings
         defaultEmbedder
         defaultFileConverter
+        defaultLlm
+        defaultReranker
         componentsWithSecrets
         enabledComponents
         modified
@@ -210,6 +233,8 @@ export const RESET_PIPELINE_SETTINGS = gql`
         componentSettings
         defaultEmbedder
         defaultFileConverter
+        defaultLlm
+        defaultReranker
         componentsWithSecrets
         enabledComponents
         modified

--- a/frontend/src/types/graphql-api.ts
+++ b/frontend/src/types/graphql-api.ts
@@ -1955,6 +1955,8 @@ export type PipelineComponentsType = {
   llmProviders?: Maybe<Array<Maybe<PipelineComponentType>>>;
   /** List of available pre-parse file converters (convert non-native formats to PDF). */
   fileConverters?: Maybe<Array<Maybe<PipelineComponentType>>>;
+  /** List of available post-retrieval rerankers. */
+  rerankers?: Maybe<Array<Maybe<PipelineComponentType>>>;
 };
 
 /** Enum for file types. */
@@ -2015,8 +2017,12 @@ export type PipelineSettingsType = {
   defaultFileConverter?: Maybe<Scalars["String"]>;
   /** Install-wide default LLM model spec for agents (e.g. 'anthropic:claude-opus-4-6'). Empty falls back to the Django settings default. */
   defaultLlm?: Maybe<Scalars["String"]>;
+  /** Default post-retrieval reranker class path. Empty string disables reranking (first-stage retrieval only). */
+  defaultReranker?: Maybe<Scalars["String"]>;
   /** List of components with encrypted secrets configured (actual secrets never exposed). */
   componentsWithSecrets?: Maybe<Array<Maybe<Scalars["String"]>>>;
+  /** List of tool keys (e.g. 'tool:web_search') with encrypted secrets configured (actual secrets never exposed). */
+  toolsWithSecrets?: Maybe<Array<Maybe<Scalars["String"]>>>;
   /** List of enabled component class paths. */
   enabledComponents?: Maybe<Array<Maybe<Scalars["String"]>>>;
   /** When settings were last modified. */

--- a/frontend/tests/admin-components.ct.tsx
+++ b/frontend/tests/admin-components.ct.tsx
@@ -1548,8 +1548,9 @@ test.describe("SystemSettings Component", () => {
     await expect(page.locator("text=Default LLM")).toBeVisible();
     await expect(page.locator("text=Using server default")).toBeVisible();
 
-    // Each default exposes its own Edit button (Default Embedder, Default LLM).
-    await expect(page.locator("button:has-text('Edit')")).toHaveCount(2);
+    // Each default exposes its own Edit button (Default Embedder, File
+    // Converter, Default LLM, Default Reranker).
+    await expect(page.locator("button:has-text('Edit')")).toHaveCount(4);
 
     await component.unmount();
   });

--- a/frontend/tests/system-settings-flows.ct.tsx
+++ b/frontend/tests/system-settings-flows.ct.tsx
@@ -1325,4 +1325,52 @@ test.describe("SystemSettings — default reranker", () => {
 
     await component.unmount();
   });
+
+  test("typing a class path and dismissing the modal do not save", async ({
+    mount,
+    page,
+  }) => {
+    const component = await mount(
+      <SystemSettingsWrapper
+        mocks={[
+          standardSettingsMock,
+          standardComponentsMock,
+          mimeTypesMock,
+          standardComponentsMock,
+          standardComponentsMock,
+        ]}
+      />
+    );
+    await waitForLoad(page);
+
+    // Typing directly into the class-path input mirrors the field (no card
+    // selection needed).
+    await page.locator('[data-testid="edit-default-reranker"]').click();
+    await expect(page.locator("text=Edit Default Reranker")).toBeVisible();
+    await page.locator("#default-reranker").fill("some.custom.Reranker");
+    await expect(page.locator("#default-reranker")).toHaveValue(
+      "some.custom.Reranker"
+    );
+
+    // The header's close (X) button dismisses without saving.
+    await page.locator(".oc-modal-header button[aria-label='Close']").click();
+    await expect(page.locator("text=Edit Default Reranker")).toBeHidden();
+
+    // Cancel also dismisses without saving.
+    await page.locator('[data-testid="edit-default-reranker"]').click();
+    await page.locator('.oc-modal-footer button:has-text("Cancel")').click();
+    await expect(page.locator("text=Edit Default Reranker")).toBeHidden();
+
+    // Escape dismisses the modal too (Modal's own onClose, distinct from the
+    // header's close button).
+    await page.locator('[data-testid="edit-default-reranker"]').click();
+    await expect(page.locator("text=Edit Default Reranker")).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(page.locator("text=Edit Default Reranker")).toBeHidden();
+
+    // Row remains disabled — nothing was saved.
+    await expect(page.locator("text=Disabled (no reranking)")).toBeVisible();
+
+    await component.unmount();
+  });
 });

--- a/frontend/tests/system-settings-flows.ct.tsx
+++ b/frontend/tests/system-settings-flows.ct.tsx
@@ -28,6 +28,7 @@ const mockSettingsBase = {
   defaultEmbedder: null,
   defaultFileConverter: null,
   defaultLlm: null,
+  defaultReranker: null,
   componentsWithSecrets: [],
   enabledComponents: [
     "opencontractserver.pipeline.parsers.docling.DoclingParser",
@@ -140,6 +141,17 @@ const mockComponents = {
         "opencontractserver.pipeline.file_converters.gotenberg_converter.GotenbergFileConverter",
       supportedExtensions: ["doc", "rtf", "odt", "ppt"],
       requiresApiKey: false,
+      enabled: true,
+      settingsSchema: [],
+    },
+  ],
+  rerankers: [
+    {
+      name: "cross_encoder",
+      title: "Cross-Encoder Reranker",
+      description: "Second-stage reranking via a cross-encoder model",
+      className:
+        "opencontractserver.pipeline.rerankers.cross_encoder_reranker.CrossEncoderReranker",
       enabled: true,
       settingsSchema: [],
     },
@@ -1148,6 +1160,165 @@ test.describe("SystemSettings — LLM providers", () => {
       .first()
       .click();
 
+    await expect(
+      page.locator("text=Settings updated successfully")
+    ).toBeVisible({ timeout: 5000 });
+
+    await component.unmount();
+  });
+});
+
+test.describe("SystemSettings — default reranker", () => {
+  // The install-wide post-retrieval reranker is toggled entirely from this GUI:
+  // picking a reranker enables second-stage reranking, picking "None" (empty
+  // class path) disables it. Both save through UPDATE_PIPELINE_SETTINGS with a
+  // single `defaultReranker` variable.
+  const RERANKER =
+    "opencontractserver.pipeline.rerankers.cross_encoder_reranker.CrossEncoderReranker";
+
+  test("enabling picks a reranker and fires UPDATE with the class path", async ({
+    mount,
+    page,
+  }) => {
+    const saveMock = {
+      request: {
+        query: UPDATE_PIPELINE_SETTINGS,
+        variables: { defaultReranker: RERANKER },
+      },
+      result: {
+        data: {
+          updatePipelineSettings: {
+            ok: true,
+            message: "Updated",
+            pipelineSettings: {
+              ...mockSettingsBase,
+              defaultReranker: RERANKER,
+            },
+          },
+        },
+      },
+    };
+    const refetch = {
+      request: { query: GET_PIPELINE_SETTINGS },
+      result: {
+        data: {
+          pipelineSettings: { ...mockSettingsBase, defaultReranker: RERANKER },
+        },
+      },
+    };
+
+    const component = await mount(
+      <SystemSettingsWrapper
+        mocks={[
+          standardSettingsMock,
+          standardComponentsMock,
+          mimeTypesMock,
+          saveMock,
+          refetch,
+          standardComponentsMock,
+        ]}
+      />
+    );
+    await waitForLoad(page);
+
+    // The row starts disabled (no reranker configured in mockSettingsBase).
+    await expect(page.locator("text=Disabled (no reranking)")).toBeVisible();
+
+    await page.locator('[data-testid="edit-default-reranker"]').click();
+    await expect(page.locator("text=Edit Default Reranker")).toBeVisible();
+
+    // Pick the Cross-Encoder reranker card; the class-path input mirrors it.
+    await page
+      .locator(".oc-modal-body")
+      .locator("text=Cross-Encoder Reranker")
+      .first()
+      .click();
+    await expect(page.locator("#default-reranker")).toHaveValue(RERANKER);
+
+    await page
+      .locator('.oc-modal-footer button:has-text("Save")')
+      .first()
+      .click();
+
+    // Success toast only appears if the mutation matched (variable == RERANKER).
+    await expect(
+      page.locator("text=Settings updated successfully")
+    ).toBeVisible({ timeout: 5000 });
+
+    await component.unmount();
+  });
+
+  test("disabling picks 'None' and fires UPDATE with an empty string", async ({
+    mount,
+    page,
+  }) => {
+    // Start from the enabled state so the row shows the configured reranker.
+    const enabledSettingsMock = {
+      request: { query: GET_PIPELINE_SETTINGS },
+      result: {
+        data: {
+          pipelineSettings: { ...mockSettingsBase, defaultReranker: RERANKER },
+        },
+      },
+    };
+    const saveMock = {
+      request: {
+        query: UPDATE_PIPELINE_SETTINGS,
+        variables: { defaultReranker: "" },
+      },
+      result: {
+        data: {
+          updatePipelineSettings: {
+            ok: true,
+            message: "Updated",
+            pipelineSettings: { ...mockSettingsBase, defaultReranker: null },
+          },
+        },
+      },
+    };
+    const refetch = {
+      request: { query: GET_PIPELINE_SETTINGS },
+      result: {
+        data: {
+          pipelineSettings: { ...mockSettingsBase, defaultReranker: null },
+        },
+      },
+    };
+
+    const component = await mount(
+      <SystemSettingsWrapper
+        mocks={[
+          enabledSettingsMock,
+          standardComponentsMock,
+          mimeTypesMock,
+          saveMock,
+          refetch,
+          standardComponentsMock,
+        ]}
+      />
+    );
+    await waitForLoad(page);
+
+    // The row starts enabled (shows the configured class path).
+    await expect(page.locator(`text=${RERANKER}`).first()).toBeVisible();
+
+    await page.locator('[data-testid="edit-default-reranker"]').click();
+    await expect(page.locator("text=Edit Default Reranker")).toBeVisible();
+
+    // Pick "None (reranking disabled)"; the class-path input clears.
+    await page
+      .locator(".oc-modal-body")
+      .locator("text=None (reranking disabled)")
+      .first()
+      .click();
+    await expect(page.locator("#default-reranker")).toHaveValue("");
+
+    await page
+      .locator('.oc-modal-footer button:has-text("Save")')
+      .first()
+      .click();
+
+    // Success toast only appears if the mutation matched (variable == "").
     await expect(
       page.locator("text=Settings updated successfully")
     ).toBeVisible({ timeout: 5000 });

--- a/opencontractserver/documents/models.py
+++ b/opencontractserver/documents/models.py
@@ -1943,6 +1943,24 @@ class PipelineSettings(django.db.models.Model):
             if key.startswith(TOOL_SETTINGS_PREFIX) and all_secrets[key]
         ]
 
+    def get_components_with_secrets(self) -> list[str]:
+        """
+        Return component class paths that have secrets configured.
+
+        Excludes ``tool:``-prefixed keys — those are agent-tool secrets tracked
+        separately by :meth:`get_tools_with_secrets`. The two secret namespaces
+        share one encrypted store, so surfacing raw ``get_secrets().keys()`` as
+        the component list leaks tool keys (e.g. ``tool:web_search``) into the
+        admin Component Library's per-component secret indicators.
+        """
+        from opencontractserver.constants.tools import TOOL_SETTINGS_PREFIX
+
+        return [
+            key
+            for key in self.get_secrets()
+            if not key.startswith(TOOL_SETTINGS_PREFIX)
+        ]
+
     # =====================================================================
     # Component Schema and Validation Methods
     # =====================================================================

--- a/opencontractserver/tests/test_pipeline_settings.py
+++ b/opencontractserver/tests/test_pipeline_settings.py
@@ -276,6 +276,36 @@ class PipelineSettingsModelTestCase(TestCase):
         # Stored plaintext dict must not be mutated by the merge
         self.assertEqual(instance.component_settings[comp_path]["api_key"], "")
 
+    def test_get_components_with_secrets_excludes_tool_keys(self):
+        """``get_components_with_secrets`` returns only component paths, never
+        ``tool:`` keys.
+
+        Component secrets and agent-tool secrets share the same encrypted store,
+        so building the component-secret list from raw ``get_secrets().keys()``
+        would leak tool keys (e.g. ``tool:web_search``) into the admin Component
+        Library's per-component secret indicators.
+        """
+        PipelineSettings.objects.all().delete()
+        instance = PipelineSettings.get_instance()
+
+        comp_path = (
+            "opencontractserver.pipeline.parsers.llamaparse_parser.LlamaParseParser"
+        )
+        instance.set_secrets(
+            {
+                comp_path: {"api_key": "sk-component"},
+                "tool:web_search": {"api_key": "brave-key"},
+            }
+        )
+        instance.save()
+
+        components = instance.get_components_with_secrets()
+        tools = instance.get_tools_with_secrets()
+
+        self.assertIn(comp_path, components)
+        self.assertNotIn("tool:web_search", components)
+        self.assertEqual(tools, ["tool:web_search"])
+
     def test_get_parser_kwargs_log_redaction_hides_secret(self):
         """The merged dict, after redact_sensitive_kwargs, must not leak the key.
 
@@ -551,6 +581,69 @@ class PipelineSettingsGraphQLTestCase(TestCase):
             "not found",
             result["data"]["updatePipelineSettings"]["message"].lower(),
         )
+
+    def test_update_preferred_thumbnailer_rejects_wrong_component_type(self):
+        """Assigning a registered PARSER class as a thumbnailer is rejected.
+
+        Registry membership alone is not enough: a parser passes the existence
+        check but has no ``generate_thumbnail`` and would fail every affected
+        document at ingest. ``validate_component_mapping`` must reject the
+        cross-type assignment (which the GUI dropdown can never produce, but a
+        raw GraphQL call can).
+        """
+        from opencontractserver.pipeline.registry import get_registry
+
+        registry = get_registry()
+        if not registry.parsers:
+            self.skipTest("No parsers registered to exercise the type guard.")
+        parser_path = registry.parsers[0].class_name
+
+        mutation = """
+            mutation UpdatePipelineSettings($preferredThumbnailers: GenericScalar) {
+                updatePipelineSettings(preferredThumbnailers: $preferredThumbnailers) {
+                    ok
+                    message
+                }
+            }
+        """
+        variables = {"preferredThumbnailers": {"application/pdf": parser_path}}
+
+        result = self.superuser_client.execute(mutation, variables=variables)
+        self.assertIsNone(result.get("errors"))
+        self.assertFalse(result["data"]["updatePipelineSettings"]["ok"])
+        self.assertIn(
+            "not a thumbnailer",
+            result["data"]["updatePipelineSettings"]["message"].lower(),
+        )
+
+    def test_pipeline_settings_query_excludes_tool_secret_keys(self):
+        """The ``componentsWithSecrets`` field must not surface ``tool:`` keys."""
+        instance = PipelineSettings.get_instance()
+        comp_path = (
+            "opencontractserver.pipeline.parsers.llamaparse_parser.LlamaParseParser"
+        )
+        instance.set_secrets(
+            {
+                comp_path: {"api_key": "sk-component"},
+                "tool:web_search": {"api_key": "brave-key"},
+            }
+        )
+        instance.save()
+
+        query = """
+            query {
+                pipelineSettings {
+                    componentsWithSecrets
+                    toolsWithSecrets
+                }
+            }
+        """
+        result = self.superuser_client.execute(query)
+        self.assertIsNone(result.get("errors"))
+        data = result["data"]["pipelineSettings"]
+        self.assertIn(comp_path, data["componentsWithSecrets"])
+        self.assertNotIn("tool:web_search", data["componentsWithSecrets"])
+        self.assertIn("tool:web_search", data["toolsWithSecrets"])
 
     def test_reset_pipeline_settings_as_superuser(self):
         """Test that superusers can reset pipeline settings to defaults."""

--- a/opencontractserver/tests/websocket/test_unified_agent_consumer.py
+++ b/opencontractserver/tests/websocket/test_unified_agent_consumer.py
@@ -782,6 +782,56 @@ class UnifiedAgentConsumerTitleGenerationTestCase(WebsocketFixtureBaseTestCase):
 
 @override_settings(USE_AUTH0=False)
 @pytest.mark.django_db(transaction=True)
+class UnifiedAgentConsumerAgentLlmTestCase(WebsocketFixtureBaseTestCase):
+    """``_initialize_agent`` must thread ``AgentConfiguration.preferred_llm``
+    into the agent factory so the per-agent model override takes effect in
+    interactive chat — parity with the Celery (``agent_tasks``) and delegation
+    (``delegation_tools``) paths, which already pass ``agent_preferred_llm=``.
+    """
+
+    def _make_corpus_consumer(self, preferred_llm: str) -> UnifiedAgentConsumer:
+        consumer = UnifiedAgentConsumer()
+        consumer.session_id = "test-session"
+        consumer.user_id = self.user.id
+        consumer.conversation_id = None
+        consumer.document = None
+        consumer.corpus = SimpleNamespace(preferred_embedder=None)
+        consumer.corpus_id = self.corpus.id
+        consumer.agent_config = SimpleNamespace(
+            preferred_llm=preferred_llm,
+            system_instructions=None,
+        )
+        return consumer
+
+    async def test_initialize_agent_threads_agent_preferred_llm(self) -> None:
+        """A non-empty agent ``preferred_llm`` reaches the factory."""
+        consumer = self._make_corpus_consumer("anthropic:claude-haiku-4-5")
+        with patch(
+            "config.websocket.consumers.unified_agent_conversation.agents.for_corpus"
+        ) as mock_for_corpus:
+            mock_for_corpus.return_value = _StubAgent(lambda: iter(()))
+            await consumer._initialize_agent()
+            mock_for_corpus.assert_called_once()
+            kwargs = mock_for_corpus.call_args.kwargs
+            self.assertEqual(
+                kwargs.get("agent_preferred_llm"), "anthropic:claude-haiku-4-5"
+            )
+
+    async def test_initialize_agent_omits_preferred_llm_when_unset(self) -> None:
+        """An empty/blank agent ``preferred_llm`` is not forwarded, so
+        lower-precedence resolution (corpus / install default) still applies."""
+        consumer = self._make_corpus_consumer("")
+        with patch(
+            "config.websocket.consumers.unified_agent_conversation.agents.for_corpus"
+        ) as mock_for_corpus:
+            mock_for_corpus.return_value = _StubAgent(lambda: iter(()))
+            await consumer._initialize_agent()
+            kwargs = mock_for_corpus.call_args.kwargs
+            self.assertNotIn("agent_preferred_llm", kwargs)
+
+
+@override_settings(USE_AUTH0=False)
+@pytest.mark.django_db(transaction=True)
 class UnifiedAgentConsumerDisconnectTestCase(WebsocketFixtureBaseTestCase):
     """Tests for graceful disconnect handling."""
 


### PR DESCRIPTION
## Summary

Audited every admin-facing pipeline setting end-to-end — **GUI control → GraphQL → model field → the code that actually reads it at ingest/retrieval** — and fixed the highest-confidence gaps. Of 16 settings: 5 worked as implied, **4 had no GUI control at all**, and **3 shipped controls that don't take effect**. This PR closes four of those; the rest are filed as tracking issues.

## Fixed here (with tests)

1. **Default Reranker GUI control** *(added)* — `PipelineSettings.default_reranker` was persisted, validated, cache-busted and read at runtime (`core_vector_stores._get_reranker`), but the admin surface never exposed it (settable only via raw GraphQL/DB). Added a "Default Reranker" picker to `FiletypeDefaults.tsx`, wired `defaultReranker` + `pipelineComponents.rerankers` through `system_settings/graphql.ts`, and filled the previously-omitted `defaultLlm`/`defaultReranker` fields on the UPDATE/RESET returns.
2. **Interactive chat honors `AgentConfiguration.preferred_llm`** — `_initialize_agent` (`config/websocket/consumers/unified_agent_conversation.py`) built the factory kwargs without `agent_preferred_llm`, so WebSocket chat silently used the corpus/install default even when the agent pinned a model. Now threaded, matching the Celery (`agent_tasks`) and delegation (`delegation_tools`) paths.
3. **Stage-type validation on component mappings** — `validate_component_mapping` only checked registry membership, so a raw `updatePipelineSettings` call could assign a parser class as a thumbnailer/embedder and fail every document at ingest. Now type-checks against the expected `ComponentType`.
4. **Tool-secret key leak** — `components_with_secrets` was built from raw `get_secrets().keys()`, leaking `tool:web_search` keys into the Component Library. Added `PipelineSettings.get_components_with_secrets()` and routed the resolver + mutation returns through it.

## Tests

- Backend (5): `test_pipeline_settings.py` (type-check + tool-key exclusion, model + resolver), `test_unified_agent_consumer.py::UnifiedAgentConsumerAgentLlmTestCase` (threads / omits per-agent LLM). All pass.
- Component (2): `system-settings-flows.ct.tsx` — reranker enable/disable fires the correct mutation. Full 18-test suite green.
- Reranker verified **end-to-end on a live stack**: set via GUI → persisted to DB → reverted via GUI → DB cleared.
- `pre-commit` (black/isort/flake8/mypy/prettier) + `tsc` clean.

## Coverage matrix (abridged)

| Setting | GUI | Runtime | Status |
|---|:--:|:--:|---|
| preferred_parsers, default_embedder, preferred_thumbnailers, default_file_converter, default_llm, Corpus.preferred_llm, component_settings, component secrets | ✅ | ✅ | working |
| **default_reranker** | ✅ | ✅ | **fixed here** |
| AgentConfiguration.preferred_llm | ❌ | ◑ | chat fixed here; form → #2119 |
| preferred_embedders (per-MIME) | ✅ | ❌ | #2114 |
| parser_kwargs (overrides config) | ❌ | ✅ | #2115, #2120 |
| enabled_components | ✅ | ❌ | #2116 |
| Tool secrets (web_search) | ❌ | ✅ | #2117 |
| preferred_enrichers | ❌ | ✅ | #2118 |

## Open items (tracking issues)

- #2114 — per-MIME `preferred_embedders` is a runtime no-op at ingest
- #2115 — `parser_kwargs` silently overrides GUI `component_settings`
- #2116 — `enabled_components` has no runtime enforcement
- #2117 — no admin GUI for agent tool secrets (`tool:web_search`)
- #2118 — `preferred_enrichers` has no GraphQL/GUI surface
- #2119 — add `AgentConfiguration.preferred_llm` to agent-management forms
- #2120 — no GUI editor for `parser_kwargs` (docling parse flags)
- #2121 — can't revert a `component_settings` field / re-widen `convert_extensions`
- #2122 — cleanup (dead code, dead GraphQL selections, Reset wording)

## Method

45-agent parallel static audit (10 dimensions, adversarial verification) → 34 verified findings → live GUI smoke test.