### PR TITLE
Agent management: add Preferred LLM picker to admin forms

### DIFF
--- a/changelog.d/2119.added.md
+++ b/changelog.d/2119.added.md
@@ -1,0 +1,36 @@
+- **Per-agent LLM picker on both agent-management admin surfaces (issue #2119).**
+  `AgentConfiguration.preferred_llm` was fully wired on the backend
+  (`config/graphql/agent_mutations.py`, `AgentConfigurationService`) but had no
+  GUI — the only way to set it was raw GraphQL. Both the global
+  (`frontend/src/components/admin/GlobalAgentManagement.tsx`) and corpus-scoped
+  (`frontend/src/components/corpuses/CorpusAgentManagement.tsx`) agent
+  create/edit forms now embed the existing `LlmModelPicker`
+  (`frontend/src/components/common/LlmModelPicker.tsx`), the same
+  provider-aware model-spec control already used for the System Settings
+  install-wide default and `Corpus.preferred_llm`. The corpus-scoped form also
+  surfaces the corpus's own `preferredLlm` as the "inherited" fallback hint
+  when the caller has it on hand (wired from `CorpusSettings.tsx`).
+  - GraphQL: `preferredLlm` added to `GET_GLOBAL_AGENTS`
+    (`global_agent_management.graphql.ts`) and `GET_CORPUS_AGENTS`
+    (`graphql/queries.ts`); `$preferredLlm`/`$clearPreferredLlm` added to both
+    create/update mutation pairs (`global_agent_management.graphql.ts`,
+    `graphql/mutations.ts`), matching the args already accepted by
+    `CreateAgentConfigurationMutation`/`UpdateAgentConfigurationMutation`.
+  - Contract: on create, an empty field sends `preferredLlm: null` (no
+    override, matching `preferred_llm or None` in
+    `AgentConfigurationService.create_agent`). On update, a non-empty value
+    sends `preferredLlm: <value>`; clearing a previously-set override sends
+    `clearPreferredLlm: true` with `preferredLlm` omitted — never an
+    empty-string `preferredLlm`, which fails the model's validation. Leaving
+    an already-empty field untouched sends neither (no-op), per
+    `AgentConfigurationService.update_agent`'s `clear_preferred_llm=True` /
+    `preferred_llm is not None` branching.
+  - `frontend/src/types/graphql-api.ts`: added `preferredLlm` to
+    `AgentConfigurationType` (hand-maintained; this repo has no active
+    GraphQL codegen script).
+  - Tests: new CT coverage in `frontend/tests/CorpusAgentManagement.ct.tsx`
+    and `frontend/tests/global-agent-management.ct.tsx` for picker visibility,
+    submit-with-value, and clear-with-`clearPreferredLlm`; existing mutation
+    mocks across `admin-components.ct.tsx`,
+    `CorpusAgentManagement.ct.tsx`, and `global-agent-management.ct.tsx`
+    updated to match the new query/mutation shapes exactly.

--- a/frontend/src/components/admin/GlobalAgentManagement.tsx
+++ b/frontend/src/components/admin/GlobalAgentManagement.tsx
@@ -18,9 +18,11 @@ import { StyledTextArea } from "../widgets/modals/styled";
 import { FormField } from "../widgets/form/FormField";
 import { ErrorMessage, InfoMessage, LoadingState } from "../widgets/feedback";
 import { StatusBadge, ToolBadge, ToolsList } from "../agents/AgentBadges";
+import { LlmModelPicker } from "../common/LlmModelPicker";
 import {
   AgentConfigurationType,
   AgentConfigurationTypeEdge,
+  LlmProviderOption,
 } from "../../types/graphql-api";
 import { OS_LEGAL_COLORS } from "../../assets/configurations/osLegalStyles";
 import {
@@ -32,6 +34,12 @@ import {
   PageHeader,
   ScrollableTableWrapper,
 } from "../layout/SharedSegments";
+import {
+  GET_LLM_PROVIDERS,
+  LlmProvidersQueryResult,
+  GET_SYSTEM_DEFAULT_LLM,
+  SystemDefaultLlmQueryResult,
+} from "../../graphql/queries";
 import {
   GET_GLOBAL_AGENTS,
   CREATE_GLOBAL_AGENT_CONFIGURATION,
@@ -67,6 +75,8 @@ interface FormState {
   avatarUrl: string;
   isPublic: boolean;
   isActive: boolean;
+  /** Per-agent LLM override ("provider:model"); "" = inherit. */
+  preferredLlm: string;
 }
 
 const CheckboxLabel = styled.label`
@@ -86,8 +96,10 @@ const FormGroup = styled.div`
 const AgentFormFields: React.FC<{
   formState: FormState;
   onChange: (updates: Partial<FormState>) => void;
+  llmProviders: LlmProviderOption[];
+  systemDefaultLlm: string;
   children?: React.ReactNode;
-}> = ({ formState, onChange, children }) => (
+}> = ({ formState, onChange, llmProviders, systemDefaultLlm, children }) => (
   <form>
     <FormField $required>
       <label>Name</label>
@@ -163,6 +175,19 @@ const AgentFormFields: React.FC<{
         }
       />
     </FormField>
+    <FormField>
+      <LlmModelPicker
+        label="Preferred LLM"
+        value={formState.preferredLlm}
+        onChange={(spec) => onChange({ preferredLlm: spec })}
+        providers={llmProviders}
+        showApiKeyBadge
+        inheritedSpec={systemDefaultLlm || null}
+        inheritedLabel="Inherited system default"
+        placeholder="e.g., anthropic:claude-opus-4-6"
+        helperText='Optional per-agent LLM override, in "provider:model" form. Leave empty to use the system default.'
+      />
+    </FormField>
     {children}
   </form>
 );
@@ -177,6 +202,7 @@ const initialFormState: FormState = {
   avatarUrl: "",
   isPublic: true,
   isActive: true,
+  preferredLlm: "",
 };
 
 export const GlobalAgentManagement: React.FC = () => {
@@ -191,6 +217,20 @@ export const GlobalAgentManagement: React.FC = () => {
   const [formState, setFormState] = useState<FormState>(initialFormState);
 
   const { loading, error, data, refetch } = useQuery(GET_GLOBAL_AGENTS);
+
+  // Providers + the install-wide default power the LlmModelPicker's chip
+  // list and "inherited" hint. Both resolvers are @login_required, secret-free
+  // projections (see queries.ts) — safe for any admin viewing this screen.
+  const { data: llmProvidersData } =
+    useQuery<LlmProvidersQueryResult>(GET_LLM_PROVIDERS);
+  const { data: systemDefaultLlmData } = useQuery<SystemDefaultLlmQueryResult>(
+    GET_SYSTEM_DEFAULT_LLM
+  );
+  const llmProviders = (
+    llmProvidersData?.pipelineComponents?.llmProviders ?? []
+  ).filter((p) => p.enabled !== false);
+  const systemDefaultLlm =
+    systemDefaultLlmData?.pipelineSettings?.defaultLlm ?? "";
 
   const [createAgent, { loading: creating }] = useMutation(
     CREATE_GLOBAL_AGENT_CONFIGURATION,
@@ -272,6 +312,10 @@ export const GlobalAgentManagement: React.FC = () => {
         avatarUrl: formState.avatarUrl || null,
         scope: "GLOBAL",
         isPublic: formState.isPublic,
+        // Create has no clear-flag: None/omitted means "no override" per
+        // AgentConfigurationService.create_agent (preferred_llm=preferred_llm
+        // or None), so an explicit null is equivalent to leaving it unset.
+        preferredLlm: formState.preferredLlm.trim() || null,
       },
     });
   };
@@ -296,6 +340,16 @@ export const GlobalAgentManagement: React.FC = () => {
       return;
     }
 
+    // AgentConfigurationService.update_agent's contract (config/graphql/
+    // agent_mutations.py): preferred_llm=None means "leave unchanged";
+    // clear_preferred_llm=True is the only way to reset the override back to
+    // the corpus/system default (an empty string would fail the model's
+    // validation). So we only ever send a non-empty preferredLlm or the
+    // clear flag — never both, and never an empty-string preferredLlm.
+    const trimmedLlm = formState.preferredLlm.trim();
+    const hadPreferredLlm = Boolean(agentToEdit.preferredLlm?.trim());
+    const clearPreferredLlm = trimmedLlm === "" && hadPreferredLlm;
+
     updateAgent({
       variables: {
         agentId: agentToEdit.id,
@@ -308,6 +362,8 @@ export const GlobalAgentManagement: React.FC = () => {
         avatarUrl: formState.avatarUrl || null,
         isActive: formState.isActive,
         isPublic: formState.isPublic,
+        preferredLlm: trimmedLlm || undefined,
+        clearPreferredLlm,
       },
     });
   };
@@ -330,6 +386,7 @@ export const GlobalAgentManagement: React.FC = () => {
       avatarUrl: agent.avatarUrl || "",
       isPublic: agent.isPublic ?? true,
       isActive: agent.isActive,
+      preferredLlm: agent.preferredLlm ?? "",
     });
     setShowEditModal(true);
   };
@@ -486,6 +543,8 @@ export const GlobalAgentManagement: React.FC = () => {
             onChange={(updates) =>
               setFormState((prev) => ({ ...prev, ...updates }))
             }
+            llmProviders={llmProviders}
+            systemDefaultLlm={systemDefaultLlm}
           >
             <FormField>
               <CheckboxLabel>
@@ -536,6 +595,8 @@ export const GlobalAgentManagement: React.FC = () => {
             onChange={(updates) =>
               setFormState((prev) => ({ ...prev, ...updates }))
             }
+            llmProviders={llmProviders}
+            systemDefaultLlm={systemDefaultLlm}
           >
             <FormGroup>
               <FormField>

--- a/frontend/src/components/admin/__tests__/GlobalAgentManagement.mount.test.tsx
+++ b/frontend/src/components/admin/__tests__/GlobalAgentManagement.mount.test.tsx
@@ -17,6 +17,10 @@ import { render } from "@testing-library/react";
 import { MockedProvider } from "@apollo/client/testing";
 import { GlobalAgentManagement } from "../GlobalAgentManagement";
 import { GET_GLOBAL_AGENTS } from "../global_agent_management.graphql";
+import {
+  GET_LLM_PROVIDERS,
+  GET_SYSTEM_DEFAULT_LLM,
+} from "../../../graphql/queries";
 
 const agentsQueryMock = {
   request: { query: GET_GLOBAL_AGENTS },
@@ -27,10 +31,30 @@ const agentsQueryMock = {
   },
 };
 
+// GlobalAgentManagement also fires these to power the Preferred LLM picker's
+// chip list + "inherited system default" hint. Mock them so the mount doesn't
+// leave a dangling unmatched-mock error in the MockedProvider.
+const llmProvidersMock = {
+  request: { query: GET_LLM_PROVIDERS },
+  result: {
+    data: { pipelineComponents: { llmProviders: [] } },
+  },
+};
+
+const systemDefaultLlmMock = {
+  request: { query: GET_SYSTEM_DEFAULT_LLM },
+  result: {
+    data: { pipelineSettings: { defaultLlm: null } },
+  },
+};
+
 describe("GlobalAgentManagement (mount smoke test)", () => {
   it("mounts without throwing under a MockedProvider", () => {
     const { container } = render(
-      <MockedProvider mocks={[agentsQueryMock]} addTypename={false}>
+      <MockedProvider
+        mocks={[agentsQueryMock, llmProvidersMock, systemDefaultLlmMock]}
+        addTypename={false}
+      >
         <GlobalAgentManagement />
       </MockedProvider>
     );

--- a/frontend/src/components/admin/global_agent_management.graphql.ts
+++ b/frontend/src/components/admin/global_agent_management.graphql.ts
@@ -33,6 +33,7 @@ export const GET_GLOBAL_AGENTS = gql`
           scope
           isActive
           isPublic
+          preferredLlm
           creator {
             id
             username
@@ -56,6 +57,7 @@ export const CREATE_GLOBAL_AGENT_CONFIGURATION = gql`
     $avatarUrl: String
     $scope: String!
     $isPublic: Boolean
+    $preferredLlm: String
   ) {
     createAgentConfiguration(
       name: $name
@@ -67,6 +69,7 @@ export const CREATE_GLOBAL_AGENT_CONFIGURATION = gql`
       avatarUrl: $avatarUrl
       scope: $scope
       isPublic: $isPublic
+      preferredLlm: $preferredLlm
     ) {
       ok
       message
@@ -92,6 +95,8 @@ export const UPDATE_GLOBAL_AGENT_CONFIGURATION = gql`
     $avatarUrl: String
     $isActive: Boolean
     $isPublic: Boolean
+    $preferredLlm: String
+    $clearPreferredLlm: Boolean
   ) {
     updateAgentConfiguration(
       agentId: $agentId
@@ -104,6 +109,8 @@ export const UPDATE_GLOBAL_AGENT_CONFIGURATION = gql`
       avatarUrl: $avatarUrl
       isActive: $isActive
       isPublic: $isPublic
+      preferredLlm: $preferredLlm
+      clearPreferredLlm: $clearPreferredLlm
     ) {
       ok
       message

--- a/frontend/src/components/corpuses/CorpusAgentManagement.tsx
+++ b/frontend/src/components/corpuses/CorpusAgentManagement.tsx
@@ -19,8 +19,14 @@ import { BadgeConfigurator, BadgeConfig } from "../agents/BadgeConfigurator";
 import { ErrorMessage, InfoMessage, LoadingState } from "../widgets/feedback";
 import { StatusBadge, ToolBadge, ToolsList } from "../agents/AgentBadges";
 import { StyledTextArea } from "../widgets/modals/styled";
+import { LlmModelPicker } from "../common/LlmModelPicker";
 import { OS_LEGAL_COLORS } from "../../assets/configurations/osLegalStyles";
-import { GET_CORPUS_AGENTS, GET_AVAILABLE_TOOLS } from "../../graphql/queries";
+import {
+  GET_CORPUS_AGENTS,
+  GET_AVAILABLE_TOOLS,
+  GET_LLM_PROVIDERS,
+  LlmProvidersQueryResult,
+} from "../../graphql/queries";
 import {
   CREATE_AGENT_CONFIGURATION,
   UPDATE_AGENT_CONFIGURATION,
@@ -241,6 +247,15 @@ const ToolHelpText = styled.small`
 interface CorpusAgentManagementProps {
   corpusId: string;
   canUpdate: boolean;
+  /**
+   * The corpus's own Corpus.preferredLlm, when the caller already has it on
+   * hand (e.g. CorpusSettings, which loads it for CorpusLanguageModelCard).
+   * Powers the LlmModelPicker's "inherited" hint — an agent's own override
+   * falls back to this corpus default (which itself falls back to the
+   * install-wide system default) when left blank. Optional: omitting it just
+   * means the picker shows no inherited-value hint.
+   */
+  corpusPreferredLlm?: string | null;
 }
 
 interface AvailableTool {
@@ -264,6 +279,7 @@ interface AgentNode {
   scope: string;
   isActive: boolean;
   isPublic?: boolean;
+  preferredLlm?: string | null;
   creator: { id: string; username: string };
   created: string;
   modified: string;
@@ -280,6 +296,8 @@ interface FormState {
   avatarUrl: string;
   isPublic: boolean;
   isActive: boolean;
+  /** Per-agent LLM override ("provider:model"); "" = inherit. */
+  preferredLlm: string;
 }
 
 const defaultBadgeConfig: BadgeConfig = {
@@ -299,11 +317,13 @@ const initialFormState: FormState = {
   avatarUrl: "",
   isPublic: false,
   isActive: true,
+  preferredLlm: "",
 };
 
 export const CorpusAgentManagement: React.FC<CorpusAgentManagementProps> = ({
   corpusId,
   canUpdate,
+  corpusPreferredLlm,
 }) => {
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [showEditModal, setShowEditModal] = useState(false);
@@ -319,6 +339,17 @@ export const CorpusAgentManagement: React.FC<CorpusAgentManagementProps> = ({
   // Fetch available tools for the selection UI
   const { data: toolsData, loading: toolsLoading } =
     useQuery(GET_AVAILABLE_TOOLS);
+
+  // Powers the LlmModelPicker's chip list. Skipped for read-only viewers, same
+  // as CorpusLanguageModelCard — the picker itself only renders inside the
+  // create/edit modals, which `canUpdate` already gates.
+  const { data: llmProvidersData } = useQuery<LlmProvidersQueryResult>(
+    GET_LLM_PROVIDERS,
+    { skip: !canUpdate }
+  );
+  const llmProviders = (
+    llmProvidersData?.pipelineComponents?.llmProviders ?? []
+  ).filter((p) => p.enabled !== false);
 
   const [createAgent, { loading: creating }] = useMutation(
     CREATE_AGENT_CONFIGURATION,
@@ -389,12 +420,26 @@ export const CorpusAgentManagement: React.FC<CorpusAgentManagementProps> = ({
         scope: "CORPUS",
         corpusId: corpusId,
         isPublic: formState.isPublic,
+        // Create has no clear-flag: None/omitted means "no override" per
+        // AgentConfigurationService.create_agent (preferred_llm=preferred_llm
+        // or None), so an explicit null is equivalent to leaving it unset.
+        preferredLlm: formState.preferredLlm.trim() || null,
       },
     });
   };
 
   const handleUpdate = () => {
     if (!agentToEdit) return;
+
+    // AgentConfigurationService.update_agent's contract (config/graphql/
+    // agent_mutations.py): preferred_llm=None means "leave unchanged";
+    // clear_preferred_llm=True is the only way to reset the override back to
+    // the corpus/system default (an empty string would fail the model's
+    // validation). So we only ever send a non-empty preferredLlm or the
+    // clear flag — never both, and never an empty-string preferredLlm.
+    const trimmedLlm = formState.preferredLlm.trim();
+    const hadPreferredLlm = Boolean(agentToEdit.preferredLlm?.trim());
+    const clearPreferredLlm = trimmedLlm === "" && hadPreferredLlm;
 
     updateAgent({
       variables: {
@@ -409,6 +454,8 @@ export const CorpusAgentManagement: React.FC<CorpusAgentManagementProps> = ({
         avatarUrl: formState.avatarUrl || null,
         isActive: formState.isActive,
         isPublic: formState.isPublic,
+        preferredLlm: trimmedLlm || undefined,
+        clearPreferredLlm,
       },
     });
   };
@@ -469,6 +516,7 @@ export const CorpusAgentManagement: React.FC<CorpusAgentManagementProps> = ({
       avatarUrl: agent.avatarUrl || "",
       isPublic: agent.isPublic ?? false,
       isActive: agent.isActive,
+      preferredLlm: agent.preferredLlm ?? "",
     });
     setShowEditModal(true);
   };
@@ -902,6 +950,22 @@ export const CorpusAgentManagement: React.FC<CorpusAgentManagementProps> = ({
               />
             </div>
             <div style={{ marginBottom: "1rem" }}>
+              <LlmModelPicker
+                id={`corpus-agent-create-llm-${corpusId}`}
+                label="Preferred LLM (optional)"
+                value={formState.preferredLlm}
+                onChange={(spec) =>
+                  setFormState({ ...formState, preferredLlm: spec })
+                }
+                providers={llmProviders}
+                showApiKeyBadge
+                inheritedSpec={corpusPreferredLlm ?? null}
+                inheritedLabel="Inherited corpus default"
+                placeholder="e.g., anthropic:claude-opus-4-6"
+                helperText='Per-agent LLM override, in "provider:model" form. Leave empty to use the corpus/system default.'
+              />
+            </div>
+            <div style={{ marginBottom: "1rem" }}>
               <label
                 style={{
                   display: "flex",
@@ -1169,6 +1233,22 @@ export const CorpusAgentManagement: React.FC<CorpusAgentManagementProps> = ({
                   setFormState({ ...formState, avatarUrl: e.target.value })
                 }
                 helperText="Custom avatar image URL. If not provided, the badge icon will be used."
+              />
+            </div>
+            <div style={{ marginBottom: "1rem" }}>
+              <LlmModelPicker
+                id={`corpus-agent-edit-llm-${corpusId}`}
+                label="Preferred LLM (optional)"
+                value={formState.preferredLlm}
+                onChange={(spec) =>
+                  setFormState({ ...formState, preferredLlm: spec })
+                }
+                providers={llmProviders}
+                showApiKeyBadge
+                inheritedSpec={corpusPreferredLlm ?? null}
+                inheritedLabel="Inherited corpus default"
+                placeholder="e.g., anthropic:claude-opus-4-6"
+                helperText='Per-agent LLM override, in "provider:model" form. Leave empty to use the corpus/system default.'
               />
             </div>
             <div

--- a/frontend/src/components/corpuses/CorpusSettings.tsx
+++ b/frontend/src/components/corpuses/CorpusSettings.tsx
@@ -452,7 +452,11 @@ export const CorpusSettings: React.FC<CorpusSettingsProps> = ({ corpus }) => {
             <SettingsCardTitle>Corpus Agents</SettingsCardTitle>
           </SettingsCardHeader>
           <SettingsCardContent>
-            <CorpusAgentManagement corpusId={corpus.id} canUpdate={canUpdate} />
+            <CorpusAgentManagement
+              corpusId={corpus.id}
+              canUpdate={canUpdate}
+              corpusPreferredLlm={corpus.preferredLlm}
+            />
           </SettingsCardContent>
         </SettingsCard>
 

--- a/frontend/src/graphql/mutations.ts
+++ b/frontend/src/graphql/mutations.ts
@@ -4149,6 +4149,7 @@ export const CREATE_AGENT_CONFIGURATION = gql`
     $scope: String!
     $corpusId: ID
     $isPublic: Boolean
+    $preferredLlm: String
   ) {
     createAgentConfiguration(
       name: $name
@@ -4162,6 +4163,7 @@ export const CREATE_AGENT_CONFIGURATION = gql`
       scope: $scope
       corpusId: $corpusId
       isPublic: $isPublic
+      preferredLlm: $preferredLlm
     ) {
       ok
       message
@@ -4193,6 +4195,8 @@ export const UPDATE_AGENT_CONFIGURATION = gql`
     $avatarUrl: String
     $isActive: Boolean
     $isPublic: Boolean
+    $preferredLlm: String
+    $clearPreferredLlm: Boolean
   ) {
     updateAgentConfiguration(
       agentId: $agentId
@@ -4206,6 +4210,8 @@ export const UPDATE_AGENT_CONFIGURATION = gql`
       avatarUrl: $avatarUrl
       isActive: $isActive
       isPublic: $isPublic
+      preferredLlm: $preferredLlm
+      clearPreferredLlm: $clearPreferredLlm
     ) {
       ok
       message

--- a/frontend/src/graphql/queries.ts
+++ b/frontend/src/graphql/queries.ts
@@ -6484,6 +6484,7 @@ export const GET_CORPUS_AGENTS = gql`
           scope
           isActive
           isPublic
+          preferredLlm
           creator {
             id
             slug

--- a/frontend/src/types/graphql-api.ts
+++ b/frontend/src/types/graphql-api.ts
@@ -1609,6 +1609,12 @@ export type AgentConfigurationType = Node & {
   isActive: Scalars["Boolean"];
   creator: UserType;
   isPublic?: Scalars["Boolean"];
+  /**
+   * Optional per-agent pydantic-ai model spec override
+   * (e.g. "anthropic:claude-haiku-4-5"). Empty/null falls back to the
+   * corpus default, then the install-wide system default.
+   */
+  preferredLlm?: Maybe<Scalars["String"]>;
   created: Scalars["DateTime"];
   modified: Scalars["DateTime"];
   myPermissions?: PermissionTypes[];

--- a/frontend/tests/AdminComponentsTestWrapper.tsx
+++ b/frontend/tests/AdminComponentsTestWrapper.tsx
@@ -6,6 +6,10 @@ import { GlobalSettingsPanel } from "../src/components/admin/GlobalSettingsPanel
 import { GlobalAgentManagement } from "../src/components/admin/GlobalAgentManagement";
 import { CorpusAgentManagement } from "../src/components/corpuses/CorpusAgentManagement";
 import { SystemSettings } from "../src/components/admin/SystemSettings";
+import {
+  GET_LLM_PROVIDERS,
+  GET_SYSTEM_DEFAULT_LLM,
+} from "../src/graphql/queries";
 
 // Wrapper for GlobalSettingsPanel with routing context
 export const GlobalSettingsPanelWrapper: React.FC = () => (
@@ -13,6 +17,21 @@ export const GlobalSettingsPanelWrapper: React.FC = () => (
     <GlobalSettingsPanel />
   </MemoryRouter>
 );
+
+// Both GlobalAgentManagement and CorpusAgentManagement fire these on mount to
+// power the Preferred LLM picker (chip list + "inherited default" hint).
+// Appended AFTER any test-supplied mocks so a test that cares about specific
+// provider data can still declare its own mock (matched first) while every
+// other test gets a harmless empty-providers fallback instead of a "no more
+// mocked responses" console error.
+const defaultLlmProvidersMock: MockedResponse = {
+  request: { query: GET_LLM_PROVIDERS },
+  result: { data: { pipelineComponents: { llmProviders: [] } } },
+};
+const defaultSystemDefaultLlmMock: MockedResponse = {
+  request: { query: GET_SYSTEM_DEFAULT_LLM },
+  result: { data: { pipelineSettings: { defaultLlm: null } } },
+};
 
 // Wrapper for GlobalAgentManagement with Apollo mocking
 interface GlobalAgentManagementWrapperProps {
@@ -22,7 +41,10 @@ interface GlobalAgentManagementWrapperProps {
 export const GlobalAgentManagementWrapper: React.FC<
   GlobalAgentManagementWrapperProps
 > = ({ mocks = [] }) => (
-  <MockedProvider mocks={mocks} addTypename={false}>
+  <MockedProvider
+    mocks={[...mocks, defaultLlmProvidersMock, defaultSystemDefaultLlmMock]}
+    addTypename={false}
+  >
     <GlobalAgentManagement />
   </MockedProvider>
 );
@@ -33,7 +55,10 @@ export const GlobalAgentManagementWrapper: React.FC<
 export const GlobalAgentManagementWithToastsWrapper: React.FC<
   GlobalAgentManagementWrapperProps
 > = ({ mocks = [] }) => (
-  <MockedProvider mocks={mocks} addTypename={false}>
+  <MockedProvider
+    mocks={[...mocks, defaultLlmProvidersMock, defaultSystemDefaultLlmMock]}
+    addTypename={false}
+  >
     <MemoryRouter>
       <GlobalAgentManagement />
       <ToastContainer />
@@ -46,13 +71,21 @@ interface CorpusAgentManagementWrapperProps {
   corpusId: string;
   canUpdate: boolean;
   mocks?: MockedResponse[];
+  corpusPreferredLlm?: string | null;
 }
 
 export const CorpusAgentManagementWrapper: React.FC<
   CorpusAgentManagementWrapperProps
-> = ({ corpusId, canUpdate, mocks = [] }) => (
-  <MockedProvider mocks={mocks} addTypename={false}>
-    <CorpusAgentManagement corpusId={corpusId} canUpdate={canUpdate} />
+> = ({ corpusId, canUpdate, mocks = [], corpusPreferredLlm }) => (
+  <MockedProvider
+    mocks={[...mocks, defaultLlmProvidersMock]}
+    addTypename={false}
+  >
+    <CorpusAgentManagement
+      corpusId={corpusId}
+      canUpdate={canUpdate}
+      corpusPreferredLlm={corpusPreferredLlm}
+    />
   </MockedProvider>
 );
 

--- a/frontend/tests/CorpusAgentManagement.ct.tsx
+++ b/frontend/tests/CorpusAgentManagement.ct.tsx
@@ -775,6 +775,45 @@ test.describe("CorpusAgentManagement", () => {
   /* Preferred LLM (per-agent model override) — issue #2119                 */
   /* ---------------------------------------------------------------------- */
 
+  test("create modal shows the inherited corpus default hint when the corpus has a preferred LLM", async ({
+    mount,
+    page,
+  }) => {
+    const component = await mount(
+      <CorpusAgentManagementTestWrapper
+        mocks={[buildAgentsMock([]), toolsMock]}
+        corpusId={TEST_CORPUS_ID}
+        corpusPreferredLlm="anthropic:claude-opus-4-6"
+      />
+    );
+
+    await expect(page.getByText("No Agent Configurations")).toBeVisible({
+      timeout: 20000,
+    });
+
+    await page.locator("button:has-text('Create Agent')").first().click();
+    await expect(
+      page.getByText("Create Agent Configuration", { exact: true })
+    ).toBeVisible({ timeout: 5000 });
+
+    const llmInput = page.locator(
+      'input[placeholder="e.g., anthropic:claude-opus-4-6"]'
+    );
+    await expect(llmInput).toHaveValue("");
+
+    // Left blank, the picker surfaces what it will actually inherit from the
+    // corpus's own default (CorpusSettings threads corpus.preferredLlm
+    // through as `corpusPreferredLlm`). This hint was previously never
+    // asserted, so a regression that silently dropped or broke the prop
+    // threading would have shipped with zero test failures.
+    await expect(page.locator("text=Inherited corpus default")).toBeVisible();
+    await expect(
+      page.locator("code:has-text('anthropic:claude-opus-4-6')")
+    ).toBeVisible();
+
+    await component.unmount();
+  });
+
   test("create modal shows the Preferred LLM picker and sends preferredLlm on submit", async ({
     mount,
     page,
@@ -953,6 +992,103 @@ test.describe("CorpusAgentManagement", () => {
     await expect(llmInput).toHaveValue("openai:gpt-4o");
 
     await llmInput.fill("");
+
+    await page
+      .getByRole("button", { name: "Save Changes", exact: true })
+      .click();
+
+    await expect(page.getByText("Agent updated successfully")).toBeVisible({
+      timeout: 10000,
+    });
+
+    await component.unmount();
+  });
+
+  test("update mutation changes an existing preferredLlm override to a different value", async ({
+    mount,
+    page,
+  }) => {
+    const agentWithLlm = {
+      ...sampleAgent,
+      id: "agent-with-llm-2",
+      preferredLlm: "openai:gpt-4o",
+    };
+
+    const updateMock: MockedResponse = {
+      request: {
+        query: UPDATE_AGENT_CONFIGURATION,
+        variables: {
+          agentId: agentWithLlm.id,
+          name: agentWithLlm.name,
+          slug: agentWithLlm.slug,
+          description: agentWithLlm.description,
+          systemInstructions: agentWithLlm.systemInstructions,
+          availableTools: agentWithLlm.availableTools,
+          permissionRequiredTools: agentWithLlm.permissionRequiredTools,
+          badgeConfig: agentWithLlm.badgeConfig,
+          avatarUrl: null,
+          isActive: agentWithLlm.isActive,
+          isPublic: agentWithLlm.isPublic,
+          // Switching an existing override to a different non-empty value
+          // must send the new preferredLlm with clearPreferredLlm: false —
+          // never the clear flag, which is reserved for resetting the
+          // override back to the corpus/system default.
+          preferredLlm: "anthropic:claude-haiku-4-5",
+          clearPreferredLlm: false,
+        },
+      },
+      result: {
+        data: {
+          updateAgentConfiguration: {
+            ok: true,
+            message: "Updated",
+            agent: {
+              id: agentWithLlm.id,
+              name: agentWithLlm.name,
+              slug: agentWithLlm.slug,
+              description: agentWithLlm.description,
+              badgeConfig: agentWithLlm.badgeConfig,
+              availableTools: agentWithLlm.availableTools,
+              permissionRequiredTools: agentWithLlm.permissionRequiredTools,
+              isActive: agentWithLlm.isActive,
+              isPublic: agentWithLlm.isPublic,
+            },
+          },
+        },
+      },
+    };
+
+    const component = await mount(
+      <CorpusAgentManagementTestWrapper
+        mocks={[
+          buildAgentsMock([agentWithLlm]),
+          toolsMock,
+          updateMock,
+          buildAgentsMock([
+            { ...agentWithLlm, preferredLlm: "anthropic:claude-haiku-4-5" },
+          ]),
+        ]}
+        corpusId={TEST_CORPUS_ID}
+      />
+    );
+
+    await expect(page.getByText("Summarizer", { exact: true })).toBeVisible({
+      timeout: 20000,
+    });
+
+    await page.getByLabel("Edit agent").click();
+    await expect(
+      page.getByText(`Edit Agent Configuration: ${agentWithLlm.name}`, {
+        exact: true,
+      })
+    ).toBeVisible({ timeout: 5000 });
+
+    const llmInput = page.locator(
+      'input[placeholder="e.g., anthropic:claude-opus-4-6"]'
+    );
+    await expect(llmInput).toHaveValue("openai:gpt-4o");
+
+    await llmInput.fill("anthropic:claude-haiku-4-5");
 
     await page
       .getByRole("button", { name: "Save Changes", exact: true })

--- a/frontend/tests/CorpusAgentManagement.ct.tsx
+++ b/frontend/tests/CorpusAgentManagement.ct.tsx
@@ -78,6 +78,7 @@ const sampleAgent = {
   scope: "CORPUS",
   isActive: true,
   isPublic: false,
+  preferredLlm: null as string | null,
   creator: { id: "u1", username: "alice" },
   created: "2026-01-01T00:00:00Z",
   modified: "2026-01-02T00:00:00Z",
@@ -177,6 +178,7 @@ test.describe("CorpusAgentManagement", () => {
           scope: "CORPUS",
           corpusId: TEST_CORPUS_ID,
           isPublic: false,
+          preferredLlm: null,
         },
       },
       result: {
@@ -561,6 +563,8 @@ test.describe("CorpusAgentManagement", () => {
           avatarUrl: null,
           isActive: sampleAgent.isActive,
           isPublic: sampleAgent.isPublic,
+          preferredLlm: undefined,
+          clearPreferredLlm: false,
         },
       },
       result: {
@@ -642,6 +646,7 @@ test.describe("CorpusAgentManagement", () => {
           scope: "CORPUS",
           corpusId: TEST_CORPUS_ID,
           isPublic: false,
+          preferredLlm: null,
         },
       },
       result: {
@@ -762,6 +767,200 @@ test.describe("CorpusAgentManagement", () => {
         exact: true,
       })
     ).not.toBeVisible({ timeout: 5000 });
+
+    await component.unmount();
+  });
+
+  /* ---------------------------------------------------------------------- */
+  /* Preferred LLM (per-agent model override) — issue #2119                 */
+  /* ---------------------------------------------------------------------- */
+
+  test("create modal shows the Preferred LLM picker and sends preferredLlm on submit", async ({
+    mount,
+    page,
+  }) => {
+    const createMock: MockedResponse = {
+      request: {
+        query: CREATE_AGENT_CONFIGURATION,
+        variables: {
+          name: "LLM Agent",
+          slug: null,
+          description: "Uses a specific model",
+          systemInstructions: "Be precise.",
+          availableTools: null,
+          permissionRequiredTools: null,
+          badgeConfig: { icon: "bot", color: "#8b5cf6", label: "AI" },
+          avatarUrl: null,
+          scope: "CORPUS",
+          corpusId: TEST_CORPUS_ID,
+          isPublic: false,
+          preferredLlm: "anthropic:claude-haiku-4-5",
+        },
+      },
+      result: {
+        data: {
+          createAgentConfiguration: {
+            ok: true,
+            message: "Created",
+            agent: {
+              id: "new-llm-agent",
+              name: "LLM Agent",
+              slug: "llm-agent",
+              description: "Uses a specific model",
+              badgeConfig: { icon: "bot", color: "#8b5cf6", label: "AI" },
+              availableTools: [],
+              permissionRequiredTools: [],
+              isActive: true,
+              isPublic: false,
+            },
+          },
+        },
+      },
+    };
+
+    const component = await mount(
+      <CorpusAgentManagementTestWrapper
+        mocks={[
+          buildAgentsMock([]),
+          toolsMock,
+          createMock,
+          // Refetch after create
+          buildAgentsMock([]),
+        ]}
+        corpusId={TEST_CORPUS_ID}
+      />
+    );
+
+    await expect(page.getByText("No Agent Configurations")).toBeVisible({
+      timeout: 20000,
+    });
+
+    await page.locator("button:has-text('Create Agent')").first().click();
+    await expect(
+      page.getByText("Create Agent Configuration", { exact: true })
+    ).toBeVisible({ timeout: 5000 });
+
+    // The picker is visible with its "optional" label and placeholder.
+    await expect(page.getByText("Preferred LLM (optional)")).toBeVisible();
+    const llmInput = page.locator(
+      'input[placeholder="e.g., anthropic:claude-opus-4-6"]'
+    );
+    await expect(llmInput).toBeVisible();
+
+    await page.locator('input[placeholder="Agent name"]').fill("LLM Agent");
+    await page
+      .locator(
+        'textarea[placeholder="Brief description of what this agent does"]'
+      )
+      .fill("Uses a specific model");
+    await page
+      .locator('textarea[placeholder="System prompt for the agent..."]')
+      .fill("Be precise.");
+    await llmInput.fill("anthropic:claude-haiku-4-5");
+
+    await page
+      .getByRole("dialog")
+      .getByRole("button", { name: "Create Agent", exact: true })
+      .click();
+
+    await expect(page.getByText("Agent created successfully")).toBeVisible({
+      timeout: 10000,
+    });
+
+    await component.unmount();
+  });
+
+  test("edit modal pre-fills an existing Preferred LLM override and sends clearPreferredLlm when cleared", async ({
+    mount,
+    page,
+  }) => {
+    const agentWithLlm = {
+      ...sampleAgent,
+      id: "agent-with-llm",
+      preferredLlm: "openai:gpt-4o",
+    };
+
+    const updateMock: MockedResponse = {
+      request: {
+        query: UPDATE_AGENT_CONFIGURATION,
+        variables: {
+          agentId: agentWithLlm.id,
+          name: agentWithLlm.name,
+          slug: agentWithLlm.slug,
+          description: agentWithLlm.description,
+          systemInstructions: agentWithLlm.systemInstructions,
+          availableTools: agentWithLlm.availableTools,
+          permissionRequiredTools: agentWithLlm.permissionRequiredTools,
+          badgeConfig: agentWithLlm.badgeConfig,
+          avatarUrl: null,
+          isActive: agentWithLlm.isActive,
+          isPublic: agentWithLlm.isPublic,
+          // Clearing a previously-set override must send clearPreferredLlm:
+          // true with preferredLlm omitted — never an empty-string
+          // preferredLlm, which AgentConfigurationService.update_agent's
+          // model validation rejects.
+          preferredLlm: undefined,
+          clearPreferredLlm: true,
+        },
+      },
+      result: {
+        data: {
+          updateAgentConfiguration: {
+            ok: true,
+            message: "Updated",
+            agent: {
+              id: agentWithLlm.id,
+              name: agentWithLlm.name,
+              slug: agentWithLlm.slug,
+              description: agentWithLlm.description,
+              badgeConfig: agentWithLlm.badgeConfig,
+              availableTools: agentWithLlm.availableTools,
+              permissionRequiredTools: agentWithLlm.permissionRequiredTools,
+              isActive: agentWithLlm.isActive,
+              isPublic: agentWithLlm.isPublic,
+            },
+          },
+        },
+      },
+    };
+
+    const component = await mount(
+      <CorpusAgentManagementTestWrapper
+        mocks={[
+          buildAgentsMock([agentWithLlm]),
+          toolsMock,
+          updateMock,
+          buildAgentsMock([{ ...agentWithLlm, preferredLlm: null }]),
+        ]}
+        corpusId={TEST_CORPUS_ID}
+      />
+    );
+
+    await expect(page.getByText("Summarizer", { exact: true })).toBeVisible({
+      timeout: 20000,
+    });
+
+    await page.getByLabel("Edit agent").click();
+    await expect(
+      page.getByText(`Edit Agent Configuration: ${agentWithLlm.name}`, {
+        exact: true,
+      })
+    ).toBeVisible({ timeout: 5000 });
+
+    const llmInput = page.locator(
+      'input[placeholder="e.g., anthropic:claude-opus-4-6"]'
+    );
+    await expect(llmInput).toHaveValue("openai:gpt-4o");
+
+    await llmInput.fill("");
+
+    await page
+      .getByRole("button", { name: "Save Changes", exact: true })
+      .click();
+
+    await expect(page.getByText("Agent updated successfully")).toBeVisible({
+      timeout: 10000,
+    });
 
     await component.unmount();
   });

--- a/frontend/tests/CorpusAgentManagementTestWrapper.tsx
+++ b/frontend/tests/CorpusAgentManagementTestWrapper.tsx
@@ -4,32 +4,54 @@ import { InMemoryCache } from "@apollo/client";
 import { Provider as JotaiProvider } from "jotai";
 import { ToastContainer } from "react-toastify";
 import { CorpusAgentManagement } from "../src/components/corpuses/CorpusAgentManagement";
+import { GET_LLM_PROVIDERS } from "../src/graphql/queries";
 
 interface Props {
   mocks: ReadonlyArray<MockedResponse>;
   corpusId: string;
   canUpdate?: boolean;
+  corpusPreferredLlm?: string | null;
 }
+
+// The component fires this (when canUpdate) to power the Preferred LLM
+// picker's chip list. Appended AFTER the test-supplied mocks so a test that
+// cares about specific provider data can declare its own mock (matched
+// first); everything else gets a harmless empty-providers fallback instead of
+// a "no more mocked responses" console error.
+const defaultLlmProvidersMock: MockedResponse = {
+  request: { query: GET_LLM_PROVIDERS },
+  result: { data: { pipelineComponents: { llmProviders: [] } } },
+};
 
 /**
  * Wrapper for CorpusAgentManagement CT tests.
  *
- * The component fetches GET_CORPUS_AGENTS and GET_AVAILABLE_TOOLS on mount;
- * `canUpdate=false` short-circuits to a permissioning notice and skips both.
+ * The component fetches GET_CORPUS_AGENTS, GET_AVAILABLE_TOOLS, and (when
+ * `canUpdate`) GET_LLM_PROVIDERS on mount; `canUpdate=false` short-circuits to
+ * a permissioning notice and skips all three.
  */
 export const CorpusAgentManagementTestWrapper: React.FC<Props> = ({
   mocks,
   corpusId,
   canUpdate = true,
+  corpusPreferredLlm,
 }) => {
   // Defined inside the wrapper so Playwright CT's per-test serialization
   // never reaches an Apollo cache instance — see CLAUDE.md pitfall #8.
   const cache = new InMemoryCache({ addTypename: false });
   return (
     <JotaiProvider>
-      <MockedProvider mocks={mocks} addTypename={false} cache={cache}>
+      <MockedProvider
+        mocks={[...mocks, defaultLlmProvidersMock]}
+        addTypename={false}
+        cache={cache}
+      >
         <div style={{ width: "100vw", padding: 16 }}>
-          <CorpusAgentManagement corpusId={corpusId} canUpdate={canUpdate} />
+          <CorpusAgentManagement
+            corpusId={corpusId}
+            canUpdate={canUpdate}
+            corpusPreferredLlm={corpusPreferredLlm}
+          />
           <ToastContainer />
         </div>
       </MockedProvider>

--- a/frontend/tests/admin-components.ct.tsx
+++ b/frontend/tests/admin-components.ct.tsx
@@ -43,6 +43,7 @@ const GET_GLOBAL_AGENTS = gql`
           scope
           isActive
           isPublic
+          preferredLlm
           creator {
             id
             username
@@ -72,6 +73,7 @@ const GET_CORPUS_AGENTS = gql`
           scope
           isActive
           isPublic
+          preferredLlm
           creator {
             id
             slug
@@ -99,6 +101,7 @@ const mockGlobalAgent = {
   scope: "GLOBAL",
   isActive: true,
   isPublic: true,
+  preferredLlm: null,
   creator: { id: "VXNlclR5cGU6MQ==", slug: "admin", username: "admin" },
   created: "2024-01-15T10:30:00Z",
   modified: "2024-01-15T10:30:00Z",
@@ -117,6 +120,7 @@ const mockCorpusAgent = {
   scope: "CORPUS",
   isActive: true,
   isPublic: false,
+  preferredLlm: null,
   creator: { id: "VXNlclR5cGU6MQ==", slug: "admin", username: "admin" },
   created: "2024-01-15T10:30:00Z",
   modified: "2024-01-15T10:30:00Z",

--- a/frontend/tests/global-agent-management.ct.tsx
+++ b/frontend/tests/global-agent-management.ct.tsx
@@ -1012,4 +1012,106 @@ test.describe("GlobalAgentManagement — preferred LLM", () => {
 
     await component.unmount();
   });
+
+  test("changes an existing preferredLlm override to a different value on update", async ({
+    mount,
+    page,
+  }) => {
+    const agentWithLlm = {
+      ...baseAgent,
+      id: "QWdlbnRDb25maWd1cmF0aW9uVHlwZTpsbG0y",
+      preferredLlm: "openai:gpt-4o",
+    };
+    const agentWithLlmMock = {
+      request: { query: GET_GLOBAL_AGENTS },
+      result: {
+        data: { agentConfigurations: { edges: [{ node: agentWithLlm }] } },
+      },
+    };
+
+    const updateMock = {
+      request: {
+        query: UPDATE_GLOBAL_AGENT_CONFIGURATION,
+        variables: {
+          agentId: agentWithLlm.id,
+          name: agentWithLlm.name,
+          description: agentWithLlm.description,
+          systemInstructions: agentWithLlm.systemInstructions,
+          availableTools: ["similarity_search", "load_document_text"],
+          permissionRequiredTools: [],
+          badgeConfig: JSON.stringify(agentWithLlm.badgeConfig),
+          avatarUrl: null,
+          isActive: true,
+          isPublic: true,
+          // Switching an existing override to a different non-empty value
+          // must send the new preferredLlm with clearPreferredLlm: false —
+          // never the clear flag, which is reserved for resetting the
+          // override back to the system default.
+          preferredLlm: "anthropic:claude-haiku-4-5",
+          clearPreferredLlm: false,
+        },
+      },
+      result: {
+        data: {
+          updateAgentConfiguration: {
+            ok: true,
+            message: "Updated",
+            agent: {
+              id: agentWithLlm.id,
+              name: agentWithLlm.name,
+              slug: agentWithLlm.slug,
+              description: agentWithLlm.description,
+            },
+          },
+        },
+      },
+    };
+
+    const afterUpdateMock = {
+      request: { query: GET_GLOBAL_AGENTS },
+      result: {
+        data: {
+          agentConfigurations: {
+            edges: [
+              {
+                node: {
+                  ...agentWithLlm,
+                  preferredLlm: "anthropic:claude-haiku-4-5",
+                },
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    const component = await mount(
+      <GlobalAgentManagementWithToastsWrapper
+        mocks={[agentWithLlmMock, updateMock, afterUpdateMock]}
+      />
+    );
+
+    await expect(page.locator("text=Research Assistant")).toBeVisible({
+      timeout: 5000,
+    });
+
+    await page.locator('button[aria-label="Edit agent"]').first().click();
+
+    const llmInput = page.locator(
+      'input[placeholder="e.g., anthropic:claude-opus-4-6"]'
+    );
+    await expect(llmInput).toHaveValue("openai:gpt-4o");
+
+    await llmInput.fill("anthropic:claude-haiku-4-5");
+
+    await page
+      .locator('.oc-modal-footer button:has-text("Save Changes")')
+      .click();
+
+    await expect(page.locator("text=Agent updated successfully")).toBeVisible({
+      timeout: 5000,
+    });
+
+    await component.unmount();
+  });
 });

--- a/frontend/tests/global-agent-management.ct.tsx
+++ b/frontend/tests/global-agent-management.ct.tsx
@@ -16,6 +16,10 @@ import {
   UPDATE_GLOBAL_AGENT_CONFIGURATION,
   DELETE_GLOBAL_AGENT_CONFIGURATION,
 } from "../src/components/admin/global_agent_management.graphql";
+import {
+  GET_LLM_PROVIDERS,
+  GET_SYSTEM_DEFAULT_LLM,
+} from "../src/graphql/queries";
 
 const baseAgent = {
   id: "QWdlbnRDb25maWd1cmF0aW9uVHlwZTox",
@@ -30,6 +34,7 @@ const baseAgent = {
   scope: "GLOBAL",
   isActive: true,
   isPublic: true,
+  preferredLlm: null as string | null,
   creator: { id: "VXNlclR5cGU6MQ==", username: "admin" },
   created: "2024-01-15T10:30:00Z",
   modified: "2024-01-15T10:30:00Z",
@@ -333,6 +338,7 @@ test.describe("GlobalAgentManagement — create flow", () => {
           avatarUrl: "https://example.com/avatar.png",
           scope: "GLOBAL",
           isPublic: false,
+          preferredLlm: null,
         },
       },
       result: {
@@ -446,6 +452,7 @@ test.describe("GlobalAgentManagement — create flow", () => {
           avatarUrl: null,
           scope: "GLOBAL",
           isPublic: true,
+          preferredLlm: null,
         },
       },
       result: {
@@ -558,6 +565,8 @@ test.describe("GlobalAgentManagement — edit flow", () => {
           avatarUrl: null,
           isActive: true,
           isPublic: true,
+          preferredLlm: undefined,
+          clearPreferredLlm: false,
         },
       },
       result: {
@@ -770,6 +779,234 @@ test.describe("GlobalAgentManagement — delete flow", () => {
     await page.getByRole("button", { name: /yes/i }).first().click();
 
     await expect(page.locator("text=Agent is in use")).toBeVisible({
+      timeout: 5000,
+    });
+
+    await component.unmount();
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* Preferred LLM (per-agent model override) — issue #2119                     */
+/* -------------------------------------------------------------------------- */
+
+test.describe("GlobalAgentManagement — preferred LLM", () => {
+  test("create modal shows the picker with the inherited system default hint", async ({
+    mount,
+    page,
+  }) => {
+    const systemDefaultMock = {
+      request: { query: GET_SYSTEM_DEFAULT_LLM },
+      result: {
+        data: { pipelineSettings: { defaultLlm: "anthropic:claude-opus-4-6" } },
+      },
+    };
+
+    const component = await mount(
+      <GlobalAgentManagementWrapper
+        mocks={[emptyAgentsMock, systemDefaultMock]}
+      />
+    );
+
+    await expect(page.locator("text=No Global Agents")).toBeVisible({
+      timeout: 5000,
+    });
+
+    await page.locator('button:has-text("Create Agent")').first().click();
+    await expect(page.locator("text=Create Global Agent")).toBeVisible();
+
+    await expect(page.locator("text=Preferred LLM")).toBeVisible();
+    const llmInput = page.locator(
+      'input[placeholder="e.g., anthropic:claude-opus-4-6"]'
+    );
+    await expect(llmInput).toBeVisible();
+    await expect(llmInput).toHaveValue("");
+
+    // Left blank, the picker surfaces what it will actually inherit.
+    await expect(page.locator("text=Inherited system default")).toBeVisible();
+    await expect(
+      page.locator("code:has-text('anthropic:claude-opus-4-6')")
+    ).toBeVisible();
+
+    await component.unmount();
+  });
+
+  test("submits a create mutation with the entered preferredLlm", async ({
+    mount,
+    page,
+  }) => {
+    const createMock = {
+      request: {
+        query: CREATE_GLOBAL_AGENT_CONFIGURATION,
+        variables: {
+          name: "Model-Pinned Agent",
+          description: "Always uses a specific model",
+          systemInstructions: "Follow the rules.",
+          availableTools: null,
+          permissionRequiredTools: null,
+          badgeConfig: JSON.stringify({
+            icon: "robot",
+            color: "#6366f1",
+            label: "AI",
+          }),
+          avatarUrl: null,
+          scope: "GLOBAL",
+          isPublic: true,
+          preferredLlm: "anthropic:claude-haiku-4-5",
+        },
+      },
+      result: {
+        data: {
+          createAgentConfiguration: {
+            ok: true,
+            message: "Agent created",
+            agent: {
+              id: "QWdlbnRDb25maWd1cmF0aW9uVHlwZTpwaW5uZWQ=",
+              name: "Model-Pinned Agent",
+              slug: "model-pinned-agent",
+              description: "Always uses a specific model",
+            },
+          },
+        },
+      },
+    };
+
+    const afterCreateMock = {
+      request: { query: GET_GLOBAL_AGENTS },
+      result: {
+        data: {
+          agentConfigurations: {
+            edges: [{ node: { ...baseAgent, name: "Model-Pinned Agent" } }],
+          },
+        },
+      },
+    };
+
+    const component = await mount(
+      <GlobalAgentManagementWithToastsWrapper
+        mocks={[emptyAgentsMock, createMock, afterCreateMock]}
+      />
+    );
+
+    await expect(page.locator("text=No Global Agents")).toBeVisible({
+      timeout: 5000,
+    });
+
+    await page.locator('button:has-text("Create Agent")').first().click();
+
+    await page
+      .locator("input[placeholder='Agent name']")
+      .fill("Model-Pinned Agent");
+    await page
+      .locator("textarea[placeholder^='Brief description']")
+      .fill("Always uses a specific model");
+    await page
+      .locator("textarea[placeholder='System prompt for the agent...']")
+      .fill("Follow the rules.");
+    await page
+      .locator('input[placeholder="e.g., anthropic:claude-opus-4-6"]')
+      .fill("anthropic:claude-haiku-4-5");
+
+    await page
+      .locator('.oc-modal-footer button:has-text("Create Agent")')
+      .click();
+
+    await expect(page.locator("text=Agent created successfully")).toBeVisible({
+      timeout: 5000,
+    });
+
+    await component.unmount();
+  });
+
+  test("pre-fills an existing preferredLlm override and clears it via clearPreferredLlm on update", async ({
+    mount,
+    page,
+  }) => {
+    const agentWithLlm = {
+      ...baseAgent,
+      id: "QWdlbnRDb25maWd1cmF0aW9uVHlwZTpsbG0=",
+      preferredLlm: "openai:gpt-4o",
+    };
+    const agentWithLlmMock = {
+      request: { query: GET_GLOBAL_AGENTS },
+      result: {
+        data: { agentConfigurations: { edges: [{ node: agentWithLlm }] } },
+      },
+    };
+
+    const updateMock = {
+      request: {
+        query: UPDATE_GLOBAL_AGENT_CONFIGURATION,
+        variables: {
+          agentId: agentWithLlm.id,
+          name: agentWithLlm.name,
+          description: agentWithLlm.description,
+          systemInstructions: agentWithLlm.systemInstructions,
+          availableTools: ["similarity_search", "load_document_text"],
+          permissionRequiredTools: [],
+          badgeConfig: JSON.stringify(agentWithLlm.badgeConfig),
+          avatarUrl: null,
+          isActive: true,
+          isPublic: true,
+          // Clearing a previously-set override must send clearPreferredLlm:
+          // true with preferredLlm omitted — never an empty-string
+          // preferredLlm, which AgentConfigurationService.update_agent's
+          // model validation rejects.
+          preferredLlm: undefined,
+          clearPreferredLlm: true,
+        },
+      },
+      result: {
+        data: {
+          updateAgentConfiguration: {
+            ok: true,
+            message: "Updated",
+            agent: {
+              id: agentWithLlm.id,
+              name: agentWithLlm.name,
+              slug: agentWithLlm.slug,
+              description: agentWithLlm.description,
+            },
+          },
+        },
+      },
+    };
+
+    const afterUpdateMock = {
+      request: { query: GET_GLOBAL_AGENTS },
+      result: {
+        data: {
+          agentConfigurations: {
+            edges: [{ node: { ...agentWithLlm, preferredLlm: null } }],
+          },
+        },
+      },
+    };
+
+    const component = await mount(
+      <GlobalAgentManagementWithToastsWrapper
+        mocks={[agentWithLlmMock, updateMock, afterUpdateMock]}
+      />
+    );
+
+    await expect(page.locator("text=Research Assistant")).toBeVisible({
+      timeout: 5000,
+    });
+
+    await page.locator('button[aria-label="Edit agent"]').first().click();
+
+    const llmInput = page.locator(
+      'input[placeholder="e.g., anthropic:claude-opus-4-6"]'
+    );
+    await expect(llmInput).toHaveValue("openai:gpt-4o");
+
+    await llmInput.fill("");
+
+    await page
+      .locator('.oc-modal-footer button:has-text("Save Changes")')
+      .click();
+
+    await expect(page.locator("text=Agent updated successfully")).toBeVisible({
       timeout: 5000,
     });
 


### PR DESCRIPTION
## Summary
- Adds an `LlmModelPicker` for `AgentConfiguration.preferred_llm` to both admin agent-management surfaces: the global agent management screen and the corpus-scoped agent management screen. The backend already fully supported this field (`config/graphql/agent_mutations.py`); neither frontend form sent or fetched it, so it was only settable via raw GraphQL.
- Create: `preferredLlm: trimmed || null` (empty = no override). Update: `preferredLlm` left `undefined` means unchanged; clearing an existing override requires `clearPreferredLlm: true` (an empty-string `preferred_llm` fails backend model validation) — verified directly against `agent_mutations.py` / `AgentConfigurationService`.
- Reuses the existing `LlmModelPicker` component and `GET_LLM_PROVIDERS`/`GET_SYSTEM_DEFAULT_LLM` queries already built for `CorpusLanguageModelCard`, showing an "Inherited system/corpus default" hint when no override is set.

Closes #2119.

## Review
- Multi-dimension adversarial review (correctness, test coverage, simplification) found no correctness bugs; two test-coverage gaps were identified and closed in a follow-up commit:
  - Added coverage asserting the "Inherited corpus default" hint actually renders.
  - Added coverage for changing an *existing* override to a different non-empty value (`clearPreferredLlm: false` path), not just set/clear.

## Test plan
- [x] `yarn tsc --noEmit` clean
- [x] `yarn lint` clean
- [x] `yarn test:ct --reporter=list -g "AgentManagement"` — 51/51 passed
- [x] `yarn vitest run src/components/admin/__tests__/GlobalAgentManagement.mount.test.tsx` passed
- [x] `python3 scripts/collate_changelog.py --check` — changelog fragment valid
- Backend untouched (field was already fully wired server-side); no backend test run needed.