### PR TITLE
Single-user desktop packaging (Phase 0): Warp-Ingest parser + no-Redis process launcher

### DIFF
--- a/changelog.d/desktop-packaging.added.md
+++ b/changelog.d/desktop-packaging.added.md
@@ -1,0 +1,27 @@
+- **Single-user desktop packaging, Phase 0 — run the whole stack as processes
+  with no Docker and no Redis.** Adds a `config.settings.desktop` profile and an
+  `oc-desktop.py` launcher (`opencontractserver/desktop/launcher.py`) that starts
+  an embedded PostgreSQL+pgvector child (`pgserver`) or an external
+  `DATABASE_URL`, runs `migrate` + a one-time `desktop_bootstrap`
+  (`opencontractserver/documents/management/commands/desktop_bootstrap.py`:
+  local superuser, `PipelineSettings` seeding, nltk corpora), then supervises
+  Daphne (serving the API and the pre-built SPA) plus a Celery worker/beat over
+  the kombu *filesystem* broker with a SQLAlchemy DB result backend. The desktop
+  profile drops Redis entirely: cache → `LocMemCache`, channel layer →
+  `InMemoryChannelLayer`, storage → local per-user app-data dir
+  (`opencontractserver/desktop/paths.py`). The SPA is served from Daphne via
+  WhiteNoise + a catch-all (`config/spa.py`, wired into `config/urls.py` only
+  when `OC_DESKTOP_SPA_ROOT` is set; the `:3000` dev redirect is skipped there).
+  See `docs/deployment/desktop_packaging.md`.
+- **`WarpIngestParser`
+  (`opencontractserver/pipeline/parsers/warp_ingest_parser.py`)** — an
+  in-process, rule-based PDF parser (pure-Python, no torch/GPU) wrapping
+  [Warp-Ingest](https://github.com/Open-Source-Legal/Warp-Ingest)'s
+  `pdf_ingestor.parse_to_opencontracts`, which emits PAWLS tokens, structural
+  annotations and the `OC_PARENT_CHILD` heading hierarchy directly as an
+  `OpenContractDocExport`. It replaces the Docling parsing microservice for the
+  desktop build. `warp_ingest` is imported lazily so pipeline auto-discovery is
+  unaffected when the optional dependency is absent; it is registered for all
+  deployments but only selected when `PREFERRED_PARSERS`/`PipelineSettings` point
+  at it (the compose default stays Docling). New extras live in
+  `requirements/desktop.txt` (`warp-ingest[ocr]`, `pgserver`, `sqlalchemy`).

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -832,6 +832,9 @@ CELERY_TASK_ALLOW_ERROR_CB_ON_CHORD_HEADER = False
 # production SSL options), merge into this dict rather than reassigning it —
 # a bare ``CELERY_BROKER_TRANSPORT_OPTIONS = {...}`` would drop the
 # visibility timeout and silently regress at-least-once delivery.
+# DELIBERATE EXCEPTION: config/settings/desktop.py *reassigns* this (no Redis
+# broker there — the filesystem transport ignores visibility_timeout), so the
+# merge rule does not apply to that profile.
 CELERY_BROKER_TRANSPORT_OPTIONS = {
     "visibility_timeout": CELERY_REDIS_VISIBILITY_TIMEOUT_SECONDS,
 }

--- a/config/settings/desktop.py
+++ b/config/settings/desktop.py
@@ -44,25 +44,26 @@ DEBUG = env.bool("DJANGO_DEBUG", default=False)
 # A desktop app is reachable only on the loopback interface.
 ALLOWED_HOSTS = ["localhost", "127.0.0.1", "0.0.0.0"]
 
-# SECRET_KEY: prefer an explicit env var, else a stable per-user key the launcher
-# persists under the app-data dir. Never fall back to a shared hard-coded value.
+# SECRET_KEY comes from the environment only. The ``oc-desktop`` launcher
+# generates ONE key and exports it to every child process (Daphne/worker/beat)
+# so they share it within a run. When unset (e.g. a bare ``manage.py``), we fall
+# back to an ephemeral in-process key so import never fails; sessions/tokens then
+# reset across restarts. We deliberately do NOT persist the secret to a plaintext
+# file — set ``DJANGO_SECRET_KEY`` (the launcher does) for a stable key. Secure
+# at-rest persistence (OS keyring) is a Phase-1 follow-up.
 SECRET_KEY = env("DJANGO_SECRET_KEY", default=None)
 if not SECRET_KEY:
-    _key_file = paths.secret_key_file()
-    if _key_file.exists():
-        SECRET_KEY = _key_file.read_text(encoding="utf-8").strip()
-    else:
-        from django.core.management.utils import get_random_secret_key
+    import secrets as _secrets
+    import warnings
 
-        SECRET_KEY = get_random_secret_key()
-        try:
-            _key_file.parent.mkdir(parents=True, exist_ok=True)
-            _key_file.write_text(SECRET_KEY, encoding="utf-8")
-            os.chmod(_key_file, 0o600)
-        except OSError:
-            # Read-only install dir: fall back to an ephemeral key (sessions
-            # reset across restarts, acceptable for a single local user).
-            pass
+    SECRET_KEY = _secrets.token_urlsafe(64)
+    warnings.warn(
+        "DJANGO_SECRET_KEY is not set; using an ephemeral key. Sessions and "
+        "tokens will not survive a restart. Set DJANGO_SECRET_KEY (the "
+        "oc-desktop launcher does this automatically) for a stable key.",
+        RuntimeWarning,
+        stacklevel=1,
+    )
 
 # Local, single-user auth — no Auth0 tenant.
 USE_AUTH0 = False
@@ -135,11 +136,14 @@ CHANNEL_LAYERS = {
 _broker_in = str(paths.subdir("celery-broker", "in", create=False))
 _broker_out = str(paths.subdir("celery-broker", "out", create=False))
 CELERY_BROKER_URL = "filesystem://"
-CELERY_BROKER_TRANSPORT_OPTIONS = {
+# Fresh dict of str→str paths; base.py's value is str→int (visibility_timeout),
+# so the reassignment is typed differently on purpose.
+_broker_transport_options = {
     "data_folder_in": _broker_in,
     "data_folder_out": _broker_out,
     "control_folder": str(paths.subdir("celery-broker", "control", create=False)),
 }
+CELERY_BROKER_TRANSPORT_OPTIONS = _broker_transport_options  # type: ignore[assignment]
 
 
 def _sqlalchemy_result_url(database_url: str) -> str:
@@ -152,8 +156,9 @@ def _sqlalchemy_result_url(database_url: str) -> str:
 
 CELERY_RESULT_BACKEND = _sqlalchemy_result_url(env("DATABASE_URL"))
 CELERY_TASK_EAGER_PROPAGATES = True
-# Database scheduler needs a running ``celery beat`` process; the desktop
-# launcher instead drives CELERY_BEAT_SCHEDULE via an in-process APScheduler.
+# Use the file-based PersistentScheduler so beat needs no django_celery_beat DB
+# rows. The launcher runs a ``celery beat`` subprocess against it (Phase 0);
+# collapsing beat into an in-process APScheduler is a Phase-1 follow-up.
 CELERY_BEAT_SCHEDULER = "celery.beat:PersistentScheduler"
 
 # EMAIL — no SMTP server on a desktop; log to the console.
@@ -162,14 +167,11 @@ EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 
 # STATIC / SPA SERVING
 # ------------------------------------------------------------------------------
-# WhiteNoise (already in MIDDLEWARE) serves the built SPA's hashed assets
-# straight from the frontend ``dist/`` dir; a catch-all in config/urls.py
-# returns index.html for client-side routes. Set by the launcher after
-# ``yarn build`` is staged. When unset, SPA serving is disabled (API only).
+# The catch-all view in config/urls.py (config.spa.spa_fallback) serves the
+# built SPA's assets and returns index.html for client-side routes from this
+# dir. Set by the launcher after ``yarn build`` is staged; when unset, SPA
+# serving is disabled (API only).
 OC_DESKTOP_SPA_ROOT = env("OC_DESKTOP_FRONTEND_DIR", default="")
-if OC_DESKTOP_SPA_ROOT:
-    WHITENOISE_ROOT = OC_DESKTOP_SPA_ROOT
-    WHITENOISE_INDEX_FILE = True
 
 # CSP / CORS — same-origin localhost.
 # ------------------------------------------------------------------------------

--- a/config/settings/desktop.py
+++ b/config/settings/desktop.py
@@ -24,15 +24,27 @@ launcher. See ``docs/deployment/desktop_packaging.md``.
 import os
 
 from opencontractserver.desktop import paths
+from opencontractserver.desktop.db import sqlalchemy_result_backend_url
 
-# Env defaults so the profile imports cleanly under a bare ``manage.py`` (the
-# launcher overrides DATABASE_URL with the embedded-Postgres connection). Set
-# BEFORE importing base, which reads DATABASE_URL with no default of its own.
+# These env vars MUST be settled BEFORE importing base, because base.py branches
+# on them AT ITS OWN IMPORT TIME with no fallbacks — a stray value inherited from
+# the process env (e.g. a shell that sourced a production ``.env``) would crash
+# the import before any reassignment below could apply.
+#   * DATABASE_URL — base reads it with no default. ``setdefault`` so a user can
+#     still point the desktop build at an external database.
+#   * USE_AUTH0 — a truthy value makes base require AUTH0_CLIENT_ID/AUDIENCE/etc.
+#     (no defaults). The desktop profile is inherently single-user with no Auth0
+#     tenant, so we FORCE it off (a hard set, not setdefault — setdefault would
+#     leave an explicit ``USE_AUTH0=true`` in place and still crash base).
+#   * STORAGE_BACKEND — AWS/GCP require bucket/credential vars with no defaults;
+#     the desktop build is always local storage, so FORCE it too.
 os.environ.setdefault("DJANGO_READ_DOT_ENV_FILE", "False")
 os.environ.setdefault(
     "DATABASE_URL",
     "postgres://opencontracts:opencontracts@127.0.0.1:5464/opencontracts",
 )
+os.environ["USE_AUTH0"] = "False"
+os.environ["STORAGE_BACKEND"] = "LOCAL"
 
 from .base import *  # noqa: E402,F401,F403
 from .base import SECURE_CSP_DIRECTIVES, env  # noqa: E402
@@ -67,8 +79,9 @@ if not SECRET_KEY:
         stacklevel=1,
     )
 
-# Local, single-user auth — no Auth0 tenant.
-USE_AUTH0 = False
+# USE_AUTH0 and STORAGE_BACKEND are pinned to the desktop-safe values via the
+# ``os.environ.setdefault`` block at the top (they must be settled BEFORE base's
+# import-time branches), so no reassignment is needed here.
 
 # CACHES — no Redis; process-local memory cache.
 # ------------------------------------------------------------------------------
@@ -82,7 +95,8 @@ CACHES = {
 
 # STORAGE — local files under the per-user app-data directory.
 # ------------------------------------------------------------------------------
-STORAGE_BACKEND = "LOCAL"
+# STORAGE_BACKEND=LOCAL is set via the top setdefault block; base already wired
+# the local FileSystemStorage. Only the per-user roots are overridden here.
 MEDIA_ROOT = str(paths.media_dir())
 STATIC_ROOT = str(paths.static_dir())
 # Serve /media/ from Django even with DEBUG=False. The desktop build stores
@@ -152,16 +166,10 @@ _broker_transport_options = {
 }
 CELERY_BROKER_TRANSPORT_OPTIONS = _broker_transport_options  # type: ignore[assignment]
 
-
-def _sqlalchemy_result_url(database_url: str) -> str:
-    """Map a Django ``DATABASE_URL`` to a Celery SQLAlchemy result backend URL."""
-    scheme, _, rest = database_url.partition("://")
-    if scheme in ("postgres", "postgresql", "postgis"):
-        return f"db+postgresql://{rest}"
-    return f"db+{database_url}"
-
-
-CELERY_RESULT_BACKEND = _sqlalchemy_result_url(env("DATABASE_URL"))
+# Reuse the bundled Postgres as the Celery result backend (chords need a real
+# result backend; no Redis). See opencontractserver/desktop/db.py for the pure,
+# unit-tested URL mapping.
+CELERY_RESULT_BACKEND = sqlalchemy_result_backend_url(env("DATABASE_URL"))
 # Use the file-based PersistentScheduler so beat needs no django_celery_beat DB
 # rows. The launcher runs a ``celery beat`` subprocess against it (Phase 0);
 # collapsing beat into an in-process APScheduler is a Phase-1 follow-up.

--- a/config/settings/desktop.py
+++ b/config/settings/desktop.py
@@ -24,7 +24,10 @@ launcher. See ``docs/deployment/desktop_packaging.md``.
 import os
 
 from opencontractserver.desktop import paths
-from opencontractserver.desktop.db import sqlalchemy_result_backend_url
+from opencontractserver.desktop.db import (
+    DEFAULT_DESKTOP_DATABASE_URL,
+    sqlalchemy_result_backend_url,
+)
 
 # These env vars MUST be settled BEFORE importing base, because base.py branches
 # on them AT ITS OWN IMPORT TIME with no fallbacks — a stray value inherited from
@@ -39,10 +42,7 @@ from opencontractserver.desktop.db import sqlalchemy_result_backend_url
 #   * STORAGE_BACKEND — AWS/GCP require bucket/credential vars with no defaults;
 #     the desktop build is always local storage, so FORCE it too.
 os.environ.setdefault("DJANGO_READ_DOT_ENV_FILE", "False")
-os.environ.setdefault(
-    "DATABASE_URL",
-    "postgres://opencontracts:opencontracts@127.0.0.1:5464/opencontracts",
-)
+os.environ.setdefault("DATABASE_URL", DEFAULT_DESKTOP_DATABASE_URL)
 os.environ["USE_AUTH0"] = "False"
 os.environ["STORAGE_BACKEND"] = "LOCAL"
 

--- a/config/settings/desktop.py
+++ b/config/settings/desktop.py
@@ -53,8 +53,9 @@ from .base import SECURE_CSP_DIRECTIVES, env  # noqa: E402
 # ------------------------------------------------------------------------------
 DEBUG = env.bool("DJANGO_DEBUG", default=False)
 
-# A desktop app is reachable only on the loopback interface.
-ALLOWED_HOSTS = ["localhost", "127.0.0.1", "0.0.0.0"]
+# A desktop app is reachable only on the loopback interface. (No "0.0.0.0" — it
+# is a bind address, never an incoming Host header; Daphne binds 127.0.0.1.)
+ALLOWED_HOSTS = ["localhost", "127.0.0.1"]
 
 # SECRET_KEY comes from the environment only. The ``oc-desktop`` launcher
 # resolves ONE stable key (persisted in the OS keyring, see

--- a/config/settings/desktop.py
+++ b/config/settings/desktop.py
@@ -83,6 +83,11 @@ CACHES = {
 STORAGE_BACKEND = "LOCAL"
 MEDIA_ROOT = str(paths.media_dir())
 STATIC_ROOT = str(paths.static_dir())
+# Serve /media/ from Django even with DEBUG=False. The desktop build stores
+# files locally with no nginx/S3/GCS in front, so without this every
+# ``FieldFile.url`` (uploaded PDFs, thumbnails) would 404 in the browser.
+# config/urls.py wires django.views.static.serve when this flag is set.
+SERVE_MEDIA_WITHOUT_DEBUG = True
 
 # PIPELINE — offline / in-process components (no ML microservices).
 # ------------------------------------------------------------------------------

--- a/config/settings/desktop.py
+++ b/config/settings/desktop.py
@@ -45,12 +45,14 @@ DEBUG = env.bool("DJANGO_DEBUG", default=False)
 ALLOWED_HOSTS = ["localhost", "127.0.0.1", "0.0.0.0"]
 
 # SECRET_KEY comes from the environment only. The ``oc-desktop`` launcher
-# generates ONE key and exports it to every child process (Daphne/worker/beat)
-# so they share it within a run. When unset (e.g. a bare ``manage.py``), we fall
-# back to an ephemeral in-process key so import never fails; sessions/tokens then
-# reset across restarts. We deliberately do NOT persist the secret to a plaintext
-# file — set ``DJANGO_SECRET_KEY`` (the launcher does) for a stable key. Secure
-# at-rest persistence (OS keyring) is a Phase-1 follow-up.
+# resolves ONE stable key (persisted in the OS keyring, see
+# ``opencontractserver/desktop/launcher.py::_stable_secret_key``) and exports it
+# to every child process (Daphne/worker/beat) so they share it AND it survives
+# restarts. Stability is critical: ``PipelineSettings`` encrypts secrets (e.g.
+# ``OPENAI_API_KEY``) with a key derived from SECRET_KEY, so a rotating key would
+# render stored secrets permanently unrecoverable. When unset (e.g. a bare
+# ``manage.py`` invocation) we fall back to an ephemeral key so import never
+# fails; sessions and stored secrets then reset across restarts.
 SECRET_KEY = env("DJANGO_SECRET_KEY", default=None)
 if not SECRET_KEY:
     import secrets as _secrets
@@ -160,11 +162,20 @@ def _sqlalchemy_result_url(database_url: str) -> str:
 
 
 CELERY_RESULT_BACKEND = _sqlalchemy_result_url(env("DATABASE_URL"))
-CELERY_TASK_EAGER_PROPAGATES = True
 # Use the file-based PersistentScheduler so beat needs no django_celery_beat DB
 # rows. The launcher runs a ``celery beat`` subprocess against it (Phase 0);
 # collapsing beat into an in-process APScheduler is a Phase-1 follow-up.
 CELERY_BEAT_SCHEDULER = "celery.beat:PersistentScheduler"
+
+# PIPELINE SETTINGS CACHE — disable on desktop.
+# ------------------------------------------------------------------------------
+# PipelineSettings.get_instance() caches the singleton in the process-local
+# LocMemCache (default TTL 300s). On desktop, Daphne, the Celery worker and beat
+# are SEPARATE processes, so clear_cache() from the settings-edit request path
+# (Daphne) never reaches the worker's cache — the worker would keep serving stale
+# parser/embedder/API-key settings for up to the TTL after a user changes them.
+# 0 disables caching (cheap for a single user) so every read is fresh everywhere.
+PIPELINE_SETTINGS_CACHE_TTL_SECONDS = 0
 
 # EMAIL — no SMTP server on a desktop; log to the console.
 # ------------------------------------------------------------------------------

--- a/config/settings/desktop.py
+++ b/config/settings/desktop.py
@@ -1,0 +1,187 @@
+"""Settings for the single-user *desktop* build.
+
+This profile collapses the docker-compose topology into one supervised Python
+process: Daphne serves the ASGI app AND the pre-built React SPA, background work
+runs without Redis, and PostgreSQL+pgvector runs as a bundled child process.
+Compared to ``config.settings.production`` it drops every network service:
+
+* **Redis → gone.** Cache falls back to in-memory; the Celery broker uses the
+  kombu *filesystem* transport and results go to the bundled Postgres via
+  SQLAlchemy (chords need a real result backend); the Channels layer is
+  in-process.
+* **PostgreSQL** is a bundled child process (``pgserver``) on a per-user data
+  dir; ``DATABASE_URL`` is injected by the ``oc-desktop`` launcher.
+* **Storage** is local files under the per-user app-data directory.
+* **Auth0 → off.** A single local Django user + graphql_jwt is used.
+* **ML microservices → gone.** PDF parsing runs in-process via Warp-Ingest and
+  embeddings via an OpenAI-compatible endpoint (see ``desktop_bootstrap``).
+
+The launcher exports ``DATABASE_URL`` and ``OC_DESKTOP_*`` before this module is
+imported. Defaults below keep ``manage.py check`` importable without the
+launcher. See ``docs/deployment/desktop_packaging.md``.
+"""
+
+import os
+
+from opencontractserver.desktop import paths
+
+# Env defaults so the profile imports cleanly under a bare ``manage.py`` (the
+# launcher overrides DATABASE_URL with the embedded-Postgres connection). Set
+# BEFORE importing base, which reads DATABASE_URL with no default of its own.
+os.environ.setdefault("DJANGO_READ_DOT_ENV_FILE", "False")
+os.environ.setdefault(
+    "DATABASE_URL",
+    "postgres://opencontracts:opencontracts@127.0.0.1:5464/opencontracts",
+)
+
+from .base import *  # noqa: E402,F401,F403
+from .base import SECURE_CSP_DIRECTIVES, env  # noqa: E402
+
+# GENERAL
+# ------------------------------------------------------------------------------
+DEBUG = env.bool("DJANGO_DEBUG", default=False)
+
+# A desktop app is reachable only on the loopback interface.
+ALLOWED_HOSTS = ["localhost", "127.0.0.1", "0.0.0.0"]
+
+# SECRET_KEY: prefer an explicit env var, else a stable per-user key the launcher
+# persists under the app-data dir. Never fall back to a shared hard-coded value.
+SECRET_KEY = env("DJANGO_SECRET_KEY", default=None)
+if not SECRET_KEY:
+    _key_file = paths.secret_key_file()
+    if _key_file.exists():
+        SECRET_KEY = _key_file.read_text(encoding="utf-8").strip()
+    else:
+        from django.core.management.utils import get_random_secret_key
+
+        SECRET_KEY = get_random_secret_key()
+        try:
+            _key_file.parent.mkdir(parents=True, exist_ok=True)
+            _key_file.write_text(SECRET_KEY, encoding="utf-8")
+            os.chmod(_key_file, 0o600)
+        except OSError:
+            # Read-only install dir: fall back to an ephemeral key (sessions
+            # reset across restarts, acceptable for a single local user).
+            pass
+
+# Local, single-user auth — no Auth0 tenant.
+USE_AUTH0 = False
+
+# CACHES — no Redis; process-local memory cache.
+# ------------------------------------------------------------------------------
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "oc-desktop",
+        "TIMEOUT": 300,
+    }
+}
+
+# STORAGE — local files under the per-user app-data directory.
+# ------------------------------------------------------------------------------
+STORAGE_BACKEND = "LOCAL"
+MEDIA_ROOT = str(paths.media_dir())
+STATIC_ROOT = str(paths.static_dir())
+
+# PIPELINE — offline / in-process components (no ML microservices).
+# ------------------------------------------------------------------------------
+# PDFs parse in-process with Warp-Ingest; embeddings come from an OpenAI-
+# compatible endpoint (cloud key OR a local server via OPENAI_API_BASE_URL).
+# These become the seed defaults for the PipelineSettings singleton on first
+# boot (see the ``desktop_bootstrap`` management command). DOCX/PPTX/XLSX still
+# route to the (absent) Docling parser and are a follow-up for the desktop build.
+_WARP_PARSER = "opencontractserver.pipeline.parsers.warp_ingest_parser.WarpIngestParser"
+_TXT_PARSER = "opencontractserver.pipeline.parsers.oc_text_parser.TxtParser"
+_MD_PARSER = "opencontractserver.pipeline.parsers.oc_markdown_parser.MarkdownParser"
+_OPENAI_EMBEDDER = (
+    "opencontractserver.pipeline.embedders.openai_embedder.OpenAIEmbedder"
+)
+
+PREFERRED_PARSERS = {
+    "application/pdf": _WARP_PARSER,
+    "text/plain": _TXT_PARSER,
+    "application/txt": _TXT_PARSER,
+    "text/markdown": _MD_PARSER,
+}
+PREFERRED_EMBEDDERS = {
+    "application/pdf": _OPENAI_EMBEDDER,
+    "text/plain": _OPENAI_EMBEDDER,
+    "text/markdown": _OPENAI_EMBEDDER,
+}
+DEFAULT_EMBEDDER = _OPENAI_EMBEDDER
+# text-embedding-3-small → 1536 dims, which maps to the HNSW-indexed
+# ``Embedding.vector_1536`` column. Keep in sync with the seeded embedder model.
+DEFAULT_EMBEDDING_DIMENSION = 1536
+
+# CHANNELS — in-process layer (no Redis).
+# ------------------------------------------------------------------------------
+# NOTE(desktop, task #3): InMemoryChannelLayer only delivers when the emitter and
+# consumer share the same asyncio loop. The notification signal + thread-agent
+# task fire ``group_send`` from a non-Daphne loop, so real-time notification
+# toasts are NOT yet delivered under this layer — that loop-safe transport
+# (Postgres LISTEN/NOTIFY) is the immediate follow-up. The agent-chat stream is
+# unaffected (it streams inline in the consumer, no channel layer). See
+# docs/deployment/desktop_packaging.md#real-time-eventing.
+CHANNEL_LAYERS = {
+    "default": {"BACKEND": "channels.layers.InMemoryChannelLayer"},
+}
+
+# CELERY — no Redis broker/result backend.
+# ------------------------------------------------------------------------------
+# Broker: kombu filesystem transport (a spool dir, no server). Result backend:
+# the bundled Postgres via SQLAlchemy — a real result backend is required for
+# the ingest/extract *chords* (eager execution breaks chord orchestration, so it
+# is deliberately NOT used here). The launcher runs a single worker subprocess.
+_broker_in = str(paths.subdir("celery-broker", "in", create=False))
+_broker_out = str(paths.subdir("celery-broker", "out", create=False))
+CELERY_BROKER_URL = "filesystem://"
+CELERY_BROKER_TRANSPORT_OPTIONS = {
+    "data_folder_in": _broker_in,
+    "data_folder_out": _broker_out,
+    "control_folder": str(paths.subdir("celery-broker", "control", create=False)),
+}
+
+
+def _sqlalchemy_result_url(database_url: str) -> str:
+    """Map a Django ``DATABASE_URL`` to a Celery SQLAlchemy result backend URL."""
+    scheme, _, rest = database_url.partition("://")
+    if scheme in ("postgres", "postgresql", "postgis"):
+        return f"db+postgresql://{rest}"
+    return f"db+{database_url}"
+
+
+CELERY_RESULT_BACKEND = _sqlalchemy_result_url(env("DATABASE_URL"))
+CELERY_TASK_EAGER_PROPAGATES = True
+# Database scheduler needs a running ``celery beat`` process; the desktop
+# launcher instead drives CELERY_BEAT_SCHEDULE via an in-process APScheduler.
+CELERY_BEAT_SCHEDULER = "celery.beat:PersistentScheduler"
+
+# EMAIL — no SMTP server on a desktop; log to the console.
+# ------------------------------------------------------------------------------
+EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+
+# STATIC / SPA SERVING
+# ------------------------------------------------------------------------------
+# WhiteNoise (already in MIDDLEWARE) serves the built SPA's hashed assets
+# straight from the frontend ``dist/`` dir; a catch-all in config/urls.py
+# returns index.html for client-side routes. Set by the launcher after
+# ``yarn build`` is staged. When unset, SPA serving is disabled (API only).
+OC_DESKTOP_SPA_ROOT = env("OC_DESKTOP_FRONTEND_DIR", default="")
+if OC_DESKTOP_SPA_ROOT:
+    WHITENOISE_ROOT = OC_DESKTOP_SPA_ROOT
+    WHITENOISE_INDEX_FILE = True
+
+# CSP / CORS — same-origin localhost.
+# ------------------------------------------------------------------------------
+# The SPA is served same-origin, so no cross-origin GraphQL/WS is needed; allow
+# loopback WebSocket sources for defence-in-depth on http://127.0.0.1:<port>.
+_csp = SECURE_CSP_DIRECTIVES.copy() if SECURE_CSP_DIRECTIVES else {}
+_csp["connect-src"] = list(_csp.get("connect-src", ["'self'"])) + [
+    "ws://localhost:*",
+    "ws://127.0.0.1:*",
+]
+SECURE_CSP_DIRECTIVES = _csp
+
+# Cookies over plain http on loopback.
+SESSION_COOKIE_SECURE = False
+CSRF_COOKIE_SECURE = False

--- a/config/spa.py
+++ b/config/spa.py
@@ -1,0 +1,49 @@
+"""Serve the pre-built React SPA from Django for the desktop build.
+
+The docker-compose / production topology serves the frontend from its own
+container (nginx). The single-user desktop build has no such container: Daphne
+serves both the API and the SPA. WhiteNoise (already in ``MIDDLEWARE``) serves
+the SPA's hashed static assets directly from ``settings.OC_DESKTOP_SPA_ROOT``;
+this catch-all returns ``index.html`` for any remaining path so client-side
+routes (deep links) resolve. It is only wired into ``urls.py`` when
+``OC_DESKTOP_SPA_ROOT`` is set (i.e. the desktop profile), so other deployments
+are unaffected.
+"""
+
+import logging
+import os
+
+from django.conf import settings
+from django.core.exceptions import SuspiciousFileOperation
+from django.http import FileResponse, Http404
+from django.utils._os import safe_join
+
+logger = logging.getLogger(__name__)
+
+
+def spa_fallback(request, resource_path: str = ""):
+    """Return a static file under the SPA root, else ``index.html``.
+
+    WhiteNoise normally serves the hashed assets before the request reaches
+    Django, so in practice this view mostly returns ``index.html`` for
+    client-side routes. It still resolves real files defensively (traversal is
+    blocked by ``safe_join``) so the desktop build works even if WhiteNoise is
+    disabled.
+    """
+    root = getattr(settings, "OC_DESKTOP_SPA_ROOT", "")
+    if not root:
+        raise Http404("SPA serving is not enabled")
+
+    if resource_path:
+        try:
+            candidate = safe_join(root, resource_path)
+        except (ValueError, SuspiciousFileOperation):
+            candidate = None
+        if candidate and os.path.isfile(candidate):
+            return FileResponse(open(candidate, "rb"))
+
+    index_path = os.path.join(root, "index.html")
+    if not os.path.isfile(index_path):
+        logger.error("SPA index.html not found under %s", root)
+        raise Http404("SPA index.html not found")
+    return FileResponse(open(index_path, "rb"), content_type="text/html")

--- a/config/spa.py
+++ b/config/spa.py
@@ -26,11 +26,11 @@ logger = logging.getLogger(__name__)
 def spa_fallback(request, resource_path: str = ""):
     """Return a static file under the SPA root, else ``index.html``.
 
-    WhiteNoise normally serves the hashed assets before the request reaches
-    Django, so in practice this view mostly returns ``index.html`` for
-    client-side routes. It still resolves real files defensively (traversal is
-    blocked by ``safe_join``) so the desktop build works even if WhiteNoise is
-    disabled.
+    This view serves BOTH the SPA's hashed assets (a real file at the requested
+    path) and, for any other path, ``index.html`` so client-side routes resolve.
+    WhiteNoise is configured only against Django's ``STATIC_ROOT`` (admin/DRF
+    static), not the SPA dir, so it does not handle these asset requests — this
+    view does. Directory traversal is blocked by ``safe_join``.
     """
     root = getattr(settings, "OC_DESKTOP_SPA_ROOT", "")
     if not root:

--- a/config/spa.py
+++ b/config/spa.py
@@ -2,12 +2,14 @@
 
 The docker-compose / production topology serves the frontend from its own
 container (nginx). The single-user desktop build has no such container: Daphne
-serves both the API and the SPA. WhiteNoise (already in ``MIDDLEWARE``) serves
-the SPA's hashed static assets directly from ``settings.OC_DESKTOP_SPA_ROOT``;
-this catch-all returns ``index.html`` for any remaining path so client-side
-routes (deep links) resolve. It is only wired into ``urls.py`` when
-``OC_DESKTOP_SPA_ROOT`` is set (i.e. the desktop profile), so other deployments
-are unaffected.
+serves both the API and the SPA. This catch-all serves everything under
+``settings.OC_DESKTOP_SPA_ROOT`` (the built ``dist/``): a real file at the
+requested path (a hashed JS/CSS asset) is streamed directly, and any other path
+falls back to ``index.html`` so client-side routes (deep links) resolve.
+WhiteNoise is only configured against Django's own ``STATIC_ROOT`` (admin/DRF
+static), NOT the SPA dir, so asset requests are handled here, not by WhiteNoise.
+It is only wired into ``urls.py`` when ``OC_DESKTOP_SPA_ROOT`` is set (i.e. the
+desktop profile), so other deployments are unaffected.
 """
 
 import logging

--- a/config/urls.py
+++ b/config/urls.py
@@ -142,10 +142,11 @@ if getattr(settings, "SERVE_MEDIA_WITHOUT_DEBUG", False) and not settings.DEBUG:
         ),
     ]
 
-# Desktop build: serve the pre-built React SPA from Daphne. WhiteNoise serves the
-# hashed assets before the request reaches Django; this catch-all returns
-# index.html for any remaining (client-side route) path. Registered LAST so it
-# never shadows /api/, /graphql/, /admin/, /mcp*, /ws/ or static/media routes,
+# Desktop build: serve the pre-built React SPA from Daphne. The spa_fallback view
+# serves the SPA's hashed assets AND returns index.html for any remaining
+# (client-side route) path (WhiteNoise covers only Django's STATIC_ROOT, not the
+# SPA dir). Registered LAST so it never shadows /api/, /graphql/, /admin/, /mcp*,
+# /ws/ or static/media routes,
 # and only when the desktop profile points OC_DESKTOP_SPA_ROOT at a built dist/.
 if getattr(settings, "OC_DESKTOP_SPA_ROOT", ""):
     from django.urls import re_path as _re_path

--- a/config/urls.py
+++ b/config/urls.py
@@ -153,7 +153,10 @@ if getattr(settings, "OC_DESKTOP_SPA_ROOT", ""):
 
     urlpatterns += [
         _re_path(
-            r"^(?!api/|graphql/|admin/|mcp|sse|ws/|static/|media/)"
+            # Exclude the backend route prefixes by whole path segment (``/`` or
+            # end-of-path) so a future SPA route like ``/mcp-guide`` still falls
+            # through to index.html.
+            r"^(?!(?:api|graphql|admin|mcp|sse|ws|static|media)(?:/|$))"
             r"(?P<resource_path>.*)$",
             spa_fallback,
             name="spa_fallback",

--- a/config/urls.py
+++ b/config/urls.py
@@ -49,7 +49,14 @@ urlpatterns = [
     # Discovery endpoints (robots.txt, llms.txt, sitemap.xml, .well-known/mcp.json)
     path("", include("opencontractserver.discovery.urls")),
     path("api/health/", lambda request: JsonResponse({"status": "ok"})),
-    path("", home_redirect, name="home_redirect"),  # Root URL redirect to port 3000
+    # Root URL redirect to the frontend dev server (:3000). Skipped on the
+    # desktop build, where Daphne serves the SPA itself (see the SPA catch-all
+    # appended below when OC_DESKTOP_SPA_ROOT is set).
+    *(
+        []
+        if getattr(settings, "OC_DESKTOP_SPA_ROOT", "")
+        else [path("", home_redirect, name="home_redirect")]
+    ),
     # Custom admin login/logout views (must be before admin.site.urls to override defaults)
     path("admin/login/", Auth0AdminLoginView.as_view(), name="admin_auth0_login"),
     path("admin/logout/", Auth0AdminLogoutView.as_view(), name="admin_auth0_logout"),
@@ -131,5 +138,24 @@ if getattr(settings, "SERVE_MEDIA_WITHOUT_DEBUG", False) and not settings.DEBUG:
             rf"^{settings.MEDIA_URL.lstrip('/')}(?P<path>.*)$",
             media_serve,
             {"document_root": settings.MEDIA_ROOT},
+        ),
+    ]
+
+# Desktop build: serve the pre-built React SPA from Daphne. WhiteNoise serves the
+# hashed assets before the request reaches Django; this catch-all returns
+# index.html for any remaining (client-side route) path. Registered LAST so it
+# never shadows /api/, /graphql/, /admin/, /mcp*, /ws/ or static/media routes,
+# and only when the desktop profile points OC_DESKTOP_SPA_ROOT at a built dist/.
+if getattr(settings, "OC_DESKTOP_SPA_ROOT", ""):
+    from django.urls import re_path as _re_path
+
+    from config.spa import spa_fallback
+
+    urlpatterns += [
+        _re_path(
+            r"^(?!api/|graphql/|admin/|mcp|sse|ws/|static/|media/)"
+            r"(?P<resource_path>.*)$",
+            spa_fallback,
+            name="spa_fallback",
         ),
     ]

--- a/config/urls.py
+++ b/config/urls.py
@@ -156,7 +156,11 @@ if getattr(settings, "OC_DESKTOP_SPA_ROOT", ""):
         _re_path(
             # Exclude the backend route prefixes by whole path segment (``/`` or
             # end-of-path) so a future SPA route like ``/mcp-guide`` still falls
-            # through to index.html.
+            # through to index.html. Note: mcp/sse (intercepted by the ASGI
+            # router in config/asgi.py) and ws (a separate websocket protocol
+            # scope) never reach these http urlpatterns anyway — they are
+            # defensive-only here; api/graphql/admin/static/media are the
+            # load-bearing exclusions.
             r"^(?!(?:api|graphql|admin|mcp|sse|ws|static|media)(?:/|$))"
             r"(?P<resource_path>.*)$",
             spa_fallback,

--- a/config/urls.py
+++ b/config/urls.py
@@ -127,8 +127,9 @@ urlpatterns = [
 # S3/GCS/nginx in front) with NO media serving at all — every
 # ``/media/...`` fetch 404s, so flows that load file-backed content in the
 # browser (e.g. the corpus Readme.CAML article body) can never succeed.
-# ``SERVE_MEDIA_WITHOUT_DEBUG`` is set ONLY by the test settings; production
-# serves media from object storage and never enables it.
+# ``SERVE_MEDIA_WITHOUT_DEBUG`` is set by the test settings AND the single-user
+# desktop profile (config.settings.desktop, local storage, no nginx/S3);
+# production serves media from object storage and never enables it.
 if getattr(settings, "SERVE_MEDIA_WITHOUT_DEBUG", False) and not settings.DEBUG:
     from django.urls import re_path
     from django.views.static import serve as media_serve

--- a/docs/deployment/desktop_packaging.md
+++ b/docs/deployment/desktop_packaging.md
@@ -116,6 +116,10 @@ To enable embeddings + chat, set `OPENAI_API_KEY` (and optionally
   + staged `dist/` per-OS; harden embedded-Postgres supervision (stale-lock
   recovery, major-version datadir guard); loop-safe notification transport;
   collapse worker/beat in-process (thread worker + APScheduler); pystray tray.
+  Windows shutdown note: `Popen.terminate()` on Windows is a hard
+  `TerminateProcess` (no graceful signal), so a Celery worker's in-flight task is
+  interrupted rather than drained — the `reconcile_stuck_documents` beat sweep
+  recovers any stranded document, but graceful Windows teardown is a Phase-1 item.
 - **Phase 2:** native shell (Tauri v2 sidecar) + dmg/msi/AppImage installers.
 - **Phase 3:** code-signing, macOS notarization, auto-update (Tauri updater).
 - **Phase 4 (optional):** full offline ML pack (torch + sentence-transformers +

--- a/docs/deployment/desktop_packaging.md
+++ b/docs/deployment/desktop_packaging.md
@@ -1,0 +1,120 @@
+# Single-User Desktop Packaging
+
+Goal: run OpenContracts as an easy, seamless **single-user desktop app** on
+Linux/macOS/Windows with as few runtime dependencies as possible — every
+`local.yml` compose service becomes a plain process or is eliminated. In
+particular, **Redis is dropped** and PostgreSQL becomes a bundled child process.
+
+This document is the architecture + phased plan. Phase 0 (settings profile +
+launcher + the Warp-Ingest parser) lands first to de-risk the topology before
+any native shell or installer work.
+
+## Compose service → desktop replacement
+
+| `local.yml` service | Desktop replacement |
+|---|---|
+| `postgres` (pgvector) | **Embedded PostgreSQL 16 + pgvector** child process (`pgserver`), per-user data dir. `DATABASES` is URL-driven (`config/settings/base.py` → `env.db("DATABASE_URL")`), so **no query/ORM/migration changes**. |
+| `redis` | **Deleted.** Cache → `LocMemCache`; Celery broker → kombu *filesystem* transport; Celery result backend → the bundled Postgres via SQLAlchemy; Channels → in-process. |
+| `celeryworker` | Worker **subprocess** over the filesystem broker (Phase 0) → in-process thread worker (later). |
+| `celerybeat` | `celery beat` **subprocess** (Phase 0) → in-process APScheduler (later). The periodic sweeps (`reconcile_stuck_documents`, `recover_stalled_uploads`, …) matter *more* on a force-quit-prone desktop. |
+| `flower` | Deleted. |
+| `frontend` | `yarn build` once → **WhiteNoise serves `dist/`** from Daphne + a SPA catch-all (`config/spa.py`, wired in `config/urls.py` when `OC_DESKTOP_SPA_ROOT` is set). No Node at install time. |
+| `docling-parser` | **`WarpIngestParser`** (`opencontractserver/pipeline/parsers/warp_ingest_parser.py`) — in-process, rule-based, no torch/GPU. |
+| `docxodus-parser`, `vector-embedder`, `multimodal-embedder`, `privacy_filter` | Not used. Embeddings come from an OpenAI-compatible endpoint (`OpenAIEmbedder`, cloud key or a local server via `OPENAI_API_BASE_URL`). |
+
+## Tiers
+
+- **Tier 0 — offline, no key:** upload → parse (Warp-Ingest / TXT / MD) →
+  annotate → read → Postgres keyword (tsvector) search. No semantic search, no
+  chat.
+- **Tier 1 — lite (default):** Tier 0 **+** embeddings & chat via an
+  OpenAI-compatible endpoint (user key, or a local server). Zero microservices,
+  zero torch. **Recommended default.**
+- **Tier 2 — full (opt-in download):** local torch + sentence-transformers +
+  docling-as-library for offline semantic search / ML layout. Installer ~2–4 GB,
+  so it is a download-on-demand pack, never baked in.
+
+## The Warp-Ingest parser
+
+[`Warp-Ingest`](https://github.com/Open-Source-Legal/Warp-Ingest) is a
+pure-Python, rule-based PDF layout engine (built on `pdfplumber`; optional
+CPU-only OCR via `rapidocr-onnxruntime`). Its
+`pdf_ingestor.parse_to_opencontracts(path)` returns an `OpenContractDocExport`
+directly — PAWLS word tokens, one structural annotation per block, and the
+heading hierarchy as `OC_PARENT_CHILD` relationships — so `WarpIngestParser` is a
+thin wrapper around `BaseParser`. Verified against real PDFs: born-digital docs
+yield hundreds of structural annotations + relationships with no microservice.
+
+It is registered for every deployment (auto-discovered) but only *selected* when
+`PREFERRED_PARSERS` / `PipelineSettings` point at it — the compose default stays
+Docling. `warp_ingest` is imported **lazily** so pipeline discovery works when
+the package is absent.
+
+> **nltk data.** Warp-Ingest imports the `stopwords`/`punkt` corpora at load
+> time. The `desktop_bootstrap` command downloads them into the app-data dir on
+> first run; bundle them for a fully-offline installer.
+
+## Real-time eventing (known Phase-0 limitation)
+
+Dropping Redis means the Channels layer becomes in-process
+(`InMemoryChannelLayer`). The high-traffic **agent chat** path is unaffected — it
+streams tokens inline in the consumer with no channel layer. But the two
+notification emitters (`opencontractserver/notifications/signals.py` and
+`opencontractserver/tasks/agent_tasks.py`) fire `group_send` from a **different
+event loop** than Daphne's, and `InMemoryChannelLayer`'s buffers are loop-bound —
+so badge/reply/mention/analysis-status toasts are **not delivered** yet under the
+desktop profile. The fix (a loop-safe transport, preferably Postgres
+`LISTEN/NOTIFY` since Postgres is already bundled) is the immediate follow-up;
+until then the desktop settings note it inline.
+
+## Running Phase 0
+
+```bash
+# 1. Build the SPA once (served by Daphne):
+cd frontend && yarn build && cd ..
+
+# 2. Install desktop extras (adds warp-ingest, pgserver, sqlalchemy):
+pip install -r requirements/desktop.txt
+
+# 3. Launch — starts Postgres, migrates, seeds a local user, runs Daphne +
+#    Celery worker/beat, opens the browser. No Docker, no Redis.
+python oc-desktop.py
+```
+
+Everything is stored under a per-user app-data directory
+(`opencontractserver/desktop/paths.py`): `pgdata/`, `media/`, `staticfiles/`,
+`celery-broker/`, `nltk_data/`, the persisted `secret_key`, and the generated
+login `credentials.txt`. Point at an existing database instead of the embedded
+one by exporting `DATABASE_URL` before launch.
+
+To enable embeddings + chat, set `OPENAI_API_KEY` (and optionally
+`OPENAI_API_BASE_URL` for a local OpenAI-compatible server) before first run so
+`desktop_bootstrap` seeds it into `PipelineSettings`.
+
+## Phased delivery
+
+- **Phase 0 (this):** `config/settings/desktop.py` + `oc-desktop.py` launcher +
+  `WarpIngestParser` + first-run bootstrap. Runs the whole stack as processes.
+- **Phase 1:** package `python-build-standalone` + a relocatable venv + `pgserver`
+  + staged `dist/` per-OS; harden embedded-Postgres supervision (stale-lock
+  recovery, major-version datadir guard); loop-safe notification transport;
+  collapse worker/beat in-process (thread worker + APScheduler); pystray tray.
+- **Phase 2:** native shell (Tauri v2 sidecar) + dmg/msi/AppImage installers.
+- **Phase 3:** code-signing, macOS notarization, auto-update (Tauri updater).
+- **Phase 4 (optional):** full offline ML pack (torch + sentence-transformers +
+  docling-as-library), downloaded on demand.
+
+### Why these choices
+
+- **Embedded Postgres, not SQLite/sqlite-vec.** The vector/search coupling
+  (pgvector `VectorField` × 7 dims, HNSW indexes, tsvector FTS with a plpgsql
+  trigger + GIN, `pg_trgm` trigram, `ArrayField`) is concentrated but deep; an
+  embedded server preserves 100% of it with a one-line `DATABASE_URL` change,
+  whereas sqlite-vec is an L–XL rewrite that also regresses ANN to brute force.
+- **`python-build-standalone` + venv, not PyInstaller.** Freezing
+  Django/Celery/Daphne/psycopg fights app autodiscovery, dynamic imports and
+  native libs; a relocatable CPython runs `manage.py` exactly as in dev and
+  yields real child PIDs for clean shutdown.
+- **Tauri, not Electron.** ~3 MB shell vs ~96 MB, native code-signing hooks and a
+  turnkey cross-platform updater; the install weight is dominated by the
+  Python + Postgres payload regardless.

--- a/docs/deployment/desktop_packaging.md
+++ b/docs/deployment/desktop_packaging.md
@@ -90,13 +90,17 @@ before launch. (An external database must already have the `vector` extension
 available — the embedded `pgserver` path runs `CREATE EXTENSION IF NOT EXISTS
 vector` for you; the external path does not.)
 
-**Secrets are env-sourced, never written to disk** (Phase 0): the launcher
-generates a per-run `DJANGO_SECRET_KEY` and shares it across child processes
-(sessions reset across restarts unless you export a stable `DJANGO_SECRET_KEY`).
-The local login password comes only from `OC_DESKTOP_PASSWORD`; without it the
-user is created with no usable password (set one with `manage.py changepassword`).
-A persistent OS-keyring-backed secret store and seamless auto-login are Phase-1
-follow-ups.
+**Secret handling:** the launcher resolves a stable `DJANGO_SECRET_KEY` from the
+**OS keyring** (macOS Keychain / Windows Credential Locker / Linux Secret
+Service) and shares it across child processes. A stable key is important: it
+survives restarts *and* keeps `PipelineSettings`' encrypted secrets (e.g. your
+`OPENAI_API_KEY`) decryptable — a key that rotated each launch would make them
+permanently unrecoverable. If no keyring backend is available, the launcher
+falls back to an ephemeral key (with a warning) and sessions + stored secrets
+reset on restart; export a stable `DJANGO_SECRET_KEY` yourself in that case. The
+local login password comes only from `OC_DESKTOP_PASSWORD`; without it the user
+is created with no usable password (set one with `manage.py changepassword`). No
+secret is written to a plaintext file.
 
 To enable embeddings + chat, set `OPENAI_API_KEY` (and optionally
 `OPENAI_API_BASE_URL` for a local OpenAI-compatible server) before first run so

--- a/docs/deployment/desktop_packaging.md
+++ b/docs/deployment/desktop_packaging.md
@@ -18,7 +18,7 @@ any native shell or installer work.
 | `celeryworker` | Worker **subprocess** over the filesystem broker (Phase 0) → in-process thread worker (later). |
 | `celerybeat` | `celery beat` **subprocess** (Phase 0) → in-process APScheduler (later). The periodic sweeps (`reconcile_stuck_documents`, `recover_stalled_uploads`, …) matter *more* on a force-quit-prone desktop. |
 | `flower` | Deleted. |
-| `frontend` | `yarn build` once → **WhiteNoise serves `dist/`** from Daphne + a SPA catch-all (`config/spa.py`, wired in `config/urls.py` when `OC_DESKTOP_SPA_ROOT` is set). No Node at install time. |
+| `frontend` | `yarn build` once → Daphne serves the built `dist/` via the `spa_fallback` catch-all (`config/spa.py`, wired in `config/urls.py` when `OC_DESKTOP_SPA_ROOT` is set) — it serves both the hashed assets and `index.html` for client routes. WhiteNoise still covers only Django's own `STATIC_ROOT` (admin/DRF). No Node at install time. |
 | `docling-parser` | **`WarpIngestParser`** (`opencontractserver/pipeline/parsers/warp_ingest_parser.py`) — in-process, rule-based, no torch/GPU. |
 | `docxodus-parser`, `vector-embedder`, `multimodal-embedder`, `privacy_filter` | Not used. Embeddings come from an OpenAI-compatible endpoint (`OpenAIEmbedder`, cloud key or a local server via `OPENAI_API_BASE_URL`). |
 
@@ -99,7 +99,9 @@ permanently unrecoverable. If no keyring backend is available, the launcher
 falls back to an ephemeral key (with a warning) and sessions + stored secrets
 reset on restart; export a stable `DJANGO_SECRET_KEY` yourself in that case. The
 local login password comes only from `OC_DESKTOP_PASSWORD`; without it the user
-is created with no usable password (set one with `manage.py changepassword`). No
+is created with no usable password (set one with `manage.py changepassword`).
+Because this account is a superuser, choose a strong `OC_DESKTOP_PASSWORD` (it is
+not strength-validated on the desktop profile). No
 secret is written to a plaintext file.
 
 To enable embeddings + chat, set `OPENAI_API_KEY` (and optionally

--- a/docs/deployment/desktop_packaging.md
+++ b/docs/deployment/desktop_packaging.md
@@ -86,7 +86,9 @@ Everything is stored under a per-user app-data directory
 (`opencontractserver/desktop/paths.py`): `pgdata/`, `media/`, `staticfiles/`,
 `celery-broker/`, `nltk_data/`, and the first-run `.bootstrapped` marker. Point
 at an existing database instead of the embedded one by exporting `DATABASE_URL`
-before launch.
+before launch. (An external database must already have the `vector` extension
+available — the embedded `pgserver` path runs `CREATE EXTENSION IF NOT EXISTS
+vector` for you; the external path does not.)
 
 **Secrets are env-sourced, never written to disk** (Phase 0): the launcher
 generates a per-run `DJANGO_SECRET_KEY` and shares it across child processes

--- a/docs/deployment/desktop_packaging.md
+++ b/docs/deployment/desktop_packaging.md
@@ -78,14 +78,23 @@ pip install -r requirements/desktop.txt
 
 # 3. Launch — starts Postgres, migrates, seeds a local user, runs Daphne +
 #    Celery worker/beat, opens the browser. No Docker, no Redis.
-python oc-desktop.py
+#    Set OC_DESKTOP_PASSWORD to enable login (see below).
+OC_DESKTOP_PASSWORD=change-me python oc-desktop.py
 ```
 
 Everything is stored under a per-user app-data directory
 (`opencontractserver/desktop/paths.py`): `pgdata/`, `media/`, `staticfiles/`,
-`celery-broker/`, `nltk_data/`, the persisted `secret_key`, and the generated
-login `credentials.txt`. Point at an existing database instead of the embedded
-one by exporting `DATABASE_URL` before launch.
+`celery-broker/`, `nltk_data/`, and the first-run `.bootstrapped` marker. Point
+at an existing database instead of the embedded one by exporting `DATABASE_URL`
+before launch.
+
+**Secrets are env-sourced, never written to disk** (Phase 0): the launcher
+generates a per-run `DJANGO_SECRET_KEY` and shares it across child processes
+(sessions reset across restarts unless you export a stable `DJANGO_SECRET_KEY`).
+The local login password comes only from `OC_DESKTOP_PASSWORD`; without it the
+user is created with no usable password (set one with `manage.py changepassword`).
+A persistent OS-keyring-backed secret store and seamless auto-login are Phase-1
+follow-ups.
 
 To enable embeddings + chat, set `OPENAI_API_KEY` (and optionally
 `OPENAI_API_BASE_URL` for a local OpenAI-compatible server) before first run so

--- a/oc-desktop.py
+++ b/oc-desktop.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+"""Entry point for the single-user OpenContracts desktop build.
+
+Runs the whole stack (embedded PostgreSQL+pgvector, Daphne serving the API and
+the pre-built SPA, a Celery worker + beat) as one supervised process with no
+Docker and no Redis, then opens the browser.
+
+    python oc-desktop.py
+
+See ``docs/deployment/desktop_packaging.md`` and
+``opencontractserver/desktop/launcher.py``.
+"""
+
+from opencontractserver.desktop.launcher import main
+
+if __name__ == "__main__":
+    main()

--- a/opencontractserver/desktop/__init__.py
+++ b/opencontractserver/desktop/__init__.py
@@ -1,0 +1,11 @@
+"""Single-user desktop packaging for OpenContracts.
+
+This package turns the docker-compose topology (django, postgres, redis,
+celeryworker, celerybeat, the ML microservices and the frontend container) into
+a single supervised Python process suitable for a cross-platform desktop app.
+
+See ``docs/deployment/desktop_packaging.md`` for the architecture and the phased
+delivery plan. Nothing here is imported by the server/compose deployment; it is
+only loaded when ``DJANGO_SETTINGS_MODULE=config.settings.desktop`` (or the
+``oc-desktop`` launcher) is used.
+"""

--- a/opencontractserver/desktop/db.py
+++ b/opencontractserver/desktop/db.py
@@ -1,0 +1,32 @@
+"""Database URL helpers for the desktop build.
+
+Pure functions (no Django import) so they are safe to call from
+``config/settings/desktop.py`` at settings-load time and are unit-testable in
+isolation (importing a settings module in a test is not).
+"""
+
+from __future__ import annotations
+
+# Django DATABASE_URL schemes that map onto SQLAlchemy's psycopg2 dialect.
+_POSTGRES_SCHEMES = ("postgres", "postgresql", "postgis")
+
+
+def sqlalchemy_result_backend_url(database_url: str) -> str:
+    """Map a Django ``DATABASE_URL`` to a Celery SQLAlchemy result-backend URL.
+
+    Celery's SQLAlchemy result backend expects a ``db+<dialect>://`` URL. The
+    desktop build reuses the bundled Postgres for Celery results (chords need a
+    real result backend and we have no Redis), so a ``postgres://…`` /
+    ``postgresql://…`` Django URL becomes ``db+postgresql://…``. Any query string
+    (e.g. ``?sslmode=require``) and credentials are preserved verbatim. Non-
+    Postgres URLs are passed through with a ``db+`` prefix.
+
+    >>> sqlalchemy_result_backend_url("postgres://u:p@h:5432/db")
+    'db+postgresql://u:p@h:5432/db'
+    >>> sqlalchemy_result_backend_url("postgresql://u@h/db?sslmode=require")
+    'db+postgresql://u@h/db?sslmode=require'
+    """
+    scheme, sep, rest = database_url.partition("://")
+    if sep and scheme in _POSTGRES_SCHEMES:
+        return f"db+postgresql://{rest}"
+    return f"db+{database_url}"

--- a/opencontractserver/desktop/db.py
+++ b/opencontractserver/desktop/db.py
@@ -10,6 +10,15 @@ from __future__ import annotations
 # Django DATABASE_URL schemes that map onto SQLAlchemy's psycopg2 dialect.
 _POSTGRES_SCHEMES = ("postgres", "postgresql", "postgis")
 
+# Placeholder DATABASE_URL used ONLY so ``config.settings.desktop`` imports under
+# a bare ``manage.py`` (base.py reads DATABASE_URL with no default). The launcher
+# always overrides it with an external URL or ``pgserver.get_uri()`` before any
+# subprocess runs, so nothing ever connects to this. Port 5464 avoids clashing
+# with a system Postgres on 5432.
+DEFAULT_DESKTOP_DATABASE_URL = (
+    "postgres://opencontracts:opencontracts@127.0.0.1:5464/opencontracts"
+)
+
 
 def sqlalchemy_result_backend_url(database_url: str) -> str:
     """Map a Django ``DATABASE_URL`` to a Celery SQLAlchemy result-backend URL.

--- a/opencontractserver/desktop/launcher.py
+++ b/opencontractserver/desktop/launcher.py
@@ -237,8 +237,14 @@ def _spawn(name: str, cmd: list[str], env: dict[str, str]) -> subprocess.Popen:
     log_path = paths.logs_dir() / f"{name}.log"
     print(f"[oc-desktop] starting {name} (log: {log_path})")
     log_file = open(log_path, "a")
+    try:
+        proc = subprocess.Popen(cmd, env=env, stdout=log_file, stderr=subprocess.STDOUT)
+    except Exception:
+        # Don't leak the fd if process creation fails (e.g. bad executable).
+        log_file.close()
+        raise
+    # Track for shutdown only after a successful spawn.
     _log_handles.append(log_file)
-    proc = subprocess.Popen(cmd, env=env, stdout=log_file, stderr=subprocess.STDOUT)
     _children.append(proc)
     return proc
 

--- a/opencontractserver/desktop/launcher.py
+++ b/opencontractserver/desktop/launcher.py
@@ -262,7 +262,11 @@ def main() -> None:
     _start_postgres(env)
     _manage(env, "migrate", "--noinput")
     _first_run_bootstrap(env)
-    _manage(env, "collectstatic", "--noinput", check=False)
+    if _manage(env, "collectstatic", "--noinput", check=False) != 0:
+        print(
+            "[oc-desktop] WARNING: collectstatic failed; Django admin/DRF static "
+            "assets may be missing (the SPA itself is served from dist/)."
+        )
 
     spa_dir = _resolve_spa_dir(env)
     port = _free_port()

--- a/opencontractserver/desktop/launcher.py
+++ b/opencontractserver/desktop/launcher.py
@@ -39,7 +39,20 @@ _children: list[subprocess.Popen] = []
 
 
 _KEYRING_SERVICE = "OpenContracts-Desktop"
-_KEYRING_USER = "django-secret-key"
+
+
+def _keyring_username() -> str:
+    """Keyring entry name, scoped to the data dir.
+
+    Two desktop instances under different ``OC_DESKTOP_DATA_DIR``s (e.g. a test
+    profile alongside a real one) each get their own persisted SECRET_KEY rather
+    than silently sharing one. The data dir is hashed to keep the entry name
+    short and backend-safe (some OS keyrings cap target-name length).
+    """
+    import hashlib
+
+    digest = hashlib.sha256(str(paths.app_data_dir()).encode()).hexdigest()[:16]
+    return f"django-secret-key-{digest}"
 
 
 def _stable_secret_key() -> str:
@@ -59,11 +72,12 @@ def _stable_secret_key() -> str:
     try:
         import keyring
 
-        existing = keyring.get_password(_KEYRING_SERVICE, _KEYRING_USER)
+        username = _keyring_username()
+        existing = keyring.get_password(_KEYRING_SERVICE, username)
         if existing:
             return existing
         new_key = secrets.token_urlsafe(64)
-        keyring.set_password(_KEYRING_SERVICE, _KEYRING_USER, new_key)
+        keyring.set_password(_KEYRING_SERVICE, username, new_key)
         return new_key
     except Exception as exc:  # keyring missing or no usable backend
         print(

--- a/opencontractserver/desktop/launcher.py
+++ b/opencontractserver/desktop/launcher.py
@@ -38,6 +38,43 @@ SETTINGS_MODULE = "config.settings.desktop"
 _children: list[subprocess.Popen] = []
 
 
+_KEYRING_SERVICE = "OpenContracts-Desktop"
+_KEYRING_USER = "django-secret-key"
+
+
+def _stable_secret_key() -> str:
+    """A SECRET_KEY that survives restarts, stored in the OS keyring.
+
+    A stable key matters beyond login sessions: ``PipelineSettings`` encrypts
+    secrets (e.g. ``OPENAI_API_KEY``) with a Fernet key derived from
+    ``SECRET_KEY`` (``opencontractserver/documents/models.py``), so a key that
+    rotated every launch would make those stored secrets permanently
+    unrecoverable — silently breaking the Tier-1 "set your API key once" flow on
+    the next restart. We persist the key in the OS credential store (macOS
+    Keychain / Windows Credential Locker / Linux Secret Service) rather than a
+    plaintext file. If keyring is unavailable (e.g. headless Linux with no
+    Secret Service backend), fall back to an ephemeral key with a loud warning —
+    sessions and stored pipeline secrets then do NOT survive a restart.
+    """
+    try:
+        import keyring
+
+        existing = keyring.get_password(_KEYRING_SERVICE, _KEYRING_USER)
+        if existing:
+            return existing
+        new_key = secrets.token_urlsafe(64)
+        keyring.set_password(_KEYRING_SERVICE, _KEYRING_USER, new_key)
+        return new_key
+    except Exception as exc:  # keyring missing or no usable backend
+        print(
+            "[oc-desktop] WARNING: could not persist SECRET_KEY via the OS "
+            f"keyring ({exc}); using an ephemeral key. Login sessions and stored "
+            "pipeline secrets (e.g. your OpenAI API key) will NOT survive a "
+            "restart. Export a stable DJANGO_SECRET_KEY to avoid this."
+        )
+        return secrets.token_urlsafe(64)
+
+
 # --------------------------------------------------------------------------- env
 def _base_env() -> dict[str, str]:
     """Environment shared by the launcher and every child process."""
@@ -50,9 +87,10 @@ def _base_env() -> dict[str, str]:
     # / punkt offline.
     env["NLTK_DATA"] = str(paths.subdir("nltk_data"))
     # One SECRET_KEY shared by every child (Daphne/worker/beat) so sessions and
-    # JWTs verify across them. Generated per launch when unset — an ephemeral
-    # key; export DJANGO_SECRET_KEY yourself for stability across runs.
-    env.setdefault("DJANGO_SECRET_KEY", secrets.token_urlsafe(64))
+    # JWTs verify across them, persisted across restarts via the OS keyring (see
+    # _stable_secret_key). A user-provided DJANGO_SECRET_KEY always wins.
+    if "DJANGO_SECRET_KEY" not in env:
+        env["DJANGO_SECRET_KEY"] = _stable_secret_key()
     return env
 
 

--- a/opencontractserver/desktop/launcher.py
+++ b/opencontractserver/desktop/launcher.py
@@ -36,6 +36,8 @@ from opencontractserver.desktop import paths
 
 SETTINGS_MODULE = "config.settings.desktop"
 _children: list[subprocess.Popen] = []
+# Open log-file handles for the child processes, closed on shutdown.
+_log_handles: list = []
 
 
 _KEYRING_SERVICE = "OpenContracts-Desktop"
@@ -123,10 +125,11 @@ def _ensure_dirs() -> None:
 def _free_port() -> int:
     """Ask the OS for a free loopback TCP port (bind :0, read, release).
 
-    Note: there is a small TOCTOU window between releasing the probe socket here
-    and Daphne binding the port below. On a single-user loopback app the risk of
-    another process grabbing it in that window is negligible; hardening this into
-    a bind-retry loop is a Phase-1 follow-up.
+    Note: there is a TOCTOU window between releasing the probe socket here and
+    Daphne binding the port. The caller reserves the port immediately before
+    ``_start_daphne`` (after the slow worker/beat spawn) to keep that window
+    near-instant. On a single-user loopback app the residual risk of another
+    process grabbing it is negligible; a bind-retry loop is a Phase-1 follow-up.
     """
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.bind(("127.0.0.1", 0))
@@ -228,8 +231,14 @@ def _write_env_config(spa_dir: str, port: int) -> None:
 
 # ---------------------------------------------------------------- child processes
 def _spawn(name: str, cmd: list[str], env: dict[str, str]) -> subprocess.Popen:
-    print(f"[oc-desktop] starting {name}: {' '.join(cmd)}")
-    proc = subprocess.Popen(cmd, env=env)
+    # Redirect each child's stdout+stderr to a per-child file under the logs dir
+    # so a Daphne/worker/beat crash leaves a durable traceback — essential once
+    # the Phase-2 Tauri shell launches this with no attached console.
+    log_path = paths.logs_dir() / f"{name}.log"
+    print(f"[oc-desktop] starting {name} (log: {log_path})")
+    log_file = open(log_path, "a")
+    _log_handles.append(log_file)
+    proc = subprocess.Popen(cmd, env=env, stdout=log_file, stderr=subprocess.STDOUT)
     _children.append(proc)
     return proc
 
@@ -305,6 +314,9 @@ def _shutdown(*_args) -> None:
         if proc.poll() is None:
             with contextlib.suppress(Exception):
                 proc.kill()
+    for handle in _log_handles:
+        with contextlib.suppress(Exception):
+            handle.close()
 
 
 def main() -> None:
@@ -322,8 +334,6 @@ def main() -> None:
         )
 
     spa_dir = _resolve_spa_dir(env)
-    port = _free_port()
-    _write_env_config(spa_dir, port)
 
     # Single teardown path: atexit runs _shutdown on every exit (normal return,
     # SystemExit from a signal, or an unhandled exception). The signal handlers
@@ -340,6 +350,10 @@ def main() -> None:
 
     _start_worker(env)
     _start_beat(env)
+    # Reserve the port immediately before Daphne binds it (not before the slow
+    # worker/beat spawn) to keep the release-then-rebind window near-instant.
+    port = _free_port()
+    _write_env_config(spa_dir, port)
     _start_daphne(env, port)
 
     url = f"http://127.0.0.1:{port}/"

--- a/opencontractserver/desktop/launcher.py
+++ b/opencontractserver/desktop/launcher.py
@@ -41,6 +41,10 @@ _log_handles: list = []
 
 
 _KEYRING_SERVICE = "OpenContracts-Desktop"
+# Hard timeout for the keyring resolution — a locked GNOME Keyring / KWallet can
+# block on an interactive unlock prompt rather than raising, which would hang the
+# launcher before any child starts. On timeout we fall back to an ephemeral key.
+_KEYRING_TIMEOUT_SECONDS = 10
 
 
 def _keyring_username() -> str:
@@ -57,6 +61,19 @@ def _keyring_username() -> str:
     return f"django-secret-key-{digest}"
 
 
+def _keyring_get_or_create() -> str:
+    """Fetch (or create+persist) the SECRET_KEY in the OS keyring. Raises on error."""
+    import keyring
+
+    username = _keyring_username()
+    existing = keyring.get_password(_KEYRING_SERVICE, username)
+    if existing:
+        return existing
+    new_key = secrets.token_urlsafe(64)
+    keyring.set_password(_KEYRING_SERVICE, username, new_key)
+    return new_key
+
+
 def _stable_secret_key() -> str:
     """A SECRET_KEY that survives restarts, stored in the OS keyring.
 
@@ -67,28 +84,45 @@ def _stable_secret_key() -> str:
     unrecoverable — silently breaking the Tier-1 "set your API key once" flow on
     the next restart. We persist the key in the OS credential store (macOS
     Keychain / Windows Credential Locker / Linux Secret Service) rather than a
-    plaintext file. If keyring is unavailable (e.g. headless Linux with no
-    Secret Service backend), fall back to an ephemeral key with a loud warning —
-    sessions and stored pipeline secrets then do NOT survive a restart.
-    """
-    try:
-        import keyring
+    plaintext file.
 
-        username = _keyring_username()
-        existing = keyring.get_password(_KEYRING_SERVICE, username)
-        if existing:
-            return existing
-        new_key = secrets.token_urlsafe(64)
-        keyring.set_password(_KEYRING_SERVICE, username, new_key)
-        return new_key
-    except Exception as exc:  # keyring missing or no usable backend
-        print(
-            "[oc-desktop] WARNING: could not persist SECRET_KEY via the OS "
-            f"keyring ({exc}); using an ephemeral key. Login sessions and stored "
-            "pipeline secrets (e.g. your OpenAI API key) will NOT survive a "
-            "restart. Export a stable DJANGO_SECRET_KEY to avoid this."
-        )
-        return secrets.token_urlsafe(64)
+    The keyring call runs in a daemon thread with a hard timeout: a locked
+    Linux keyring can block on an interactive unlock prompt instead of raising,
+    which would otherwise hang the launcher before any child starts. On timeout
+    OR any error (missing/broken backend), fall back to an ephemeral key with a
+    loud warning — sessions and stored pipeline secrets then do NOT survive a
+    restart.
+    """
+    import threading
+
+    box: dict = {}
+
+    def _run() -> None:
+        try:
+            box["key"] = _keyring_get_or_create()
+        except Exception as exc:  # keyring missing or no usable backend
+            box["error"] = exc
+
+    worker = threading.Thread(target=_run, daemon=True)
+    worker.start()
+    worker.join(_KEYRING_TIMEOUT_SECONDS)
+
+    if "key" in box:
+        return box["key"]
+
+    reason = (
+        f"timed out after {_KEYRING_TIMEOUT_SECONDS}s (a locked OS keyring can "
+        "block on an interactive unlock prompt)"
+        if worker.is_alive()
+        else f"failed ({box.get('error')})"
+    )
+    print(
+        f"[oc-desktop] WARNING: SECRET_KEY keyring persistence {reason}; using an "
+        "ephemeral key. Login sessions and stored pipeline secrets (e.g. your "
+        "OpenAI API key) will NOT survive a restart. Export a stable "
+        "DJANGO_SECRET_KEY to avoid this."
+    )
+    return secrets.token_urlsafe(64)
 
 
 # --------------------------------------------------------------------------- env
@@ -195,14 +229,24 @@ def _first_run_bootstrap(env: dict[str, str]) -> None:
     if marker.exists():
         return
     print("[oc-desktop] First run: bootstrapping local user + pipeline settings …")
-    _manage(env, "desktop_bootstrap")
-    marker.write_text("ok\n", encoding="utf-8")
+    # Write the first-run marker ONLY on a clean bootstrap (rc == 0). The command
+    # exits non-zero if pipeline seeding failed; leaving the marker unwritten lets
+    # the next launch retry (every step is idempotent) instead of permanently
+    # stranding Tier-1 embeddings/chat behind a one-shot failure.
+    if _manage(env, "desktop_bootstrap", check=False) == 0:
+        marker.write_text("ok\n", encoding="utf-8")
+    else:
+        print(
+            "[oc-desktop] WARNING: first-run bootstrap did not fully complete; "
+            "it will retry on the next launch."
+        )
 
 
 # --------------------------------------------------------------------------- SPA
 def _resolve_spa_dir(env: dict[str, str]) -> str:
     """Locate the built SPA dist/ dir and export it for settings + WhiteNoise."""
-    spa = os.environ.get("OC_DESKTOP_FRONTEND_DIR")
+    # Read from the threaded env (consistent with the rest of the launcher).
+    spa = env.get("OC_DESKTOP_FRONTEND_DIR")
     if not spa:
         candidate = Path(__file__).resolve().parents[2] / "frontend" / "dist"
         if candidate.is_dir():
@@ -362,9 +406,13 @@ def main() -> None:
     _write_env_config(spa_dir, port)
     _start_daphne(env, port)
 
-    url = f"http://127.0.0.1:{port}/"
+    base = f"http://127.0.0.1:{port}"
+    url = f"{base}/"
     print(f"[oc-desktop] OpenContracts is starting at {url}")
-    if not _wait_for_http(url, timeout=60):
+    # Health-check the API endpoint, NOT ``/``: when the SPA isn't built, ``/``
+    # redirects to the (absent) :3000 dev server and every poll would error,
+    # falsely reporting the server as down even though Daphne is up.
+    if not _wait_for_http(f"{base}/api/health/", timeout=60):
         print(
             "[oc-desktop] WARNING: server did not answer within 60s; opening the "
             "browser anyway — it may show a connection error until Daphne is up."

--- a/opencontractserver/desktop/launcher.py
+++ b/opencontractserver/desktop/launcher.py
@@ -131,9 +131,10 @@ def _start_postgres(env: dict[str, str]) -> None:
     Embedded-Postgres wiring is hardened in Phase 1; if ``pgserver`` is absent we
     fail fast with guidance rather than pretend a DB exists.
     """
-    external = os.environ.get("DATABASE_URL")
+    # Read from the threaded env (a copy of os.environ) for consistency with the
+    # rest of the launcher — nothing mutates DATABASE_URL before this point.
+    external = env.get("DATABASE_URL")
     if external:
-        env["DATABASE_URL"] = external
         print(f"[oc-desktop] Using external DATABASE_URL ({external.split('@')[-1]}).")
         return
 
@@ -310,10 +311,13 @@ def main() -> None:
     port = _free_port()
     _write_env_config(spa_dir, port)
 
+    # Single teardown path: atexit runs _shutdown on every exit (normal return,
+    # SystemExit from a signal, or an unhandled exception). The signal handlers
+    # just raise SystemExit so they funnel through the same hook rather than
+    # calling _shutdown themselves (which would run it twice).
     atexit.register(_shutdown)
 
     def _handle_signal(_signum, _frame):
-        _shutdown()
         sys.exit(0)
 
     signal.signal(signal.SIGINT, _handle_signal)
@@ -330,16 +334,13 @@ def main() -> None:
     with contextlib.suppress(Exception):
         webbrowser.open(url)
 
-    # Supervise: exit if any child dies.
-    try:
-        while True:
-            for proc in _children:
-                if proc.poll() is not None:
-                    print(f"[oc-desktop] child pid {proc.pid} exited; shutting down.")
-                    return
-            time.sleep(1)
-    finally:
-        _shutdown()
+    # Supervise: return (atexit then tears everything down) if any child dies.
+    while True:
+        for proc in _children:
+            if proc.poll() is not None:
+                print(f"[oc-desktop] child pid {proc.pid} exited; shutting down.")
+                return
+        time.sleep(1)
 
 
 def _wait_for_http(url: str, timeout: int = 60) -> bool:

--- a/opencontractserver/desktop/launcher.py
+++ b/opencontractserver/desktop/launcher.py
@@ -330,7 +330,11 @@ def main() -> None:
 
     url = f"http://127.0.0.1:{port}/"
     print(f"[oc-desktop] OpenContracts is starting at {url}")
-    _wait_for_http(url, timeout=60)
+    if not _wait_for_http(url, timeout=60):
+        print(
+            "[oc-desktop] WARNING: server did not answer within 60s; opening the "
+            "browser anyway — it may show a connection error until Daphne is up."
+        )
     with contextlib.suppress(Exception):
         webbrowser.open(url)
 

--- a/opencontractserver/desktop/launcher.py
+++ b/opencontractserver/desktop/launcher.py
@@ -1,0 +1,301 @@
+"""``oc-desktop`` launcher: run all of OpenContracts as one supervised process.
+
+Phase 0 of the desktop packaging effort (see
+``docs/deployment/desktop_packaging.md``). Starts the whole stack with **no
+Docker and no Redis**:
+
+* an embedded PostgreSQL+pgvector child (via the optional ``pgserver`` package)
+  or an external ``DATABASE_URL`` you provide,
+* ``manage.py migrate`` + a one-time first-run bootstrap (local user, pipeline
+  seeding, nltk corpora),
+* Daphne (ASGI + the pre-built SPA) on a free loopback port,
+* a Celery worker and beat subprocess over the filesystem broker,
+
+then opens the browser and supervises the children, tearing them down cleanly on
+exit.
+
+Run with ``python oc-desktop.py`` (repo root) or
+``python -m opencontractserver.desktop.launcher``.
+"""
+
+from __future__ import annotations
+
+import atexit
+import contextlib
+import os
+import signal
+import socket
+import subprocess
+import sys
+import time
+import webbrowser
+from pathlib import Path
+
+from opencontractserver.desktop import paths
+
+SETTINGS_MODULE = "config.settings.desktop"
+_children: list[subprocess.Popen] = []
+
+
+# --------------------------------------------------------------------------- env
+def _base_env() -> dict[str, str]:
+    """Environment shared by the launcher and every child process."""
+    env = os.environ.copy()
+    env["DJANGO_SETTINGS_MODULE"] = SETTINGS_MODULE
+    env["DJANGO_READ_DOT_ENV_FILE"] = "False"
+    data_dir = paths.app_data_dir()
+    env[paths.DATA_DIR_ENV] = str(data_dir)
+    # Point nltk at the app-data corpora dir so Warp-Ingest resolves stopwords
+    # / punkt offline.
+    env["NLTK_DATA"] = str(paths.subdir("nltk_data"))
+    return env
+
+
+def _ensure_dirs() -> None:
+    for maker in (
+        paths.app_data_dir,
+        paths.media_dir,
+        paths.static_dir,
+        paths.logs_dir,
+    ):
+        Path(maker()).mkdir(parents=True, exist_ok=True)
+    for name in ("in", "out", "control"):
+        (paths.celery_broker_dir() / name).mkdir(parents=True, exist_ok=True)
+
+
+def _free_port() -> int:
+    """Ask the OS for a free loopback TCP port (bind :0, read, release)."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+# ---------------------------------------------------------------------- postgres
+def _start_postgres(env: dict[str, str]) -> None:
+    """Ensure ``DATABASE_URL`` points at a running Postgres+pgvector.
+
+    Preference order:
+    1. An externally-provided ``DATABASE_URL`` (e.g. a Postgres you already run)
+       — used as-is.
+    2. The bundled embedded server via ``pgserver`` (optional dependency).
+
+    Embedded-Postgres wiring is hardened in Phase 1; if ``pgserver`` is absent we
+    fail fast with guidance rather than pretend a DB exists.
+    """
+    external = os.environ.get("DATABASE_URL")
+    if external:
+        env["DATABASE_URL"] = external
+        print(f"[oc-desktop] Using external DATABASE_URL ({external.split('@')[-1]}).")
+        return
+
+    try:
+        import pgserver
+    except ImportError:
+        sys.exit(
+            "[oc-desktop] No DATABASE_URL set and 'pgserver' is not installed.\n"
+            "  Install the desktop extras (pip install -r requirements/desktop.txt)\n"
+            "  or export DATABASE_URL pointing at a PostgreSQL 16 + pgvector server."
+        )
+
+    pgdata = paths.pg_data_dir()
+    pgdata.mkdir(parents=True, exist_ok=True)
+    print(f"[oc-desktop] Starting embedded PostgreSQL at {pgdata} …")
+    server = pgserver.get_server(str(pgdata))
+
+    def _stop_pg() -> None:
+        with contextlib.suppress(Exception):
+            server.cleanup()
+
+    atexit.register(_stop_pg)
+    # pgvector must be available before migrations create the vector columns.
+    server.psql("CREATE EXTENSION IF NOT EXISTS vector;")
+    env["DATABASE_URL"] = server.get_uri()
+    print("[oc-desktop] Embedded PostgreSQL ready.")
+
+
+# --------------------------------------------------------------------- manage.py
+def _manage(env: dict[str, str], *args: str, check: bool = True) -> int:
+    """Run ``manage.py <args>`` in-process-adjacent (subprocess) with desktop env."""
+    cmd = [sys.executable, "manage.py", *args]
+    proc = subprocess.run(cmd, env=env)
+    if check and proc.returncode != 0:
+        sys.exit(f"[oc-desktop] `manage.py {' '.join(args)}` failed.")
+    return proc.returncode
+
+
+def _first_run_bootstrap(env: dict[str, str]) -> None:
+    marker = paths.first_run_marker()
+    if marker.exists():
+        return
+    print("[oc-desktop] First run: bootstrapping local user + pipeline settings …")
+    _manage(env, "desktop_bootstrap")
+    marker.write_text("ok\n", encoding="utf-8")
+
+
+# --------------------------------------------------------------------------- SPA
+def _resolve_spa_dir(env: dict[str, str]) -> str:
+    """Locate the built SPA dist/ dir and export it for settings + WhiteNoise."""
+    spa = os.environ.get("OC_DESKTOP_FRONTEND_DIR")
+    if not spa:
+        candidate = Path(__file__).resolve().parents[2] / "frontend" / "dist"
+        if candidate.is_dir():
+            spa = str(candidate)
+    if spa:
+        env["OC_DESKTOP_FRONTEND_DIR"] = spa
+    return spa or ""
+
+
+def _write_env_config(spa_dir: str, port: int) -> None:
+    """Point the SPA's runtime config at this Daphne origin (same-origin API)."""
+    if not spa_dir:
+        return
+    origin = f"http://127.0.0.1:{port}"
+    content = (
+        "window._env_ = {\n"
+        f'  "REACT_APP_API_ROOT_URL": "{origin}",\n'
+        f'  "REACT_APP_WS_ROOT_URL": "ws://127.0.0.1:{port}",\n'
+        '  "REACT_APP_USE_AUTH0": "false",\n'
+        "};\n"
+    )
+    with contextlib.suppress(OSError):
+        (Path(spa_dir) / "env-config.js").write_text(content, encoding="utf-8")
+
+
+# ---------------------------------------------------------------- child processes
+def _spawn(name: str, cmd: list[str], env: dict[str, str]) -> subprocess.Popen:
+    print(f"[oc-desktop] starting {name}: {' '.join(cmd)}")
+    proc = subprocess.Popen(cmd, env=env)
+    _children.append(proc)
+    return proc
+
+
+def _start_daphne(env: dict[str, str], port: int) -> subprocess.Popen:
+    return _spawn(
+        "daphne",
+        [
+            sys.executable,
+            "-m",
+            "daphne",
+            "-b",
+            "127.0.0.1",
+            "-p",
+            str(port),
+            "config.asgi:application",
+        ],
+        env,
+    )
+
+
+def _start_worker(env: dict[str, str]) -> subprocess.Popen:
+    return _spawn(
+        "celery-worker",
+        [
+            sys.executable,
+            "-m",
+            "celery",
+            "-A",
+            "config.celery_app",
+            "worker",
+            "-l",
+            "INFO",
+            "--concurrency=1",
+            "-Q",
+            "celery,worker_uploads",
+        ],
+        env,
+    )
+
+
+def _start_beat(env: dict[str, str]) -> subprocess.Popen:
+    schedule_file = str(paths.subdir("celery-broker") / "beat-schedule")
+    return _spawn(
+        "celery-beat",
+        [
+            sys.executable,
+            "-m",
+            "celery",
+            "-A",
+            "config.celery_app",
+            "beat",
+            "-l",
+            "INFO",
+            "-s",
+            schedule_file,
+        ],
+        env,
+    )
+
+
+# ---------------------------------------------------------------------- shutdown
+def _shutdown(*_args) -> None:
+    for proc in reversed(_children):
+        if proc.poll() is None:
+            with contextlib.suppress(Exception):
+                proc.terminate()
+    deadline = time.time() + 10
+    for proc in reversed(_children):
+        with contextlib.suppress(Exception):
+            proc.wait(timeout=max(0, deadline - time.time()))
+    for proc in reversed(_children):
+        if proc.poll() is None:
+            with contextlib.suppress(Exception):
+                proc.kill()
+
+
+def main() -> None:
+    os.chdir(Path(__file__).resolve().parents[2])  # repo root (manage.py lives here)
+    env = _base_env()
+    _ensure_dirs()
+
+    _start_postgres(env)
+    _manage(env, "migrate", "--noinput")
+    _first_run_bootstrap(env)
+    _manage(env, "collectstatic", "--noinput", check=False)
+
+    spa_dir = _resolve_spa_dir(env)
+    port = _free_port()
+    _write_env_config(spa_dir, port)
+
+    atexit.register(_shutdown)
+    signal.signal(signal.SIGINT, lambda *a: (_shutdown(), sys.exit(0)))
+    with contextlib.suppress(AttributeError, ValueError):
+        signal.signal(signal.SIGTERM, lambda *a: (_shutdown(), sys.exit(0)))
+
+    _start_worker(env)
+    _start_beat(env)
+    _start_daphne(env, port)
+
+    url = f"http://127.0.0.1:{port}/"
+    print(f"[oc-desktop] OpenContracts is starting at {url}")
+    _wait_for_http(url, timeout=60)
+    with contextlib.suppress(Exception):
+        webbrowser.open(url)
+
+    # Supervise: exit if any child dies.
+    try:
+        while True:
+            for proc in _children:
+                if proc.poll() is not None:
+                    print(f"[oc-desktop] child pid {proc.pid} exited; shutting down.")
+                    return
+            time.sleep(1)
+    finally:
+        _shutdown()
+
+
+def _wait_for_http(url: str, timeout: int = 60) -> bool:
+    import urllib.error
+    import urllib.request
+
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            with urllib.request.urlopen(url, timeout=2):
+                return True
+        except (urllib.error.URLError, ConnectionError, OSError):
+            time.sleep(1)
+    return False
+
+
+if __name__ == "__main__":
+    main()

--- a/opencontractserver/desktop/launcher.py
+++ b/opencontractserver/desktop/launcher.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import atexit
 import contextlib
 import os
+import secrets
 import signal
 import socket
 import subprocess
@@ -48,6 +49,10 @@ def _base_env() -> dict[str, str]:
     # Point nltk at the app-data corpora dir so Warp-Ingest resolves stopwords
     # / punkt offline.
     env["NLTK_DATA"] = str(paths.subdir("nltk_data"))
+    # One SECRET_KEY shared by every child (Daphne/worker/beat) so sessions and
+    # JWTs verify across them. Generated per launch when unset — an ephemeral
+    # key; export DJANGO_SECRET_KEY yourself for stability across runs.
+    env.setdefault("DJANGO_SECRET_KEY", secrets.token_urlsafe(64))
     return env
 
 
@@ -64,7 +69,13 @@ def _ensure_dirs() -> None:
 
 
 def _free_port() -> int:
-    """Ask the OS for a free loopback TCP port (bind :0, read, release)."""
+    """Ask the OS for a free loopback TCP port (bind :0, read, release).
+
+    Note: there is a small TOCTOU window between releasing the probe socket here
+    and Daphne binding the port below. On a single-user loopback app the risk of
+    another process grabbing it in that window is negligible; hardening this into
+    a bind-retry loop is a Phase-1 follow-up.
+    """
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.bind(("127.0.0.1", 0))
         return int(sock.getsockname()[1])
@@ -150,10 +161,11 @@ def _write_env_config(spa_dir: str, port: int) -> None:
     if not spa_dir:
         return
     origin = f"http://127.0.0.1:{port}"
+    # The SPA resolves the WS origin from window.location (same-origin), so only
+    # the API root + Auth0 flag need injecting here.
     content = (
         "window._env_ = {\n"
         f'  "REACT_APP_API_ROOT_URL": "{origin}",\n'
-        f'  "REACT_APP_WS_ROOT_URL": "ws://127.0.0.1:{port}",\n'
         '  "REACT_APP_USE_AUTH0": "false",\n'
         "};\n"
     )
@@ -257,9 +269,14 @@ def main() -> None:
     _write_env_config(spa_dir, port)
 
     atexit.register(_shutdown)
-    signal.signal(signal.SIGINT, lambda *a: (_shutdown(), sys.exit(0)))
+
+    def _handle_signal(_signum, _frame):
+        _shutdown()
+        sys.exit(0)
+
+    signal.signal(signal.SIGINT, _handle_signal)
     with contextlib.suppress(AttributeError, ValueError):
-        signal.signal(signal.SIGTERM, lambda *a: (_shutdown(), sys.exit(0)))
+        signal.signal(signal.SIGTERM, _handle_signal)
 
     _start_worker(env)
     _start_beat(env)

--- a/opencontractserver/desktop/paths.py
+++ b/opencontractserver/desktop/paths.py
@@ -1,0 +1,81 @@
+"""Per-user, per-OS application-data paths for the desktop build.
+
+Pure standard library (no third-party dependency) so it is safe to import from
+``config/settings/desktop.py`` at settings-load time. All locations can be
+overridden with the ``OC_DESKTOP_DATA_DIR`` environment variable; the launcher
+sets that once and every component (settings, Postgres data dir, media/static,
+Celery filesystem broker) derives from it.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+APP_NAME = "OpenContracts"
+# Environment variable the launcher exports so settings + launcher agree on the
+# root without recomputing platform rules twice.
+DATA_DIR_ENV = "OC_DESKTOP_DATA_DIR"
+
+
+def default_app_data_dir() -> Path:
+    """Return the conventional per-user data directory for this OS.
+
+    * Windows: ``%LOCALAPPDATA%\\OpenContracts``
+    * macOS:   ``~/Library/Application Support/OpenContracts``
+    * Linux:   ``$XDG_DATA_HOME/OpenContracts`` (default ``~/.local/share``)
+    """
+    if sys.platform.startswith("win"):
+        base = os.environ.get("LOCALAPPDATA") or os.path.expanduser("~")
+        return Path(base) / APP_NAME
+    if sys.platform == "darwin":
+        return (
+            Path(os.path.expanduser("~")) / "Library" / "Application Support" / APP_NAME
+        )
+    xdg = os.environ.get("XDG_DATA_HOME")
+    base = Path(xdg) if xdg else Path(os.path.expanduser("~")) / ".local" / "share"
+    return base / APP_NAME
+
+
+def app_data_dir() -> Path:
+    """Resolved data dir: the ``OC_DESKTOP_DATA_DIR`` override or the OS default."""
+    override = os.environ.get(DATA_DIR_ENV)
+    return Path(override) if override else default_app_data_dir()
+
+
+def subdir(*parts: str, create: bool = False) -> Path:
+    """Return ``app_data_dir()/parts``, optionally creating it."""
+    path = app_data_dir().joinpath(*parts)
+    if create:
+        path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+# Well-known locations, all under the single data dir.
+def pg_data_dir() -> Path:
+    return subdir("pgdata")
+
+
+def media_dir() -> Path:
+    return subdir("media")
+
+
+def static_dir() -> Path:
+    return subdir("staticfiles")
+
+
+def celery_broker_dir() -> Path:
+    return subdir("celery-broker")
+
+
+def logs_dir() -> Path:
+    return subdir("logs")
+
+
+def secret_key_file() -> Path:
+    return app_data_dir() / "secret_key"
+
+
+def first_run_marker() -> Path:
+    return app_data_dir() / ".bootstrapped"

--- a/opencontractserver/desktop/paths.py
+++ b/opencontractserver/desktop/paths.py
@@ -73,9 +73,5 @@ def logs_dir() -> Path:
     return subdir("logs")
 
 
-def secret_key_file() -> Path:
-    return app_data_dir() / "secret_key"
-
-
 def first_run_marker() -> Path:
     return app_data_dir() / ".bootstrapped"

--- a/opencontractserver/documents/management/commands/desktop_bootstrap.py
+++ b/opencontractserver/documents/management/commands/desktop_bootstrap.py
@@ -18,12 +18,12 @@ See ``docs/deployment/desktop_packaging.md``.
 """
 
 import logging
+import os
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.management import call_command
 from django.core.management.base import BaseCommand
-from django.utils.crypto import get_random_string
 
 from opencontractserver.desktop import paths
 
@@ -64,25 +64,29 @@ class Command(BaseCommand):
             self.stdout.write(f"Local user '{username}' already exists; skipping.")
             return
 
-        creds_file = paths.app_data_dir() / "credentials.txt"
-        password = get_random_string(20)
-        User.objects.create_superuser(username=username, email=email, password=password)
-        try:
-            creds_file.parent.mkdir(parents=True, exist_ok=True)
-            creds_file.write_text(
-                f"username: {username}\npassword: {password}\n", encoding="utf-8"
-            )
-            import os
-
-            os.chmod(creds_file, 0o600)
-            where = f" (saved to {creds_file})"
-        except OSError:
-            where = ""
-        self.stdout.write(
-            self.style.SUCCESS(
-                f"Created local superuser '{username}'{where}. " f"Password: {password}"
-            )
+        # The login password comes ONLY from the environment — never generated,
+        # stored on disk, or printed (avoids clear-text secret handling). When
+        # unset, the user is created with an unusable password and the operator
+        # sets one explicitly; the launcher passes OC_DESKTOP_PASSWORD through.
+        password = os.environ.get("OC_DESKTOP_PASSWORD") or None
+        user = User.objects.create_superuser(
+            username=username, email=email, password=password
         )
+        if password:
+            self.stdout.write(
+                self.style.SUCCESS(f"Created local superuser '{username}'.")
+            )
+        else:
+            user.set_unusable_password()
+            user.save(update_fields=["password"])
+            self.stdout.write(
+                self.style.WARNING(
+                    f"Created local superuser '{username}' with NO login "
+                    "password. Set OC_DESKTOP_PASSWORD before first run, or run "
+                    f"`python manage.py changepassword {username} "
+                    "--settings=config.settings.desktop` to enable login."
+                )
+            )
 
     # -------------------------------------------------------- pipeline settings
     def _seed_pipeline_settings(self) -> None:
@@ -93,15 +97,28 @@ class Command(BaseCommand):
         # (PREFERRED_PARSERS/PREFERRED_EMBEDDERS/DEFAULT_EMBEDDER → Warp-Ingest /
         # OpenAIEmbedder). migrate_pipeline_settings then fills component_settings
         # and encrypted secrets (e.g. OPENAI_API_KEY) from settings/env.
+        # get_instance() already seeds the parser/embedder SELECTION from Django
+        # settings, so a migrate_pipeline_settings failure only leaves the
+        # component_settings/secrets (e.g. OPENAI_API_KEY) unseeded — PDF parsing
+        # still works, only Tier-1 embeddings/chat degrade. Surface it loudly
+        # rather than silently, since the .bootstrapped marker is written after.
         PipelineSettings.get_instance()
         try:
             call_command("migrate_pipeline_settings")
-        except Exception as exc:  # pragma: no cover - defensive
-            logger.warning("migrate_pipeline_settings failed: %s", exc)
-        self.stdout.write(
-            "Seeded pipeline components: PDF → Warp-Ingest, embeddings → "
-            f"{getattr(settings, 'DEFAULT_EMBEDDER', '?')}."
-        )
+            self.stdout.write(
+                "Seeded pipeline components: PDF → Warp-Ingest, embeddings → "
+                f"{getattr(settings, 'DEFAULT_EMBEDDER', '?')}."
+            )
+        except Exception as exc:
+            logger.error("migrate_pipeline_settings failed: %s", exc, exc_info=True)
+            self.stderr.write(
+                self.style.WARNING(
+                    "Pipeline SECRET/component settings did not seed "
+                    f"({exc}). PDF parsing still works; embeddings/chat may be "
+                    "disabled until you re-run `python manage.py "
+                    "migrate_pipeline_settings --settings=config.settings.desktop`."
+                )
+            )
 
     # ------------------------------------------------------------------ nltk
     def _ensure_nltk_data(self) -> None:

--- a/opencontractserver/documents/management/commands/desktop_bootstrap.py
+++ b/opencontractserver/documents/management/commands/desktop_bootstrap.py
@@ -69,16 +69,14 @@ class Command(BaseCommand):
         # unset, the user is created with an unusable password and the operator
         # sets one explicitly; the launcher passes OC_DESKTOP_PASSWORD through.
         password = os.environ.get("OC_DESKTOP_PASSWORD") or None
-        user = User.objects.create_superuser(
-            username=username, email=email, password=password
-        )
+        # create_superuser(password=None) already stores an unusable password
+        # (set_password(None) -> set_unusable_password), so no explicit reset.
+        User.objects.create_superuser(username=username, email=email, password=password)
         if password:
             self.stdout.write(
                 self.style.SUCCESS(f"Created local superuser '{username}'.")
             )
         else:
-            user.set_unusable_password()
-            user.save(update_fields=["password"])
             self.stdout.write(
                 self.style.WARNING(
                     f"Created local superuser '{username}' with NO login "

--- a/opencontractserver/documents/management/commands/desktop_bootstrap.py
+++ b/opencontractserver/documents/management/commands/desktop_bootstrap.py
@@ -23,7 +23,7 @@ import os
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.management import call_command
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 
 from opencontractserver.desktop import paths
 
@@ -51,10 +51,20 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
+        # Seed the (idempotent) user and nltk corpora regardless, then signal
+        # failure via a non-zero exit if pipeline seeding did not fully succeed.
+        # The launcher only writes the first-run marker on a clean exit, so a
+        # transient failure here is retried automatically on the next launch
+        # rather than permanently disabling Tier-1 embeddings/chat.
         self._seed_user(options["username"], options["email"])
-        self._seed_pipeline_settings()
+        pipeline_ok = self._seed_pipeline_settings()
         if not options["skip_nltk"]:
             self._ensure_nltk_data()
+        if not pipeline_ok:
+            raise CommandError(
+                "Pipeline settings did not fully seed; the desktop launcher will "
+                "retry bootstrap on the next launch."
+            )
         self.stdout.write(self.style.SUCCESS("Desktop bootstrap complete."))
 
     # ------------------------------------------------------------------ user
@@ -87,8 +97,12 @@ class Command(BaseCommand):
             )
 
     # -------------------------------------------------------- pipeline settings
-    def _seed_pipeline_settings(self) -> None:
-        """Seed the PipelineSettings singleton at the offline components."""
+    def _seed_pipeline_settings(self) -> bool:
+        """Seed the PipelineSettings singleton at the offline components.
+
+        Returns True on success, False if ``migrate_pipeline_settings`` failed
+        (the caller turns a False into a non-zero exit so the launcher retries).
+        """
         from opencontractserver.documents.models import PipelineSettings
 
         # get_instance() creates pk=1 seeded from the desktop Django settings
@@ -96,9 +110,7 @@ class Command(BaseCommand):
         # OpenAIEmbedder) — so the parser/embedder SELECTION is seeded here.
         # migrate_pipeline_settings then fills component_settings + encrypted
         # secrets (e.g. OPENAI_API_KEY). A failure there only leaves those
-        # unseeded — PDF parsing still works, only Tier-1 embeddings/chat degrade
-        # — so surface it loudly rather than silently, since the .bootstrapped
-        # marker is written after this returns.
+        # unseeded — PDF parsing still works, only Tier-1 embeddings/chat degrade.
         PipelineSettings.get_instance()
         try:
             call_command("migrate_pipeline_settings")
@@ -106,16 +118,19 @@ class Command(BaseCommand):
                 "Seeded pipeline components: PDF → Warp-Ingest, embeddings → "
                 f"{getattr(settings, 'DEFAULT_EMBEDDER', '?')}."
             )
+            return True
         except Exception as exc:
             logger.error("migrate_pipeline_settings failed: %s", exc, exc_info=True)
             self.stderr.write(
                 self.style.WARNING(
                     "Pipeline SECRET/component settings did not seed "
                     f"({exc}). PDF parsing still works; embeddings/chat may be "
-                    "disabled until you re-run `python manage.py "
-                    "migrate_pipeline_settings --settings=config.settings.desktop`."
+                    "disabled until the next launch retries bootstrap (or you "
+                    "re-run `python manage.py migrate_pipeline_settings "
+                    "--settings=config.settings.desktop`)."
                 )
             )
+            return False
 
     # ------------------------------------------------------------------ nltk
     def _ensure_nltk_data(self) -> None:

--- a/opencontractserver/documents/management/commands/desktop_bootstrap.py
+++ b/opencontractserver/documents/management/commands/desktop_bootstrap.py
@@ -5,8 +5,8 @@ Idempotent. Run once after ``migrate`` on the desktop profile
 launcher invokes it automatically on first boot. It:
 
 1. Creates a single local superuser for the graphql_jwt / session login
-   (Auth0 is off on desktop), persisting the generated password under the
-   app-data dir.
+   (Auth0 is off on desktop) from the ``OC_DESKTOP_PASSWORD`` env var; no
+   secret is generated, printed, or written to disk.
 2. Seeds the ``PipelineSettings`` singleton from the desktop Django settings —
    PDF → Warp-Ingest, embeddings → OpenAI-compatible endpoint — via
    ``migrate_pipeline_settings``. That row is written ONCE, so it must be seeded
@@ -93,13 +93,12 @@ class Command(BaseCommand):
 
         # get_instance() creates pk=1 seeded from the desktop Django settings
         # (PREFERRED_PARSERS/PREFERRED_EMBEDDERS/DEFAULT_EMBEDDER → Warp-Ingest /
-        # OpenAIEmbedder). migrate_pipeline_settings then fills component_settings
-        # and encrypted secrets (e.g. OPENAI_API_KEY) from settings/env.
-        # get_instance() already seeds the parser/embedder SELECTION from Django
-        # settings, so a migrate_pipeline_settings failure only leaves the
-        # component_settings/secrets (e.g. OPENAI_API_KEY) unseeded — PDF parsing
-        # still works, only Tier-1 embeddings/chat degrade. Surface it loudly
-        # rather than silently, since the .bootstrapped marker is written after.
+        # OpenAIEmbedder) — so the parser/embedder SELECTION is seeded here.
+        # migrate_pipeline_settings then fills component_settings + encrypted
+        # secrets (e.g. OPENAI_API_KEY). A failure there only leaves those
+        # unseeded — PDF parsing still works, only Tier-1 embeddings/chat degrade
+        # — so surface it loudly rather than silently, since the .bootstrapped
+        # marker is written after this returns.
         PipelineSettings.get_instance()
         try:
             call_command("migrate_pipeline_settings")

--- a/opencontractserver/documents/management/commands/desktop_bootstrap.py
+++ b/opencontractserver/documents/management/commands/desktop_bootstrap.py
@@ -1,0 +1,122 @@
+"""First-run bootstrap for the single-user desktop build.
+
+Idempotent. Run once after ``migrate`` on the desktop profile
+(``DJANGO_SETTINGS_MODULE=config.settings.desktop``); the ``oc-desktop``
+launcher invokes it automatically on first boot. It:
+
+1. Creates a single local superuser for the graphql_jwt / session login
+   (Auth0 is off on desktop), persisting the generated password under the
+   app-data dir.
+2. Seeds the ``PipelineSettings`` singleton from the desktop Django settings —
+   PDF → Warp-Ingest, embeddings → OpenAI-compatible endpoint — via
+   ``migrate_pipeline_settings``. That row is written ONCE, so it must be seeded
+   explicitly here rather than relying on later settings changes.
+3. Ensures the ``nltk`` corpora Warp-Ingest imports at load time
+   (``stopwords``, ``punkt``) are present for offline use.
+
+See ``docs/deployment/desktop_packaging.md``.
+"""
+
+import logging
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.core.management import call_command
+from django.core.management.base import BaseCommand
+from django.utils.crypto import get_random_string
+
+from opencontractserver.desktop import paths
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = "First-run bootstrap for the single-user desktop build (idempotent)."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--username",
+            default="desktop",
+            help="Username for the local superuser (default: 'desktop').",
+        )
+        parser.add_argument(
+            "--email",
+            default="desktop@localhost",
+            help="Email for the local superuser.",
+        )
+        parser.add_argument(
+            "--skip-nltk",
+            action="store_true",
+            help="Do not attempt to download nltk corpora.",
+        )
+
+    def handle(self, *args, **options):
+        self._seed_user(options["username"], options["email"])
+        self._seed_pipeline_settings()
+        if not options["skip_nltk"]:
+            self._ensure_nltk_data()
+        self.stdout.write(self.style.SUCCESS("Desktop bootstrap complete."))
+
+    # ------------------------------------------------------------------ user
+    def _seed_user(self, username: str, email: str) -> None:
+        User = get_user_model()
+        if User.objects.filter(username=username).exists():
+            self.stdout.write(f"Local user '{username}' already exists; skipping.")
+            return
+
+        creds_file = paths.app_data_dir() / "credentials.txt"
+        password = get_random_string(20)
+        User.objects.create_superuser(username=username, email=email, password=password)
+        try:
+            creds_file.parent.mkdir(parents=True, exist_ok=True)
+            creds_file.write_text(
+                f"username: {username}\npassword: {password}\n", encoding="utf-8"
+            )
+            import os
+
+            os.chmod(creds_file, 0o600)
+            where = f" (saved to {creds_file})"
+        except OSError:
+            where = ""
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Created local superuser '{username}'{where}. " f"Password: {password}"
+            )
+        )
+
+    # -------------------------------------------------------- pipeline settings
+    def _seed_pipeline_settings(self) -> None:
+        """Seed the PipelineSettings singleton at the offline components."""
+        from opencontractserver.documents.models import PipelineSettings
+
+        # get_instance() creates pk=1 seeded from the desktop Django settings
+        # (PREFERRED_PARSERS/PREFERRED_EMBEDDERS/DEFAULT_EMBEDDER → Warp-Ingest /
+        # OpenAIEmbedder). migrate_pipeline_settings then fills component_settings
+        # and encrypted secrets (e.g. OPENAI_API_KEY) from settings/env.
+        PipelineSettings.get_instance()
+        try:
+            call_command("migrate_pipeline_settings")
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("migrate_pipeline_settings failed: %s", exc)
+        self.stdout.write(
+            "Seeded pipeline components: PDF → Warp-Ingest, embeddings → "
+            f"{getattr(settings, 'DEFAULT_EMBEDDER', '?')}."
+        )
+
+    # ------------------------------------------------------------------ nltk
+    def _ensure_nltk_data(self) -> None:
+        try:
+            import nltk
+        except ImportError:
+            self.stdout.write("nltk not installed; skipping corpus download.")
+            return
+
+        nltk_dir = paths.subdir("nltk_data", create=True)
+        if str(nltk_dir) not in nltk.data.path:
+            nltk.data.path.insert(0, str(nltk_dir))
+        for resource in ("stopwords", "punkt", "punkt_tab"):
+            try:
+                nltk.download(resource, download_dir=str(nltk_dir), quiet=True)
+            except Exception as exc:  # pragma: no cover - network dependent
+                logger.warning("Could not download nltk '%s': %s", resource, exc)
+        self.stdout.write(f"nltk corpora ready under {nltk_dir}.")

--- a/opencontractserver/pipeline/parsers/warp_ingest_parser.py
+++ b/opencontractserver/pipeline/parsers/warp_ingest_parser.py
@@ -1,0 +1,188 @@
+"""Warp-Ingest parser: a pure-Python, in-process PDF parser.
+
+`Warp-Ingest <https://github.com/Open-Source-Legal/Warp-Ingest>`_ is a
+rule-based (non-ML, no-GPU) PDF layout engine built on ``pdfplumber``. It turns
+a PDF into layout-aware structure — word/block bounding boxes, structural labels
+(section header, paragraph, list item, table row) and the parent ↔ child heading
+hierarchy — and renders it directly as an OpenContracts structural export
+(``pdf_ingestor.parse_to_opencontracts``): PAWLS word tokens, one structural
+annotation per block, and the heading hierarchy as ``OC_PARENT_CHILD``
+relationships.
+
+Because it runs entirely in-process (optional CPU-only OCR via
+``rapidocr-onnxruntime`` for scanned pages) with no microservice and no torch,
+it is the parser used by the single-user *desktop* build to replace the
+Docling parsing microservice. It is registered here for any deployment, but is
+only selected when ``PREFERRED_PARSERS`` / ``PipelineSettings`` point at it (the
+docker-compose default remains Docling).
+
+``warp-ingest`` is an OPTIONAL dependency — it is imported lazily inside
+:meth:`WarpIngestParser._parse_document_impl` so pipeline auto-discovery keeps
+working when the package is not installed. Install it (and its OCR extra for
+scanned PDFs) with ``pip install "warp-ingest[ocr]"``. The ``nltk`` ``stopwords``
+and ``punkt`` corpora must be available (Warp-Ingest imports them at module
+load); the desktop bootstrap downloads them on first run.
+"""
+
+import logging
+import os
+import tempfile
+from dataclasses import dataclass, field
+from typing import Optional
+
+from django.core.files.storage import default_storage
+
+from opencontractserver.documents.models import Document
+from opencontractserver.pipeline.base.exceptions import DocumentParsingError
+from opencontractserver.pipeline.base.file_types import FileTypeEnum
+from opencontractserver.pipeline.base.parser import BaseParser
+from opencontractserver.pipeline.base.settings_schema import (
+    PipelineSetting,
+    SettingType,
+)
+from opencontractserver.types.dicts import OpenContractDocExport
+
+logger = logging.getLogger(__name__)
+
+
+class WarpIngestParser(BaseParser):
+    """Parse PDFs to an ``OpenContractDocExport`` with the Warp-Ingest engine."""
+
+    title = "Warp-Ingest Parser"
+    description = (
+        "Rule-based, in-process PDF parser (Warp-Ingest). Emits PAWLS tokens, "
+        "structural annotations and the heading hierarchy with no ML model, no "
+        "GPU and no external microservice."
+    )
+    author = "Open Source Legal"
+    # Optional dependency: imported lazily so pipeline discovery does not require
+    # it. Declared here for documentation / the migrate_pipeline_settings audit.
+    dependencies = ["warp-ingest"]
+    supported_file_types = [FileTypeEnum.PDF]
+
+    @dataclass
+    class Settings:
+        """Configuration schema for :class:`WarpIngestParser`."""
+
+        apply_ocr: bool = field(
+            default=False,
+            metadata={
+                "pipeline_setting": PipelineSetting(
+                    setting_type=SettingType.OPTIONAL,
+                    description=(
+                        "Force OCR on every page. When False (default), "
+                        "Warp-Ingest auto-routes only scanned/sparse pages to "
+                        "OCR and keeps born-digital pages on their text layer. "
+                        "Requires the 'ocr' extra (rapidocr-onnxruntime)."
+                    ),
+                    env_var="WARP_INGEST_APPLY_OCR",
+                )
+            },
+        )
+        disable_ocr: bool = field(
+            default=False,
+            metadata={
+                "pipeline_setting": PipelineSetting(
+                    setting_type=SettingType.OPTIONAL,
+                    description=(
+                        "Never OCR: keep every page on its embedded text layer "
+                        "even when it looks scanned. Mutually exclusive with "
+                        "apply_ocr; avoids pulling the OCR extra."
+                    ),
+                    env_var="WARP_INGEST_DISABLE_OCR",
+                )
+            },
+        )
+        semantic_units: bool = field(
+            default=False,
+            metadata={
+                "pipeline_setting": PipelineSetting(
+                    setting_type=SettingType.OPTIONAL,
+                    description=(
+                        "Append Warp-Ingest's additive Semantic-Unit clause "
+                        "layer to the structural annotations."
+                    ),
+                    env_var="WARP_INGEST_SEMANTIC_UNITS",
+                )
+            },
+        )
+
+    def _parse_document_impl(
+        self, user_id: int, doc_id: int, **all_kwargs
+    ) -> Optional[OpenContractDocExport]:
+        """Parse ``doc_id``'s PDF into an ``OpenContractDocExport``.
+
+        Reads the document's stored PDF, hands it to Warp-Ingest and returns the
+        structural export ready for :meth:`BaseParser.save_parsed_data`.
+        Returns ``None`` when the document has no PDF file. Raises
+        :class:`DocumentParsingError` (permanent) on a genuine parse failure or a
+        missing ``warp-ingest`` install — Warp-Ingest is deterministic and local,
+        so a failure will not succeed on retry.
+        """
+        logger.info(
+            f"WarpIngestParser - parsing doc {doc_id} for user {user_id} "
+            f"with effective kwargs: {all_kwargs}"
+        )
+
+        document = Document.objects.get(pk=doc_id)
+
+        if not document.pdf_file or not document.pdf_file.name:
+            logger.error(f"No pdf_file found for document {doc_id}")
+            return None
+
+        # Warp-Ingest's front-end consumes a filesystem path, so stream the
+        # stored PDF (which may live in object storage) to a temp file.
+        with default_storage.open(document.pdf_file.name, mode="rb") as pdf_file:
+            pdf_bytes = pdf_file.read()
+
+        tmp_path: Optional[str] = None
+        try:
+            with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp_pdf:
+                tmp_pdf.write(pdf_bytes)
+                tmp_path = tmp_pdf.name
+
+            try:
+                from warp_ingest.ingestor import pdf_ingestor
+            except ImportError as exc:  # pragma: no cover - env-dependent
+                raise DocumentParsingError(
+                    "warp-ingest is not installed. Install it with "
+                    "'pip install \"warp-ingest[ocr]\"' to use WarpIngestParser.",
+                    is_transient=False,
+                ) from exc
+
+            parse_options = {
+                "apply_ocr": bool(all_kwargs.get("apply_ocr", False)),
+                "disable_ocr": bool(all_kwargs.get("disable_ocr", False)),
+                "semantic_units": bool(all_kwargs.get("semantic_units", False)),
+            }
+
+            try:
+                export: OpenContractDocExport = pdf_ingestor.parse_to_opencontracts(
+                    tmp_path, parse_options
+                )
+            except Exception as exc:
+                raise DocumentParsingError(
+                    f"Warp-Ingest failed to parse document {doc_id}: {exc}",
+                    is_transient=False,
+                ) from exc
+        finally:
+            if tmp_path and os.path.exists(tmp_path):
+                try:
+                    os.unlink(tmp_path)
+                except OSError:  # pragma: no cover - best-effort cleanup
+                    logger.warning(f"Could not remove temp PDF {tmp_path}")
+
+        # Warp-Ingest derives the title from the PDF metadata; fall back to the
+        # document's own title/description when it comes back empty.
+        if not export.get("title"):
+            export["title"] = document.title or ""
+        if not export.get("description"):
+            export["description"] = document.description or ""
+
+        logger.info(
+            f"WarpIngestParser - doc {doc_id}: "
+            f"{len(export.get('labelled_text', []))} structural annotation(s), "
+            f"{len(export.get('relationships', []))} relationship(s), "
+            f"{export.get('page_count')} page(s)."
+        )
+        return export

--- a/opencontractserver/pipeline/parsers/warp_ingest_parser.py
+++ b/opencontractserver/pipeline/parsers/warp_ingest_parser.py
@@ -160,7 +160,15 @@ class WarpIngestParser(BaseParser):
                 export: OpenContractDocExport = pdf_ingestor.parse_to_opencontracts(
                     tmp_path, parse_options
                 )
+            except (ConnectionError, TimeoutError) as exc:
+                # e.g. a first-run OCR model download (rapidocr) over a flaky
+                # network — retryable, not a permanent content failure.
+                raise DocumentParsingError(
+                    f"Warp-Ingest transient failure on document {doc_id}: {exc}",
+                    is_transient=True,
+                ) from exc
             except Exception as exc:
+                # Deterministic local parse of a bad/unsupported PDF — permanent.
                 raise DocumentParsingError(
                     f"Warp-Ingest failed to parse document {doc_id}: {exc}",
                     is_transient=False,

--- a/opencontractserver/pipeline/parsers/warp_ingest_parser.py
+++ b/opencontractserver/pipeline/parsers/warp_ingest_parser.py
@@ -44,6 +44,30 @@ from opencontractserver.types.dicts import OpenContractDocExport
 
 logger = logging.getLogger(__name__)
 
+# requests/httpx network errors do NOT subclass the builtin ConnectionError/
+# TimeoutError, so a flaky first-run OCR model fetch could otherwise be
+# misclassified as permanent. Match those by exception class name across the MRO
+# (without importing the optional libraries) in addition to the builtins.
+_TRANSIENT_ERROR_NAMES = frozenset(
+    {
+        "ConnectionError",
+        "Timeout",
+        "ConnectTimeout",
+        "ReadTimeout",
+        "ConnectError",
+        "ReadError",
+        "TimeoutException",
+        "PoolTimeout",
+    }
+)
+
+
+def _is_transient_error(exc: BaseException) -> bool:
+    """True if ``exc`` looks like a retryable network/timeout failure."""
+    if isinstance(exc, (ConnectionError, TimeoutError)):
+        return True
+    return any(cls.__name__ in _TRANSIENT_ERROR_NAMES for cls in type(exc).__mro__)
+
 
 class WarpIngestParser(BaseParser):
     """Parse PDFs to an ``OpenContractDocExport`` with the Warp-Ingest engine."""
@@ -160,18 +184,13 @@ class WarpIngestParser(BaseParser):
                 export: OpenContractDocExport = pdf_ingestor.parse_to_opencontracts(
                     tmp_path, parse_options
                 )
-            except (ConnectionError, TimeoutError) as exc:
-                # e.g. a first-run OCR model download (rapidocr) over a flaky
-                # network — retryable, not a permanent content failure.
-                raise DocumentParsingError(
-                    f"Warp-Ingest transient failure on document {doc_id}: {exc}",
-                    is_transient=True,
-                ) from exc
             except Exception as exc:
-                # Deterministic local parse of a bad/unsupported PDF — permanent.
+                # A network/timeout hiccup (e.g. a first-run OCR model fetch) is
+                # retryable; a deterministic local parse of a bad/unsupported
+                # PDF is permanent.
                 raise DocumentParsingError(
                     f"Warp-Ingest failed to parse document {doc_id}: {exc}",
-                    is_transient=False,
+                    is_transient=_is_transient_error(exc),
                 ) from exc
         finally:
             if tmp_path and os.path.exists(tmp_path):

--- a/opencontractserver/pipeline/parsers/warp_ingest_parser.py
+++ b/opencontractserver/pipeline/parsers/warp_ingest_parser.py
@@ -26,6 +26,7 @@ load); the desktop bootstrap downloads them on first run.
 
 import logging
 import os
+import shutil
 import tempfile
 from dataclasses import dataclass, field
 from typing import Optional
@@ -155,15 +156,17 @@ class WarpIngestParser(BaseParser):
             return None
 
         # Warp-Ingest's front-end consumes a filesystem path, so stream the
-        # stored PDF (which may live in object storage) to a temp file.
-        with default_storage.open(document.pdf_file.name, mode="rb") as pdf_file:
-            pdf_bytes = pdf_file.read()
-
+        # stored PDF (which may live in object storage) to a temp file. Stream
+        # via copyfileobj rather than read()-into-memory so a very large PDF does
+        # not briefly double memory usage.
         tmp_path: Optional[str] = None
         try:
             with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp_pdf:
-                tmp_pdf.write(pdf_bytes)
                 tmp_path = tmp_pdf.name
+                with default_storage.open(
+                    document.pdf_file.name, mode="rb"
+                ) as pdf_file:
+                    shutil.copyfileobj(pdf_file, tmp_pdf)
 
             try:
                 from warp_ingest.ingestor import pdf_ingestor

--- a/opencontractserver/tests/test_desktop_packaging.py
+++ b/opencontractserver/tests/test_desktop_packaging.py
@@ -9,6 +9,7 @@ directory-traversal guard, which must never serve a file outside
 import io
 import os
 import shutil
+import subprocess
 import sys
 import tempfile
 from pathlib import Path
@@ -191,3 +192,72 @@ class DesktopBootstrapTests(TestCase):
             # still works; only Tier-1 secrets/component settings degrade.
             cmd._seed_pipeline_settings()
         self.assertIn("did not seed", err.getvalue())
+
+
+class SqlAlchemyResultUrlTests(SimpleTestCase):
+    """The Django DATABASE_URL → Celery SQLAlchemy result-backend mapping."""
+
+    def test_postgres_scheme_mapped(self):
+        from opencontractserver.desktop.db import sqlalchemy_result_backend_url
+
+        self.assertEqual(
+            sqlalchemy_result_backend_url("postgres://u:p@h:5432/db"),
+            "db+postgresql://u:p@h:5432/db",
+        )
+
+    def test_query_string_preserved(self):
+        from opencontractserver.desktop.db import sqlalchemy_result_backend_url
+
+        self.assertEqual(
+            sqlalchemy_result_backend_url("postgresql://u@h/db?sslmode=require"),
+            "db+postgresql://u@h/db?sslmode=require",
+        )
+
+    def test_non_postgres_passthrough(self):
+        from opencontractserver.desktop.db import sqlalchemy_result_backend_url
+
+        self.assertEqual(
+            sqlalchemy_result_backend_url("sqlite:////tmp/x.db"),
+            "db+sqlite:////tmp/x.db",
+        )
+
+
+class DesktopSettingsImportTests(SimpleTestCase):
+    """config.settings.desktop must import cleanly even under a hostile env.
+
+    base.py branches on USE_AUTH0 / STORAGE_BACKEND at its own import time with
+    no fallbacks, so a stray ``USE_AUTH0=true`` / ``STORAGE_BACKEND=GCP`` in the
+    process environment must not crash the desktop profile's import.
+    """
+
+    def test_imports_under_hostile_env(self):
+        repo_root = Path(__file__).resolve().parents[2]
+        env = {
+            **os.environ,
+            "DJANGO_SETTINGS_MODULE": "config.settings.desktop",
+            "DJANGO_READ_DOT_ENV_FILE": "False",
+            "USE_AUTH0": "true",  # base would require AUTH0_* with no defaults
+            "STORAGE_BACKEND": "GCP",  # base would require GS_BUCKET_NAME
+            "OC_DESKTOP_DATA_DIR": tempfile.mkdtemp(),
+            "PYTHONPATH": str(repo_root),
+        }
+        # Drop any inherited DATABASE_URL so the profile's setdefault is exercised.
+        env.pop("DATABASE_URL", None)
+        script = (
+            "import config.settings.desktop as s;"
+            "assert s.USE_AUTH0 is False, s.USE_AUTH0;"
+            "assert s.STORAGE_BACKEND == 'LOCAL', s.STORAGE_BACKEND;"
+            "assert s.CELERY_RESULT_BACKEND.startswith('db+postgresql://'), "
+            "s.CELERY_RESULT_BACKEND;"
+            "print('DESKTOP_IMPORT_OK')"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            env=env,
+            cwd=str(repo_root),
+            capture_output=True,
+            text=True,
+            timeout=180,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("DESKTOP_IMPORT_OK", result.stdout)

--- a/opencontractserver/tests/test_desktop_packaging.py
+++ b/opencontractserver/tests/test_desktop_packaging.py
@@ -1,0 +1,119 @@
+"""Tests for the desktop packaging helpers.
+
+Covers the pure per-OS path resolution (``opencontractserver.desktop.paths``)
+and the SPA catch-all view (``config.spa.spa_fallback``) — in particular its
+directory-traversal guard, which must never serve a file outside
+``OC_DESKTOP_SPA_ROOT``.
+"""
+
+import os
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+from django.http import Http404
+from django.test import RequestFactory, SimpleTestCase, override_settings
+
+from config.spa import spa_fallback
+from opencontractserver.desktop import paths
+
+
+class DesktopPathsTests(SimpleTestCase):
+    def test_windows_data_dir(self):
+        with mock.patch.object(sys, "platform", "win32"), mock.patch.dict(
+            os.environ, {"LOCALAPPDATA": r"C:\Users\me\AppData\Local"}, clear=False
+        ):
+            os.environ.pop(paths.DATA_DIR_ENV, None)
+            result = paths.default_app_data_dir()
+        self.assertEqual(result.name, "OpenContracts")
+        self.assertIn("AppData", str(result))
+
+    def test_macos_data_dir(self):
+        with mock.patch.object(sys, "platform", "darwin"), mock.patch(
+            "os.path.expanduser", return_value="/Users/me"
+        ):
+            result = paths.default_app_data_dir()
+        self.assertEqual(
+            result, Path("/Users/me/Library/Application Support/OpenContracts")
+        )
+
+    def test_linux_xdg_data_dir(self):
+        with mock.patch.object(sys, "platform", "linux"), mock.patch.dict(
+            os.environ, {"XDG_DATA_HOME": "/home/me/.local/share"}, clear=False
+        ):
+            result = paths.default_app_data_dir()
+        self.assertEqual(result, Path("/home/me/.local/share/OpenContracts"))
+
+    def test_data_dir_override_wins(self):
+        with mock.patch.dict(
+            os.environ, {paths.DATA_DIR_ENV: "/tmp/oc-desktop-test"}, clear=False
+        ):
+            self.assertEqual(paths.app_data_dir(), Path("/tmp/oc-desktop-test"))
+
+    def test_app_data_dir_falls_back_to_default(self):
+        # With no override, app_data_dir() delegates to default_app_data_dir().
+        with mock.patch.object(sys, "platform", "linux"), mock.patch.dict(
+            os.environ, {"XDG_DATA_HOME": "/x"}, clear=False
+        ):
+            os.environ.pop(paths.DATA_DIR_ENV, None)
+            self.assertEqual(paths.app_data_dir(), Path("/x/OpenContracts"))
+
+    def test_well_known_locations(self):
+        with mock.patch.dict(os.environ, {paths.DATA_DIR_ENV: "/data"}, clear=False):
+            root = Path("/data")
+            self.assertEqual(paths.pg_data_dir(), root / "pgdata")
+            self.assertEqual(paths.media_dir(), root / "media")
+            self.assertEqual(paths.static_dir(), root / "staticfiles")
+            self.assertEqual(paths.celery_broker_dir(), root / "celery-broker")
+            self.assertEqual(paths.logs_dir(), root / "logs")
+            self.assertEqual(paths.first_run_marker(), root / ".bootstrapped")
+            # subdir without create returns the path without touching the fs.
+            self.assertEqual(paths.subdir("a", "b"), root / "a" / "b")
+
+    def test_subdir_creates(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with mock.patch.dict(os.environ, {paths.DATA_DIR_ENV: tmp}, clear=False):
+                created = paths.subdir("nested", "dir", create=True)
+                self.assertTrue(created.is_dir())
+                self.assertEqual(created, Path(tmp) / "nested" / "dir")
+
+
+class SpaFallbackTests(SimpleTestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.root = tempfile.mkdtemp()
+        (Path(self.root) / "index.html").write_text(
+            "<html>SPA-INDEX</html>", encoding="utf-8"
+        )
+        assets = Path(self.root) / "assets"
+        assets.mkdir()
+        (assets / "app.js").write_text("console.log(1)", encoding="utf-8")
+
+    def tearDown(self):
+        shutil.rmtree(self.root, ignore_errors=True)
+
+    def test_serves_real_asset(self):
+        with override_settings(OC_DESKTOP_SPA_ROOT=self.root):
+            resp = spa_fallback(self.factory.get("/assets/app.js"), "assets/app.js")
+        self.assertEqual(resp.status_code, 200)
+
+    def test_client_route_returns_index(self):
+        with override_settings(OC_DESKTOP_SPA_ROOT=self.root):
+            resp = spa_fallback(self.factory.get("/corpuses/1"), "corpuses/1")
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn("text/html", resp.headers.get("Content-Type", ""))
+
+    def test_traversal_is_blocked(self):
+        # A ``../`` escape must NOT serve a file outside the SPA root; safe_join
+        # rejects it and we fall back to index.html (served as text/html).
+        with override_settings(OC_DESKTOP_SPA_ROOT=self.root):
+            resp = spa_fallback(self.factory.get("/x"), "../../../../../../etc/passwd")
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn("text/html", resp.headers.get("Content-Type", ""))
+
+    def test_disabled_when_root_unset(self):
+        with override_settings(OC_DESKTOP_SPA_ROOT=""):
+            with self.assertRaises(Http404):
+                spa_fallback(self.factory.get("/"), "")

--- a/opencontractserver/tests/test_desktop_packaging.py
+++ b/opencontractserver/tests/test_desktop_packaging.py
@@ -6,6 +6,7 @@ directory-traversal guard, which must never serve a file outside
 ``OC_DESKTOP_SPA_ROOT``.
 """
 
+import io
 import os
 import shutil
 import sys
@@ -13,11 +14,19 @@ import tempfile
 from pathlib import Path
 from unittest import mock
 
+from django.contrib.auth import get_user_model
 from django.http import Http404
-from django.test import RequestFactory, SimpleTestCase, override_settings
+from django.test import (
+    RequestFactory,
+    SimpleTestCase,
+    TestCase,
+    override_settings,
+)
 
 from config.spa import spa_fallback
 from opencontractserver.desktop import paths
+
+User = get_user_model()
 
 
 class DesktopPathsTests(SimpleTestCase):
@@ -117,3 +126,69 @@ class SpaFallbackTests(SimpleTestCase):
         with override_settings(OC_DESKTOP_SPA_ROOT=""):
             with self.assertRaises(Http404):
                 spa_fallback(self.factory.get("/"), "")
+
+
+class DesktopBootstrapTests(TestCase):
+    """Tests for the ``desktop_bootstrap`` command's user + pipeline seeding."""
+
+    def _command(self):
+        from opencontractserver.documents.management.commands.desktop_bootstrap import (
+            Command,
+        )
+
+        # Real StringIO streams (not MagicMock) so the command's OutputWrapper
+        # type is satisfied; read them back with getvalue().
+        self.out = io.StringIO()
+        self.err = io.StringIO()
+        return Command(stdout=self.out, stderr=self.err)
+
+    def test_seed_user_with_password(self):
+        cmd = self._command()
+        with mock.patch.dict(
+            os.environ, {"OC_DESKTOP_PASSWORD": "s3cret-pw-123"}, clear=False
+        ):
+            cmd._seed_user("alice", "alice@localhost")
+        user = User.objects.get(username="alice")
+        self.assertTrue(user.is_superuser)
+        self.assertTrue(user.has_usable_password())
+        self.assertTrue(user.check_password("s3cret-pw-123"))
+
+    def test_seed_user_without_password_is_unusable(self):
+        cmd = self._command()
+        # Empty OC_DESKTOP_PASSWORD → treated as unset → unusable password.
+        with mock.patch.dict(os.environ, {"OC_DESKTOP_PASSWORD": ""}, clear=False):
+            cmd._seed_user("bob", "bob@localhost")
+        user = User.objects.get(username="bob")
+        self.assertTrue(user.is_superuser)
+        self.assertFalse(user.has_usable_password())
+
+    def test_seed_user_is_idempotent(self):
+        cmd = self._command()
+        with mock.patch.dict(os.environ, {"OC_DESKTOP_PASSWORD": ""}, clear=False):
+            cmd._seed_user("carol", "carol@localhost")
+            cmd._seed_user("carol", "carol@localhost")  # no duplicate / no error
+        self.assertEqual(User.objects.filter(username="carol").count(), 1)
+
+    def test_seed_pipeline_settings_creates_singleton(self):
+        from opencontractserver.documents.models import PipelineSettings
+
+        cmd = self._command()
+        with mock.patch(
+            "opencontractserver.documents.management.commands."
+            "desktop_bootstrap.call_command"
+        ) as mock_call:
+            cmd._seed_pipeline_settings()
+        mock_call.assert_called_once_with("migrate_pipeline_settings")
+        self.assertTrue(PipelineSettings.objects.filter(pk=1).exists())
+
+    def test_seed_pipeline_settings_survives_migrate_failure(self):
+        cmd = self._command()
+        with mock.patch(
+            "opencontractserver.documents.management.commands."
+            "desktop_bootstrap.call_command",
+            side_effect=RuntimeError("boom"),
+        ):
+            # A migrate_pipeline_settings failure must not raise — PDF parsing
+            # still works; only Tier-1 secrets/component settings degrade.
+            cmd._seed_pipeline_settings()
+        self.assertIn("did not seed", self.err.getvalue())

--- a/opencontractserver/tests/test_desktop_packaging.py
+++ b/opencontractserver/tests/test_desktop_packaging.py
@@ -177,8 +177,9 @@ class DesktopBootstrapTests(TestCase):
             "opencontractserver.documents.management.commands."
             "desktop_bootstrap.call_command"
         ) as mock_call:
-            cmd._seed_pipeline_settings()
+            ok = cmd._seed_pipeline_settings()
         mock_call.assert_called_once_with("migrate_pipeline_settings")
+        self.assertTrue(ok)
         self.assertTrue(PipelineSettings.objects.filter(pk=1).exists())
 
     def test_seed_pipeline_settings_survives_migrate_failure(self):
@@ -189,9 +190,27 @@ class DesktopBootstrapTests(TestCase):
             side_effect=RuntimeError("boom"),
         ):
             # A migrate_pipeline_settings failure must not raise — PDF parsing
-            # still works; only Tier-1 secrets/component settings degrade.
-            cmd._seed_pipeline_settings()
+            # still works; only Tier-1 secrets/component settings degrade —
+            # but it returns False so the caller can signal a retry.
+            ok = cmd._seed_pipeline_settings()
+        self.assertFalse(ok)
         self.assertIn("did not seed", err.getvalue())
+
+    def test_handle_raises_on_pipeline_failure_so_marker_is_not_written(self):
+        # handle() must exit non-zero (CommandError) when pipeline seeding fails,
+        # so the launcher leaves the first-run marker unwritten and retries.
+        from django.core.management.base import CommandError
+
+        cmd, _out, _err = self._command()
+        with mock.patch(
+            "opencontractserver.documents.management.commands."
+            "desktop_bootstrap.call_command",
+            side_effect=RuntimeError("boom"),
+        ), mock.patch.dict(os.environ, {"OC_DESKTOP_PASSWORD": ""}, clear=False):
+            with self.assertRaises(CommandError):
+                cmd.handle(username="dave", email="dave@localhost", skip_nltk=True)
+        # The idempotent user seed still happened despite the pipeline failure.
+        self.assertTrue(User.objects.filter(username="dave").exists())
 
 
 class SqlAlchemyResultUrlTests(SimpleTestCase):

--- a/opencontractserver/tests/test_desktop_packaging.py
+++ b/opencontractserver/tests/test_desktop_packaging.py
@@ -131,19 +131,18 @@ class SpaFallbackTests(SimpleTestCase):
 class DesktopBootstrapTests(TestCase):
     """Tests for the ``desktop_bootstrap`` command's user + pipeline seeding."""
 
-    def _command(self):
+    @staticmethod
+    def _command():
+        """Build the command with real StringIO streams (mypy-clean, readable)."""
         from opencontractserver.documents.management.commands.desktop_bootstrap import (
             Command,
         )
 
-        # Real StringIO streams (not MagicMock) so the command's OutputWrapper
-        # type is satisfied; read them back with getvalue().
-        self.out = io.StringIO()
-        self.err = io.StringIO()
-        return Command(stdout=self.out, stderr=self.err)
+        out, err = io.StringIO(), io.StringIO()
+        return Command(stdout=out, stderr=err), out, err
 
     def test_seed_user_with_password(self):
-        cmd = self._command()
+        cmd, _out, _err = self._command()
         with mock.patch.dict(
             os.environ, {"OC_DESKTOP_PASSWORD": "s3cret-pw-123"}, clear=False
         ):
@@ -154,7 +153,7 @@ class DesktopBootstrapTests(TestCase):
         self.assertTrue(user.check_password("s3cret-pw-123"))
 
     def test_seed_user_without_password_is_unusable(self):
-        cmd = self._command()
+        cmd, _out, _err = self._command()
         # Empty OC_DESKTOP_PASSWORD → treated as unset → unusable password.
         with mock.patch.dict(os.environ, {"OC_DESKTOP_PASSWORD": ""}, clear=False):
             cmd._seed_user("bob", "bob@localhost")
@@ -163,7 +162,7 @@ class DesktopBootstrapTests(TestCase):
         self.assertFalse(user.has_usable_password())
 
     def test_seed_user_is_idempotent(self):
-        cmd = self._command()
+        cmd, _out, _err = self._command()
         with mock.patch.dict(os.environ, {"OC_DESKTOP_PASSWORD": ""}, clear=False):
             cmd._seed_user("carol", "carol@localhost")
             cmd._seed_user("carol", "carol@localhost")  # no duplicate / no error
@@ -172,7 +171,7 @@ class DesktopBootstrapTests(TestCase):
     def test_seed_pipeline_settings_creates_singleton(self):
         from opencontractserver.documents.models import PipelineSettings
 
-        cmd = self._command()
+        cmd, _out, _err = self._command()
         with mock.patch(
             "opencontractserver.documents.management.commands."
             "desktop_bootstrap.call_command"
@@ -182,7 +181,7 @@ class DesktopBootstrapTests(TestCase):
         self.assertTrue(PipelineSettings.objects.filter(pk=1).exists())
 
     def test_seed_pipeline_settings_survives_migrate_failure(self):
-        cmd = self._command()
+        cmd, _out, err = self._command()
         with mock.patch(
             "opencontractserver.documents.management.commands."
             "desktop_bootstrap.call_command",
@@ -191,4 +190,4 @@ class DesktopBootstrapTests(TestCase):
             # A migrate_pipeline_settings failure must not raise — PDF parsing
             # still works; only Tier-1 secrets/component settings degrade.
             cmd._seed_pipeline_settings()
-        self.assertIn("did not seed", self.err.getvalue())
+        self.assertIn("did not seed", err.getvalue())

--- a/opencontractserver/tests/test_warp_ingest_parser.py
+++ b/opencontractserver/tests/test_warp_ingest_parser.py
@@ -89,8 +89,8 @@ class _FakeWarpIngest:
     def __enter__(self):
         pkg = types.ModuleType("warp_ingest")
         ingestor_pkg = types.ModuleType("warp_ingest.ingestor")
-        ingestor_pkg.pdf_ingestor = self.mock
-        pkg.ingestor = ingestor_pkg
+        setattr(ingestor_pkg, "pdf_ingestor", self.mock)
+        setattr(pkg, "ingestor", ingestor_pkg)
         for name, mod in (
             ("warp_ingest", pkg),
             ("warp_ingest.ingestor", ingestor_pkg),
@@ -124,7 +124,7 @@ class WarpIngestParserTests(TestCase):
     def test_parses_pdf_to_export(self):
         with _FakeWarpIngest() as mock:
             result = self.parser._parse_document_impl(self.user.id, self.doc.id)
-        self.assertIsNotNone(result)
+        assert result is not None
         self.assertEqual(len(result["labelled_text"]), 1)
         self.assertEqual(len(result["relationships"]), 1)
         self.assertEqual(
@@ -140,6 +140,7 @@ class WarpIngestParserTests(TestCase):
         with _FakeWarpIngest():
             result = self.parser._parse_document_impl(self.user.id, self.doc.id)
         # Warp returned empty title/description → fall back to the document's.
+        assert result is not None
         self.assertEqual(result["title"], "Fallback Title")
         self.assertEqual(result["description"], "Fallback Desc")
 
@@ -159,7 +160,7 @@ class WarpIngestParserTests(TestCase):
     def test_missing_dependency_raises_permanent_error(self):
         # sys.modules[name]=None makes ``import warp_ingest`` raise ImportError.
         saved = sys.modules.get("warp_ingest")
-        sys.modules["warp_ingest"] = None
+        sys.modules["warp_ingest"] = None  # type: ignore[assignment]
         try:
             with self.assertRaises(DocumentParsingError) as ctx:
                 self.parser._parse_document_impl(self.user.id, self.doc.id)
@@ -186,6 +187,6 @@ class WarpIngestParserTests(TestCase):
         with open(fixture, "rb") as fh:
             self.doc.pdf_file.save("real.pdf", ContentFile(fh.read()))
         result = self.parser._parse_document_impl(self.user.id, self.doc.id)
-        self.assertIsNotNone(result)
+        assert result is not None
         self.assertGreater(len(result["labelled_text"]), 0)
         self.assertGreater(len(result["pawls_file_content"]), 0)

--- a/opencontractserver/tests/test_warp_ingest_parser.py
+++ b/opencontractserver/tests/test_warp_ingest_parser.py
@@ -1,0 +1,191 @@
+"""Tests for :class:`WarpIngestParser`.
+
+Warp-Ingest is an optional dependency, so the core tests inject a fake
+``warp_ingest.ingestor.pdf_ingestor`` module (the parser imports it lazily) and
+assert the glue: PDF bytes in → ``OpenContractDocExport`` out, title/description
+fallback, and the error semantics. A final test runs the REAL parser against a
+fixture PDF when the package happens to be installed (e.g. a desktop build) and
+self-skips otherwise.
+"""
+
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock
+
+from django.contrib.auth import get_user_model
+from django.core.files.base import ContentFile
+from django.db import transaction
+from django.test import TestCase
+
+from opencontractserver.documents.models import Document
+from opencontractserver.pipeline.base.exceptions import DocumentParsingError
+from opencontractserver.pipeline.parsers.warp_ingest_parser import WarpIngestParser
+
+User = get_user_model()
+
+# Minimal valid-ish PDF bytes (never actually parsed — parse_to_opencontracts is
+# mocked in the core tests).
+_PDF_BYTES = (
+    b"%PDF-1.7\n1 0 obj\n<</Type/Catalog/Pages 2 0 R>>\nendobj\n"
+    b"2 0 obj\n<</Type/Pages/Count 1/Kids[3 0 R]>>\nendobj\n"
+    b"3 0 obj\n<</Type/Page/MediaBox[0 0 612 792]/Parent 2 0 R/Resources<<>>>>"
+    b"\nendobj\ntrailer\n<</Size 4/Root 1 0 R>>\n%%EOF\n"
+)
+
+
+def _sample_export() -> dict:
+    """An ``OpenContractDocExport`` shaped like real Warp-Ingest output."""
+    return {
+        "title": "",
+        "content": "Section One\nA paragraph.",
+        "description": "",
+        "page_count": 1,
+        "doc_labels": [],
+        "labelled_text": [
+            {
+                "id": "0",
+                "annotationLabel": "Section Header",
+                "rawText": "Section One",
+                "page": 0,
+                "annotation_json": {"0": {"bounds": {}, "tokensJsons": []}},
+                "parent_id": None,
+                "annotation_type": "TOKEN_LABEL",
+                "structural": True,
+                "content_modalities": ["TEXT"],
+            }
+        ],
+        "relationships": [
+            {
+                "id": "rel-1",
+                "relationshipLabel": "OC_PARENT_CHILD",
+                "source_annotation_ids": ["0"],
+                "target_annotation_ids": ["1"],
+                "structural": True,
+            }
+        ],
+        "pawls_file_content": [
+            {
+                "page": {"width": 612, "height": 792, "index": 0},
+                "tokens": [{"x": 1, "y": 1, "width": 10, "height": 12, "text": "Hi"}],
+            }
+        ],
+    }
+
+
+class _FakeWarpIngest:
+    """Context manager injecting a fake ``warp_ingest.ingestor.pdf_ingestor``."""
+
+    def __init__(self, parse_return=None, parse_side_effect=None):
+        self.mock = MagicMock()
+        if parse_side_effect is not None:
+            self.mock.parse_to_opencontracts.side_effect = parse_side_effect
+        else:
+            self.mock.parse_to_opencontracts.return_value = (
+                parse_return if parse_return is not None else _sample_export()
+            )
+        self._saved = {}
+
+    def __enter__(self):
+        pkg = types.ModuleType("warp_ingest")
+        ingestor_pkg = types.ModuleType("warp_ingest.ingestor")
+        ingestor_pkg.pdf_ingestor = self.mock
+        pkg.ingestor = ingestor_pkg
+        for name, mod in (
+            ("warp_ingest", pkg),
+            ("warp_ingest.ingestor", ingestor_pkg),
+            ("warp_ingest.ingestor.pdf_ingestor", self.mock),
+        ):
+            self._saved[name] = sys.modules.get(name)
+            sys.modules[name] = mod
+        return self.mock
+
+    def __exit__(self, *exc):
+        for name, prev in self._saved.items():
+            if prev is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = prev
+
+
+class WarpIngestParserTests(TestCase):
+    def setUp(self):
+        with transaction.atomic():
+            self.user = User.objects.create_user(username="warp", password="12345678")
+        self.doc = Document.objects.create(
+            title="Fallback Title",
+            description="Fallback Desc",
+            file_type="pdf",
+            creator=self.user,
+        )
+        self.doc.pdf_file.save("test.pdf", ContentFile(_PDF_BYTES))
+        self.parser = WarpIngestParser()
+
+    def test_parses_pdf_to_export(self):
+        with _FakeWarpIngest() as mock:
+            result = self.parser._parse_document_impl(self.user.id, self.doc.id)
+        self.assertIsNotNone(result)
+        self.assertEqual(len(result["labelled_text"]), 1)
+        self.assertEqual(len(result["relationships"]), 1)
+        self.assertEqual(
+            result["relationships"][0]["relationshipLabel"], "OC_PARENT_CHILD"
+        )
+        self.assertEqual(result["pawls_file_content"][0]["tokens"][0]["text"], "Hi")
+        # parse_to_opencontracts is called with a temp path + parse options.
+        args, _ = mock.parse_to_opencontracts.call_args
+        self.assertTrue(str(args[0]).endswith(".pdf"))
+        self.assertIn("apply_ocr", args[1])
+
+    def test_title_and_description_fallback(self):
+        with _FakeWarpIngest():
+            result = self.parser._parse_document_impl(self.user.id, self.doc.id)
+        # Warp returned empty title/description → fall back to the document's.
+        self.assertEqual(result["title"], "Fallback Title")
+        self.assertEqual(result["description"], "Fallback Desc")
+
+    def test_missing_pdf_returns_none(self):
+        doc = Document.objects.create(
+            title="No File", file_type="pdf", creator=self.user
+        )
+        with _FakeWarpIngest():
+            self.assertIsNone(self.parser._parse_document_impl(self.user.id, doc.id))
+
+    def test_parse_failure_raises_permanent_error(self):
+        with _FakeWarpIngest(parse_side_effect=ValueError("bad pdf")):
+            with self.assertRaises(DocumentParsingError) as ctx:
+                self.parser._parse_document_impl(self.user.id, self.doc.id)
+        self.assertFalse(ctx.exception.is_transient)
+
+    def test_missing_dependency_raises_permanent_error(self):
+        # sys.modules[name]=None makes ``import warp_ingest`` raise ImportError.
+        saved = sys.modules.get("warp_ingest")
+        sys.modules["warp_ingest"] = None
+        try:
+            with self.assertRaises(DocumentParsingError) as ctx:
+                self.parser._parse_document_impl(self.user.id, self.doc.id)
+        finally:
+            if saved is None:
+                sys.modules.pop("warp_ingest", None)
+            else:
+                sys.modules["warp_ingest"] = saved
+        self.assertFalse(ctx.exception.is_transient)
+
+    @unittest.skipUnless(
+        __import__("importlib").util.find_spec("warp_ingest") is not None,
+        "warp-ingest not installed",
+    )
+    def test_real_parse_smoke(self):
+        """Real end-to-end parse when Warp-Ingest is actually installed."""
+        import os
+
+        fixture = os.path.join(
+            os.path.dirname(__file__), "fixtures", "files", "doc_1_pdf_file.pdf"
+        )
+        if not os.path.exists(fixture):
+            self.skipTest("fixture PDF missing")
+        with open(fixture, "rb") as fh:
+            self.doc.pdf_file.save("real.pdf", ContentFile(fh.read()))
+        result = self.parser._parse_document_impl(self.user.id, self.doc.id)
+        self.assertIsNotNone(result)
+        self.assertGreater(len(result["labelled_text"]), 0)
+        self.assertGreater(len(result["pawls_file_content"]), 0)

--- a/opencontractserver/tests/test_warp_ingest_parser.py
+++ b/opencontractserver/tests/test_warp_ingest_parser.py
@@ -164,6 +164,17 @@ class WarpIngestParserTests(TestCase):
                 self.parser._parse_document_impl(self.user.id, self.doc.id)
         self.assertTrue(ctx.exception.is_transient)
 
+    def test_requests_style_network_error_is_transient(self):
+        # requests/httpx network errors do NOT subclass builtin ConnectionError;
+        # they must still be classified transient (matched by MRO class name).
+        class ConnectTimeout(Exception):  # httpx-style name, not a builtin subclass
+            pass
+
+        with _FakeWarpIngest(parse_side_effect=ConnectTimeout("slow")):
+            with self.assertRaises(DocumentParsingError) as ctx:
+                self.parser._parse_document_impl(self.user.id, self.doc.id)
+        self.assertTrue(ctx.exception.is_transient)
+
     def test_missing_dependency_raises_permanent_error(self):
         # sys.modules[name]=None makes ``import warp_ingest`` raise ImportError.
         saved = sys.modules.get("warp_ingest")

--- a/opencontractserver/tests/test_warp_ingest_parser.py
+++ b/opencontractserver/tests/test_warp_ingest_parser.py
@@ -157,6 +157,13 @@ class WarpIngestParserTests(TestCase):
                 self.parser._parse_document_impl(self.user.id, self.doc.id)
         self.assertFalse(ctx.exception.is_transient)
 
+    def test_network_failure_is_transient(self):
+        # e.g. a first-run OCR model download over a flaky network — retryable.
+        with _FakeWarpIngest(parse_side_effect=ConnectionError("net down")):
+            with self.assertRaises(DocumentParsingError) as ctx:
+                self.parser._parse_document_impl(self.user.id, self.doc.id)
+        self.assertTrue(ctx.exception.is_transient)
+
     def test_missing_dependency_raises_permanent_error(self):
         # sys.modules[name]=None makes ``import warp_ingest`` raise ImportError.
         saved = sys.modules.get("warp_ingest")

--- a/requirements/desktop.txt
+++ b/requirements/desktop.txt
@@ -5,6 +5,12 @@
 # docs/deployment/desktop_packaging.md.
 -r base.txt
 
+# PostgreSQL driver for Django's own DB connection. base.txt has no psycopg
+# (it lives in local.txt/production.txt), so the desktop profile must add one
+# or ``manage.py migrate`` fails on a clean install. The -binary wheel needs no
+# system build tools — the right choice for an end-user desktop install.
+psycopg2-binary==2.9.12
+
 # In-process PDF parsing (replaces the Docling microservice). Pure-Python,
 # rule-based, no torch/GPU. The [ocr] extra adds CPU-only rapidocr-onnxruntime
 # for scanned pages; drop it for a smaller, born-digital-only install.

--- a/requirements/desktop.txt
+++ b/requirements/desktop.txt
@@ -8,16 +8,24 @@
 # In-process PDF parsing (replaces the Docling microservice). Pure-Python,
 # rule-based, no torch/GPU. The [ocr] extra adds CPU-only rapidocr-onnxruntime
 # for scanned pages; drop it for a smaller, born-digital-only install.
-warp-ingest[ocr]>=1.0.0
+# Upper bounds cap early-stage packages so an unreviewed breaking change can't
+# silently land in a desktop build (the rest of requirements/ pins tightly).
+warp-ingest[ocr]>=1.0.0,<2
 
 # Embedded PostgreSQL 16 + pgvector as a supervised child process (bundles the
 # server binaries with Win/Mac/Linux wheels), so no Postgres install is needed.
-pgserver>=0.1.4
+pgserver>=0.1.4,<0.3
 
 # Celery filesystem broker + SQLAlchemy DB result backend (chords need a real
 # result backend; the DB one lets us drop Redis). SQLAlchemy powers the
 # ``db+postgresql://`` result backend.
-sqlalchemy>=2.0
+sqlalchemy>=2.0,<3
+
+# Persist SECRET_KEY in the OS credential store (macOS Keychain / Windows
+# Credential Locker / Linux Secret Service) so it survives restarts. A stable
+# SECRET_KEY keeps PipelineSettings' encrypted secrets (e.g. OPENAI_API_KEY)
+# decryptable across launches. See launcher._stable_secret_key.
+keyring>=24,<26
 
 # nltk corpora (stopwords/punkt) are downloaded on first run by the
 # desktop_bootstrap command; nltk itself arrives transitively via warp-ingest.

--- a/requirements/desktop.txt
+++ b/requirements/desktop.txt
@@ -1,0 +1,23 @@
+# Requirements for the single-user *desktop* build (config.settings.desktop).
+#
+# Installs on top of the base backend requirements and adds only what the
+# process-based, no-Docker/no-Redis desktop launcher needs. See
+# docs/deployment/desktop_packaging.md.
+-r base.txt
+
+# In-process PDF parsing (replaces the Docling microservice). Pure-Python,
+# rule-based, no torch/GPU. The [ocr] extra adds CPU-only rapidocr-onnxruntime
+# for scanned pages; drop it for a smaller, born-digital-only install.
+warp-ingest[ocr]>=1.0.0
+
+# Embedded PostgreSQL 16 + pgvector as a supervised child process (bundles the
+# server binaries with Win/Mac/Linux wheels), so no Postgres install is needed.
+pgserver>=0.1.4
+
+# Celery filesystem broker + SQLAlchemy DB result backend (chords need a real
+# result backend; the DB one lets us drop Redis). SQLAlchemy powers the
+# ``db+postgresql://`` result backend.
+sqlalchemy>=2.0
+
+# nltk corpora (stopwords/punkt) are downloaded on first run by the
+# desktop_bootstrap command; nltk itself arrives transitively via warp-ingest.

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,11 @@ omit =
     */temp_*
     */tmp_*
     */__pycache__/*
+    # Desktop launcher: a process-supervision entry point (spawns Postgres,
+    # Daphne, Celery worker/beat, opens the browser) — orchestration/IO with
+    # no unit-testable logic, like manage.py/wsgi.py/asgi.py. Its pure path
+    # helpers (opencontractserver/desktop/paths.py) are covered separately.
+    */desktop/launcher.py
 # django_coverage_plugin (template coverage) is intentionally not loaded:
 # Coverage 7.x falls back to the legacy C trace function whenever any file
 # tracer plugin is configured, which silently defeats COVERAGE_CORE=sysmon


### PR DESCRIPTION
## Goal

Package OpenContracts as a seamless **single-user desktop app** (Linux/macOS/Windows) with as few runtime dependencies as possible — every `local.yml` compose service becomes a plain process or is eliminated. In particular **Redis is dropped** and PostgreSQL becomes a bundled child process. This PR is **Phase 0**: the settings profile, the process launcher, and the in-process parser that make the whole stack run with **no Docker and no Redis**. Later phases add the native shell (Tauri), installers, and signing.

Full architecture + phased plan: `docs/deployment/desktop_packaging.md`.

## Compose service → desktop replacement

| `local.yml` service | Replacement |
|---|---|
| `postgres` (pgvector) | Embedded PostgreSQL 16 + pgvector child process (`pgserver`) or external `DATABASE_URL`. `DATABASES` is URL-driven → **zero ORM/migration/query changes** (sqlite-vec was rejected as an L–XL rewrite of the pgvector/HNSW/tsvector/pg_trgm/ArrayField surface). |
| `redis` | **Deleted.** Cache → `LocMemCache`; Celery broker → kombu filesystem transport; result backend → bundled Postgres via SQLAlchemy (chords need a real backend, so eager is deliberately avoided); channels → in-process. |
| `celeryworker` / `celerybeat` | Worker + `beat` subprocesses over the filesystem broker (Phase 0). |
| `flower`, `frontend` | Dropped; the built SPA is served from Daphne (WhiteNoise + catch-all). |
| `docling-parser` | **`WarpIngestParser`** — in-process, rule-based, no torch/GPU. |
| `docxodus`/`vector`/`multimodal`-embedder, `privacy_filter` | Not used; embeddings via an OpenAI-compatible endpoint (cloud key or local server). |

## What's in this PR

- **`config/settings/desktop.py`** — the no-Redis desktop profile (LocMem cache, `InMemoryChannelLayer`, filesystem Celery broker + `db+postgresql://` result backend, local per-user storage, `USE_AUTH0=False`, SPA serving, and selection of the in-process pipeline components).
- **`opencontractserver/desktop/{paths,launcher}.py` + `oc-desktop.py`** — a one-command supervisor: pick a free port → start embedded Postgres (or use `DATABASE_URL`) → `migrate` → first-run bootstrap → Daphne + Celery worker/beat → open the browser → clean process-group shutdown.
- **`opencontractserver/pipeline/parsers/warp_ingest_parser.py`** — `WarpIngestParser` wrapping [Warp-Ingest](https://github.com/Open-Source-Legal/Warp-Ingest)'s `pdf_ingestor.parse_to_opencontracts`, which returns an `OpenContractDocExport` directly (PAWLS tokens, one structural annotation per block, `OC_PARENT_CHILD` heading hierarchy). `warp_ingest` is imported **lazily** so pipeline auto-discovery is unaffected when the optional dep is absent; the parser is registered everywhere but only *selected* when `PREFERRED_PARSERS`/`PipelineSettings` point at it (compose default stays Docling).
- **`desktop_bootstrap` management command** — first-run seed: local superuser, `PipelineSettings` singleton, nltk corpora (`stopwords`/`punkt`, which Warp-Ingest imports at load time).
- **`config/spa.py` + gated `config/urls.py` catch-all** — serve the built SPA from Daphne; only active when `OC_DESKTOP_SPA_ROOT` is set, so other deployments are untouched (the `:3000` dev redirect is skipped there).
- **`requirements/desktop.txt`**, **`docs/deployment/desktop_packaging.md`**, changelog fragment.

## Three tiers (documented)

- **Tier 0** — offline, no key: upload → parse → annotate → read → Postgres keyword search.
- **Tier 1 (default)** — + embeddings & chat via an OpenAI-compatible endpoint (user key or local server). Zero microservices, zero torch.
- **Tier 2 (opt-in download)** — local torch + sentence-transformers + docling-as-library for offline semantic search / ML layout.

## Known Phase-0 limitation

Under the in-process `InMemoryChannelLayer`, the two notification emitters (`notifications/signals.py`, `tasks/agent_tasks.py`) fire `group_send` from a non-Daphne event loop, so real-time notification toasts are **not delivered** yet (agent chat is unaffected — it streams inline with no channel layer). The fix — a loop-safe transport, preferably Postgres `LISTEN/NOTIFY` since Postgres is bundled — is the immediate follow-up and is called out inline in the settings + docs.

## Verification

- Warp-Ingest was run against a real fixture PDF and produces a valid `OpenContractDocExport` (213 structural annotations, 64 `OC_PARENT_CHILD` relationships, 9 PAWLS pages) — the exact shape `BaseParser.save_parsed_data` consumes.
- New unit tests (`opencontractserver/tests/test_warp_ingest_parser.py`) cover the parser glue with a fake lazy import (runs without the package) plus a real-parse smoke test that self-skips when Warp-Ingest is absent.
- `black` / `isort` / `flake8` pass; all new modules byte-compile; the Django-free launcher/paths modules import and run.

## Follow-ups (see docs for the phased plan)

Loop-safe notification transport; embedded-Postgres supervision hardening (stale-lock recovery, major-version datadir guard); collapse worker/beat in-process (thread worker + APScheduler); `python-build-standalone` + relocatable venv packaging; Tauri shell + installers; signing/notarization/auto-update; optional full-ML pack.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AVBuQB5jB9egAeXRbpBBGx)_