### PR TITLE
Authority packs: baseline-origin collision guard + multi-YAML taxonomy merge (#2057)

### DIFF
--- a/changelog.d/2057-baseline-origin-guard.fixed.md
+++ b/changelog.d/2057-baseline-origin-guard.fixed.md
@@ -1,0 +1,19 @@
+- **Baseline-vs-baseline namespace clobbering fixed (issue #2057).** Two
+  `source="baseline"` writers on the same authority prefix — the core
+  `authority_mappings.yaml` vs. a pack's mappings YAML, or two packs — previously
+  last-write-wins'd each other silently
+  (`AuthorityMappingLoader.load_namespaces`' `update_or_create` had no writer
+  partition). Every baseline `AuthorityNamespace` row is now stamped with its
+  writer origin (new nullable `baseline_origin` column, migration
+  `annotations/0101`; `"core"` for the shipped YAML / `post_migrate` seed, else
+  the pack's manifest `name`), and a load skips + warns (counted as
+  `skipped_foreign_baseline`) instead of overwriting a prefix a different origin
+  owns — first writer wins; curator `manual` rows still trump everything. The
+  `post_migrate` convergence (`opencontractserver/enrichment/_namespace_seed.py`)
+  honours the same guard, so a `migrate`/flush can no longer revert a pack-owned
+  prefix to the constants baseline. Legacy baseline rows (null origin) are
+  adopted — stamped — by the next owning load. The pack name `core` is reserved
+  (`load_authority_pack` rejects it fail-fast). Re-loading two packs that touch
+  distinct prefixes can never clobber each other. Tests:
+  `opencontractserver/tests/test_authority_mapping_loader.py::BaselineOriginGuardTests`
+  and the reseed-ownership additions in the same file.

--- a/changelog.d/2057-loader-multi-yaml.added.md
+++ b/changelog.d/2057-loader-multi-yaml.added.md
@@ -1,0 +1,15 @@
+- **One-command multi-YAML taxonomy merge (issue #2057).**
+  `manage.py load_authority_mappings --include-packs` now converges the shipped
+  core baseline **plus every installed authority pack's mappings YAML** (in-tree
+  `authority_packs/` + `AUTHORITY_PACK_PATHS`) in one idempotent run, each file
+  stamped with its writer origin (`AuthorityMappingLoader.load_installed`,
+  reusing `authority_pack_config.iter_pack_mapping_files` — now public and
+  yielding the parsed manifest — for pack discovery). Core loads first, so on a
+  same-prefix collision the shipped baseline wins and the pack's claim is
+  skipped + warned, mirroring the shape-rules/abbreviations merge rule.
+  Per-origin summaries (including `skipped_foreign_baseline`) are printed for
+  both commands (`load_authority_mappings`, `load_authority_pack`). Docs:
+  "Prefix ownership" section in `docs/guides/authoring-authority-packs.md`;
+  gap 7 closed in `docs/architecture/proposals/0002-authority-packs.md` §7.
+  Tests: `test_authority_mapping_loader.py::LoadInstalledTests` +
+  command tests.

--- a/config/graphql/annotation_types.py
+++ b/config/graphql/annotation_types.py
@@ -457,6 +457,11 @@ class AuthorityNamespaceNode(DjangoObjectType):
             "source_root_url",
             "license",
             "is_global",
+            # Which baseline writer owns the row ("core" or a pack name; null on
+            # manual/corpus-linked and pre-#2057 rows) — lets the console show
+            # who owns a prefix when a load reports a skipped foreign-baseline
+            # collision. Plain CharField (no choices) → auto-resolves as String.
+            "baseline_origin",
             "authority_corpus",
             "created",
             "modified",

--- a/docs/architecture/proposals/0002-authority-packs.md
+++ b/docs/architecture/proposals/0002-authority-packs.md
@@ -83,6 +83,22 @@ rather than against a `scraping/` app that was never built.
 > `test_discover_authority_candidates_command.py`, plus the pack-discovery
 > additions in `test_authority_pack_providers.py`.
 
+> **Update — gap 7 closed (issue #2057).** The mappings loader now guards
+> baseline-vs-baseline collisions and merge-loads multiple YAMLs. Every
+> `source="baseline"` `AuthorityNamespace` row is stamped with its writer origin
+> (`baseline_origin`: `"core"` for the shipped YAML, else the pack's manifest
+> `name`), and a load **skips + warns instead of clobbering** a prefix a
+> different origin owns — first writer wins; curator `manual` rows still trump
+> everything (`AuthorityMappingLoader.load_namespaces`; the `post_migrate`
+> convergence in `enrichment/_namespace_seed.py` honours the same guard). So
+> re-loading two packs that touch distinct prefixes can never clobber each
+> other, and a same-prefix collision is loud instead of silent.
+> `manage.py load_authority_mappings --include-packs` converges the core
+> baseline plus every installed pack's mappings in one idempotent run
+> (`AuthorityMappingLoader.load_installed`). Tests:
+> `test_authority_mapping_loader.py::BaselineOriginGuardTests` /
+> `LoadInstalledTests`.
+
 ## 1. Context — three artifacts, one intent
 
 | Artifact | What it is | Status |
@@ -228,13 +244,13 @@ co-author.
 
 | # | Gap | Severity | Needed for Bolivia? | Phase |
 |---|---|---|---|---|
-| 1 | Host allowlist is a hardcoded frozenset — a pack cannot open a new fetch host as data | **Blocker** (trivial fix) | Only with a live provider | Phase 2 (one-line edit) / #2057 makes it declarative |
+| 1 | Host allowlist is a hardcoded frozenset — a pack cannot open a new fetch host as data | **Blocker** (trivial fix) | Only with a live provider | **Shipped** — `pack.yaml` `source_hosts` (see update callout) |
 | 2 | No scheduled/recurring scraping (`CELERY_BEAT_SCHEDULE` has no crawl entries) | Major | If continuous ingestion is in scope | Phase 3 (= #1444 Phase A) |
 | 3 | Provider rail is citation-keyed; no listing-page bulk-discovery shape | Major | If publisher-crawl is in scope | **Phase 2 — shipped, issue #2054** |
 | 4 | No multi-corpus orchestration (`CorpusGroup` / cross-corpus retrieval) | Major | No (per-area corpora work independently) | Phase 4 (= #1444 Phase B) |
 | 5 | Spanish / sala-aware classification has no core primitive | Minor | Spanish: no (data); sala-aware: with provider | Phase 1 handles Spanish via aliases/persona; sala-aware → Phase 2 provider code |
-| 6 | Provider discovery scans one hardcoded package — no out-of-tree isolation | Minor | No | Future (enables entry-point packs + DB-driven allowlist) |
-| 7 | Loader reads one default path; no multi-YAML merge; two baseline writers can collide on a prefix | Minor | No | Future |
+| 6 | Provider discovery scans one hardcoded package — no out-of-tree isolation | Minor | No | **Shipped** — in-pack providers + `AUTHORITY_PACK_PATHS` (see update callout) |
+| 7 | Loader reads one default path; no multi-YAML merge; two baseline writers can collide on a prefix | Minor | No | **Shipped** — issue #2057 (see update callout) |
 
 **Recommended phasing.** The pack's *core job* — taxonomy + provider + ingestion
 of cited/known authorities — binds cleanly today. Everything beyond that is the

--- a/docs/guides/authoring-authority-packs.md
+++ b/docs/guides/authoring-authority-packs.md
@@ -173,7 +173,10 @@ another (issue #2057):
   `skipped_foreign_baseline` in the command output) — first writer wins. Resolve
   a genuine collision by dropping the prefix from one YAML, or by curating the
   row through the console (making it manual-owned). The pack name `core` is
-  reserved for the shipped baseline.
+  reserved for the shipped baseline, and a pack's `name:` must be **unique
+  across every installed pack directory** (in-tree + `AUTHORITY_PACK_PATHS`):
+  two directories declaring the same name are treated as the same pack — they
+  co-own their prefixes with no collision guard between them.
 
 To converge the whole installed taxonomy — the shipped baseline plus every
 installed pack's mappings — in one idempotent run (e.g. after editing several

--- a/docs/guides/authoring-authority-packs.md
+++ b/docs/guides/authoring-authority-packs.md
@@ -157,6 +157,36 @@ already-loaded taxonomy/content rows persist (the loader upserts, it does not
 delete prefixes dropped from a YAML); remove them deliberately via the Authority
 Console if you want them gone.
 
+## Prefix ownership (what a re-load can and cannot clobber)
+
+Namespace rows are ownership-partitioned so no writer silently overwrites
+another (issue #2057):
+
+- A **curator edit** through the console stamps `source="manual"` — no loader
+  run ever touches the row again.
+- A **corpus-linked** namespace (`is_global=False`) is bootstrap-owned — same.
+- A **baseline** row is stamped with the writer that loaded it
+  (`AuthorityNamespace.baseline_origin`: the pack's manifest `name`, or `"core"`
+  for the shipped `authority_mappings.yaml`). Re-loading the same pack updates
+  its own rows (its YAML stays authoritative); a load that hits a prefix a
+  *different* origin owns **skips it with a warning** (counted as
+  `skipped_foreign_baseline` in the command output) — first writer wins. Resolve
+  a genuine collision by dropping the prefix from one YAML, or by curating the
+  row through the console (making it manual-owned). The pack name `core` is
+  reserved for the shipped baseline.
+
+To converge the whole installed taxonomy — the shipped baseline plus every
+installed pack's mappings — in one idempotent run (e.g. after editing several
+packs' YAMLs):
+
+```bash
+docker compose -f local.yml run --rm django python manage.py load_authority_mappings --include-packs
+```
+
+`load_authority_pack` stays the full per-pack loader (taxonomy **+ content +
+personas**); `load_authority_mappings --include-packs` re-converges taxonomy
+only, across every installed pack at once.
+
 ## Carrying a jurisdiction's citation vocabulary in the pack
 
 Beyond `prefixes`/`equivalences`/`rewrite_rules`, a pack's mappings YAML may carry

--- a/opencontractserver/annotations/management/commands/load_authority_mappings.py
+++ b/opencontractserver/annotations/management/commands/load_authority_mappings.py
@@ -2,35 +2,73 @@
 
 Re-runnable: upserts ``prefixes:`` into AuthorityNamespace (global) and
 ``equivalences:`` into AuthorityKeyEquivalence (source="baseline"), never
-clobbering ``source="manual"`` overrides or corpus-linked namespaces. Use after
-editing ``opencontractserver/enrichment/data/authority_mappings.yaml``.
+clobbering ``source="manual"`` overrides, corpus-linked namespaces, or a
+baseline prefix another writer origin owns. Use after editing
+``opencontractserver/enrichment/data/authority_mappings.yaml``.
+
+``--include-packs`` additionally merge-loads every installed authority pack's
+mappings YAML (in-tree ``authority_packs/`` + ``AUTHORITY_PACK_PATHS``), each
+stamped with the pack's name as its baseline origin — one command converges the
+whole installed taxonomy.
 """
 
 from django.core.management.base import BaseCommand
 
+from opencontractserver.enrichment.constants import BASELINE_ORIGIN_CORE
 from opencontractserver.enrichment.services.authority_mapping_loader import (
     AuthorityMappingLoader,
 )
 
 
 class Command(BaseCommand):
-    help = "Load the declarative authority-mappings baseline (prefixes + equivalences)."
+    help = (
+        "Load the declarative authority-mappings baseline (prefixes + "
+        "equivalences); --include-packs also merge-loads every installed "
+        "authority pack's mappings YAML."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--include-packs",
+            action="store_true",
+            help=(
+                "Also load every installed authority pack's mappings YAML "
+                "(in-tree authority_packs/ + AUTHORITY_PACK_PATHS), each "
+                "stamped with its pack name as baseline origin."
+            ),
+        )
 
     def handle(self, *args, **options):
-        summary = AuthorityMappingLoader.load_all()
+        if options["include_packs"]:
+            results = AuthorityMappingLoader.load_installed()
+        else:
+            results = {BASELINE_ORIGIN_CORE: AuthorityMappingLoader.load_all()}
+        for origin, summary in results.items():
+            self._report(origin, summary)
+
+    def _report(self, origin: str, summary: dict) -> None:
+        if "error" in summary:
+            # A malformed pack YAML was skipped (per-pack fault isolation in
+            # load_installed); surface it without failing the other packs.
+            self.stderr.write(
+                self.style.WARNING(f"[{origin}] SKIPPED: {summary['error']}")
+            )
+            return
         ns = summary["namespaces"]
         eq = summary["equivalences"]
         self.stdout.write(
             self.style.SUCCESS(
-                "authority namespaces loaded: "
+                f"[{origin}] authority namespaces loaded: "
                 f"created={ns['created']} updated={ns['updated']} "
                 f"skipped_corpus_linked={ns['skipped_corpus_linked']} "
+                f"skipped_manual={ns['skipped_manual']} "
+                f"skipped_foreign_baseline={ns['skipped_foreign_baseline']} "
                 f"total={ns['total']}"
             )
         )
         self.stdout.write(
             self.style.SUCCESS(
-                "authority equivalences loaded: "
+                f"[{origin}] authority equivalences loaded: "
                 f"created={eq['created']} updated={eq['updated']} "
                 f"skipped_owned={eq['skipped_owned']} total={eq['total']}"
             )

--- a/opencontractserver/annotations/migrations/0101_authoritynamespace_baseline_origin.py
+++ b/opencontractserver/annotations/migrations/0101_authoritynamespace_baseline_origin.py
@@ -1,0 +1,20 @@
+# Adds AuthorityNamespace.baseline_origin: provenance "which baseline writer"
+# (the core YAML vs. a specific pack's mappings YAML) so two source="baseline"
+# writers on the same prefix no longer silently last-write-wins (issue #2057).
+# Existing baseline rows stay NULL and are adopted (stamped) by the next owning
+# loader run / post_migrate seed.
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("annotations", "0100_alter_authorityfrontier_discovery_state"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="authoritynamespace",
+            name="baseline_origin",
+            field=models.CharField(blank=True, max_length=64, null=True),
+        ),
+    ]

--- a/opencontractserver/annotations/models.py
+++ b/opencontractserver/annotations/models.py
@@ -2115,7 +2115,11 @@ class AuthorityNamespace(django.db.models.Model):
     # two baseline writers on the same prefix (issue #2057). Null on
     # manual/corpus-linked rows and on legacy baseline rows written before this
     # field existed (those are adopted — stamped — by the next owning load).
-    baseline_origin = django.db.models.CharField(max_length=64, null=True, blank=True)
+    baseline_origin = django.db.models.CharField(
+        max_length=enrichment_constants.BASELINE_ORIGIN_MAX_LENGTH,
+        null=True,
+        blank=True,
+    )
     # Global namespaces always contribute aliases; corpus-linked ones only when
     # the corpus is visible (wired in authority_alias_registry).
     is_global = django.db.models.BooleanField(default=True, db_index=True)

--- a/opencontractserver/annotations/models.py
+++ b/opencontractserver/annotations/models.py
@@ -2106,6 +2106,16 @@ class AuthorityNamespace(django.db.models.Model):
         default="baseline",
         db_index=True,
     )
+    # Provenance "which baseline writer": for a ``source="baseline"`` row, the
+    # loader origin that owns the prefix — ``BASELINE_ORIGIN_CORE`` ("core") for
+    # the shipped authority_mappings.yaml / post_migrate seed, or a pack's
+    # manifest ``name`` for that pack's mappings YAML. The loader never
+    # overwrites a baseline row stamped with a DIFFERENT origin (first writer
+    # wins; the collision is logged), closing the last-write-wins hole between
+    # two baseline writers on the same prefix (issue #2057). Null on
+    # manual/corpus-linked rows and on legacy baseline rows written before this
+    # field existed (those are adopted — stamped — by the next owning load).
+    baseline_origin = django.db.models.CharField(max_length=64, null=True, blank=True)
     # Global namespaces always contribute aliases; corpus-linked ones only when
     # the corpus is visible (wired in authority_alias_registry).
     is_global = django.db.models.BooleanField(default=True, db_index=True)

--- a/opencontractserver/corpuses/management/commands/load_authority_pack.py
+++ b/opencontractserver/corpuses/management/commands/load_authority_pack.py
@@ -49,7 +49,10 @@ from opencontractserver.enrichment.authorities import (
     bootstrap_authority_corpus,
     read_section_spec,
 )
-from opencontractserver.enrichment.constants import BASELINE_ORIGIN_CORE
+from opencontractserver.enrichment.constants import (
+    BASELINE_ORIGIN_CORE,
+    BASELINE_ORIGIN_MAX_LENGTH,
+)
 from opencontractserver.enrichment.services.authority_mapping_loader import (
     AuthorityMappingLoader,
 )
@@ -125,6 +128,14 @@ class Command(BaseCommand):
                 f"Pack name {BASELINE_ORIGIN_CORE!r} is reserved for the shipped "
                 "core baseline (it is the namespace rows' baseline_origin stamp); "
                 "rename the pack."
+            )
+        if len(origin) > BASELINE_ORIGIN_MAX_LENGTH:
+            # The name becomes the baseline_origin stamp verbatim; an over-long
+            # one would only surface as a DB DataError mid-load, breaking the
+            # validate-before-write guarantee.
+            raise CommandError(
+                f"Pack name {origin!r} exceeds {BASELINE_ORIGIN_MAX_LENGTH} "
+                "characters (the baseline_origin column width); shorten it."
             )
 
         self._validate_source_hosts(manifest)

--- a/opencontractserver/corpuses/management/commands/load_authority_pack.py
+++ b/opencontractserver/corpuses/management/commands/load_authority_pack.py
@@ -49,6 +49,7 @@ from opencontractserver.enrichment.authorities import (
     bootstrap_authority_corpus,
     read_section_spec,
 )
+from opencontractserver.enrichment.constants import BASELINE_ORIGIN_CORE
 from opencontractserver.enrichment.services.authority_mapping_loader import (
     AuthorityMappingLoader,
 )
@@ -113,6 +114,12 @@ class Command(BaseCommand):
                 "Pack manifest declares neither 'mappings' nor 'corpora' — "
                 "nothing to load. Check the pack.yaml keys for typos."
             )
+        if str(manifest.get("name") or pack_dir.name) == BASELINE_ORIGIN_CORE:
+            raise CommandError(
+                f"Pack name {BASELINE_ORIGIN_CORE!r} is reserved for the shipped "
+                "core baseline (it is the namespace rows' baseline_origin stamp); "
+                "rename the pack."
+            )
 
         self._validate_source_hosts(manifest)
         if mappings_path is not None:
@@ -131,9 +138,12 @@ class Command(BaseCommand):
         validated = [self._validate_corpus_entry(entry, pack_dir) for entry in corpora]
 
         # ---- DB writes start here (pack fully validated) ----------------------
-        # 1) Taxonomy
+        # 1) Taxonomy — namespace rows are stamped with this pack's name as
+        # their baseline origin so another baseline writer (the core YAML or a
+        # different pack) can never silently clobber them, and vice versa.
         if mappings_path is not None:
-            self._load_taxonomy(mappings_path)
+            origin = str(manifest.get("name") or pack_dir.name)
+            self._load_taxonomy(mappings_path, origin=origin)
 
         # 2) Corpora + content + personas. Defer the reactive re-link until the
         # whole pack has loaded: each bootstrap_authority_corpus(relink=True)
@@ -196,18 +206,28 @@ class Command(BaseCommand):
             raise CommandError(f"Manifest 'mappings' not found: {mappings_path}")
         return mappings_path
 
-    def _load_taxonomy(self, mappings_path: Path) -> None:
+    def _load_taxonomy(self, mappings_path: Path, *, origin: str) -> None:
         """Load a pre-validated authority-mappings YAML into the registry."""
-        summary = AuthorityMappingLoader.load_all(path=mappings_path)
+        summary = AuthorityMappingLoader.load_all(path=mappings_path, origin=origin)
         ns, eq = summary["namespaces"], summary["equivalences"]
         self.stdout.write(
             self.style.SUCCESS(
                 f"taxonomy loaded: namespaces created={ns['created']} "
-                f"updated={ns['updated']} total={ns['total']}; "
+                f"updated={ns['updated']} "
+                f"skipped_foreign_baseline={ns['skipped_foreign_baseline']} "
+                f"total={ns['total']}; "
                 f"equivalences created={eq['created']} updated={eq['updated']} "
                 f"total={eq['total']}"
             )
         )
+        if ns["skipped_foreign_baseline"]:
+            self.stdout.write(
+                self.style.WARNING(
+                    f"{ns['skipped_foreign_baseline']} prefix(es) already owned "
+                    "by another baseline origin were left untouched (first "
+                    "writer wins) — see the log for the colliding prefixes."
+                )
+            )
 
     def _validate_corpus_entry(self, entry: dict, pack_dir: Path) -> tuple:
         """Validate one ``corpora[]`` entry without touching the database.

--- a/opencontractserver/corpuses/management/commands/load_authority_pack.py
+++ b/opencontractserver/corpuses/management/commands/load_authority_pack.py
@@ -53,6 +53,9 @@ from opencontractserver.enrichment.constants import BASELINE_ORIGIN_CORE
 from opencontractserver.enrichment.services.authority_mapping_loader import (
     AuthorityMappingLoader,
 )
+from opencontractserver.enrichment.services.authority_pack_config import (
+    pack_origin_name,
+)
 from opencontractserver.enrichment.services.authority_source_hosts import (
     is_valid_source_host,
 )
@@ -114,7 +117,10 @@ class Command(BaseCommand):
                 "Pack manifest declares neither 'mappings' nor 'corpora' — "
                 "nothing to load. Check the pack.yaml keys for typos."
             )
-        if str(manifest.get("name") or pack_dir.name) == BASELINE_ORIGIN_CORE:
+        origin = pack_origin_name(pack_dir, manifest)
+        if origin.lower() == BASELINE_ORIGIN_CORE:
+            # Case-insensitive so "Core" can't sail past while reading as the
+            # reserved name to a human.
             raise CommandError(
                 f"Pack name {BASELINE_ORIGIN_CORE!r} is reserved for the shipped "
                 "core baseline (it is the namespace rows' baseline_origin stamp); "
@@ -142,7 +148,6 @@ class Command(BaseCommand):
         # their baseline origin so another baseline writer (the core YAML or a
         # different pack) can never silently clobber them, and vice versa.
         if mappings_path is not None:
-            origin = str(manifest.get("name") or pack_dir.name)
             self._load_taxonomy(mappings_path, origin=origin)
 
         # 2) Corpora + content + personas. Defer the reactive re-link until the

--- a/opencontractserver/enrichment/_namespace_seed.py
+++ b/opencontractserver/enrichment/_namespace_seed.py
@@ -30,6 +30,11 @@ def seed(apps, schema_editor):
     # the field's presence (no manual/corpus rows can exist before the console
     # shipped anyway, so seeding unconditionally at those states is correct).
     has_source = any(f.name == "source" for f in AuthorityNamespace._meta.get_fields())
+    # ``baseline_origin`` (migration 0101) partitions baseline rows per WRITER
+    # ("core" vs. a pack's manifest name); guard on presence like ``source``.
+    has_origin = any(
+        f.name == "baseline_origin" for f in AuthorityNamespace._meta.get_fields()
+    )
 
     # Collect aliases per prefix from the reverse of AUTHORITY_PREFIX.
     aliases_by_prefix: dict[str, list[str]] = {}
@@ -47,6 +52,17 @@ def seed(apps, schema_editor):
                 # never clobber it. (authority_corpus predates ``source``, so it
                 # is always present when ``source`` is.)
                 continue
+            if (
+                has_origin
+                and existing is not None
+                and existing.baseline_origin
+                and existing.baseline_origin != C.BASELINE_ORIGIN_CORE
+            ):
+                # Another baseline writer (a pack) claimed this prefix first —
+                # the convergence mirrors AuthorityMappingLoader.load_namespaces'
+                # first-writer-wins guard and never clobbers it back to the
+                # constants baseline.
+                continue
 
         # Graceful fallback so adding a prefix to AUTHORITY_PREFIX without its
         # classification/display-name entry can never crash ``migrate`` on a
@@ -63,6 +79,10 @@ def seed(apps, schema_editor):
             # Stamp ownership explicitly so a re-converged row is unambiguously
             # loader-owned (matches load_namespaces' source="baseline").
             defaults["source"] = "baseline"
+        if has_origin:
+            # The convergence writes from the shipped constants — the same
+            # writer as the core-YAML loader run.
+            defaults["baseline_origin"] = C.BASELINE_ORIGIN_CORE
         AuthorityNamespace.objects.update_or_create(
             prefix=prefix,
             defaults=defaults,

--- a/opencontractserver/enrichment/constants.py
+++ b/opencontractserver/enrichment/constants.py
@@ -53,6 +53,12 @@ SEC_RULE_PREFIX = "sec-rule"
 # prefix another origin owns (see ``AuthorityMappingLoader.load_namespaces``).
 BASELINE_ORIGIN_CORE = "core"
 
+# Column width of ``AuthorityNamespace.baseline_origin`` (migration 0101). A
+# pack's manifest ``name`` becomes the stamp verbatim, so ``load_authority_pack``
+# fail-fasts a longer name up-front rather than surfacing a DB DataError
+# mid-load.
+BASELINE_ORIGIN_MAX_LENGTH = 64
+
 # Document-level relationship type for graph rollups — must match
 # DocumentRelationship.RELATIONSHIP_TYPE_CHOICES.
 DOC_REL_RELATIONSHIP = "RELATIONSHIP"

--- a/opencontractserver/enrichment/constants.py
+++ b/opencontractserver/enrichment/constants.py
@@ -46,6 +46,13 @@ AUTHORITY_PREFIX = _mappings.authority_prefix_map()
 # 17 CFR rules cited without a named authority.
 SEC_RULE_PREFIX = "sec-rule"
 
+# ``AuthorityNamespace.baseline_origin`` stamp for rows written from the shipped
+# core ``authority_mappings.yaml`` (loader default path + post_migrate seed).
+# Pack loads stamp the pack's manifest ``name`` instead, so two baseline writers
+# on the same prefix are distinguishable and the loader can refuse to clobber a
+# prefix another origin owns (see ``AuthorityMappingLoader.load_namespaces``).
+BASELINE_ORIGIN_CORE = "core"
+
 # Document-level relationship type for graph rollups — must match
 # DocumentRelationship.RELATIONSHIP_TYPE_CHOICES.
 DOC_REL_RELATIONSHIP = "RELATIONSHIP"

--- a/opencontractserver/enrichment/services/authority_mapping_loader.py
+++ b/opencontractserver/enrichment/services/authority_mapping_loader.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
-import yaml
 from django.db import transaction
 
 from opencontractserver.annotations.models import AuthorityNamespace
@@ -286,21 +285,25 @@ class AuthorityMappingLoader:
                 )
             try:
                 results[origin] = cls.load_all(path=mappings_path, origin=origin)
-            except (ValueError, OSError, yaml.YAMLError) as exc:
-                # Per-pack fault isolation, mirroring authority_pack_config's
-                # runtime scans: one malformed pack YAML must not abort the
-                # converge run for every other installed pack. ValueError is the
-                # reader's schema failure; yaml.YAMLError is a genuine parse
-                # failure (NOT a ValueError subclass); OSError an unreadable
-                # file. (A DIRECT ``load_all(path=...)`` on the same file still
-                # raises — the fail-fast path ``load_authority_pack`` relies on.)
+            except Exception as exc:
+                # Per-pack fault isolation, mirroring the registry's in-pack
+                # provider import: one broken pack must not abort the converge
+                # run for every other installed pack. Deliberately broad — a
+                # schema ValueError, a yaml.YAMLError parse failure (NOT a
+                # ValueError subclass), an unreadable file, or a DB-level
+                # DataError (e.g. an over-length name/prefix) all mean the same
+                # thing here: this pack didn't load (load_all's transaction
+                # rolled its writes back), report it and continue. (A DIRECT
+                # ``load_all(path=...)`` on the same file still raises — the
+                # fail-fast path ``load_authority_pack`` relies on.)
                 logger.error(
-                    "Skipping authority pack %r mappings (%s): %s",
+                    "Skipping authority pack %r mappings (%s): %s: %s",
                     origin,
                     mappings_path,
+                    type(exc).__name__,
                     exc,
                 )
-                results[origin] = {"error": str(exc)}
+                results[origin] = {"error": f"{type(exc).__name__}: {exc}"}
         # A pack whose pack.yaml itself failed to parse never reaches the loop
         # above; surface it in the report (keyed by directory name — the
         # manifest name is unreadable) instead of leaving it log-only.

--- a/opencontractserver/enrichment/services/authority_mapping_loader.py
+++ b/opencontractserver/enrichment/services/authority_mapping_loader.py
@@ -286,15 +286,20 @@ class AuthorityMappingLoader:
                     },
                 )
                 continue
-            if origin in results:
-                # Two installed pack dirs declaring the same manifest name are,
-                # by declaration, the same pack (e.g. an in-tree copy + an
-                # AUTHORITY_PACK_PATHS copy): they co-own their prefixes and the
-                # load stays idempotent, but flag it — the later summary
-                # replaces the earlier one in the report.
+            if any(origin.lower() == seen.lower() for seen in results):
+                # Case-insensitive, matching the reserved-name check. Two
+                # installed pack dirs declaring the SAME manifest name are, by
+                # declaration, the same pack (e.g. an in-tree copy + an
+                # AUTHORITY_PACK_PATHS copy): they co-own their prefixes, the
+                # load stays idempotent, and the later summary replaces the
+                # earlier one in the report. A case-DIFFERENT name ("Bolivia"
+                # vs "bolivia") loads as a distinct origin — the collision
+                # guard keeps the two from clobbering each other — but is
+                # almost certainly an authoring typo, so flag it either way.
                 logger.warning(
-                    "Duplicate authority pack name %r (dir %s); loading anyway "
-                    "under the same baseline origin.",
+                    "Duplicate authority pack name %r (dir %s); pack names "
+                    "must be unique (case-insensitively) across installed "
+                    "packs.",
                     origin,
                     pack_dir,
                 )

--- a/opencontractserver/enrichment/services/authority_mapping_loader.py
+++ b/opencontractserver/enrichment/services/authority_mapping_loader.py
@@ -1,23 +1,31 @@
 """Idempotent, source-scoped loader for the declarative authority-mappings baseline.
 
 ``opencontractserver/enrichment/data/authority_mappings.yaml`` is the single
-source of truth. This loader upserts it into the database:
+source of truth for the CORE baseline; each installed authority pack may carry
+its own mappings YAML (the file its ``pack.yaml`` points at via ``mappings:``).
+This loader upserts either into the database:
 
 - ``prefixes:``     → ``AuthorityNamespace`` registry rows (global, baseline)
 - ``equivalences:`` → ``AuthorityKeyEquivalence`` rows tagged ``source="baseline"``
 
 It NEVER overwrites a ``source="manual"`` equivalence (runtime curator override)
 nor a corpus-linked ``AuthorityNamespace`` (``is_global=False``, bootstrap-owned),
-so a re-load can't clobber operator/runtime state. Parsing + validation are
+so a re-load can't clobber operator/runtime state. Baseline namespace rows are
+additionally stamped with a writer ``baseline_origin`` (``"core"`` or the pack's
+manifest name) so two baseline writers on the same prefix cannot silently
+last-write-wins each other either — the first writer owns the prefix and a
+foreign origin is skipped with a warning (issue #2057). Parsing + validation are
 delegated to the pure ``enrichment.data.mappings`` reader (no Django models), so
 the YAML grammar has exactly one definition shared with ``enrichment.constants``.
 """
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 from opencontractserver.annotations.models import AuthorityNamespace
+from opencontractserver.enrichment.constants import BASELINE_ORIGIN_CORE
 from opencontractserver.enrichment.data import mappings as _mappings
 from opencontractserver.enrichment.services.authority_equivalence_ingest import (
     CREATED,
@@ -26,9 +34,11 @@ from opencontractserver.enrichment.services.authority_equivalence_ingest import 
     upsert_equivalence,
 )
 
+logger = logging.getLogger(__name__)
+
 
 class AuthorityMappingLoader:
-    """Load the declarative authority-mappings YAML into the database."""
+    """Load a declarative authority-mappings YAML into the database."""
 
     BASELINE = "baseline"
     MANUAL = "manual"
@@ -43,6 +53,12 @@ class AuthorityMappingLoader:
         untouched and counted under ``skipped_owned``. Mirrors
         ``authority_equivalence_ingest.upsert_equivalence``'s symmetric guard so
         no writer ever overwrites a row another source owns.
+
+        Unlike namespaces, equivalence rows carry no per-writer origin: the
+        ``(from_key, to_key)`` pair IS the row's content, so two baseline
+        writers declaring the same pair assert the same fact (only the optional
+        ``note`` can differ, and the last load's note wins — cosmetic, not a
+        clobber). Distinct pairs never touch each other.
 
         Returns ``{created, updated, skipped_owned, total}`` where ``total`` is
         the count of distinct validated ``(from_key, to_key)`` pairs in the file.
@@ -91,26 +107,42 @@ class AuthorityMappingLoader:
         }
 
     @classmethod
-    def load_namespaces(cls, *, path: Path | str | None = None) -> dict:
+    def load_namespaces(
+        cls, *, path: Path | str | None = None, origin: str | None = None
+    ) -> dict:
         """Upsert global ``AuthorityNamespace`` registry rows from ``prefixes:``.
 
-        Source-ownership partition (the loader owns only ``baseline``): a
-        pre-existing row is left untouched when EITHER
+        ``origin`` identifies the baseline WRITER — ``BASELINE_ORIGIN_CORE``
+        (``"core"``) for the shipped default YAML (the default when ``path`` is
+        omitted), or the pack's manifest ``name`` when loading a pack's mappings.
+
+        Source-ownership partition (the loader owns only ``baseline``, and each
+        baseline writer owns only its own prefixes): a pre-existing row is left
+        untouched when ANY of
 
         - it is corpus-linked (``is_global=False``, bootstrap-owned) — a re-load
           must never flip a corpus namespace to global (see
           ``AuthorityNamespace.save()``), OR
         - it is ``source="manual"`` — a curator created/edited it through the
           admin console; clobbering it on the next loader run would silently
-          discard the operator's edits.
+          discard the operator's edits, OR
+        - it is a baseline row stamped with a DIFFERENT ``baseline_origin`` —
+          another baseline writer (the core YAML vs. a pack, or two packs)
+          already owns the prefix. First writer wins; the collision is logged
+          and counted under ``skipped_foreign_baseline`` so two packs (or a
+          pack and the core baseline) can never silently clobber each other
+          (issue #2057). A legacy baseline row with a null origin is adopted —
+          updated and stamped with this run's origin.
 
-        Mirrors the equivalence loader's ``skipped_owned`` guard exactly.
         Returns ``{created, updated, skipped_corpus_linked, skipped_manual,
-        total}``.
+        skipped_foreign_baseline, total}``.
         """
+        if origin is None and path is None:
+            origin = BASELINE_ORIGIN_CORE
         prefixes = _mappings.iter_prefixes(path)
 
-        created = updated = skipped_corpus_linked = skipped_manual = 0
+        created = updated = 0
+        skipped_corpus_linked = skipped_manual = skipped_foreign_baseline = 0
         for prefix, spec in prefixes.items():
             existing = AuthorityNamespace.objects.filter(prefix=prefix).first()
             if existing is not None and existing.authority_corpus_id:
@@ -120,6 +152,25 @@ class AuthorityMappingLoader:
             if existing is not None and existing.source == cls.MANUAL:
                 # A curator owns this prefix via the admin console; never clobber.
                 skipped_manual += 1
+                continue
+            if (
+                existing is not None
+                and existing.baseline_origin
+                and existing.baseline_origin != origin
+            ):
+                # Another baseline writer owns this prefix; never clobber. (An
+                # unattributed run — origin=None with an explicit path — can
+                # never steal an owned prefix either.)
+                skipped_foreign_baseline += 1
+                logger.warning(
+                    "Baseline collision on authority prefix %r: owned by origin "
+                    "%r, skipping the load from origin %r (first writer wins; "
+                    "resolve by removing the prefix from one YAML, or curate the "
+                    "row through the console to make it manual-owned).",
+                    prefix,
+                    existing.baseline_origin,
+                    origin,
+                )
                 continue
 
             _, was_created = AuthorityNamespace.objects.update_or_create(
@@ -131,6 +182,7 @@ class AuthorityMappingLoader:
                     "aliases": sorted(set(spec["aliases"])),
                     "is_global": True,
                     "source": cls.BASELINE,
+                    "baseline_origin": origin,
                 },
             )
             created += int(was_created)
@@ -141,17 +193,87 @@ class AuthorityMappingLoader:
             "updated": updated,
             "skipped_corpus_linked": skipped_corpus_linked,
             "skipped_manual": skipped_manual,
+            "skipped_foreign_baseline": skipped_foreign_baseline,
             "total": len(prefixes),
         }
 
     @classmethod
-    def load_all(cls, *, path: Path | str | None = None) -> dict:
-        """Upsert both namespaces and equivalences from the YAML.
+    def load_all(
+        cls, *, path: Path | str | None = None, origin: str | None = None
+    ) -> dict:
+        """Upsert both namespaces and equivalences from one YAML.
 
         Returns ``{"namespaces": {...}, "equivalences": {...}}``. Namespaces are
         loaded first so an equivalence's prefix always has a registry row.
+        ``origin`` is threaded to :meth:`load_namespaces` (equivalence rows carry
+        no per-writer origin — see :meth:`load`).
         """
         return {
-            "namespaces": cls.load_namespaces(path=path),
+            "namespaces": cls.load_namespaces(path=path, origin=origin),
             "equivalences": cls.load(path=path),
         }
+
+    @classmethod
+    def load_installed(cls) -> dict[str, dict]:
+        """Merge-load the core baseline YAML plus every installed pack's mappings.
+
+        One idempotent call converges the whole installed taxonomy: the shipped
+        ``authority_mappings.yaml`` first (origin ``"core"``), then each
+        installed pack's mappings YAML (in-tree ``authority_packs/`` +
+        ``AUTHORITY_PACK_PATHS``, in ``authority_pack_dirs()`` discovery order)
+        stamped with the pack's manifest ``name`` (falling back to its directory
+        name). Core loading first means that on a same-prefix collision the
+        shipped engine baseline wins and the pack's claim is skipped + warned —
+        the same "the baseline always wins" merge rule
+        ``authority_pack_config`` applies to shape rules / abbreviations.
+
+        Returns ``{origin: load_all()-summary}`` in load order.
+        """
+        # Lazy import: authority_pack_config reaches the pipeline registry to
+        # enumerate packs; consuming it lazily (like constants.classify_prefix
+        # does) keeps this module import-light for the migration/seed path.
+        from opencontractserver.enrichment.services.authority_pack_config import (
+            iter_pack_mapping_files,
+        )
+
+        results: dict[str, dict] = {BASELINE_ORIGIN_CORE: cls.load_all()}
+        for pack_dir, mappings_path, manifest in iter_pack_mapping_files():
+            origin = str(manifest.get("name") or pack_dir.name)
+            if origin == BASELINE_ORIGIN_CORE:
+                # A pack literally named "core" would impersonate the shipped
+                # baseline and bypass the collision guard — refuse it.
+                logger.warning(
+                    "Skipping authority pack at %s: pack name %r is reserved "
+                    "for the shipped core baseline.",
+                    pack_dir,
+                    origin,
+                )
+                continue
+            if origin in results:
+                # Two installed pack dirs declaring the same manifest name are,
+                # by declaration, the same pack (e.g. an in-tree copy + an
+                # AUTHORITY_PACK_PATHS copy): they co-own their prefixes and the
+                # load stays idempotent, but flag it — the later summary
+                # replaces the earlier one in the report.
+                logger.warning(
+                    "Duplicate authority pack name %r (dir %s); loading anyway "
+                    "under the same baseline origin.",
+                    origin,
+                    pack_dir,
+                )
+            try:
+                results[origin] = cls.load_all(path=mappings_path, origin=origin)
+            except ValueError as exc:
+                # Per-pack fault isolation, mirroring authority_pack_config's
+                # runtime scans: one malformed pack YAML must not abort the
+                # converge run for every other installed pack. (A DIRECT
+                # ``load_all(path=...)`` on the same file still raises — the
+                # fail-fast path ``load_authority_pack`` relies on.)
+                logger.error(
+                    "Skipping authority pack %r mappings (%s): %s",
+                    origin,
+                    mappings_path,
+                    exc,
+                )
+                results[origin] = {"error": str(exc)}
+        return results

--- a/opencontractserver/enrichment/services/authority_mapping_loader.py
+++ b/opencontractserver/enrichment/services/authority_mapping_loader.py
@@ -246,6 +246,12 @@ class AuthorityMappingLoader:
         ``authority_pack_config`` applies to shape rules / abbreviations.
 
         Returns ``{origin: load_all()-summary}`` in load order.
+
+        Deliberate asymmetry: only PACK loads get per-origin fault isolation.
+        The initial core load raises on failure — a broken shipped
+        ``authority_mappings.yaml`` is a build defect (its own test suite and
+        the plain ``load_authority_mappings`` path fail on it), not an
+        installed-pack problem to route around.
         """
         # Lazy import: authority_pack_config reaches the pipeline registry to
         # enumerate packs; consuming it lazily (like constants.classify_prefix

--- a/opencontractserver/enrichment/services/authority_mapping_loader.py
+++ b/opencontractserver/enrichment/services/authority_mapping_loader.py
@@ -25,6 +25,7 @@ import logging
 from pathlib import Path
 
 import yaml
+from django.db import transaction
 
 from opencontractserver.annotations.models import AuthorityNamespace
 from opencontractserver.enrichment.constants import BASELINE_ORIGIN_CORE
@@ -212,17 +213,24 @@ class AuthorityMappingLoader:
     def load_all(
         cls, *, path: Path | str | None = None, origin: str | None = None
     ) -> dict:
-        """Upsert both namespaces and equivalences from one YAML.
+        """Upsert both namespaces and equivalences from one YAML, atomically.
 
         Returns ``{"namespaces": {...}, "equivalences": {...}}``. Namespaces are
         loaded first so an equivalence's prefix always has a registry row.
         ``origin`` is threaded to :meth:`load_namespaces` (equivalence rows carry
         no per-writer origin — see :meth:`load`).
+
+        The two steps run in ONE transaction: without it, a YAML with valid
+        ``prefixes:`` but a malformed ``equivalences:`` entry would durably
+        commit the namespace rows and then raise — leaving a half-loaded file
+        that ``load_installed`` / ``load_authority_pack`` would report as
+        "errored / nothing loaded". An error must mean nothing took effect.
         """
-        return {
-            "namespaces": cls.load_namespaces(path=path, origin=origin),
-            "equivalences": cls.load(path=path),
-        }
+        with transaction.atomic():
+            return {
+                "namespaces": cls.load_namespaces(path=path, origin=origin),
+                "equivalences": cls.load(path=path),
+            }
 
     @classmethod
     def load_installed(cls) -> dict[str, dict]:
@@ -245,6 +253,7 @@ class AuthorityMappingLoader:
         # does) keeps this module import-light for the migration/seed path.
         from opencontractserver.enrichment.services.authority_pack_config import (
             iter_pack_mapping_files,
+            pack_origin_name,
         )
 
         results: dict[str, dict] = {BASELINE_ORIGIN_CORE: cls.load_all()}
@@ -252,8 +261,8 @@ class AuthorityMappingLoader:
         for pack_dir, mappings_path, manifest in iter_pack_mapping_files(
             errors=manifest_errors
         ):
-            origin = str(manifest.get("name") or pack_dir.name)
-            if origin == BASELINE_ORIGIN_CORE:
+            origin = pack_origin_name(pack_dir, manifest)
+            if origin.lower() == BASELINE_ORIGIN_CORE:
                 # A pack literally named "core" would impersonate the shipped
                 # baseline and bypass the collision guard — refuse it.
                 logger.warning(

--- a/opencontractserver/enrichment/services/authority_mapping_loader.py
+++ b/opencontractserver/enrichment/services/authority_mapping_loader.py
@@ -263,12 +263,27 @@ class AuthorityMappingLoader:
             origin = pack_origin_name(pack_dir, manifest)
             if origin.lower() == BASELINE_ORIGIN_CORE:
                 # A pack literally named "core" would impersonate the shipped
-                # baseline and bypass the collision guard — refuse it.
+                # baseline and bypass the collision guard — refuse it, and put
+                # the refusal in the report (keyed by directory name — the
+                # reserved origin itself already keys the real core summary;
+                # setdefault keeps the loaded entry if even the dir is named
+                # "core") so the operator sees it in the command output, same
+                # as every other per-pack failure. load_authority_pack raises
+                # CommandError for the same condition.
                 logger.warning(
                     "Skipping authority pack at %s: pack name %r is reserved "
                     "for the shipped core baseline.",
                     pack_dir,
                     origin,
+                )
+                results.setdefault(
+                    pack_dir.name,
+                    {
+                        "error": (
+                            f"pack name {origin!r} is reserved for the shipped "
+                            "core baseline; rename the pack"
+                        )
+                    },
                 )
                 continue
             if origin in results:

--- a/opencontractserver/enrichment/services/authority_mapping_loader.py
+++ b/opencontractserver/enrichment/services/authority_mapping_loader.py
@@ -24,6 +24,8 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
+import yaml
+
 from opencontractserver.annotations.models import AuthorityNamespace
 from opencontractserver.enrichment.constants import BASELINE_ORIGIN_CORE
 from opencontractserver.enrichment.data import mappings as _mappings
@@ -144,6 +146,15 @@ class AuthorityMappingLoader:
         created = updated = 0
         skipped_corpus_linked = skipped_manual = skipped_foreign_baseline = 0
         for prefix, spec in prefixes.items():
+            # NOTE: read-then-decide-then-write without select_for_update. Two
+            # CONCURRENT loader runs with different origins racing on a
+            # brand-new prefix could both see "absent" and the second write
+            # would win without hitting the ownership guard. Accepted: namespace
+            # loads are operator-run management commands / migrations, not
+            # concurrent runtime writers (unlike equivalences, whose
+            # ``upsert_equivalence`` IS invoked from concurrent ingest tasks and
+            # therefore locks). Revisit if namespace loading ever moves into a
+            # task fan-out.
             existing = AuthorityNamespace.objects.filter(prefix=prefix).first()
             if existing is not None and existing.authority_corpus_id:
                 # A corpus-scoped namespace owns this prefix; never overwrite it.
@@ -237,7 +248,10 @@ class AuthorityMappingLoader:
         )
 
         results: dict[str, dict] = {BASELINE_ORIGIN_CORE: cls.load_all()}
-        for pack_dir, mappings_path, manifest in iter_pack_mapping_files():
+        manifest_errors: list = []
+        for pack_dir, mappings_path, manifest in iter_pack_mapping_files(
+            errors=manifest_errors
+        ):
             origin = str(manifest.get("name") or pack_dir.name)
             if origin == BASELINE_ORIGIN_CORE:
                 # A pack literally named "core" would impersonate the shipped
@@ -263,12 +277,14 @@ class AuthorityMappingLoader:
                 )
             try:
                 results[origin] = cls.load_all(path=mappings_path, origin=origin)
-            except ValueError as exc:
+            except (ValueError, OSError, yaml.YAMLError) as exc:
                 # Per-pack fault isolation, mirroring authority_pack_config's
                 # runtime scans: one malformed pack YAML must not abort the
-                # converge run for every other installed pack. (A DIRECT
-                # ``load_all(path=...)`` on the same file still raises — the
-                # fail-fast path ``load_authority_pack`` relies on.)
+                # converge run for every other installed pack. ValueError is the
+                # reader's schema failure; yaml.YAMLError is a genuine parse
+                # failure (NOT a ValueError subclass); OSError an unreadable
+                # file. (A DIRECT ``load_all(path=...)`` on the same file still
+                # raises — the fail-fast path ``load_authority_pack`` relies on.)
                 logger.error(
                     "Skipping authority pack %r mappings (%s): %s",
                     origin,
@@ -276,4 +292,9 @@ class AuthorityMappingLoader:
                     exc,
                 )
                 results[origin] = {"error": str(exc)}
+        # A pack whose pack.yaml itself failed to parse never reaches the loop
+        # above; surface it in the report (keyed by directory name — the
+        # manifest name is unreadable) instead of leaving it log-only.
+        for pack_dir, message in manifest_errors:
+            results.setdefault(pack_dir.name, {"error": message})
         return results

--- a/opencontractserver/enrichment/services/authority_mapping_loader.py
+++ b/opencontractserver/enrichment/services/authority_mapping_loader.py
@@ -256,34 +256,29 @@ class AuthorityMappingLoader:
         )
 
         results: dict[str, dict] = {BASELINE_ORIGIN_CORE: cls.load_all()}
-        manifest_errors: list = []
+        pack_errors: list = []
         for pack_dir, mappings_path, manifest in iter_pack_mapping_files(
-            errors=manifest_errors
+            errors=pack_errors
         ):
             origin = pack_origin_name(pack_dir, manifest)
             if origin.lower() == BASELINE_ORIGIN_CORE:
                 # A pack literally named "core" would impersonate the shipped
                 # baseline and bypass the collision guard — refuse it, and put
-                # the refusal in the report (keyed by directory name — the
-                # reserved origin itself already keys the real core summary;
-                # setdefault keeps the loaded entry if even the dir is named
-                # "core") so the operator sees it in the command output, same
-                # as every other per-pack failure. load_authority_pack raises
-                # CommandError for the same condition.
+                # the refusal in the report so the operator sees it in the
+                # command output, same as every other per-pack failure.
+                # load_authority_pack raises CommandError for the same
+                # condition.
                 logger.warning(
                     "Skipping authority pack at %s: pack name %r is reserved "
                     "for the shipped core baseline.",
                     pack_dir,
                     origin,
                 )
-                results.setdefault(
-                    pack_dir.name,
-                    {
-                        "error": (
-                            f"pack name {origin!r} is reserved for the shipped "
-                            "core baseline; rename the pack"
-                        )
-                    },
+                _report_pack_error(
+                    results,
+                    pack_dir,
+                    f"pack name {origin!r} is reserved for the shipped "
+                    "core baseline; rename the pack",
                 )
                 continue
             if any(origin.lower() == seen.lower() for seen in results):
@@ -324,9 +319,19 @@ class AuthorityMappingLoader:
                     exc,
                 )
                 results[origin] = {"error": f"{type(exc).__name__}: {exc}"}
-        # A pack whose pack.yaml itself failed to parse never reaches the loop
-        # above; surface it in the report (keyed by directory name — the
-        # manifest name is unreadable) instead of leaving it log-only.
-        for pack_dir, message in manifest_errors:
-            results.setdefault(pack_dir.name, {"error": message})
+        # A pack the iterator classified as broken (unparsable pack.yaml, or a
+        # declared mappings file missing on disk) never reaches the loop above;
+        # surface it in the report instead of leaving it log-only.
+        for pack_dir, message in pack_errors:
+            _report_pack_error(results, pack_dir, message)
         return results
+
+
+def _report_pack_error(results: dict, pack_dir: Path, message: str) -> None:
+    """Record a per-pack failure in ``load_installed``'s report without ever
+    displacing (or being hidden behind) another entry: keyed by the pack's
+    directory name, falling back to its full path when that key is already
+    taken (e.g. a directory literally named "core" — the reserved origin keys
+    the real core summary)."""
+    key = pack_dir.name if pack_dir.name not in results else str(pack_dir)
+    results.setdefault(key, {"error": message})

--- a/opencontractserver/enrichment/services/authority_pack_config.py
+++ b/opencontractserver/enrichment/services/authority_pack_config.py
@@ -54,13 +54,20 @@ ShapeRule = tuple[re.Pattern, "str | None", "str | None"]
 AbbrevEntry = tuple[str, str, str]
 
 
-def iter_pack_mapping_files():
+def iter_pack_mapping_files(errors: "list | None" = None):
     """Yield ``(pack_dir, mappings_yaml_path, manifest)`` for every installed pack
     that declares a ``mappings:`` file that exists on disk.
 
     ``manifest`` is the parsed ``pack.yaml`` dict — yielded so callers that need
     manifest metadata (e.g. ``AuthorityMappingLoader.load_installed`` deriving the
     pack's baseline origin from ``name:``) don't re-read/re-parse the file.
+
+    ``errors``: optional list to which ``(pack_dir, message)`` is appended for a
+    pack whose ``pack.yaml`` cannot be parsed, so a reporting caller
+    (``load_installed``) can surface the skip to the operator instead of it
+    living only in the log. The runtime vocab scans omit it (log-and-skip is
+    their whole contract). A manifest with no ``mappings:`` key is a
+    content-only pack — skipped by design, never an error.
     """
     for pack_dir in authority_pack_dirs():
         manifest = pack_dir / "pack.yaml"
@@ -70,6 +77,8 @@ def iter_pack_mapping_files():
             data = yaml.safe_load(manifest.read_text(encoding="utf-8")) or {}
         except yaml.YAMLError as exc:
             logger.warning("Could not parse %s: %s", manifest, exc)
+            if errors is not None:
+                errors.append((pack_dir, f"could not parse pack.yaml: {exc}"))
             continue
         rel = data.get("mappings")
         if not rel:

--- a/opencontractserver/enrichment/services/authority_pack_config.py
+++ b/opencontractserver/enrichment/services/authority_pack_config.py
@@ -54,6 +54,14 @@ ShapeRule = tuple[re.Pattern, "str | None", "str | None"]
 AbbrevEntry = tuple[str, str, str]
 
 
+def pack_origin_name(pack_dir: Path, manifest: dict) -> str:
+    """A pack's identity string (its ``baseline_origin`` stamp / registry key):
+    the manifest ``name:``, falling back to the pack directory's name. Shared by
+    the mapping loader and ``load_authority_pack`` so the two can never derive
+    different origins for the same pack."""
+    return str((manifest or {}).get("name") or pack_dir.name)
+
+
 def iter_pack_mapping_files(errors: "list | None" = None):
     """Yield ``(pack_dir, mappings_yaml_path, manifest)`` for every installed pack
     that declares a ``mappings:`` file that exists on disk.

--- a/opencontractserver/enrichment/services/authority_pack_config.py
+++ b/opencontractserver/enrichment/services/authority_pack_config.py
@@ -62,7 +62,7 @@ def pack_origin_name(pack_dir: Path, manifest: dict) -> str:
     return str((manifest or {}).get("name") or pack_dir.name)
 
 
-def iter_pack_mapping_files(errors: "list | None" = None):
+def iter_pack_mapping_files(errors: list | None = None):
     """Yield ``(pack_dir, mappings_yaml_path, manifest)`` for every installed pack
     that declares a ``mappings:`` file that exists on disk.
 

--- a/opencontractserver/enrichment/services/authority_pack_config.py
+++ b/opencontractserver/enrichment/services/authority_pack_config.py
@@ -54,9 +54,14 @@ ShapeRule = tuple[re.Pattern, "str | None", "str | None"]
 AbbrevEntry = tuple[str, str, str]
 
 
-def _iter_pack_mapping_files():
-    """Yield ``(pack_dir, mappings_yaml_path)`` for every installed pack that
-    declares a ``mappings:`` file that exists on disk."""
+def iter_pack_mapping_files():
+    """Yield ``(pack_dir, mappings_yaml_path, manifest)`` for every installed pack
+    that declares a ``mappings:`` file that exists on disk.
+
+    ``manifest`` is the parsed ``pack.yaml`` dict — yielded so callers that need
+    manifest metadata (e.g. ``AuthorityMappingLoader.load_installed`` deriving the
+    pack's baseline origin from ``name:``) don't re-read/re-parse the file.
+    """
     for pack_dir in authority_pack_dirs():
         manifest = pack_dir / "pack.yaml"
         if not manifest.is_file():
@@ -71,7 +76,7 @@ def _iter_pack_mapping_files():
             continue
         path = pack_dir / rel
         if path.is_file():
-            yield pack_dir, path
+            yield pack_dir, path, data
 
 
 def _load_yaml(path: Path) -> dict:
@@ -170,7 +175,7 @@ def validate_pack_taxonomy_extensions(mappings_path: Path) -> None:
 def pack_declared_shape_rules() -> tuple[ShapeRule, ...]:
     """Compiled shape rules contributed by every installed pack (cached)."""
     rules: list[ShapeRule] = []
-    for pack_dir, mappings_path in _iter_pack_mapping_files():
+    for pack_dir, mappings_path, _manifest in iter_pack_mapping_files():
         data = _load_yaml(mappings_path)
         try:
             parsed = iter_shape_rules(data, label=str(mappings_path))
@@ -203,7 +208,7 @@ def pack_declared_abbreviations() -> (
     """
     state: dict[str, AbbrevEntry] = {}
     municipal: dict[str, AbbrevEntry] = {}
-    for pack_dir, mappings_path in _iter_pack_mapping_files():
+    for pack_dir, mappings_path, _manifest in iter_pack_mapping_files():
         data = _load_yaml(mappings_path)
         try:
             parsed = iter_abbreviations(data, label=str(mappings_path))

--- a/opencontractserver/enrichment/services/authority_pack_config.py
+++ b/opencontractserver/enrichment/services/authority_pack_config.py
@@ -71,11 +71,13 @@ def iter_pack_mapping_files(errors: list | None = None):
     pack's baseline origin from ``name:``) don't re-read/re-parse the file.
 
     ``errors``: optional list to which ``(pack_dir, message)`` is appended for a
-    pack whose ``pack.yaml`` cannot be parsed, so a reporting caller
-    (``load_installed``) can surface the skip to the operator instead of it
-    living only in the log. The runtime vocab scans omit it (log-and-skip is
-    their whole contract). A manifest with no ``mappings:`` key is a
-    content-only pack — skipped by design, never an error.
+    pack that is broken rather than merely mappings-less — an unparsable
+    ``pack.yaml``, or a declared ``mappings:`` file missing on disk (the classic
+    typo) — so a reporting caller (``load_installed``) can surface the skip to
+    the operator instead of it living only in the log. The runtime vocab scans
+    omit it (log-and-skip is their whole contract). A manifest with no
+    ``mappings:`` key is a content-only pack — skipped by design, never an
+    error.
     """
     for pack_dir in authority_pack_dirs():
         manifest = pack_dir / "pack.yaml"
@@ -92,8 +94,20 @@ def iter_pack_mapping_files(errors: list | None = None):
         if not rel:
             continue
         path = pack_dir / rel
-        if path.is_file():
-            yield pack_dir, path, data
+        if not path.is_file():
+            # Declared but absent — a typo'd path would otherwise make the
+            # pack's taxonomy silently never load (load_authority_pack raises
+            # CommandError for this same condition).
+            logger.warning(
+                "Pack %s declares mappings %r but %s does not exist",
+                pack_dir.name,
+                rel,
+                path,
+            )
+            if errors is not None:
+                errors.append((pack_dir, f"declared mappings file not found: {path}"))
+            continue
+        yield pack_dir, path, data
 
 
 def _load_yaml(path: Path) -> dict:

--- a/opencontractserver/tests/test_authority_mapping_loader.py
+++ b/opencontractserver/tests/test_authority_mapping_loader.py
@@ -795,6 +795,33 @@ class LoadAuthorityMappingsCommandTests(TestCase):
         assert f"[{BASELINE_ORIGIN_CORE}]" in out.getvalue()
         assert "[bolivia]" in out.getvalue()
 
+    def test_command_include_packs_prints_skipped_for_broken_pack(self):
+        # A broken pack's error entry must reach the command's stderr as a
+        # SKIPPED line — the operator-facing half of the per-pack isolation.
+        import tempfile as _tempfile
+        from pathlib import Path as _Path
+        from unittest import mock
+
+        from opencontractserver.enrichment.services import authority_pack_config as apc
+
+        with _tempfile.TemporaryDirectory() as tmp:
+            pack = _Path(tmp) / "brokenpack"
+            pack.mkdir()
+            (pack / "pack.yaml").write_text(
+                "name: brokenpack\nmappings: m.yaml\n", encoding="utf-8"
+            )
+            (pack / "m.yaml").write_text("prefixes: [unclosed\n", encoding="utf-8")
+            out, err = StringIO(), StringIO()
+            with mock.patch.object(apc, "authority_pack_dirs", return_value=[pack]):
+                call_command(
+                    "load_authority_mappings",
+                    "--include-packs",
+                    stdout=out,
+                    stderr=err,
+                )
+        assert "[brokenpack] SKIPPED:" in err.getvalue()
+        assert f"[{BASELINE_ORIGIN_CORE}]" in out.getvalue()
+
 
 class AuthorityMappingsMigrationTests(TestCase):
     """Verify the data migration's effect: the shipped baseline loads.

--- a/opencontractserver/tests/test_authority_mapping_loader.py
+++ b/opencontractserver/tests/test_authority_mapping_loader.py
@@ -466,6 +466,43 @@ class LoadInstalledTests(TestCase):
         assert "error" in results["badpack"]
         assert not AuthorityNamespace.objects.filter(prefix="test-atomic").exists()
 
+    def test_load_installed_isolates_a_db_level_failure(self):
+        # An over-length pack name only fails at the DB layer (DataError writing
+        # baseline_origin) — not a ValueError/YAMLError. The per-pack isolation
+        # must still contain it: load_all's transaction rolls the pack back, the
+        # error is reported under its origin, and the core baseline survives.
+        import tempfile as _tempfile
+        from pathlib import Path as _Path
+        from unittest import mock
+
+        from opencontractserver.enrichment.constants import (
+            BASELINE_ORIGIN_MAX_LENGTH,
+        )
+        from opencontractserver.enrichment.services import authority_pack_config as apc
+
+        long_name = "x" * (BASELINE_ORIGIN_MAX_LENGTH + 1)
+        with _tempfile.TemporaryDirectory() as tmp:
+            pack = _Path(tmp) / "longname"
+            pack.mkdir()
+            (pack / "pack.yaml").write_text(
+                f"name: {long_name}\nmappings: m.yaml\n", encoding="utf-8"
+            )
+            (pack / "m.yaml").write_text(
+                "prefixes:\n"
+                "  test-longname:\n"
+                '    display_name: "Long"\n'
+                '    jurisdiction: "aa"\n'
+                '    authority_type: "statute"\n'
+                '    aliases: ["long name body"]\n',
+                encoding="utf-8",
+            )
+            with mock.patch.object(apc, "authority_pack_dirs", return_value=[pack]):
+                results = AuthorityMappingLoader.load_installed()
+
+        assert "error" in results[long_name]
+        assert not AuthorityNamespace.objects.filter(prefix="test-longname").exists()
+        assert AuthorityNamespace.objects.filter(prefix="exchange-act").exists()
+
     def test_load_installed_reports_an_unparsable_manifest(self):
         # A pack whose pack.yaml ITSELF cannot be parsed never yields a mappings
         # file — it must still appear in the report as an error (keyed by its

--- a/opencontractserver/tests/test_authority_mapping_loader.py
+++ b/opencontractserver/tests/test_authority_mapping_loader.py
@@ -35,6 +35,9 @@ _FIXTURE_TO = "usc-99:1"
 _FIXTURE_FROM_2 = "test-act:2"
 _FIXTURE_TO_2 = "usc-99:2"
 
+# Logger the loader emits its ownership/collision warnings on (assertLogs target).
+_LOADER_LOGGER = "opencontractserver.enrichment.services.authority_mapping_loader"
+
 
 class AuthorityKeyEquivalenceBaselineChoiceTests(TestCase):
     def test_baseline_is_a_valid_source(self):
@@ -272,7 +275,6 @@ class BaselineOriginGuardTests(TestCase):
     (``update_or_create`` with no writer partition).
     """
 
-    _LOADER_LOGGER = "opencontractserver.enrichment.services.authority_mapping_loader"
     _PACK_A_YAML = (
         "prefixes:\n"
         "  test-pack-a:\n"
@@ -330,7 +332,7 @@ class BaselineOriginGuardTests(TestCase):
         AuthorityMappingLoader.load_namespaces(
             path=_write_yaml(self._PACK_A_YAML), origin="pack-a"
         )
-        with self.assertLogs(self._LOADER_LOGGER, level="WARNING"):
+        with self.assertLogs(_LOADER_LOGGER, level="WARNING"):
             summary = AuthorityMappingLoader.load_namespaces(
                 path=_write_yaml(self._PACK_B_CLAIMS_A_YAML), origin="pack-b"
             )
@@ -538,15 +540,13 @@ class LoadInstalledTests(TestCase):
                 _mk(root, "dup-b", "duppack", "test-dup-b"),
             ]
             with mock.patch.object(apc, "authority_pack_dirs", return_value=packs):
-                with self.assertLogs(self._LOADER_LOGGER, level="WARNING") as logs:
+                with self.assertLogs(_LOADER_LOGGER, level="WARNING") as logs:
                     results = AuthorityMappingLoader.load_installed()
 
         assert any("Duplicate authority pack name" in line for line in logs.output)
         # Both still load, as distinct origins the guard keeps apart.
         assert results["DupPack"]["namespaces"]["created"] == 1
         assert results["duppack"]["namespaces"]["created"] == 1
-
-    _LOADER_LOGGER = "opencontractserver.enrichment.services.authority_mapping_loader"
 
     def test_load_installed_reports_a_reserved_core_pack_name(self):
         # An installed pack named "core" (any case) is refused — and the refusal

--- a/opencontractserver/tests/test_authority_mapping_loader.py
+++ b/opencontractserver/tests/test_authority_mapping_loader.py
@@ -548,6 +548,73 @@ class LoadInstalledTests(TestCase):
         assert results["DupPack"]["namespaces"]["created"] == 1
         assert results["duppack"]["namespaces"]["created"] == 1
 
+    def test_load_installed_reports_a_missing_mappings_file(self):
+        # `mappings: typo.yaml` with no such file on disk — the most likely
+        # authoring mistake — must show up in the report, not silently make the
+        # pack's taxonomy never load.
+        import tempfile as _tempfile
+        from pathlib import Path as _Path
+        from unittest import mock
+
+        from opencontractserver.enrichment.services import authority_pack_config as apc
+
+        with _tempfile.TemporaryDirectory() as tmp:
+            pack = _Path(tmp) / "typo-pack"
+            pack.mkdir()
+            (pack / "pack.yaml").write_text(
+                "name: typo-pack\nmappings: typo.yaml\n", encoding="utf-8"
+            )
+            with mock.patch.object(apc, "authority_pack_dirs", return_value=[pack]):
+                results = AuthorityMappingLoader.load_installed()
+
+        assert "not found" in results["typo-pack"]["error"]
+        assert BASELINE_ORIGIN_CORE in results
+
+    def test_load_installed_exact_duplicate_names_coown_and_warn(self):
+        # Two directories declaring the SAME manifest name are by declaration
+        # the same pack: both load under one origin (idempotent, co-owned
+        # prefixes), the duplicate warning fires, and the report carries one
+        # entry for that origin.
+        import tempfile as _tempfile
+        from pathlib import Path as _Path
+        from unittest import mock
+
+        from opencontractserver.enrichment.services import authority_pack_config as apc
+
+        def _mk(root: _Path, dirname: str, prefix: str) -> _Path:
+            pack = root / dirname
+            pack.mkdir()
+            (pack / "pack.yaml").write_text(
+                "name: SamePack\nmappings: m.yaml\n", encoding="utf-8"
+            )
+            (pack / "m.yaml").write_text(
+                f"prefixes:\n"
+                f"  {prefix}:\n"
+                f'    display_name: "Same"\n'
+                f'    jurisdiction: "aa"\n'
+                f'    authority_type: "statute"\n'
+                f'    aliases: ["{prefix} body"]\n',
+                encoding="utf-8",
+            )
+            return pack
+
+        with _tempfile.TemporaryDirectory() as tmp:
+            root = _Path(tmp)
+            packs = [
+                _mk(root, "same-a", "test-same-a"),
+                _mk(root, "same-b", "test-same-b"),
+            ]
+            with mock.patch.object(apc, "authority_pack_dirs", return_value=packs):
+                with self.assertLogs(_LOADER_LOGGER, level="WARNING") as logs:
+                    results = AuthorityMappingLoader.load_installed()
+
+        assert any("Duplicate authority pack name" in line for line in logs.output)
+        # One shared origin: both dirs' prefixes exist, stamped identically.
+        assert "error" not in results["SamePack"]
+        for prefix in ("test-same-a", "test-same-b"):
+            ns = AuthorityNamespace.objects.get(prefix=prefix)
+            assert ns.baseline_origin == "SamePack"
+
     def test_load_installed_reports_a_reserved_core_pack_name(self):
         # An installed pack named "core" (any case) is refused — and the refusal
         # must appear in the report keyed by the pack's directory name, not
@@ -749,3 +816,16 @@ class AuthorityMappingsMigrationTests(TestCase):
         assert AuthorityKeyEquivalence.objects.filter(
             from_key="exchange-act:10", to_key="usc-15:78j", source="baseline"
         ).exists()
+
+
+class BaselineOriginGraphQLExposureTests(TestCase):
+    """Pin the console surface of the collision guard: ``baseline_origin`` is
+    queryable on ``AuthorityNamespaceNode`` (whose ``get_queryset`` already
+    gates the whole type behind ``is_authority_admin``), so a curator can see
+    which origin owns a prefix when a load reports a skipped collision."""
+
+    def test_baseline_origin_exposed_on_namespace_node(self):
+        from config.graphql.schema import schema
+
+        fields = schema.graphql_schema.type_map["AuthorityNamespaceNode"].fields
+        assert "baselineOrigin" in fields

--- a/opencontractserver/tests/test_authority_mapping_loader.py
+++ b/opencontractserver/tests/test_authority_mapping_loader.py
@@ -9,6 +9,7 @@ from opencontractserver.annotations.models import (
     AuthorityKeyEquivalence,
     AuthorityNamespace,
 )
+from opencontractserver.enrichment.constants import BASELINE_ORIGIN_CORE
 from opencontractserver.enrichment.services.authority_mapping_loader import (
     AuthorityMappingLoader,
 )
@@ -260,6 +261,182 @@ class AuthorityNamespaceLoaderTests(TestCase):
         assert "exchange act" in ns.aliases
 
 
+class BaselineOriginGuardTests(TestCase):
+    """Baseline-vs-baseline collision guard (issue #2057).
+
+    Every ``source="baseline"`` namespace row is stamped with its WRITER origin
+    (``baseline_origin``: "core" for the shipped YAML, else the pack's name), and
+    a loader run never overwrites a prefix a DIFFERENT origin owns — first
+    writer wins, the collision is warned + counted. Before the guard, two
+    baseline writers on the same prefix silently last-write-wins'd each other
+    (``update_or_create`` with no writer partition).
+    """
+
+    _LOADER_LOGGER = "opencontractserver.enrichment.services.authority_mapping_loader"
+    _PACK_A_YAML = (
+        "prefixes:\n"
+        "  test-pack-a:\n"
+        '    display_name: "Pack A Body"\n'
+        '    jurisdiction: "aa"\n'
+        '    authority_type: "statute"\n'
+        '    aliases: ["pack a body"]\n'
+    )
+    _PACK_B_YAML = (
+        "prefixes:\n"
+        "  test-pack-b:\n"
+        '    display_name: "Pack B Body"\n'
+        '    jurisdiction: "bb"\n'
+        '    authority_type: "statute"\n'
+        '    aliases: ["pack b body"]\n'
+    )
+    # Pack B claiming Pack A's prefix — the collision case.
+    _PACK_B_CLAIMS_A_YAML = (
+        "prefixes:\n"
+        "  test-pack-a:\n"
+        '    display_name: "Pack B CLOBBER"\n'
+        '    jurisdiction: "bb"\n'
+        '    authority_type: "regulation"\n'
+        '    aliases: ["clobbered"]\n'
+    )
+
+    def test_default_core_load_stamps_core_origin(self):
+        AuthorityMappingLoader.load_namespaces()
+        ns = AuthorityNamespace.objects.get(prefix="exchange-act")
+        assert ns.baseline_origin == BASELINE_ORIGIN_CORE
+
+    def test_reloading_two_packs_with_distinct_prefixes_never_clobbers(self):
+        # Issue #2057 acceptance criterion: re-loading two packs that touch
+        # distinct prefixes never clobbers each other.
+        path_a = _write_yaml(self._PACK_A_YAML)
+        path_b = _write_yaml(self._PACK_B_YAML)
+        AuthorityMappingLoader.load_namespaces(path=path_a, origin="pack-a")
+        AuthorityMappingLoader.load_namespaces(path=path_b, origin="pack-b")
+        summary = AuthorityMappingLoader.load_namespaces(path=path_a, origin="pack-a")
+        assert summary["updated"] == 1
+        assert summary["skipped_foreign_baseline"] == 0
+
+        row_a = AuthorityNamespace.objects.get(prefix="test-pack-a")
+        row_b = AuthorityNamespace.objects.get(prefix="test-pack-b")
+        assert (row_a.display_name, row_a.baseline_origin) == (
+            "Pack A Body",
+            "pack-a",
+        )
+        assert (row_b.display_name, row_b.baseline_origin) == (
+            "Pack B Body",
+            "pack-b",
+        )
+
+    def test_same_prefix_foreign_origin_is_skipped_and_warned(self):
+        AuthorityMappingLoader.load_namespaces(
+            path=_write_yaml(self._PACK_A_YAML), origin="pack-a"
+        )
+        with self.assertLogs(self._LOADER_LOGGER, level="WARNING"):
+            summary = AuthorityMappingLoader.load_namespaces(
+                path=_write_yaml(self._PACK_B_CLAIMS_A_YAML), origin="pack-b"
+            )
+        assert summary["skipped_foreign_baseline"] == 1
+        assert summary["created"] == 0
+        assert summary["updated"] == 0
+        row = AuthorityNamespace.objects.get(prefix="test-pack-a")
+        assert row.display_name == "Pack A Body"  # first writer wins
+        assert row.baseline_origin == "pack-a"
+
+    def test_unattributed_run_cannot_steal_owned_prefix(self):
+        # origin=None with an explicit path (an untagged ad-hoc load) must not
+        # be able to overwrite a prefix a named origin owns.
+        AuthorityMappingLoader.load_namespaces(
+            path=_write_yaml(self._PACK_A_YAML), origin="pack-a"
+        )
+        summary = AuthorityMappingLoader.load_namespaces(
+            path=_write_yaml(self._PACK_B_CLAIMS_A_YAML)
+        )
+        assert summary["skipped_foreign_baseline"] == 1
+        assert (
+            AuthorityNamespace.objects.get(prefix="test-pack-a").display_name
+            == "Pack A Body"
+        )
+
+    def test_legacy_null_origin_baseline_row_is_adopted(self):
+        # Pre-0101 baseline rows have no origin; the next owning load updates
+        # them and stamps its origin (adoption), so the fleet converges.
+        AuthorityNamespace.objects.create(
+            prefix="test-pack-a", display_name="Legacy row", source="baseline"
+        )
+        summary = AuthorityMappingLoader.load_namespaces(
+            path=_write_yaml(self._PACK_A_YAML), origin="pack-a"
+        )
+        assert summary["updated"] == 1
+        row = AuthorityNamespace.objects.get(prefix="test-pack-a")
+        assert row.display_name == "Pack A Body"
+        assert row.baseline_origin == "pack-a"
+
+    def test_manual_row_still_trumps_any_origin(self):
+        AuthorityNamespace.objects.create(
+            prefix="test-pack-a", display_name="CURATOR", source="manual"
+        )
+        summary = AuthorityMappingLoader.load_namespaces(
+            path=_write_yaml(self._PACK_A_YAML), origin="pack-a"
+        )
+        assert summary["skipped_manual"] == 1
+        assert (
+            AuthorityNamespace.objects.get(prefix="test-pack-a").display_name
+            == "CURATOR"
+        )
+
+
+class LoadInstalledTests(TestCase):
+    """``load_installed`` merge-loads the core YAML + every installed pack."""
+
+    def test_load_installed_merges_core_and_installed_packs(self):
+        results = AuthorityMappingLoader.load_installed()
+        # The in-tree reference bolivia pack is always installed.
+        assert BASELINE_ORIGIN_CORE in results
+        assert "bolivia" in results
+
+        core_ns = AuthorityNamespace.objects.get(prefix="exchange-act")
+        assert core_ns.baseline_origin == BASELINE_ORIGIN_CORE
+        pack_ns = AuthorityNamespace.objects.get(prefix="cpe")
+        assert pack_ns.baseline_origin == "bolivia"
+        assert pack_ns.is_global is True
+
+    def test_load_installed_is_idempotent(self):
+        AuthorityMappingLoader.load_installed()
+        second = AuthorityMappingLoader.load_installed()
+        for origin, summary in second.items():
+            ns = summary["namespaces"]
+            assert ns["created"] == 0, origin
+            assert ns["skipped_foreign_baseline"] == 0, origin
+
+    def test_load_installed_isolates_a_malformed_pack(self):
+        # One pack with a broken mappings YAML must not abort the converge run:
+        # it is reported under its origin as an error, the core baseline (and
+        # any other pack) still loads.
+        import tempfile as _tempfile
+        from pathlib import Path as _Path
+        from unittest import mock
+
+        from opencontractserver.enrichment.services import (
+            authority_pack_config as apc,
+        )
+
+        with _tempfile.TemporaryDirectory() as tmp:
+            bad_pack = _Path(tmp) / "badpack"
+            bad_pack.mkdir()
+            (bad_pack / "pack.yaml").write_text(
+                "name: badpack\nmappings: m.yaml\n", encoding="utf-8"
+            )
+            (bad_pack / "m.yaml").write_text(
+                'prefixes:\n  "NOT A VALID PREFIX!!":\n    display_name: "x"\n',
+                encoding="utf-8",
+            )
+            with mock.patch.object(apc, "authority_pack_dirs", return_value=[bad_pack]):
+                results = AuthorityMappingLoader.load_installed()
+
+        assert "error" in results["badpack"]
+        assert BASELINE_ORIGIN_CORE in results
+        assert AuthorityNamespace.objects.filter(prefix="exchange-act").exists()
+
+
 class NamespaceReseedOwnershipTests(TestCase):
     """The ``post_migrate`` namespace convergence (``ensure_seeded``) must honour
     the same source-ownership partition as ``AuthorityMappingLoader.load_namespaces``.
@@ -324,7 +501,8 @@ class NamespaceReseedOwnershipTests(TestCase):
 
     def test_reseed_still_converges_baseline_rows(self):
         # The convergence must still (re)create a shipped baseline prefix that is
-        # absent — its whole reason for existing (post-flush re-seed).
+        # absent — its whole reason for existing (post-flush re-seed). Rows it
+        # writes are stamped as core-origin baseline, same as the loader.
         from opencontractserver.enrichment._namespace_seed import ensure_seeded
 
         AuthorityNamespace.objects.filter(prefix="dgcl").delete()
@@ -332,6 +510,29 @@ class NamespaceReseedOwnershipTests(TestCase):
         ns = AuthorityNamespace.objects.get(prefix="dgcl")
         assert ns.is_global is True
         assert ns.source == "baseline"
+        assert ns.baseline_origin == BASELINE_ORIGIN_CORE
+
+    def test_reseed_respects_pack_owned_prefix(self):
+        # A shipped-constants prefix that a PACK claimed first (baseline_origin
+        # != "core") must survive the convergence: the seed mirrors the loader's
+        # first-writer-wins baseline-origin guard (issue #2057).
+        from opencontractserver.enrichment._namespace_seed import ensure_seeded
+
+        AuthorityNamespace.objects.update_or_create(
+            prefix="dgcl",
+            defaults={
+                "display_name": "PACK OWNED",
+                "is_global": True,
+                "source": "baseline",
+                "baseline_origin": "somepack",
+            },
+        )
+
+        ensure_seeded()
+
+        ns = AuthorityNamespace.objects.get(prefix="dgcl")
+        assert ns.display_name == "PACK OWNED"
+        assert ns.baseline_origin == "somepack"
 
 
 class LoadAuthorityMappingsCommandTests(TestCase):
@@ -343,6 +544,26 @@ class LoadAuthorityMappingsCommandTests(TestCase):
         ).exists()
         assert AuthorityNamespace.objects.filter(prefix="exchange-act").exists()
         assert "created" in out.getvalue().lower()
+
+    def test_command_default_does_not_load_packs(self):
+        # "cpe" ships only in the in-tree bolivia PACK, not the core YAML —
+        # clear any leaked copy, then verify the default (pack-less) run does
+        # not create it.
+        AuthorityNamespace.objects.filter(prefix="cpe").delete()
+        out = StringIO()
+        call_command("load_authority_mappings", stdout=out)
+        assert not AuthorityNamespace.objects.filter(prefix="cpe").exists()
+        assert f"[{BASELINE_ORIGIN_CORE}]" in out.getvalue()
+        assert "[bolivia]" not in out.getvalue()
+
+    def test_command_include_packs_merges_installed_packs(self):
+        out = StringIO()
+        call_command("load_authority_mappings", "--include-packs", stdout=out)
+        assert AuthorityNamespace.objects.filter(
+            prefix="cpe", baseline_origin="bolivia"
+        ).exists()
+        assert f"[{BASELINE_ORIGIN_CORE}]" in out.getvalue()
+        assert "[bolivia]" in out.getvalue()
 
 
 class AuthorityMappingsMigrationTests(TestCase):

--- a/opencontractserver/tests/test_authority_mapping_loader.py
+++ b/opencontractserver/tests/test_authority_mapping_loader.py
@@ -447,6 +447,25 @@ class LoadInstalledTests(TestCase):
         assert BASELINE_ORIGIN_CORE in results
         assert AuthorityNamespace.objects.filter(prefix="exchange-act").exists()
 
+    def test_load_all_error_leaves_no_partial_namespace_rows(self):
+        # load_all is atomic: valid prefixes: + a malformed equivalences: entry
+        # must roll the namespace writes back — an "errored" pack in the
+        # load_installed report means NOTHING took effect, not "namespaces
+        # landed, equivalences didn't".
+        body = (
+            "prefixes:\n"
+            "  test-atomic:\n"
+            '    display_name: "Atomic Body"\n'
+            '    jurisdiction: "aa"\n'
+            '    authority_type: "statute"\n'
+            '    aliases: ["atomic body"]\n'
+            "equivalences:\n"
+            '  - {from_key: "test-atomic:1"}\n'  # missing to_key -> ValueError
+        )
+        results = self._load_installed_with_bad_pack(body)
+        assert "error" in results["badpack"]
+        assert not AuthorityNamespace.objects.filter(prefix="test-atomic").exists()
+
     def test_load_installed_reports_an_unparsable_manifest(self):
         # A pack whose pack.yaml ITSELF cannot be parsed never yields a mappings
         # file — it must still appear in the report as an error (keyed by its

--- a/opencontractserver/tests/test_authority_mapping_loader.py
+++ b/opencontractserver/tests/test_authority_mapping_loader.py
@@ -503,6 +503,51 @@ class LoadInstalledTests(TestCase):
         assert not AuthorityNamespace.objects.filter(prefix="test-longname").exists()
         assert AuthorityNamespace.objects.filter(prefix="exchange-act").exists()
 
+    def test_load_installed_warns_on_case_different_duplicate_names(self):
+        # "Bolivia" vs "bolivia" is almost certainly an authoring typo: the two
+        # load as distinct origins (the collision guard keeps them from
+        # clobbering each other) but the duplicate-name warning must fire,
+        # case-insensitively — matching the reserved-name check.
+        import tempfile as _tempfile
+        from pathlib import Path as _Path
+        from unittest import mock
+
+        from opencontractserver.enrichment.services import authority_pack_config as apc
+
+        def _mk(root: _Path, dirname: str, name: str, prefix: str) -> _Path:
+            pack = root / dirname
+            pack.mkdir()
+            (pack / "pack.yaml").write_text(
+                f"name: {name}\nmappings: m.yaml\n", encoding="utf-8"
+            )
+            (pack / "m.yaml").write_text(
+                f"prefixes:\n"
+                f"  {prefix}:\n"
+                f'    display_name: "{name}"\n'
+                f'    jurisdiction: "aa"\n'
+                f'    authority_type: "statute"\n'
+                f'    aliases: ["{prefix} body"]\n',
+                encoding="utf-8",
+            )
+            return pack
+
+        with _tempfile.TemporaryDirectory() as tmp:
+            root = _Path(tmp)
+            packs = [
+                _mk(root, "dup-a", "DupPack", "test-dup-a"),
+                _mk(root, "dup-b", "duppack", "test-dup-b"),
+            ]
+            with mock.patch.object(apc, "authority_pack_dirs", return_value=packs):
+                with self.assertLogs(self._LOADER_LOGGER, level="WARNING") as logs:
+                    results = AuthorityMappingLoader.load_installed()
+
+        assert any("Duplicate authority pack name" in line for line in logs.output)
+        # Both still load, as distinct origins the guard keeps apart.
+        assert results["DupPack"]["namespaces"]["created"] == 1
+        assert results["duppack"]["namespaces"]["created"] == 1
+
+    _LOADER_LOGGER = "opencontractserver.enrichment.services.authority_mapping_loader"
+
     def test_load_installed_reports_a_reserved_core_pack_name(self):
         # An installed pack named "core" (any case) is refused — and the refusal
         # must appear in the report keyed by the pack's directory name, not

--- a/opencontractserver/tests/test_authority_mapping_loader.py
+++ b/opencontractserver/tests/test_authority_mapping_loader.py
@@ -503,6 +503,37 @@ class LoadInstalledTests(TestCase):
         assert not AuthorityNamespace.objects.filter(prefix="test-longname").exists()
         assert AuthorityNamespace.objects.filter(prefix="exchange-act").exists()
 
+    def test_load_installed_reports_a_reserved_core_pack_name(self):
+        # An installed pack named "core" (any case) is refused — and the refusal
+        # must appear in the report keyed by the pack's directory name, not
+        # vanish into the log. Nothing from the pack's YAML may load.
+        import tempfile as _tempfile
+        from pathlib import Path as _Path
+        from unittest import mock
+
+        from opencontractserver.enrichment.services import authority_pack_config as apc
+
+        with _tempfile.TemporaryDirectory() as tmp:
+            pack = _Path(tmp) / "impostor"
+            pack.mkdir()
+            (pack / "pack.yaml").write_text(
+                "name: Core\nmappings: m.yaml\n", encoding="utf-8"
+            )
+            (pack / "m.yaml").write_text(
+                "prefixes:\n"
+                "  test-impostor:\n"
+                '    display_name: "Impostor"\n'
+                '    jurisdiction: "aa"\n'
+                '    authority_type: "statute"\n'
+                '    aliases: ["impostor body"]\n',
+                encoding="utf-8",
+            )
+            with mock.patch.object(apc, "authority_pack_dirs", return_value=[pack]):
+                results = AuthorityMappingLoader.load_installed()
+
+        assert "reserved" in results["impostor"]["error"]
+        assert not AuthorityNamespace.objects.filter(prefix="test-impostor").exists()
+
     def test_load_installed_reports_an_unparsable_manifest(self):
         # A pack whose pack.yaml ITSELF cannot be parsed never yields a mappings
         # file — it must still appear in the report as an error (keyed by its

--- a/opencontractserver/tests/test_authority_mapping_loader.py
+++ b/opencontractserver/tests/test_authority_mapping_loader.py
@@ -415,9 +415,7 @@ class LoadInstalledTests(TestCase):
         from pathlib import Path as _Path
         from unittest import mock
 
-        from opencontractserver.enrichment.services import (
-            authority_pack_config as apc,
-        )
+        from opencontractserver.enrichment.services import authority_pack_config as apc
 
         with _tempfile.TemporaryDirectory() as tmp:
             bad_pack = _Path(tmp) / "badpack"

--- a/opencontractserver/tests/test_authority_mapping_loader.py
+++ b/opencontractserver/tests/test_authority_mapping_loader.py
@@ -407,10 +407,10 @@ class LoadInstalledTests(TestCase):
             assert ns["created"] == 0, origin
             assert ns["skipped_foreign_baseline"] == 0, origin
 
-    def test_load_installed_isolates_a_malformed_pack(self):
-        # One pack with a broken mappings YAML must not abort the converge run:
-        # it is reported under its origin as an error, the core baseline (and
-        # any other pack) still loads.
+    @staticmethod
+    def _load_installed_with_bad_pack(mappings_body: str) -> dict:
+        """Run ``load_installed`` with one synthetic pack whose mappings YAML is
+        *mappings_body* as the only installed pack."""
         import tempfile as _tempfile
         from pathlib import Path as _Path
         from unittest import mock
@@ -423,16 +423,49 @@ class LoadInstalledTests(TestCase):
             (bad_pack / "pack.yaml").write_text(
                 "name: badpack\nmappings: m.yaml\n", encoding="utf-8"
             )
-            (bad_pack / "m.yaml").write_text(
-                'prefixes:\n  "NOT A VALID PREFIX!!":\n    display_name: "x"\n',
-                encoding="utf-8",
-            )
+            (bad_pack / "m.yaml").write_text(mappings_body, encoding="utf-8")
             with mock.patch.object(apc, "authority_pack_dirs", return_value=[bad_pack]):
-                results = AuthorityMappingLoader.load_installed()
+                return AuthorityMappingLoader.load_installed()
 
+    def test_load_installed_isolates_a_schema_invalid_pack(self):
+        # One pack whose YAML parses but fails shape validation (ValueError from
+        # the reader) must not abort the converge run: it is reported under its
+        # origin as an error, the core baseline (and any other pack) still loads.
+        results = self._load_installed_with_bad_pack(
+            'prefixes:\n  "NOT A VALID PREFIX!!":\n    display_name: "x"\n'
+        )
         assert "error" in results["badpack"]
         assert BASELINE_ORIGIN_CORE in results
         assert AuthorityNamespace.objects.filter(prefix="exchange-act").exists()
+
+    def test_load_installed_isolates_an_unparsable_pack(self):
+        # A genuine YAML *syntax* error raises yaml.YAMLError — which is NOT a
+        # ValueError subclass — so the isolation guard must catch it explicitly
+        # or one broken file aborts every other installed pack's load.
+        results = self._load_installed_with_bad_pack("prefixes: [unclosed\n")
+        assert "error" in results["badpack"]
+        assert BASELINE_ORIGIN_CORE in results
+        assert AuthorityNamespace.objects.filter(prefix="exchange-act").exists()
+
+    def test_load_installed_reports_an_unparsable_manifest(self):
+        # A pack whose pack.yaml ITSELF cannot be parsed never yields a mappings
+        # file — it must still appear in the report as an error (keyed by its
+        # directory name) rather than vanishing into the log.
+        import tempfile as _tempfile
+        from pathlib import Path as _Path
+        from unittest import mock
+
+        from opencontractserver.enrichment.services import authority_pack_config as apc
+
+        with _tempfile.TemporaryDirectory() as tmp:
+            bad_pack = _Path(tmp) / "broken-manifest"
+            bad_pack.mkdir()
+            (bad_pack / "pack.yaml").write_text("name: [unclosed\n", encoding="utf-8")
+            with mock.patch.object(apc, "authority_pack_dirs", return_value=[bad_pack]):
+                results = AuthorityMappingLoader.load_installed()
+
+        assert "error" in results["broken-manifest"]
+        assert BASELINE_ORIGIN_CORE in results
 
 
 class NamespaceReseedOwnershipTests(TestCase):

--- a/opencontractserver/tests/test_authority_pack.py
+++ b/opencontractserver/tests/test_authority_pack.py
@@ -371,7 +371,11 @@ class LoadAuthorityPackEdgeCaseTests(TestCase):
         # "core" is the baseline_origin stamp of the shipped core YAML; a pack
         # named "core" would impersonate it and bypass the #2057 collision
         # guard. Rejected fail-fast, before any DB write.
-        AuthorityNamespace.objects.filter(jurisdiction="bo").delete()  # leaked rows
+        # Defensive baseline for the assertFalse below: "bo" rows are not part
+        # of this TestCase's transaction-start state, but a reused --keepdb
+        # database can carry cross-module leakage; clearing makes the
+        # nothing-was-written assertion unambiguous.
+        AuthorityNamespace.objects.filter(jurisdiction="bo").delete()
         self._write_pack(
             {"name": "core", "mappings": "m.yaml"},
             copy_mappings=True,

--- a/opencontractserver/tests/test_authority_pack.py
+++ b/opencontractserver/tests/test_authority_pack.py
@@ -291,6 +291,27 @@ class LoadAuthorityPackEdgeCaseTests(TestCase):
         self.assertGreaterEqual(rows.count(), 5)
         self.assertTrue(all(ns.baseline_origin == "p" for ns in rows))
 
+    def test_foreign_owned_prefix_reported_in_output(self):
+        # A prefix another baseline origin already owns is skipped (first
+        # writer wins) — and the command must SAY so in its output, not just
+        # count it: the operator-facing half of the collision guard.
+        AuthorityNamespace.objects.create(
+            prefix="cpe",
+            display_name="Owned elsewhere",
+            source="baseline",
+            baseline_origin="otherpack",
+        )
+        self._write_pack(
+            {"name": "p", "mappings": "m.yaml"},
+            copy_mappings=True,
+        )
+        output = self._run()
+        self.assertIn("skipped_foreign_baseline=1", output)
+        self.assertIn("already owned by another baseline origin", output)
+        ns = AuthorityNamespace.objects.get(prefix="cpe")
+        self.assertEqual(ns.display_name, "Owned elsewhere")
+        self.assertEqual(ns.baseline_origin, "otherpack")
+
     def test_persona_idempotent_and_modified_persisted(self):
         # Finding #7: an unchanged persona must NOT rewrite the corpus.
         # Finding #2: a CHANGED persona must save AND advance ``modified``.

--- a/opencontractserver/tests/test_authority_pack.py
+++ b/opencontractserver/tests/test_authority_pack.py
@@ -280,15 +280,16 @@ class LoadAuthorityPackEdgeCaseTests(TestCase):
 
     def test_taxonomy_only_pack_loads_namespaces(self):
         # A pack may declare just taxonomy (no corpora) — that is valid, not a
-        # silent no-op.
+        # silent no-op. Every namespace row is stamped with the pack's name as
+        # its baseline_origin (the #2057 collision guard).
         self._write_pack(
             {"name": "p", "mappings": "m.yaml"},
             copy_mappings=True,
         )
         self._run()
-        self.assertGreaterEqual(
-            AuthorityNamespace.objects.filter(jurisdiction="bo").count(), 5
-        )
+        rows = AuthorityNamespace.objects.filter(jurisdiction="bo")
+        self.assertGreaterEqual(rows.count(), 5)
+        self.assertTrue(all(ns.baseline_origin == "p" for ns in rows))
 
     def test_persona_idempotent_and_modified_persisted(self):
         # Finding #7: an unchanged persona must NOT rewrite the corpus.
@@ -365,6 +366,19 @@ class LoadAuthorityPackEdgeCaseTests(TestCase):
         self._write_pack({"name": "p"})
         with self.assertRaises(CommandError):
             self._run()
+
+    def test_reserved_core_pack_name_rejected(self):
+        # "core" is the baseline_origin stamp of the shipped core YAML; a pack
+        # named "core" would impersonate it and bypass the #2057 collision
+        # guard. Rejected fail-fast, before any DB write.
+        AuthorityNamespace.objects.filter(jurisdiction="bo").delete()  # leaked rows
+        self._write_pack(
+            {"name": "core", "mappings": "m.yaml"},
+            copy_mappings=True,
+        )
+        with self.assertRaises(CommandError):
+            self._run()
+        self.assertFalse(AuthorityNamespace.objects.filter(jurisdiction="bo").exists())
 
     def test_corpora_null_rejected(self):
         self._write("pack.yaml", "name: p\ncorpora:\n")

--- a/opencontractserver/tests/test_authority_pack.py
+++ b/opencontractserver/tests/test_authority_pack.py
@@ -384,6 +384,20 @@ class LoadAuthorityPackEdgeCaseTests(TestCase):
             self._run()
         self.assertFalse(AuthorityNamespace.objects.filter(jurisdiction="bo").exists())
 
+    def test_over_length_pack_name_rejected(self):
+        # The manifest name becomes the baseline_origin stamp verbatim; longer
+        # than the column allows must fail fast, not as a DataError mid-load.
+        from opencontractserver.enrichment.constants import (
+            BASELINE_ORIGIN_MAX_LENGTH,
+        )
+
+        self._write_pack(
+            {"name": "x" * (BASELINE_ORIGIN_MAX_LENGTH + 1), "mappings": "m.yaml"},
+            copy_mappings=True,
+        )
+        with self.assertRaisesMessage(CommandError, "exceeds"):
+            self._run()
+
     def test_corpora_null_rejected(self):
         self._write("pack.yaml", "name: p\ncorpora:\n")
         with self.assertRaises(CommandError):

--- a/opencontractserver/tests/test_authority_pack_config.py
+++ b/opencontractserver/tests/test_authority_pack_config.py
@@ -10,7 +10,7 @@ module pins the *defensive* contract:
   ``ValueError`` on every malformed shape so ``load_authority_pack`` aborts a bad
   install loudly, and
 * the runtime scan (``pack_declared_shape_rules`` / ``pack_declared_abbreviations``
-  / ``_iter_pack_mapping_files`` / ``_load_yaml``) downgrades those raises to
+  / ``iter_pack_mapping_files`` / ``_load_yaml``) downgrades those raises to
   log-and-skip so a single broken pack can never break extraction for every
   jurisdiction.
 
@@ -146,7 +146,7 @@ class LoadYamlTests(SimpleTestCase):
 
 
 class IterPackMappingFilesSkipTests(SimpleTestCase):
-    """``_iter_pack_mapping_files`` skips packs it cannot use, never raises."""
+    """``iter_pack_mapping_files`` skips packs it cannot use, never raises."""
 
     def _patch_dirs(self, *dirs: Path):
         return mock.patch.object(apc, "authority_pack_dirs", return_value=list(dirs))
@@ -156,7 +156,7 @@ class IterPackMappingFilesSkipTests(SimpleTestCase):
             pack = Path(tmp) / "no-manifest"
             pack.mkdir()
             with self._patch_dirs(pack):
-                self.assertEqual(list(apc._iter_pack_mapping_files()), [])
+                self.assertEqual(list(apc.iter_pack_mapping_files()), [])
 
     def test_pack_with_malformed_manifest_is_skipped(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -165,7 +165,7 @@ class IterPackMappingFilesSkipTests(SimpleTestCase):
             (pack / "pack.yaml").write_text(_BAD_YAML, encoding="utf-8")
             with self._patch_dirs(pack):
                 with self.assertLogs(_MODULE, level="WARNING"):
-                    self.assertEqual(list(apc._iter_pack_mapping_files()), [])
+                    self.assertEqual(list(apc.iter_pack_mapping_files()), [])
 
     def test_pack_without_mappings_key_is_skipped(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -173,7 +173,7 @@ class IterPackMappingFilesSkipTests(SimpleTestCase):
             pack.mkdir()
             (pack / "pack.yaml").write_text("name: x\n", encoding="utf-8")
             with self._patch_dirs(pack):
-                self.assertEqual(list(apc._iter_pack_mapping_files()), [])
+                self.assertEqual(list(apc.iter_pack_mapping_files()), [])
 
     def test_well_formed_pack_is_yielded(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -184,8 +184,11 @@ class IterPackMappingFilesSkipTests(SimpleTestCase):
             )
             (pack / "m.yaml").write_text("shape_rules: []\n", encoding="utf-8")
             with self._patch_dirs(pack):
-                yielded = list(apc._iter_pack_mapping_files())
-            self.assertEqual([p for p, _ in yielded], [pack])
+                yielded = list(apc.iter_pack_mapping_files())
+            self.assertEqual([p for p, _, _ in yielded], [pack])
+            # The parsed manifest rides along so callers (e.g. load_installed
+            # deriving the pack's baseline origin) never re-read pack.yaml.
+            self.assertEqual(yielded[0][2].get("name"), "x")
 
 
 class RuntimeScanFaultIsolationTests(SimpleTestCase):

--- a/opencontractserver/tests/test_authority_pack_config.py
+++ b/opencontractserver/tests/test_authority_pack_config.py
@@ -173,7 +173,27 @@ class IterPackMappingFilesSkipTests(SimpleTestCase):
             pack.mkdir()
             (pack / "pack.yaml").write_text("name: x\n", encoding="utf-8")
             with self._patch_dirs(pack):
-                self.assertEqual(list(apc.iter_pack_mapping_files()), [])
+                errors: list = []
+                self.assertEqual(list(apc.iter_pack_mapping_files(errors)), [])
+            # Content-only pack: skipped by design, NOT an error.
+            self.assertEqual(errors, [])
+
+    def test_declared_but_missing_mappings_file_is_skipped_and_reported(self):
+        # `mappings: typo.yaml` with no such file is the classic authoring
+        # mistake: the pack must be skipped with a warning AND land in the
+        # errors sink so load_installed can surface it — not vanish silently.
+        with tempfile.TemporaryDirectory() as tmp:
+            pack = Path(tmp) / "typo-mappings"
+            pack.mkdir()
+            (pack / "pack.yaml").write_text(
+                "name: x\nmappings: typo.yaml\n", encoding="utf-8"
+            )
+            with self._patch_dirs(pack):
+                errors: list = []
+                with self.assertLogs(_MODULE, level="WARNING"):
+                    self.assertEqual(list(apc.iter_pack_mapping_files(errors)), [])
+        self.assertEqual(len(errors), 1)
+        self.assertIn("not found", errors[0][1])
 
     def test_well_formed_pack_is_yielded(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
Closes #2057.

## Scope note (what was already done)

Issue #2057 lists three items. Two of them **already shipped** in PR #2064 (merged the day after the issue was filed), with a deliberately different design than the issue text sketches:

- **(a) Host allowlist as data** — shipped as `pack.yaml` `source_hosts:` unioned into the SSRF allowlist at runtime (`enrichment/services/authority_source_hosts.py`; install-is-trust, not a DB table).
- **(b) Out-of-tree provider discovery** — shipped as `<pack>/providers/*.py` scanning + the `AUTHORITY_PACK_PATHS` setting (the issue's "configured-extra-package" alternative).

The proposal doc already declares gaps 1 & 6 closed. This PR therefore implements the **remaining item (c)** — loader multi-YAML merge + the baseline-vs-baseline collision guard (gap 7 in proposal 0002 §7) — which is also acceptance criterion 3 ("re-loading two packs that touch distinct prefixes never clobbers each other").

> **Flagging one open design question:** if you still want the literal part (a) — a superuser-curated, runtime-editable **DB** host allowlist on top of the pack.yaml mechanism (value: no filesystem access / no restart needed) — say the word and I'll add it as a follow-up. I kept it out here since it would be a second, overlapping allowlist-widening mechanism.

## What changed

### Baseline-origin collision guard (fixes silent last-write-wins)

Two `source="baseline"` writers on the same prefix — core `authority_mappings.yaml` vs. a pack, or two packs — previously clobbered each other silently (`AuthorityMappingLoader.load_namespaces`' `update_or_create` had no writer partition; the last loader run won).

- New nullable `AuthorityNamespace.baseline_origin` column (migration `annotations/0101`): `"core"` for the shipped YAML / `post_migrate` seed, else the pack's manifest `name`.
- `load_namespaces` (`enrichment/services/authority_mapping_loader.py`) now **skips + warns** (counted as `skipped_foreign_baseline`) when a different origin owns the prefix — first writer wins; curator `manual` rows and corpus-linked namespaces still trump everything, unchanged.
- The `post_migrate` convergence (`enrichment/_namespace_seed.py`) honours the same guard (field-presence-guarded for historical migration states), so `migrate`/flush can no longer revert a pack-owned prefix to the constants baseline — and it stamps its own rows `"core"`.
- Legacy null-origin baseline rows are **adopted** (stamped) by the next owning load, so fleets converge without a data migration.
- The pack name `core` is **reserved**; `load_authority_pack` rejects it fail-fast before any DB write.

### Multi-YAML merge (one command converges everything)

- `AuthorityMappingLoader.load_installed()` loads the core baseline **plus every installed pack's mappings YAML** (in-tree `authority_packs/` + `AUTHORITY_PACK_PATHS`), each stamped with its origin. Core loads first, so on a same-prefix collision the shipped baseline wins — mirroring `authority_pack_config`'s "baseline always wins" merge rule for shape rules/abbreviations. Per-pack fault isolation: one malformed pack YAML is logged + reported as an error, the rest still load.
- `manage.py load_authority_mappings --include-packs` exposes it; both commands now print per-origin summaries including `skipped_foreign_baseline`.
- DRY: pack discovery reuses `authority_pack_config.iter_pack_mapping_files` (made public; now yields the parsed manifest so callers don't re-read `pack.yaml`).

### Docs & changelog

- `docs/guides/authoring-authority-packs.md`: new "Prefix ownership" section (what a re-load can/cannot clobber, how to resolve a collision, the one-command converge).
- `docs/architecture/proposals/0002-authority-packs.md`: gap-7 update callout; §7 table rows 1/6/7 marked shipped.
- Changelog fragments: `changelog.d/2057-baseline-origin-guard.fixed.md`, `changelog.d/2057-loader-multi-yaml.added.md`.

## Tests

- `test_authority_mapping_loader.py` — `BaselineOriginGuardTests` (distinct-prefix packs never clobber; foreign origin skipped + warned; unattributed run can't steal; legacy adoption; manual still wins; core stamp), `LoadInstalledTests` (core+bolivia merge, idempotency, malformed-pack isolation), reseed-ownership additions, `--include-packs` command coverage.
- `test_authority_pack.py` — pack-origin stamping via `load_authority_pack`; reserved `core` name rejected.
- `test_authority_pack_config.py` — updated for the public 3-tuple `iter_pack_mapping_files` (mechanical rename; logic unchanged) + manifest-passthrough assertion.