### PR TITLE
Add optional turbopuffer-style object-storage vector search backend

### DIFF
--- a/changelog.d/object-storage-vector-backend.added.md
+++ b/changelog.d/object-storage-vector-backend.added.md
@@ -1,0 +1,17 @@
+- **Optional object-storage vector search backend (turbopuffer-style), disabled by default.**
+  New `VECTOR_SEARCH_BACKEND` setting (`pgvector` default | `object_storage`) routes the
+  single similarity call site (`opencontractserver/shared/mixins.py::VectorSearchViaEmbeddingMixin.search_by_embedding`)
+  through a WAL + centroid-ANN index kept in the default file storage (local disk, S3/MinIO, or GCS
+  under `VECTOR_INDEX_STORAGE_PREFIX`), with Postgres `Embedding` rows remaining the source of truth.
+  Engine (`opencontractserver/vector_search/engine.py`) provides strongly consistent reads
+  (WAL-tail overlay), deterministic k-means compaction (Celery, cache-lock serialised,
+  auto-triggered at `OBJECT_INDEX_COMPACT_MIN_WAL_FILES`), tombstones, and a per-process LRU for
+  warm queries. Write path fans out from `Embedding.objects.store_embedding`
+  (`opencontractserver/shared/Managers.py`) via `opencontractserver/tasks/vector_index_tasks.py`;
+  candidate ids are re-filtered through the caller's queryset so all permission/visibility scoping
+  is preserved; unindexed namespaces and engine errors fall back to pgvector automatically.
+  Includes `manage.py rebuild_object_vector_index`, system check `opencontracts.E002` for invalid
+  backend values, constants in `opencontractserver/constants/search.py`, design doc
+  `docs/architecture/object_storage_vector_search.md`, MinIO manual test script
+  `docs/test_scripts/object_storage_vector_backend_minio.md`, and 18 tests in
+  `opencontractserver/tests/test_object_storage_vector_backend.py`.

--- a/changelog.d/object-storage-vector-backend.added.md
+++ b/changelog.d/object-storage-vector-backend.added.md
@@ -12,6 +12,7 @@
   is preserved; unindexed namespaces and engine errors fall back to pgvector automatically.
   Includes `manage.py rebuild_object_vector_index`, system check `opencontracts.E002` for invalid
   backend values, constants in `opencontractserver/constants/search.py`, design doc
-  `docs/architecture/object_storage_vector_search.md`, MinIO manual test script
-  `docs/test_scripts/object_storage_vector_backend_minio.md`, and 18 tests in
-  `opencontractserver/tests/test_object_storage_vector_backend.py`.
+  `docs/architecture/object_storage_vector_search.md`, manual verification scripts
+  against real S3 (MinIO — `docs/test_scripts/object_storage_vector_backend_minio.md`)
+  and the GCS API (fake-gcs-server — `docs/test_scripts/object_storage_vector_backend_gcs.md`),
+  and the test suite in `opencontractserver/tests/test_object_storage_vector_backend.py`.

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -1462,6 +1462,22 @@ DEFAULT_EMBEDDER = "opencontractserver.pipeline.embedders.sent_transformer_micro
 # Default embedding dimension to use if no dimension is specified
 DEFAULT_EMBEDDING_DIMENSION = 768
 
+# Vector search backend
+# ------------------------------------------------------------------------------
+# "pgvector" (default): similarity search runs in Postgres via HNSW indexes.
+# "object_storage": similarity ranking is served from a turbopuffer-style
+# WAL + centroid index kept in the default file storage (S3/GCS/local disk),
+# with Postgres remaining the source of truth (automatic fallback to pgvector
+# for unindexed namespaces or engine errors). See
+# docs/architecture/object_storage_vector_search.md.
+VECTOR_SEARCH_BACKEND = env.str("VECTOR_SEARCH_BACKEND", default="pgvector")
+
+# Key prefix under which the object-storage vector index lives inside the
+# default storage backend.
+VECTOR_INDEX_STORAGE_PREFIX = env.str(
+    "VECTOR_INDEX_STORAGE_PREFIX", default="vector-index"
+)
+
 
 # Default runner
 TEST_RUNNER = "opencontractserver.tests.runner.TerminateConnectionsTestRunner"

--- a/docs/architecture/embeddings_creation_and_retrieval.md
+++ b/docs/architecture/embeddings_creation_and_retrieval.md
@@ -208,6 +208,9 @@ When working in async contexts (such as Django Channels WebSocket consumers), al
    - Core store builds Django queryset with filters (corpus, document, user, metadata)
    - Applies structural annotation logic (structural annotations bypass corpus filtering)
    - Uses `.search_by_embedding(...)` from `VectorSearchViaEmbeddingMixin` for similarity search
+     (backend-pluggable: pgvector HNSW by default, or the object-storage index
+     when `VECTOR_SEARCH_BACKEND=object_storage` — see
+     `docs/architecture/object_storage_vector_search.md`)
    - Returns `VectorSearchResult` objects with annotations and similarity scores
 
 4. **Result Conversion**

--- a/docs/architecture/object_storage_vector_search.md
+++ b/docs/architecture/object_storage_vector_search.md
@@ -92,16 +92,28 @@ list[Model instance] with .similarity_score  ← identical contract to pgvector
 - **Namespace** = `(parent kind, embedder_path, dimension)` — mirroring the
   filters the pgvector path applies (`embedder_path` + `vector_<dim>`
   column). See `router.build_namespace`.
-- **Consistency**: reads always list the WAL tail and overlay it on segment
-  results (newest upsert/tombstone per id wins), so a write is searchable the
-  moment its WAL PUT returns — same "strongly consistent by default" contract
-  turbopuffer advertises. The manifest GET per query is the equivalent of
-  their consistency roundtrip.
+- **Consistency**: reads list the WAL tail **before** reading the manifest —
+  this ordering is load-bearing. Compaction commits the new manifest strictly
+  before GC'ing folded WAL files, so a WAL-first reader sees either the
+  folded files (served from the overlay) or a manifest that already includes
+  them; a manifest-first reader could pair an old manifest with an
+  already-GC'd tail and silently drop writes. The manifest records the WAL
+  files folded into its generation (`folded_wals`); readers skip those when
+  building the overlay so lingering folded files are never replayed over
+  newer segment state. Net effect: a write is searchable the moment its WAL
+  PUT returns (the same "strongly consistent by default" contract turbopuffer
+  advertises), with the manifest GET per query as the consistency roundtrip.
 - **Compaction** folds segments + WAL into generation N+1; the manifest PUT
-  is the atomic commit point; folded WAL files and the old generation are
-  garbage-collected best-effort afterwards (orphans are harmless: upserts are
-  idempotent and replay order is preserved by time-ordered WAL names).
-  A Django-cache lock serialises compactors per namespace.
+  is the atomic commit point. GC is **deferred by one compaction cycle**:
+  committing generation N+1 deletes the WAL files and segment blobs that
+  generation *N* superseded, never its own — so in-flight readers holding
+  manifest N can still fetch every blob it references instead of hitting
+  `ObjectNotFound` and falling back to pgvector mid-race. Deletion failures
+  are harmless (readers skip folded files via `folded_wals`; dead-generation
+  segment blobs are never referenced again). A Django-cache lock serialises
+  compactors per namespace — which requires a **shared cache backend**
+  (e.g. Redis) in multi-worker deployments; system check `opencontracts.W003`
+  warns when the backend is enabled over `LocMemCache`.
 - **Caching**: centroid and cluster blobs are immutable per generation and
   held in a per-process LRU (`OBJECT_INDEX_CACHE_MAX_ENTRIES`), giving the
   warm-query tier. Cold queries pay object-storage GETs, exactly as designed.
@@ -167,9 +179,26 @@ Parameters*.
   structure; real embedding corpora have it, uniform random data does not
   (recall test in the suite uses clustered fixtures for this reason). Raise
   `OBJECT_INDEX_NPROBE_RATIO` / `OBJECT_INDEX_NPROBE_MIN` for higher recall.
+- **Write visibility lags the Postgres commit.** The WAL PUT happens in a
+  Celery task dispatched on transaction commit, not synchronously inside
+  `store_embedding` — so "searchable the moment the WAL PUT returns" is
+  measured from the task's PUT, and there is a queue-depth-dependent window
+  after the Postgres write during which an already-indexed namespace won't
+  return the new vector. (pgvector fallback still covers *never-indexed*
+  namespaces, not this per-row lag.) turbopuffer's client-synchronous write
+  ack does not have this window.
+- **WAL ordering across workers uses wall-clock names** (`time.time_ns()`),
+  so last-writer-wins between two re-embeds of the same parent on different
+  Celery workers is subject to clock skew. Low impact in practice —
+  embeddings are regenerated infrequently and deterministically per
+  `(parent, embedder)` — and any skew is healed by the next rebuild.
 - **No group commit.** Every `store_embedding` is one WAL PUT (batch
   producers already batch upstream). turbopuffer batches concurrent writers
   per namespace; we could buffer through Redis if PUT volume matters.
+- **Sequential WAL-tail GETs.** A query fetches unfolded WAL files one at a
+  time (tail is bounded by `OBJECT_INDEX_COMPACT_MIN_WAL_FILES`); fetching
+  them concurrently would cut cold/tail latency if p50 matters before
+  compaction catches up.
 - **Deletes are lazy.** Parent deletions are not tombstoned automatically;
   stale ids are dropped by the ORM refilter at query time and purged on the
   next `rebuild_object_vector_index`/compaction cycle.

--- a/docs/architecture/object_storage_vector_search.md
+++ b/docs/architecture/object_storage_vector_search.md
@@ -135,9 +135,15 @@ truth).
 
 Enabling the flag can never make search worse than pgvector: unsupported
 models, never-indexed namespaces, and any engine exception all fall back to
-the pgvector path inside `search_by_embedding` (logged). An invalid
-`VECTOR_SEARCH_BACKEND` value fails startup via system check
-`opencontracts.E002` (`opencontractserver/shared/checks.py`).
+the pgvector path inside `search_by_embedding` (logged). So does a **filter
+shortfall**: post-ANN filtering has a recall cliff when the caller's queryset
+is very selective, so if re-filtering consumes a *truncated* candidate set
+(engine returned a full `fetch_n`) without filling `top_k`, the router falls
+back to pgvector rather than under-filling; a short result from an
+*exhausted* namespace is genuinely complete and is returned as-is
+(`router.search_via_object_index`). An invalid `VECTOR_SEARCH_BACKEND` value
+fails startup via system check `opencontracts.E002`
+(`opencontractserver/shared/checks.py`).
 
 ## Storage backends
 

--- a/docs/architecture/object_storage_vector_search.md
+++ b/docs/architecture/object_storage_vector_search.md
@@ -209,6 +209,15 @@ Parameters*.
   return the new vector. (pgvector fallback still covers *never-indexed*
   namespaces, not this per-row lag.) turbopuffer's client-synchronous write
   ack does not have this window.
+- **Manifest overwrite is not atomic for readers.** Django's `Storage.save`
+  never overwrites, so the per-compaction manifest commit is a delete + save
+  pair; a reader can catch the sub-second window where the key is missing.
+  Readers of namespaces with a non-empty WAL retry the manifest read once
+  (`engine._load_manifest_expecting_data`) before proceeding, which covers
+  the realistic window; the residual risk (retry also landing inside the
+  window) degrades one query to WAL-tail-only results and self-heals on the
+  next. A backend-native atomic PUT (S3 conditional writes) would remove
+  the window entirely — backend-specific follow-up.
 - **WAL ordering across workers uses wall-clock names** (`time.time_ns()`),
   so last-writer-wins between two re-embeds of the same parent on different
   Celery workers is subject to clock skew. Low impact in practice —

--- a/docs/architecture/object_storage_vector_search.md
+++ b/docs/architecture/object_storage_vector_search.md
@@ -163,13 +163,15 @@ The engine talks to Django's default file storage through
 `DjangoStorageObjectStore` (put/get/list/delete/exists), so the index lives
 wherever `STORAGE_BACKEND` points: local disk (`LOCAL`), S3 or any
 S3-compatible store like MinIO (`AWS`), or GCS (`GCP`), under
-`VECTOR_INDEX_STORAGE_PREFIX` (default `vector-index/`). Local filesystem is
-covered by the automated suite and S3 is verified against MinIO via the real
-S3 API — see `docs/test_scripts/object_storage_vector_backend_minio.md`.
-**GCS is currently unverified**: `list_keys()` (load-bearing for the WAL
-overlay and `wal_tail_count`) relies on `Storage.listdir` semantics, which
-GCS emulates over a flat namespace — run an equivalent smoke test before
-enabling the backend on `GCP`.
+`VECTOR_INDEX_STORAGE_PREFIX` (default `vector-index/`). All three are
+verified: local filesystem by the automated suite, S3 against MinIO via the
+real S3 API (`docs/test_scripts/object_storage_vector_backend_minio.md`),
+and GCS against `fake-gcs-server` via the real GCS JSON API + django-storages
+`GoogleCloudStorage` (`docs/test_scripts/object_storage_vector_backend_gcs.md`)
+— including the load-bearing `listdir` emulation over GCS's flat namespace,
+the manifest delete-then-save overwrite, and multi-generation deferred GC.
+As with any emulator-verified path, run the recorded smoke script once
+against your production bucket before flipping the flag on `GCP`.
 
 ## Operations
 

--- a/docs/architecture/object_storage_vector_search.md
+++ b/docs/architecture/object_storage_vector_search.md
@@ -163,9 +163,13 @@ The engine talks to Django's default file storage through
 `DjangoStorageObjectStore` (put/get/list/delete/exists), so the index lives
 wherever `STORAGE_BACKEND` points: local disk (`LOCAL`), S3 or any
 S3-compatible store like MinIO (`AWS`), or GCS (`GCP`), under
-`VECTOR_INDEX_STORAGE_PREFIX` (default `vector-index/`). Verified against
-MinIO via the real S3 API — see
-`docs/test_scripts/object_storage_vector_backend_minio.md`.
+`VECTOR_INDEX_STORAGE_PREFIX` (default `vector-index/`). Local filesystem is
+covered by the automated suite and S3 is verified against MinIO via the real
+S3 API — see `docs/test_scripts/object_storage_vector_backend_minio.md`.
+**GCS is currently unverified**: `list_keys()` (load-bearing for the WAL
+overlay and `wal_tail_count`) relies on `Storage.listdir` semantics, which
+GCS emulates over a flat namespace — run an equivalent smoke test before
+enabling the backend on `GCP`.
 
 ## Operations
 
@@ -234,3 +238,9 @@ Parameters*.
   per namespace, revisit beyond.
 - **Per-process memory LRU only** — no shared SSD cache tier between
   workers yet.
+- **Namespaces are deployment-wide, not corpus-scoped.** A very narrow
+  corpus-scoped query on a large multi-tenant deployment may exhaust the
+  oversampled candidate set and take the shortfall fallback to pgvector
+  often — correct, but eroding the backend's benefit for that access
+  pattern. Corpus-sharded namespaces are the natural follow-up if this
+  dominates.

--- a/docs/architecture/object_storage_vector_search.md
+++ b/docs/architecture/object_storage_vector_search.md
@@ -65,8 +65,9 @@ prior art covers this.)
 ## Architecture
 
 ```
-Embedding.objects.store_embedding()          ← single write chokepoint (all producers)
-        │  on_commit, only when enabled
+Embedding.objects.store_embedding()          ← write chokepoint (in-app pipeline)
+  + worker_uploads/tasks.py bulk writes      ← hooked explicitly (bulk_create
+        │  on_commit, only when enabled         bypasses the manager)
         ▼
 sync_embedding_to_object_index (Celery)      ← WAL append, fire-and-forget
         │                                       auto-compaction at WAL threshold

--- a/docs/architecture/object_storage_vector_search.md
+++ b/docs/architecture/object_storage_vector_search.md
@@ -91,7 +91,10 @@ list[Model instance] with .similarity_score  ← identical contract to pgvector
 
 - **Namespace** = `(parent kind, embedder_path, dimension)` — mirroring the
   filters the pgvector path applies (`embedder_path` + `vector_<dim>`
-  column). See `router.build_namespace`.
+  column). See `router.build_namespace`. Indexed kinds are **document,
+  annotation, note** — the parents whose reads route through the mixin
+  (`EMBEDDABLE_PARENT_KINDS` is the single source of truth; see its comment
+  for why conversation/message/relationship are excluded).
 - **Consistency**: reads list the WAL tail **before** reading the manifest —
   this ordering is load-bearing. Compaction commits the new manifest strictly
   before GC'ing folded WAL files, so a WAL-first reader sees either the
@@ -199,6 +202,14 @@ Parameters*.
 - **Vector arm only.** The FTS arm of hybrid search stays in Postgres
   (`search_vector` tsvector), so hybrid/RRF behavior is unchanged. A BM25
   index on object storage (turbopuffer's other half) is future work.
+- **Document/annotation/note only.** Conversation, ChatMessage and
+  Relationship vector search stays on pgvector regardless of the flag:
+  their read paths don't go through `VectorSearchViaEmbeddingMixin`
+  (separate inline implementations with a different result contract — see
+  the `EMBEDDABLE_PARENT_KINDS` comment), and their writes are accordingly
+  not fanned out to the object index either (no write amplification without
+  a read benefit). Migrating those read paths onto
+  `router.search_via_object_index` is the follow-up that unlocks them.
 - **Recall on unclustered data.** IVF-style probing depends on cluster
   structure; real embedding corpora have it, uniform random data does not
   (recall test in the suite uses clustered fixtures for this reason). Raise

--- a/docs/architecture/object_storage_vector_search.md
+++ b/docs/architecture/object_storage_vector_search.md
@@ -131,6 +131,18 @@ filtered querysets full. Rows deleted from Postgres after indexing drop out
 at the same refilter (the index tolerates staleness; Postgres is ground
 truth).
 
+**Storage exposure caveat:** query-time permissions are enforced by that ORM
+re-filter, NOT at the storage layer — the index blobs themselves
+(`wal/*.jsonl`, `segments/*/…`) carry no ACL. The
+`VECTOR_INDEX_STORAGE_PREFIX` **must live in non-publicly-readable storage**:
+a bucket with a public ACL, unsigned URLs, or a CDN custom domain fronting it
+would let anyone with bucket read access enumerate raw vectors + parent ids
+for private documents, entirely outside Django auth (a larger blast radius
+than pgvector, where vectors never leave Postgres). System check
+`opencontracts.W004` warns at boot when the backend is enabled over an AWS
+storage config showing public-read signals (`AWS_DEFAULT_ACL=public-read*`,
+`AWS_QUERYSTRING_AUTH=False`, or `AWS_S3_CUSTOM_DOMAIN`).
+
 ### Fallback semantics
 
 Enabling the flag can never make search worse than pgvector: unsupported
@@ -198,16 +210,25 @@ Parameters*.
   Celery workers is subject to clock skew. Low impact in practice —
   embeddings are regenerated infrequently and deterministically per
   `(parent, embedder)` — and any skew is healed by the next rebuild.
-- **No group commit.** Every `store_embedding` is one WAL PUT (batch
-  producers already batch upstream). turbopuffer batches concurrent writers
-  per namespace; we could buffer through Redis if PUT volume matters.
+- **No group commit.** Every `store_embedding` costs ~3 object-store
+  roundtrips (WAL PUT + the `wal_tail_count` list/manifest reads that decide
+  auto-compaction), fired per Celery task per embedding. Bulk backfills
+  through the normal write path will generate proportionally high request
+  volume — prefer `rebuild_object_vector_index`, which batches hundreds of
+  vectors per PUT. turbopuffer group-commits concurrent writers per
+  namespace; we could buffer through Redis if PUT volume matters.
 - **Sequential WAL-tail GETs.** A query fetches unfolded WAL files one at a
   time (tail is bounded by `OBJECT_INDEX_COMPACT_MIN_WAL_FILES`); fetching
   them concurrently would cut cold/tail latency if p50 matters before
   compaction catches up.
 - **Deletes are lazy.** Parent deletions are not tombstoned automatically;
   stale ids are dropped by the ORM refilter at query time and purged on the
-  next `rebuild_object_vector_index`/compaction cycle.
+  next `rebuild_object_vector_index`/compaction cycle. The refilter only
+  protects against *parent* deletion, though: a future code path that
+  deletes an `Embedding` row independent of its parent must tombstone the
+  namespace entry (`ObjectStorageVectorEngine.delete`) or trigger a rebuild
+  — otherwise the stale vector keeps matching its still-alive parent (see
+  the note on `EmbeddingManager`).
 - **Full recluster per compaction** (k-means from scratch) rather than
   SPFresh-style incremental cluster maintenance — fine up to ~10⁶ vectors
   per namespace, revisit beyond.

--- a/docs/architecture/object_storage_vector_search.md
+++ b/docs/architecture/object_storage_vector_search.md
@@ -1,0 +1,180 @@
+# Object-Storage Vector Search Backend (turbopuffer-style)
+
+**Status:** implemented, opt-in, disabled by default.
+**Toggle:** `VECTOR_SEARCH_BACKEND=object_storage` (default `pgvector`).
+**Code:** `opencontractserver/vector_search/` (`engine.py`, `object_store.py`,
+`router.py`, `hooks.py`), `opencontractserver/tasks/vector_index_tasks.py`,
+`opencontractserver/annotations/management/commands/rebuild_object_vector_index.py`.
+**Tests:** `opencontractserver/tests/test_object_storage_vector_backend.py`.
+
+## Why
+
+pgvector HNSW indexes live in Postgres RAM/disk and grow with every embedding.
+[turbopuffer](https://turbopuffer.com/architecture) demonstrated that vector
+search can instead treat **object storage as the source of truth** (~10–100×
+cheaper per GB than RAM-resident indexes), accepting a cold-query latency
+penalty that tiered caching amortises: cold p50 ≈ 500ms–1s per namespace,
+warm p50 ≈ 10–20ms, with strong consistency by default (WAL on object
+storage, async indexing, exhaustive scan of the unindexed tail).
+
+This backend brings that architecture to OpenContracts as an **optional,
+reversible** alternative to pgvector — Postgres remains the source of truth
+for vectors (`Embedding` rows), so the object index is always rebuildable and
+flipping the flag back is zero-risk.
+
+## Build on turbopuffer, or from scratch?
+
+Flagged explicitly (this was the design question):
+
+- **turbopuffer is closed-source SaaS.** There is nothing to self-host or
+  vendor; "building on turbopuffer" can only mean an HTTP client against
+  their hosted API — a non-starter as the *only* option for an MIT-licensed,
+  self-hostable platform with users who have data-egress constraints.
+- **From scratch is feasible and was done here** (~500 lines of numpy +
+  blob-store primitives) because OpenContracts only needs the *architecture*
+  (WAL + async indexing + centroid ANN + tail scan), not turbopuffer's scale
+  targets (billions of vectors, SPFresh incremental clustering, BM25 on
+  object storage). Everything hard about multi-tenant SaaS operation is out
+  of scope — namespaces here are per-deployment, and Django/Celery already
+  provide the orchestration.
+- **A hosted-turbopuffer driver remains easy to add later**: the seam is
+  `search_via_object_index()` / `enqueue_embedding_index_sync()` — a driver
+  that maps namespace → turbopuffer namespace and implements upsert/query
+  against their API would slot into the same
+  `VECTOR_SEARCH_BACKEND` dispatch without touching callers.
+
+### Prior open-source art considered
+
+(From the HN discussion of turbopuffer's launch, which asked whether Lucene
+prior art covers this.)
+
+- **OpenSearch/Elasticsearch searchable snapshots** — plain Lucene segment
+  files on S3 with node-local caching. Proven, but drags in a JVM search
+  cluster; the cold path is slow and the operational surface is exactly what
+  this feature is trying to avoid for small/medium deployments.
+- **Quickwit** — OSS sub-second search on object storage, but designed for
+  **append-only** datasets (logs/traces). OpenContracts embeddings are
+  mutable (re-embedding, corpus edits, deletes), which is why this design
+  follows turbopuffer's LSM-ish shape — WAL upserts/tombstones folded into
+  rewritten segments — rather than Quickwit's immutable splits.
+- **pgvector itself** — the incumbent default; the HN thread's fair critique
+  is that pgvector is fine until index size and write amplification compete
+  with your OLTP workload in the same Postgres. The toggle preserves it as
+  the default and the permanent fallback.
+
+## Architecture
+
+```
+Embedding.objects.store_embedding()          ← single write chokepoint (all producers)
+        │  on_commit, only when enabled
+        ▼
+sync_embedding_to_object_index (Celery)      ← WAL append, fire-and-forget
+        │                                       auto-compaction at WAL threshold
+        ▼
+<prefix>/<namespace>/wal/<ns-timestamp>.jsonl        one PUT per batch, durable
+<prefix>/<namespace>/index/manifest.json             generation pointer (atomic swap)
+<prefix>/<namespace>/index/segments/<gen>/centroids.npy
+<prefix>/<namespace>/index/segments/<gen>/cluster_<i>.npz
+        ▲
+        │  compact_object_vector_namespace (Celery, cache-lock serialised)
+        │  k-means (k = √n, capped), deterministic seed
+        ▼
+VectorSearchViaEmbeddingMixin.search_by_embedding()  ← single pgvector call site
+        │  router.search_via_object_index()
+        │  1. manifest GET (consistency roundtrip)
+        │  2. centroid GET (LRU-cached per generation) → probe nprobe clusters
+        │  3. WAL-tail GETs, replay as overlay (strong consistency)
+        │  4. candidate ids → REFILTERED THROUGH THE CALLER'S QUERYSET
+        ▼
+list[Model instance] with .similarity_score  ← identical contract to pgvector
+```
+
+- **Namespace** = `(parent kind, embedder_path, dimension)` — mirroring the
+  filters the pgvector path applies (`embedder_path` + `vector_<dim>`
+  column). See `router.build_namespace`.
+- **Consistency**: reads always list the WAL tail and overlay it on segment
+  results (newest upsert/tombstone per id wins), so a write is searchable the
+  moment its WAL PUT returns — same "strongly consistent by default" contract
+  turbopuffer advertises. The manifest GET per query is the equivalent of
+  their consistency roundtrip.
+- **Compaction** folds segments + WAL into generation N+1; the manifest PUT
+  is the atomic commit point; folded WAL files and the old generation are
+  garbage-collected best-effort afterwards (orphans are harmless: upserts are
+  idempotent and replay order is preserved by time-ordered WAL names).
+  A Django-cache lock serialises compactors per namespace.
+- **Caching**: centroid and cluster blobs are immutable per generation and
+  held in a per-process LRU (`OBJECT_INDEX_CACHE_MAX_ENTRIES`), giving the
+  warm-query tier. Cold queries pay object-storage GETs, exactly as designed.
+
+### Permissions (critical)
+
+The engine stores **only** `(parent_pk, vector)` — no ACLs. Candidate ids are
+re-filtered through the **caller's own queryset** (`qs.filter(pk__in=...)`),
+so every rule already applied to that queryset — `visible_to_user`,
+`MIN(document, corpus)` scoping, structural rules, corpus/document filters in
+`CoreAnnotationVectorStore._build_base_queryset` — is enforced by exactly the
+same code as the pgvector path. This is post-ANN filtering, so the router
+oversamples (`OBJECT_INDEX_FILTER_OVERSAMPLE × top_k`) to keep heavily
+filtered querysets full. Rows deleted from Postgres after indexing drop out
+at the same refilter (the index tolerates staleness; Postgres is ground
+truth).
+
+### Fallback semantics
+
+Enabling the flag can never make search worse than pgvector: unsupported
+models, never-indexed namespaces, and any engine exception all fall back to
+the pgvector path inside `search_by_embedding` (logged). An invalid
+`VECTOR_SEARCH_BACKEND` value fails startup via system check
+`opencontracts.E002` (`opencontractserver/shared/checks.py`).
+
+## Storage backends
+
+The engine talks to Django's default file storage through
+`DjangoStorageObjectStore` (put/get/list/delete/exists), so the index lives
+wherever `STORAGE_BACKEND` points: local disk (`LOCAL`), S3 or any
+S3-compatible store like MinIO (`AWS`), or GCS (`GCP`), under
+`VECTOR_INDEX_STORAGE_PREFIX` (default `vector-index/`). Verified against
+MinIO via the real S3 API — see
+`docs/test_scripts/object_storage_vector_backend_minio.md`.
+
+## Operations
+
+```bash
+# 1. Build the index while still on pgvector (safe, idempotent):
+python manage.py rebuild_object_vector_index            # all embedders
+python manage.py rebuild_object_vector_index --embedder-path <path>
+
+# 2. Flip the flag:
+VECTOR_SEARCH_BACKEND=object_storage
+
+# 3. Roll back any time:
+VECTOR_SEARCH_BACKEND=pgvector
+```
+
+New embeddings written while enabled fan out automatically from
+`store_embedding`; compaction triggers itself when a namespace's WAL tail
+reaches `OBJECT_INDEX_COMPACT_MIN_WAL_FILES`. Tuning knobs (nprobe, k-means
+parameters, oversample, thresholds) live in
+`opencontractserver/constants/search.py` under *Object-Storage Vector Index
+Parameters*.
+
+## Current limitations / future work
+
+- **Vector arm only.** The FTS arm of hybrid search stays in Postgres
+  (`search_vector` tsvector), so hybrid/RRF behavior is unchanged. A BM25
+  index on object storage (turbopuffer's other half) is future work.
+- **Recall on unclustered data.** IVF-style probing depends on cluster
+  structure; real embedding corpora have it, uniform random data does not
+  (recall test in the suite uses clustered fixtures for this reason). Raise
+  `OBJECT_INDEX_NPROBE_RATIO` / `OBJECT_INDEX_NPROBE_MIN` for higher recall.
+- **No group commit.** Every `store_embedding` is one WAL PUT (batch
+  producers already batch upstream). turbopuffer batches concurrent writers
+  per namespace; we could buffer through Redis if PUT volume matters.
+- **Deletes are lazy.** Parent deletions are not tombstoned automatically;
+  stale ids are dropped by the ORM refilter at query time and purged on the
+  next `rebuild_object_vector_index`/compaction cycle.
+- **Full recluster per compaction** (k-means from scratch) rather than
+  SPFresh-style incremental cluster maintenance — fine up to ~10⁶ vectors
+  per namespace, revisit beyond.
+- **Per-process memory LRU only** — no shared SSD cache tier between
+  workers yet.

--- a/docs/extract_and_retrieval/vector_stores.md
+++ b/docs/extract_and_retrieval/vector_stores.md
@@ -10,6 +10,13 @@ Our approach uses a **two-layer architecture**:
 
 This design enables efficient vector search across granular, visually-locatable annotations from PDF pages while supporting multiple agent frameworks through a single, well-tested codebase.
 
+> **Storage backend note:** the similarity ranking underneath all of this
+> (`VectorSearchViaEmbeddingMixin.search_by_embedding`) is itself pluggable via
+> `VECTOR_SEARCH_BACKEND` — `pgvector` (default, Postgres HNSW) or
+> `object_storage` (turbopuffer-style WAL + centroid index in S3/GCS/local
+> storage). See `docs/architecture/object_storage_vector_search.md`. All
+> permission filtering described below applies identically to both backends.
+
 ## Architecture Overview
 
 ### Core Layer: `CoreAnnotationVectorStore`

--- a/docs/test_scripts/object_storage_vector_backend_gcs.md
+++ b/docs/test_scripts/object_storage_vector_backend_gcs.md
@@ -1,0 +1,71 @@
+# Test: Object-storage vector backend against GCS API (fake-gcs-server)
+
+## Purpose
+
+Verify that the object-storage vector search engine
+(`opencontractserver/vector_search/engine.py`) works end-to-end against the
+**Google Cloud Storage API** through django-storages'
+`GoogleCloudStorage` backend — the path taken when `STORAGE_BACKEND=GCP`.
+GCS has no real directories, so `Storage.listdir()` (load-bearing for the
+WAL overlay and `wal_tail_count`) is emulated with prefix+delimiter listing;
+this test proves that emulation, the manifest delete-then-save overwrite,
+and multi-generation deferred GC all behave correctly over the GCS API.
+
+## Prerequisites
+
+- Docker available.
+- Project virtualenv with `requirements/local.txt` installed
+  (django-storages `[google]` extra provides `GoogleCloudStorage` and
+  `google-cloud-storage`).
+
+## Steps
+
+1. Start the GCS emulator:
+   ```bash
+   docker run -d --name oc-fake-gcs -p 4443:4443 \
+     fsouza/fake-gcs-server -scheme http -port 4443 -backend memory
+   curl -s http://localhost:4443/storage/v1/b -o /dev/null -w "%{http_code}\n"  # expect 200
+   ```
+2. Run the smoke script with `STORAGE_EMULATOR_HOST=http://localhost:4443`
+   (Django settings `config.settings.test`; no database needed). The script:
+   - creates bucket `oc-vector-index` via `google.cloud.storage.Client` with
+     `AnonymousCredentials`;
+   - builds a `DjangoStorageObjectStore` over
+     `GoogleCloudStorage(bucket_name=..., project_id=..., credentials=...)`;
+   - upserts 200 clustered 384-dim vectors in 4 WAL batches into a
+     run-unique namespace;
+   - asserts a pre-compaction (WAL-only) query returns the inserted vector
+     with similarity ≈ 1.0 (strong consistency over GCS `listdir`);
+   - compacts and asserts full-probe results exactly match numpy brute
+     force;
+   - tombstones the top hit and asserts it disappears;
+   - runs two more compactions and asserts: generation numbers increment,
+     the tombstone survives folding, generation N-2's segment blobs are
+     GC'd while N-1's remain (deferred GC), and the manifest overwrite
+     (delete-then-save on a mutable GCS key) round-trips;
+   - asserts `wal_tail_count` counts only unfolded files;
+   - lists the bucket via the raw GCS client and asserts the
+     `vector-index/<namespace>/{wal,index/manifest.json,index/segments/...}`
+     layout.
+
+   Script source: the engine calls mirror
+   `opencontractserver/tests/test_object_storage_vector_backend.py::ObjectStorageVectorEngineTests`,
+   with the `FileSystemStorage` swapped for `GoogleCloudStorage` against the
+   emulator.
+
+## Expected Results
+
+- All assertions pass; final output `ALL GCS SMOKE TESTS PASSED`.
+- No engine or adapter code changes were required for GCS — the
+  `DjangoStorageObjectStore` primitives (put/get/list/delete/exists) behave
+  identically over `GoogleCloudStorage` (its `delete` is NotFound-tolerant
+  and `_open` raises `FileNotFoundError`, matching the adapter's contract).
+
+Last verified: 2026-07-07 (fake-gcs-server `latest`, django-storages 1.14.6)
+— all steps passed.
+
+## Cleanup
+
+```bash
+docker rm -f oc-fake-gcs
+```

--- a/docs/test_scripts/object_storage_vector_backend_minio.md
+++ b/docs/test_scripts/object_storage_vector_backend_minio.md
@@ -1,0 +1,60 @@
+# Test: Object-storage vector backend against MinIO (real S3 API)
+
+## Purpose
+
+Verify that the object-storage vector search engine
+(`opencontractserver/vector_search/engine.py`) works end-to-end against a
+real S3-compatible object store — WAL append, strong-consistency tail
+search, compaction into centroid segments, tombstones, and the expected
+bucket key layout — not just against the local filesystem used by the
+automated suite.
+
+## Prerequisites
+
+- Docker available.
+- Project virtualenv with `requirements/local.txt` installed (django-storages
+  `[boto3]` extra provides `S3Boto3Storage` and `boto3`).
+
+## Steps
+
+1. Start MinIO:
+   ```bash
+   docker run -d --name oc-minio -p 9000:9000 \
+     -e MINIO_ROOT_USER=minioadmin -e MINIO_ROOT_PASSWORD=minioadmin \
+     minio/minio server /data --address :9000
+   curl -s http://localhost:9000/minio/health/live -o /dev/null -w "%{http_code}\n"  # expect 200
+   ```
+2. Run the smoke script (Django settings `config.settings.test`; no database
+   needed). The script:
+   - creates bucket `oc-vector-index` via boto3;
+   - builds a `DjangoStorageObjectStore` over `S3Boto3Storage`
+     (`endpoint_url=http://localhost:9000`, `file_overwrite=False` to match
+     production non-overwriting semantics);
+   - upserts 200 clustered 384-dim vectors in 4 WAL batches;
+   - asserts a pre-compaction (WAL-only) query returns the inserted vector
+     with similarity ≈ 1.0 (strong consistency);
+   - compacts and asserts full-probe results exactly match numpy brute force;
+   - tombstones the top hit and asserts it disappears;
+   - lists the bucket and asserts the
+     `vector-index/<namespace>/{wal,index/manifest.json,index/segments/...}`
+     layout.
+
+   Script source: the engine calls mirror
+   `opencontractserver/tests/test_object_storage_vector_backend.py::ObjectStorageVectorEngineTests`,
+   with the `FileSystemStorage` swapped for `S3Boto3Storage`.
+
+## Expected Results
+
+- All assertions pass; final output `ALL MINIO SMOKE TESTS PASSED`.
+- Bucket listing shows `manifest.json`, `centroids.npy`, and
+  `cluster_*.npz` under `index/segments/000001/`, and an empty WAL dir
+  after compaction.
+
+Last verified: 2026-07-07 (MinIO `latest`, engine at introduction commit) —
+all steps passed.
+
+## Cleanup
+
+```bash
+docker rm -f oc-minio
+```

--- a/opencontractserver/annotations/management/commands/rebuild_object_vector_index.py
+++ b/opencontractserver/annotations/management/commands/rebuild_object_vector_index.py
@@ -8,15 +8,20 @@ while ``VECTOR_SEARCH_BACKEND`` is still ``pgvector`` — build the index
 first, then flip the flag.
 """
 
+from django.core.cache import cache
 from django.core.management.base import BaseCommand
 
 from opencontractserver.annotations.models import Embedding
 from opencontractserver.constants.search import (
     DIM_TO_FIELD_MAP,
+    OBJECT_INDEX_COMPACT_LOCK_TIMEOUT_SECONDS,
     OBJECT_INDEX_REBUILD_BATCH_SIZE,
     OBJECT_INDEX_REBUILD_PROGRESS_EVERY,
 )
-from opencontractserver.tasks.vector_index_tasks import PARENT_FK_TO_KIND
+from opencontractserver.tasks.vector_index_tasks import (
+    PARENT_FK_TO_KIND,
+    compact_lock_key,
+)
 from opencontractserver.vector_search.router import (
     build_namespace,
     get_default_engine,
@@ -110,7 +115,27 @@ class Command(BaseCommand):
                     f"{totals[namespace]} vectors and compact"
                 )
                 continue
-            stats = engine.compact(namespace)
+            # Same per-namespace mutex as the auto-compaction Celery task:
+            # engine.compact() is not concurrency-safe with itself, and this
+            # command may be re-run for drift repair while background
+            # compactions are active.
+            lock_key = compact_lock_key(namespace)
+            if not cache.add(
+                lock_key, "1", timeout=OBJECT_INDEX_COMPACT_LOCK_TIMEOUT_SECONDS
+            ):
+                self.stdout.write(
+                    self.style.WARNING(
+                        f"{namespace}: replayed {totals[namespace]} vectors, "
+                        "but a compaction is already running — skipping "
+                        "compaction here (the replayed WAL will fold on the "
+                        "next compaction cycle)."
+                    )
+                )
+                continue
+            try:
+                stats = engine.compact(namespace)
+            finally:
+                cache.delete(lock_key)
             self.stdout.write(
                 self.style.SUCCESS(
                     f"{namespace}: replayed {totals[namespace]} vectors, "

--- a/opencontractserver/annotations/management/commands/rebuild_object_vector_index.py
+++ b/opencontractserver/annotations/management/commands/rebuild_object_vector_index.py
@@ -14,6 +14,7 @@ from opencontractserver.annotations.models import Embedding
 from opencontractserver.constants.search import (
     DIM_TO_FIELD_MAP,
     OBJECT_INDEX_REBUILD_BATCH_SIZE,
+    OBJECT_INDEX_REBUILD_PROGRESS_EVERY,
 )
 from opencontractserver.tasks.vector_index_tasks import PARENT_FK_TO_KIND
 from opencontractserver.vector_search.router import (
@@ -26,7 +27,12 @@ class Command(BaseCommand):
     help = (
         "Replay all Embedding vectors into the object-storage vector index "
         "and compact each namespace. Idempotent; run before enabling "
-        "VECTOR_SEARCH_BACKEND=object_storage."
+        "VECTOR_SEARCH_BACKEND=object_storage. Runtime expectation: this is "
+        "a FULL WAL replay plus a full k-means recluster per namespace — on "
+        "large deployments expect it to run for a while (progress is printed "
+        "every %d embeddings); use --embedder-path to scope, or --dry-run to "
+        "preview namespaces and counts without writing."
+        % OBJECT_INDEX_REBUILD_PROGRESS_EVERY
     )
 
     def add_arguments(self, parser):
@@ -41,23 +47,36 @@ class Command(BaseCommand):
             default=OBJECT_INDEX_REBUILD_BATCH_SIZE,
             help="Vectors per WAL file written during the replay.",
         )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Report namespaces and vector counts without writing anything.",
+        )
 
     def handle(self, *args, **options):
         engine = get_default_engine()
         batch_size = options["batch_size"]
+        dry_run = options["dry_run"]
         queryset = Embedding.objects.all()
         if options["embedder_path"]:
             queryset = queryset.filter(embedder_path=options["embedder_path"])
 
         buffers: dict[str, list[tuple[int, list[float]]]] = {}
         totals: dict[str, int] = {}
+        processed = 0
 
         def flush(namespace: str) -> None:
             batch = buffers.pop(namespace, [])
-            if batch:
+            if batch and not dry_run:
                 engine.upsert(namespace, batch)
 
         for embedding in queryset.iterator(chunk_size=batch_size):
+            processed += 1
+            if processed % OBJECT_INDEX_REBUILD_PROGRESS_EVERY == 0:
+                self.stdout.write(
+                    f"...processed {processed} embeddings across "
+                    f"{len(totals)} namespace(s)"
+                )
             parent = next(
                 (
                     (kind, getattr(embedding, fk_attr))
@@ -85,6 +104,12 @@ class Command(BaseCommand):
             flush(namespace)
 
         for namespace in sorted(totals):
+            if dry_run:
+                self.stdout.write(
+                    f"[dry-run] {namespace}: would replay "
+                    f"{totals[namespace]} vectors and compact"
+                )
+                continue
             stats = engine.compact(namespace)
             self.stdout.write(
                 self.style.SUCCESS(

--- a/opencontractserver/annotations/management/commands/rebuild_object_vector_index.py
+++ b/opencontractserver/annotations/management/commands/rebuild_object_vector_index.py
@@ -1,0 +1,97 @@
+"""
+Rebuild the object-storage vector index from the ``Embedding`` table.
+
+Postgres is the source of truth for vectors; this command replays every
+stored vector into its object-storage namespace (WAL batches) and compacts
+each touched namespace into a fresh indexed generation. It is safe to run
+while ``VECTOR_SEARCH_BACKEND`` is still ``pgvector`` — build the index
+first, then flip the flag.
+"""
+
+from django.core.management.base import BaseCommand
+
+from opencontractserver.annotations.models import Embedding
+from opencontractserver.constants.search import (
+    DIM_TO_FIELD_MAP,
+    OBJECT_INDEX_REBUILD_BATCH_SIZE,
+)
+from opencontractserver.tasks.vector_index_tasks import PARENT_FK_TO_KIND
+from opencontractserver.vector_search.router import (
+    build_namespace,
+    get_default_engine,
+)
+
+
+class Command(BaseCommand):
+    help = (
+        "Replay all Embedding vectors into the object-storage vector index "
+        "and compact each namespace. Idempotent; run before enabling "
+        "VECTOR_SEARCH_BACKEND=object_storage."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--embedder-path",
+            default=None,
+            help="Only rebuild namespaces for this embedder_path.",
+        )
+        parser.add_argument(
+            "--batch-size",
+            type=int,
+            default=OBJECT_INDEX_REBUILD_BATCH_SIZE,
+            help="Vectors per WAL file written during the replay.",
+        )
+
+    def handle(self, *args, **options):
+        engine = get_default_engine()
+        batch_size = options["batch_size"]
+        queryset = Embedding.objects.all()
+        if options["embedder_path"]:
+            queryset = queryset.filter(embedder_path=options["embedder_path"])
+
+        buffers: dict[str, list[tuple[int, list[float]]]] = {}
+        totals: dict[str, int] = {}
+
+        def flush(namespace: str) -> None:
+            batch = buffers.pop(namespace, [])
+            if batch:
+                engine.upsert(namespace, batch)
+
+        for embedding in queryset.iterator(chunk_size=batch_size):
+            parent = next(
+                (
+                    (kind, getattr(embedding, fk_attr))
+                    for fk_attr, kind in PARENT_FK_TO_KIND.items()
+                    if getattr(embedding, fk_attr)
+                ),
+                None,
+            )
+            if parent is None:
+                continue
+            parent_kind, parent_pk = parent
+            for dimension, field_name in DIM_TO_FIELD_MAP.items():
+                vector = getattr(embedding, field_name, None)
+                if vector is None:
+                    continue
+                namespace = build_namespace(
+                    parent_kind, embedding.embedder_path, dimension
+                )
+                buffers.setdefault(namespace, []).append((parent_pk, list(vector)))
+                totals[namespace] = totals.get(namespace, 0) + 1
+                if len(buffers[namespace]) >= batch_size:
+                    flush(namespace)
+
+        for namespace in list(buffers):
+            flush(namespace)
+
+        for namespace in sorted(totals):
+            stats = engine.compact(namespace)
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"{namespace}: replayed {totals[namespace]} vectors, "
+                    f"compacted to generation {stats.get('generation')} "
+                    f"({stats.get('cluster_count')} clusters)"
+                )
+            )
+        if not totals:
+            self.stdout.write("No embeddings matched; nothing rebuilt.")

--- a/opencontractserver/annotations/management/commands/rebuild_object_vector_index.py
+++ b/opencontractserver/annotations/management/commands/rebuild_object_vector_index.py
@@ -21,6 +21,7 @@ from opencontractserver.constants.search import (
 from opencontractserver.tasks.vector_index_tasks import (
     PARENT_FK_TO_KIND,
     compact_lock_key,
+    compact_pending_key,
 )
 from opencontractserver.vector_search.router import (
     build_namespace,
@@ -136,6 +137,11 @@ class Command(BaseCommand):
                 stats = engine.compact(namespace)
             finally:
                 cache.delete(lock_key)
+                # Also clear any pending auto-compaction marker: this manual
+                # compaction just serviced it, and a stale marker would
+                # suppress the next threshold-crossing enqueue for up to the
+                # marker TTL.
+                cache.delete(compact_pending_key(namespace))
             self.stdout.write(
                 self.style.SUCCESS(
                     f"{namespace}: replayed {totals[namespace]} vectors, "

--- a/opencontractserver/constants/search.py
+++ b/opencontractserver/constants/search.py
@@ -211,6 +211,11 @@ OBJECT_INDEX_CACHE_MAX_ENTRIES = 64
 # vectors are folded into a single WAL file per PUT.
 OBJECT_INDEX_REBUILD_BATCH_SIZE = 500
 
+# How often (in embeddings processed) the rebuild command prints a progress
+# line — the full-table replay can run for a long time on large deployments
+# and should not be silent throughout.
+OBJECT_INDEX_REBUILD_PROGRESS_EVERY = 10_000
+
 # =============================================================================
 # Full-Text Search Configuration
 # =============================================================================

--- a/opencontractserver/constants/search.py
+++ b/opencontractserver/constants/search.py
@@ -156,6 +156,27 @@ VALID_VECTOR_SEARCH_BACKENDS = frozenset(
 # =============================================================================
 # Tuning knobs for opencontractserver/vector_search/engine.py.
 
+# Single source of truth for the embeddable parent-type taxonomy:
+# Django model_name -> (Embedding FK attribute, namespace parent-kind).
+# opencontractserver/vector_search/router.py derives its model-name map and
+# opencontractserver/tasks/vector_index_tasks.py its FK-attribute map from
+# this dict, so the two can never silently diverge (divergent kind values
+# would route reads and writes into different namespaces with no error —
+# just silently-empty search results).
+#
+# NOTE: the engine stores parent pks as int64 (engine.upsert casts via
+# ``int(doc_id)``). Every model listed here uses an integer AutoField pk;
+# adding an embeddable parent with a non-integer pk (e.g. UUID) requires
+# changing the engine's id representation first.
+EMBEDDABLE_PARENT_KINDS: dict[str, tuple[str, str]] = {
+    "document": ("document_id", "document"),
+    "annotation": ("annotation_id", "annotation"),
+    "note": ("note_id", "note"),
+    "conversation": ("conversation_id", "conversation"),
+    "chatmessage": ("message_id", "message"),
+    "relationship": ("relationship_id", "relationship"),
+}
+
 # Below this many vectors a namespace is stored as a single brute-force
 # cluster — k-means clustering only pays off once fetching the whole segment
 # per query costs more than the extra centroid roundtrip.
@@ -206,6 +227,9 @@ OBJECT_INDEX_COMPACT_LOCK_TIMEOUT_SECONDS = 600
 # (non-empty WAL) are retried once after this delay: put_bytes overwrites the
 # manifest via delete-then-save, so a reader can catch the sub-second window
 # between the two and would otherwise silently serve only the WAL tail.
+# NOTE: this is a synchronous time.sleep that can run on a request-serving
+# thread (GraphQL resolver -> search_by_embedding); it only fires in the
+# rare mid-overwrite/pre-first-compaction case, but keep it small.
 OBJECT_INDEX_MANIFEST_RETRY_DELAY_SECONDS = 0.05
 
 # Bounded retries for the delete-then-save overwrite dance in

--- a/opencontractserver/constants/search.py
+++ b/opencontractserver/constants/search.py
@@ -156,13 +156,26 @@ VALID_VECTOR_SEARCH_BACKENDS = frozenset(
 # =============================================================================
 # Tuning knobs for opencontractserver/vector_search/engine.py.
 
-# Single source of truth for the embeddable parent-type taxonomy:
+# Single source of truth for the object-indexed parent-type taxonomy:
 # Django model_name -> (Embedding FK attribute, namespace parent-kind).
 # opencontractserver/vector_search/router.py derives its model-name map and
 # opencontractserver/tasks/vector_index_tasks.py its FK-attribute map from
 # this dict, so the two can never silently diverge (divergent kind values
 # would route reads and writes into different namespaces with no error —
 # just silently-empty search results).
+#
+# ONLY parent kinds whose READ path routes through
+# ``VectorSearchViaEmbeddingMixin.search_by_embedding`` are listed —
+# document/annotation/note (their querysets in shared/QuerySets.py inherit
+# the mixin). Conversation, ChatMessage and Relationship embeddings
+# deliberately stay pgvector-only: their reads use separate inline
+# CosineDistance implementations with a *different result contract*
+# (QuerySet + distance-valued ``similarity_score`` in
+# opencontractserver/conversations/models.py; an inlined join in
+# opencontractserver/llms/vector_stores/core_relationship_vector_store.py),
+# so indexing their writes would be pure write amplification with no read
+# benefit. To add a kind: first route its read path through
+# ``router.search_via_object_index``, then list it here.
 #
 # NOTE: the engine stores parent pks as int64 (engine.upsert casts via
 # ``int(doc_id)``). Every model listed here uses an integer AutoField pk;
@@ -172,9 +185,6 @@ EMBEDDABLE_PARENT_KINDS: dict[str, tuple[str, str]] = {
     "document": ("document_id", "document"),
     "annotation": ("annotation_id", "annotation"),
     "note": ("note_id", "note"),
-    "conversation": ("conversation_id", "conversation"),
-    "chatmessage": ("message_id", "message"),
-    "relationship": ("relationship_id", "relationship"),
 }
 
 # Below this many vectors a namespace is stored as a single brute-force

--- a/opencontractserver/constants/search.py
+++ b/opencontractserver/constants/search.py
@@ -196,6 +196,12 @@ OBJECT_INDEX_COMPACT_MIN_WAL_FILES = 16
 # put_bytes) — raise this together with any namespace-size increase.
 OBJECT_INDEX_COMPACT_LOCK_TIMEOUT_SECONDS = 600
 
+# Manifest reads that come back missing while the namespace clearly has data
+# (non-empty WAL) are retried once after this delay: put_bytes overwrites the
+# manifest via delete-then-save, so a reader can catch the sub-second window
+# between the two and would otherwise silently serve only the WAL tail.
+OBJECT_INDEX_MANIFEST_RETRY_DELAY_SECONDS = 0.05
+
 # Bounded retries for the delete-then-save overwrite dance in
 # DjangoStorageObjectStore.put_bytes (Django's Storage.save never overwrites;
 # it uniquifies names on collision). Contention on a mutable key means the

--- a/opencontractserver/constants/search.py
+++ b/opencontractserver/constants/search.py
@@ -183,6 +183,12 @@ OBJECT_INDEX_NPROBE_RATIO = 0.25
 # querysets can still fill top_k results.
 OBJECT_INDEX_FILTER_OVERSAMPLE = 4
 
+# Hard cap on the oversampled candidate fetch, independent of caller top_k —
+# bounds the in-memory ranking and the pk__in re-filter query for abusive or
+# buggy top_k values. When the cap truncates, the shortfall rule falls back
+# to pgvector rather than under-filling.
+OBJECT_INDEX_MAX_FETCH_CANDIDATES = 2048
+
 # WAL tail length that triggers async compaction after a write. Each tail file
 # costs one GET per query, so this bounds worst-case query roundtrips.
 OBJECT_INDEX_COMPACT_MIN_WAL_FILES = 16

--- a/opencontractserver/constants/search.py
+++ b/opencontractserver/constants/search.py
@@ -188,8 +188,20 @@ OBJECT_INDEX_FILTER_OVERSAMPLE = 4
 OBJECT_INDEX_COMPACT_MIN_WAL_FILES = 16
 
 # Cache-lock TTL for the per-namespace compaction mutex (seconds). Must exceed
-# the slowest realistic compaction so a crashed worker's lock expires.
+# the slowest realistic compaction so a crashed worker's lock expires. This
+# bound is coupled to the "full recluster per compaction is fine up to ~1M
+# vectors per namespace" scaling note in the design doc: if compactions ever
+# approach this ceiling, a second compactor can start while the first is
+# still running (racing manifest writes, resolved last-writer-wins by
+# put_bytes) — raise this together with any namespace-size increase.
 OBJECT_INDEX_COMPACT_LOCK_TIMEOUT_SECONDS = 600
+
+# Bounded retries for the delete-then-save overwrite dance in
+# DjangoStorageObjectStore.put_bytes (Django's Storage.save never overwrites;
+# it uniquifies names on collision). Contention on a mutable key means the
+# compaction lock was breached, so after this many attempts we concede
+# last-writer-wins to the racing writer instead of looping.
+OBJECT_STORE_PUT_OVERWRITE_MAX_ATTEMPTS = 3
 
 # Max entries in the per-process LRU for immutable index artifacts
 # (centroids + cluster blobs, keyed by generation).

--- a/opencontractserver/constants/search.py
+++ b/opencontractserver/constants/search.py
@@ -139,6 +139,67 @@ HNSW_MAX_INDEXED_DIM = max(HNSW_INDEXED_DIMS)
 MAX_SELECT_ALL_DOCUMENT_IDS = 25_000
 
 # =============================================================================
+# Vector Search Backend Selection
+# =============================================================================
+# Values accepted by settings.VECTOR_SEARCH_BACKEND. "pgvector" is the default
+# Postgres HNSW path; "object_storage" serves similarity ranking from the
+# turbopuffer-style WAL + centroid index in object storage (see
+# docs/architecture/object_storage_vector_search.md).
+VECTOR_SEARCH_BACKEND_PGVECTOR = "pgvector"
+VECTOR_SEARCH_BACKEND_OBJECT_STORAGE = "object_storage"
+VALID_VECTOR_SEARCH_BACKENDS = frozenset(
+    {VECTOR_SEARCH_BACKEND_PGVECTOR, VECTOR_SEARCH_BACKEND_OBJECT_STORAGE}
+)
+
+# =============================================================================
+# Object-Storage Vector Index Parameters
+# =============================================================================
+# Tuning knobs for opencontractserver/vector_search/engine.py.
+
+# Below this many vectors a namespace is stored as a single brute-force
+# cluster — k-means clustering only pays off once fetching the whole segment
+# per query costs more than the extra centroid roundtrip.
+OBJECT_INDEX_MIN_VECTORS_FOR_ANN = 256
+
+# Upper bound on k-means centroids per namespace (k = sqrt(n) capped here).
+# 1024 clusters keeps the centroid blob < 6 MB for 1536-dim float32 vectors.
+OBJECT_INDEX_MAX_CENTROIDS = 1024
+
+# Lloyd iterations during compaction. Compaction is offline/async, but each
+# iteration is O(n*k); 8 gets within a few percent of converged assignment.
+OBJECT_INDEX_KMEANS_ITERATIONS = 8
+
+# Fixed seed so compaction is deterministic (same data -> same segments),
+# which makes rebuilds reproducible and cache keys stable.
+OBJECT_INDEX_KMEANS_SEED = 0
+
+# How many nearest clusters a query probes: max(NPROBE_MIN, k * NPROBE_RATIO),
+# clamped to k. Higher = better recall, more object-store roundtrips.
+OBJECT_INDEX_NPROBE_MIN = 4
+OBJECT_INDEX_NPROBE_RATIO = 0.25
+
+# Permission filtering happens AFTER ANN retrieval (post-filtering), so the
+# engine is asked for this multiple of top_k so that heavily-filtered
+# querysets can still fill top_k results.
+OBJECT_INDEX_FILTER_OVERSAMPLE = 4
+
+# WAL tail length that triggers async compaction after a write. Each tail file
+# costs one GET per query, so this bounds worst-case query roundtrips.
+OBJECT_INDEX_COMPACT_MIN_WAL_FILES = 16
+
+# Cache-lock TTL for the per-namespace compaction mutex (seconds). Must exceed
+# the slowest realistic compaction so a crashed worker's lock expires.
+OBJECT_INDEX_COMPACT_LOCK_TIMEOUT_SECONDS = 600
+
+# Max entries in the per-process LRU for immutable index artifacts
+# (centroids + cluster blobs, keyed by generation).
+OBJECT_INDEX_CACHE_MAX_ENTRIES = 64
+
+# Batch size for the rebuild_object_vector_index management command — how many
+# vectors are folded into a single WAL file per PUT.
+OBJECT_INDEX_REBUILD_BATCH_SIZE = 500
+
+# =============================================================================
 # Full-Text Search Configuration
 # =============================================================================
 # PostgreSQL text search configuration name for tsvector generation.

--- a/opencontractserver/shared/Managers.py
+++ b/opencontractserver/shared/Managers.py
@@ -1335,6 +1335,16 @@ class EmbeddingManager(BaseVisibilityManager):
     Manager for Embedding that can store or update embeddings
     without creating accidental duplicates for the same dimension,
     embedder_path, and parent references (document/annotation/note).
+
+    NOTE for future deletion paths: the object-storage vector index (see
+    ``docs/architecture/object_storage_vector_search.md``) only hears about
+    writes (via ``enqueue_embedding_index_sync`` below). Deleting a parent
+    object is safe — the query-time ORM re-filter drops its id — but any
+    code path that deletes/replaces an ``Embedding`` row *independent of its
+    parent* (e.g. a stale-embedder cleanup command) must also tombstone the
+    corresponding namespace entry (``ObjectStorageVectorEngine.delete``) or
+    run ``rebuild_object_vector_index``, or the stale vector keeps matching
+    its still-alive parent indefinitely.
     """
 
     def _get_vector_field_name(self, dimension: int) -> str:

--- a/opencontractserver/shared/Managers.py
+++ b/opencontractserver/shared/Managers.py
@@ -29,6 +29,7 @@ from opencontractserver.types.enums import PermissionTypes as _PermissionTypes
 from opencontractserver.types.protocols import (  # noqa: F401
     PermissionedQueryManagerProtocol,
 )
+from opencontractserver.vector_search.hooks import enqueue_embedding_index_sync
 
 # Subset of permission codes Annotation / Relationship recognise for
 # row-creator shortcuts. PUBLISH/PERMISSION are intentionally excluded so they
@@ -1423,13 +1424,14 @@ class EmbeddingManager(BaseVisibilityManager):
         if embedding:
             setattr(embedding, field_name, vector)
             embedding.save(update_fields=[field_name, "modified"])
+            enqueue_embedding_index_sync(embedding, dimension)
             return embedding
 
         # Try to create a new embedding. If a race condition causes a constraint
         # violation (another worker created the same embedding between our check
         # and create), catch the IntegrityError and update the existing record.
         try:
-            return self.create(
+            embedding = self.create(
                 creator=creator,
                 **lookup,
                 **{field_name: vector},
@@ -1444,4 +1446,5 @@ class EmbeddingManager(BaseVisibilityManager):
             embedding = self.get(**lookup)
             setattr(embedding, field_name, vector)
             embedding.save(update_fields=[field_name, "modified"])
-            return embedding
+        enqueue_embedding_index_sync(embedding, dimension)
+        return embedding

--- a/opencontractserver/shared/checks.py
+++ b/opencontractserver/shared/checks.py
@@ -153,17 +153,15 @@ def check_vector_index_storage_exposure(
     if getattr(settings, "STORAGE_BACKEND", "LOCAL") != "AWS":
         return []
     public_signals = []
-    if getattr(settings, "AWS_DEFAULT_ACL", None) in (
-        "public-read",
-        "public-read-write",
-    ):
-        public_signals.append(f"AWS_DEFAULT_ACL={settings.AWS_DEFAULT_ACL!r}")
+    default_acl = getattr(settings, "AWS_DEFAULT_ACL", None)
+    if default_acl in ("public-read", "public-read-write"):
+        public_signals.append(f"AWS_DEFAULT_ACL={default_acl!r}")
     if getattr(settings, "AWS_QUERYSTRING_AUTH", True) is False:
         public_signals.append("AWS_QUERYSTRING_AUTH=False (unsigned URLs)")
-    if getattr(settings, "AWS_S3_CUSTOM_DOMAIN", None):
+    custom_domain = getattr(settings, "AWS_S3_CUSTOM_DOMAIN", None)
+    if custom_domain:
         public_signals.append(
-            f"AWS_S3_CUSTOM_DOMAIN={settings.AWS_S3_CUSTOM_DOMAIN!r} "
-            "(CDN fronting the bucket)"
+            f"AWS_S3_CUSTOM_DOMAIN={custom_domain!r} (CDN fronting the bucket)"
         )
     if public_signals:
         return [

--- a/opencontractserver/shared/checks.py
+++ b/opencontractserver/shared/checks.py
@@ -135,8 +135,11 @@ def check_vector_index_storage_exposure(
     independently readable (public ACL, unsigned URLs, or a CDN custom
     domain fronting the whole bucket), anyone with bucket read access could
     enumerate vectors for every document/annotation in the system outside
-    Django auth entirely. Warning ``opencontracts.W004``; see the
-    "Permissions" section of
+    Django auth entirely. Covers AWS (``AWS_DEFAULT_ACL``,
+    ``AWS_QUERYSTRING_AUTH``, ``AWS_S3_CUSTOM_DOMAIN``) and GCS
+    (``GS_DEFAULT_ACL``, ``GS_QUERYSTRING_AUTH``) signals; ``LOCAL`` storage
+    is not network-readable and passes. Warning ``opencontracts.W004``; see
+    the "Permissions" section of
     ``docs/architecture/object_storage_vector_search.md``.
     """
     from django.conf import settings
@@ -150,19 +153,32 @@ def check_vector_index_storage_exposure(
         != VECTOR_SEARCH_BACKEND_OBJECT_STORAGE
     ):
         return []
-    if getattr(settings, "STORAGE_BACKEND", "LOCAL") != "AWS":
-        return []
+    storage_backend = getattr(settings, "STORAGE_BACKEND", "LOCAL")
     public_signals = []
-    default_acl = getattr(settings, "AWS_DEFAULT_ACL", None)
-    if default_acl in ("public-read", "public-read-write"):
-        public_signals.append(f"AWS_DEFAULT_ACL={default_acl!r}")
-    if getattr(settings, "AWS_QUERYSTRING_AUTH", True) is False:
-        public_signals.append("AWS_QUERYSTRING_AUTH=False (unsigned URLs)")
-    custom_domain = getattr(settings, "AWS_S3_CUSTOM_DOMAIN", None)
-    if custom_domain:
-        public_signals.append(
-            f"AWS_S3_CUSTOM_DOMAIN={custom_domain!r} (CDN fronting the bucket)"
-        )
+    if storage_backend == "AWS":
+        default_acl = getattr(settings, "AWS_DEFAULT_ACL", None)
+        if default_acl in ("public-read", "public-read-write"):
+            public_signals.append(f"AWS_DEFAULT_ACL={default_acl!r}")
+        if getattr(settings, "AWS_QUERYSTRING_AUTH", True) is False:
+            public_signals.append("AWS_QUERYSTRING_AUTH=False (unsigned URLs)")
+        custom_domain = getattr(settings, "AWS_S3_CUSTOM_DOMAIN", None)
+        if custom_domain:
+            public_signals.append(
+                f"AWS_S3_CUSTOM_DOMAIN={custom_domain!r} (CDN fronting the bucket)"
+            )
+    elif storage_backend == "GCP":
+        gs_default_acl = getattr(settings, "GS_DEFAULT_ACL", None)
+        if gs_default_acl in (
+            "publicRead",
+            "public-read",
+            "publicReadWrite",
+            "public-read-write",
+        ):
+            public_signals.append(f"GS_DEFAULT_ACL={gs_default_acl!r}")
+        if getattr(settings, "GS_QUERYSTRING_AUTH", True) is False:
+            public_signals.append("GS_QUERYSTRING_AUTH=False (unsigned URLs)")
+    else:
+        return []
     if public_signals:
         return [
             Warning(

--- a/opencontractserver/shared/checks.py
+++ b/opencontractserver/shared/checks.py
@@ -14,7 +14,7 @@ Wired in by ``opencontractserver.users.apps.UsersConfig.ready`` (the same
 
 from typing import Any
 
-from django.core.checks import Error, register
+from django.core.checks import Error, Warning, register
 
 
 @register("architecture")
@@ -78,6 +78,46 @@ def check_vector_search_backend(app_configs: Any, **kwargs: Any) -> list[Error]:
                 f"search backend.",
                 hint=f"Valid values: {sorted(VALID_VECTOR_SEARCH_BACKENDS)}.",
                 id="opencontracts.E002",
+            )
+        ]
+    return []
+
+
+@register("settings")
+def check_vector_search_cache(app_configs: Any, **kwargs: Any) -> list[Warning]:
+    """Warn when the object-storage backend runs on a process-local cache.
+
+    The per-namespace compaction mutex (``compact_object_vector_namespace``)
+    is a ``cache.add`` lock, so it only serialises compactors if all Celery
+    workers share one cache backend. ``LocMemCache`` is per-process: with it,
+    two workers can compact the same namespace concurrently and clobber each
+    other's manifest (last-writer-wins), losing one compaction's fold.
+    Warning (``opencontracts.W003``), not Error, because single-process
+    deployments (and eager-Celery test runs) are perfectly safe.
+    """
+    from django.conf import settings
+
+    from opencontractserver.constants.search import (
+        VECTOR_SEARCH_BACKEND_OBJECT_STORAGE,
+    )
+
+    if (
+        getattr(settings, "VECTOR_SEARCH_BACKEND", None)
+        != VECTOR_SEARCH_BACKEND_OBJECT_STORAGE
+    ):
+        return []
+    default_cache = settings.CACHES.get("default", {}).get("BACKEND", "")
+    if "locmem" in default_cache.lower() or "dummy" in default_cache.lower():
+        return [
+            Warning(
+                "VECTOR_SEARCH_BACKEND=object_storage with a process-local "
+                f"default cache ({default_cache}): the compaction lock cannot "
+                "serialise compactors across worker processes.",
+                hint=(
+                    "Use a shared cache backend (e.g. django_redis) in any "
+                    "multi-worker deployment, or compactions may race."
+                ),
+                id="opencontracts.W003",
             )
         ]
     return []

--- a/opencontractserver/shared/checks.py
+++ b/opencontractserver/shared/checks.py
@@ -189,7 +189,10 @@ def check_vector_index_storage_exposure(
                 hint=(
                     "Keep VECTOR_INDEX_STORAGE_PREFIX in a non-public bucket/"
                     "path (e.g. block public access on the prefix, or use a "
-                    "dedicated private bucket via a custom Storage)."
+                    "dedicated private bucket via a custom Storage). Note this "
+                    "check is best-effort: it inspects Django settings signals "
+                    "only — bucket policies set outside Django (console/IaC) "
+                    "are invisible here, so a clean check is not a guarantee."
                 ),
                 id="opencontracts.W004",
             )

--- a/opencontractserver/shared/checks.py
+++ b/opencontractserver/shared/checks.py
@@ -55,3 +55,29 @@ def check_graphql_service_layer(app_configs: Any, **kwargs: Any) -> list[Error]:
         short, hint = format_violation(module_path, lineno, name)
         issues.append(Error(short, hint=hint, id="opencontracts.E001"))
     return issues
+
+
+@register("settings")
+def check_vector_search_backend(app_configs: Any, **kwargs: Any) -> list[Error]:
+    """Fail startup on an invalid ``VECTOR_SEARCH_BACKEND`` value.
+
+    The backend flag is compared by string equality at query time, so a typo
+    (``objectstorage``, ``turbopuffer``…) would otherwise silently degrade to
+    the pgvector path — exactly the kind of misconfiguration that should fail
+    loudly at boot instead (``opencontracts.E002``).
+    """
+    from django.conf import settings
+
+    from opencontractserver.constants.search import VALID_VECTOR_SEARCH_BACKENDS
+
+    configured = getattr(settings, "VECTOR_SEARCH_BACKEND", None)
+    if configured is not None and configured not in VALID_VECTOR_SEARCH_BACKENDS:
+        return [
+            Error(
+                f"VECTOR_SEARCH_BACKEND={configured!r} is not a valid vector "
+                f"search backend.",
+                hint=f"Valid values: {sorted(VALID_VECTOR_SEARCH_BACKENDS)}.",
+                id="opencontracts.E002",
+            )
+        ]
+    return []

--- a/opencontractserver/shared/checks.py
+++ b/opencontractserver/shared/checks.py
@@ -121,3 +121,63 @@ def check_vector_search_cache(app_configs: Any, **kwargs: Any) -> list[Warning]:
             )
         ]
     return []
+
+
+@register("settings")
+def check_vector_index_storage_exposure(
+    app_configs: Any, **kwargs: Any
+) -> list[Warning]:
+    """Warn when the vector index may live in publicly-readable storage.
+
+    The object-storage index stores raw ``(parent_pk, vector)`` blobs with no
+    ACL of their own — query-time permissions are enforced by the ORM
+    re-filter, NOT at the storage layer. If the default storage bucket is
+    independently readable (public ACL, unsigned URLs, or a CDN custom
+    domain fronting the whole bucket), anyone with bucket read access could
+    enumerate vectors for every document/annotation in the system outside
+    Django auth entirely. Warning ``opencontracts.W004``; see the
+    "Permissions" section of
+    ``docs/architecture/object_storage_vector_search.md``.
+    """
+    from django.conf import settings
+
+    from opencontractserver.constants.search import (
+        VECTOR_SEARCH_BACKEND_OBJECT_STORAGE,
+    )
+
+    if (
+        getattr(settings, "VECTOR_SEARCH_BACKEND", None)
+        != VECTOR_SEARCH_BACKEND_OBJECT_STORAGE
+    ):
+        return []
+    if getattr(settings, "STORAGE_BACKEND", "LOCAL") != "AWS":
+        return []
+    public_signals = []
+    if getattr(settings, "AWS_DEFAULT_ACL", None) in (
+        "public-read",
+        "public-read-write",
+    ):
+        public_signals.append(f"AWS_DEFAULT_ACL={settings.AWS_DEFAULT_ACL!r}")
+    if getattr(settings, "AWS_QUERYSTRING_AUTH", True) is False:
+        public_signals.append("AWS_QUERYSTRING_AUTH=False (unsigned URLs)")
+    if getattr(settings, "AWS_S3_CUSTOM_DOMAIN", None):
+        public_signals.append(
+            f"AWS_S3_CUSTOM_DOMAIN={settings.AWS_S3_CUSTOM_DOMAIN!r} "
+            "(CDN fronting the bucket)"
+        )
+    if public_signals:
+        return [
+            Warning(
+                "VECTOR_SEARCH_BACKEND=object_storage but the default storage "
+                "shows public-read signals: " + "; ".join(public_signals) + ". "
+                "The vector index has no ACL of its own — a readable bucket "
+                "leaks raw vectors and parent ids for private documents.",
+                hint=(
+                    "Keep VECTOR_INDEX_STORAGE_PREFIX in a non-public bucket/"
+                    "path (e.g. block public access on the prefix, or use a "
+                    "dedicated private bucket via a custom Storage)."
+                ),
+                id="opencontracts.W004",
+            )
+        ]
+    return []

--- a/opencontractserver/shared/mixins.py
+++ b/opencontractserver/shared/mixins.py
@@ -50,6 +50,13 @@ class VectorSearchViaEmbeddingMixin:
         Vector search for records of this model by embeddings stored in
         a reverse relation to Embedding (embedding->document, for instance).
 
+        Backend selection: when ``settings.VECTOR_SEARCH_BACKEND`` is
+        ``"object_storage"``, the similarity ranking is served from the
+        object-storage index (opencontractserver/vector_search/) and candidate
+        ids are re-filtered through this queryset, preserving all scoping
+        already applied to it. Unindexed namespaces and engine errors fall
+        back to the pgvector path below.
+
         - dimension is inferred from len(query_vector)
         - filters on embedder_path
         - excludes cases where the chosen vector field is null
@@ -70,6 +77,18 @@ class VectorSearchViaEmbeddingMixin:
         Returns a **list** (not a QuerySet) of model instances annotated
         with 'similarity_score'. Do not chain QuerySet methods on the result.
         """
+        # Late import: vector_search.router has no model imports, but keeping
+        # it out of module scope avoids import-order coupling with settings.
+        from opencontractserver.vector_search.router import (
+            object_storage_backend_enabled,
+            search_via_object_index,
+        )
+
+        if object_storage_backend_enabled():
+            results = search_via_object_index(self, query_vector, embedder_path, top_k)
+            if results is not None:
+                return results
+
         dimension = len(query_vector)
         if dimension > HNSW_MAX_INDEXED_DIM:
             _logger.warning(

--- a/opencontractserver/tasks/__init__.py
+++ b/opencontractserver/tasks/__init__.py
@@ -26,6 +26,10 @@ from .permissioning_tasks import make_analysis_public_task, make_corpus_public_t
 from .research_tasks import reap_stalled_research, run_deep_research
 from .stats_tasks import refresh_system_stats
 from .telemetry_tasks import send_usage_heartbeat
+from .vector_index_tasks import (
+    compact_object_vector_namespace,
+    sync_embedding_to_object_index,
+)
 
 # Great, quick guidance on how to restructure tasks into multiple modules:
 # https://blog.sneawo.com/blog/2018/12/05/how-to-split-celery-tasks-file/
@@ -59,4 +63,6 @@ __all__ = [
     "reap_stalled_research",
     "check_conversations_for_curation",
     "curate_corpus_memory",
+    "sync_embedding_to_object_index",
+    "compact_object_vector_namespace",
 ]

--- a/opencontractserver/tasks/vector_index_tasks.py
+++ b/opencontractserver/tasks/vector_index_tasks.py
@@ -1,0 +1,98 @@
+"""
+Celery tasks maintaining the object-storage vector index
+(``VECTOR_SEARCH_BACKEND=object_storage``).
+
+Writes are fire-and-forget WAL appends fanned out from
+``Embedding.objects.store_embedding`` (see ``vector_search/hooks.py``);
+compaction folds the WAL into a new indexed generation and is serialised
+per-namespace with a cache lock.
+"""
+
+import logging
+
+from celery import shared_task
+from django.core.cache import cache
+
+from opencontractserver.constants.search import (
+    DIM_TO_FIELD_MAP,
+    OBJECT_INDEX_COMPACT_LOCK_TIMEOUT_SECONDS,
+    OBJECT_INDEX_COMPACT_MIN_WAL_FILES,
+)
+from opencontractserver.vector_search.router import (
+    build_namespace,
+    get_default_engine,
+    object_storage_backend_enabled,
+)
+
+logger = logging.getLogger(__name__)
+
+# Mirrors Embedding's parent FK columns -> namespace parent-kind segment.
+PARENT_FK_TO_KIND = {
+    "document_id": "document",
+    "annotation_id": "annotation",
+    "note_id": "note",
+    "conversation_id": "conversation",
+    "message_id": "message",
+    "relationship_id": "relationship",
+}
+
+
+def _parent_ref(embedding) -> tuple[str, int] | None:
+    """Return (parent_kind, parent_pk) for the single populated parent FK."""
+    for fk_attr, kind in PARENT_FK_TO_KIND.items():
+        parent_pk = getattr(embedding, fk_attr)
+        if parent_pk:
+            return kind, parent_pk
+    return None
+
+
+@shared_task
+def sync_embedding_to_object_index(embedding_id: int, dimension: int) -> str:
+    """
+    Upsert one stored embedding into its object-storage namespace, then
+    trigger compaction when the WAL tail has grown past the threshold.
+    """
+    if not object_storage_backend_enabled():
+        return "skipped: backend disabled"
+    from opencontractserver.annotations.models import Embedding
+
+    embedding = Embedding.objects.filter(pk=embedding_id).first()
+    if embedding is None:
+        # Row deleted between commit and task execution — nothing to sync;
+        # a stale index entry (if any) is dropped at query time by the ORM
+        # re-filter and removed for good on the next rebuild.
+        return f"skipped: embedding {embedding_id} no longer exists"
+
+    vector = getattr(embedding, DIM_TO_FIELD_MAP[dimension], None)
+    if vector is None:
+        return f"skipped: embedding {embedding_id} has no vector_{dimension}"
+    parent = _parent_ref(embedding)
+    if parent is None:
+        return f"skipped: embedding {embedding_id} has no parent reference"
+
+    parent_kind, parent_pk = parent
+    namespace = build_namespace(parent_kind, embedding.embedder_path, dimension)
+    engine = get_default_engine()
+    engine.upsert(namespace, [(parent_pk, list(vector))])
+
+    if engine.wal_tail_count(namespace) >= OBJECT_INDEX_COMPACT_MIN_WAL_FILES:
+        compact_object_vector_namespace.si(namespace).apply_async()
+    return f"upserted {parent_kind} {parent_pk} into {namespace}"
+
+
+@shared_task
+def compact_object_vector_namespace(namespace: str) -> str:
+    """
+    Fold the namespace's WAL tail into a new segment generation. A cache lock
+    guarantees a single compactor per namespace; contenders skip (the next
+    threshold crossing re-triggers).
+    """
+    lock_key = f"object-vector-index-compact:{namespace}"
+    if not cache.add(lock_key, "1", timeout=OBJECT_INDEX_COMPACT_LOCK_TIMEOUT_SECONDS):
+        return f"skipped: compaction already running for {namespace}"
+    try:
+        stats = get_default_engine().compact(namespace)
+        logger.info("Compacted object vector namespace: %s", stats)
+        return f"compacted {namespace}: {stats}"
+    finally:
+        cache.delete(lock_key)

--- a/opencontractserver/tasks/vector_index_tasks.py
+++ b/opencontractserver/tasks/vector_index_tasks.py
@@ -77,7 +77,7 @@ def sync_embedding_to_object_index(embedding_id: int, dimension: int) -> str:
         return f"skipped: embedding {embedding_id} has no vector_{dimension}"
     parent = _parent_ref(embedding)
     if parent is None:
-        return f"skipped: embedding {embedding_id} has no parent reference"
+        return f"skipped: embedding {embedding_id} has no indexed parent kind"
 
     parent_kind, parent_pk = parent
     namespace = build_namespace(parent_kind, embedding.embedder_path, dimension)

--- a/opencontractserver/tasks/vector_index_tasks.py
+++ b/opencontractserver/tasks/vector_index_tasks.py
@@ -91,7 +91,7 @@ def sync_embedding_to_object_index(embedding_id: int, dimension: int) -> str:
         # cleared when compaction finishes (or by TTL if the queued task is
         # lost), letting the next threshold crossing re-trigger.
         if cache.add(
-            _compact_pending_key(namespace),
+            compact_pending_key(namespace),
             "1",
             timeout=OBJECT_INDEX_COMPACT_LOCK_TIMEOUT_SECONDS,
         ):
@@ -99,7 +99,7 @@ def sync_embedding_to_object_index(embedding_id: int, dimension: int) -> str:
     return f"upserted {parent_kind} {parent_pk} into {namespace}"
 
 
-def _compact_pending_key(namespace: str) -> str:
+def compact_pending_key(namespace: str) -> str:
     return f"object-vector-index-compact-pending:{namespace}"
 
 
@@ -129,4 +129,4 @@ def compact_object_vector_namespace(namespace: str) -> str:
         return f"compacted {namespace}: {stats}"
     finally:
         cache.delete(lock_key)
-        cache.delete(_compact_pending_key(namespace))
+        cache.delete(compact_pending_key(namespace))

--- a/opencontractserver/tasks/vector_index_tasks.py
+++ b/opencontractserver/tasks/vector_index_tasks.py
@@ -27,6 +27,10 @@ from opencontractserver.vector_search.router import (
 logger = logging.getLogger(__name__)
 
 # Mirrors Embedding's parent FK columns -> namespace parent-kind segment.
+# KEEP IN SYNC with PARENT_KIND_BY_MODEL_NAME in
+# opencontractserver/vector_search/router.py — same taxonomy keyed by model
+# name; kind VALUES must match exactly or writes and reads land in different
+# namespaces.
 PARENT_FK_TO_KIND = {
     "document_id": "document",
     "annotation_id": "annotation",
@@ -46,11 +50,22 @@ def _parent_ref(embedding) -> tuple[str, int] | None:
     return None
 
 
-@shared_task
+@shared_task(
+    autoretry_for=(Exception,),
+    max_retries=3,
+    retry_backoff=True,
+    retry_jitter=True,
+)
 def sync_embedding_to_object_index(embedding_id: int, dimension: int) -> str:
     """
     Upsert one stored embedding into its object-storage namespace, then
     trigger compaction when the WAL tail has grown past the threshold.
+
+    Retries with backoff on any exception (typically transient object-store
+    throttling/network errors) — the upsert is idempotent, and without a
+    retry a failed sync silently drops this embedding from the index until
+    the next rebuild. After retries are exhausted the failure is visible in
+    Celery, and pgvector remains ground truth either way.
     """
     if not object_storage_backend_enabled():
         return "skipped: backend disabled"
@@ -94,6 +109,16 @@ def _compact_pending_key(namespace: str) -> str:
     return f"object-vector-index-compact-pending:{namespace}"
 
 
+def compact_lock_key(namespace: str) -> str:
+    """
+    Per-namespace compaction mutex key. Shared by the Celery task below and
+    ``rebuild_object_vector_index`` (the management command) so that a manual
+    rebuild can never compact concurrently with an auto-compaction —
+    ``ObjectStorageVectorEngine.compact`` is not concurrency-safe with itself.
+    """
+    return f"object-vector-index-compact:{namespace}"
+
+
 @shared_task
 def compact_object_vector_namespace(namespace: str) -> str:
     """
@@ -101,7 +126,7 @@ def compact_object_vector_namespace(namespace: str) -> str:
     guarantees a single compactor per namespace; contenders skip (the next
     threshold crossing re-triggers).
     """
-    lock_key = f"object-vector-index-compact:{namespace}"
+    lock_key = compact_lock_key(namespace)
     if not cache.add(lock_key, "1", timeout=OBJECT_INDEX_COMPACT_LOCK_TIMEOUT_SECONDS):
         return f"skipped: compaction already running for {namespace}"
     try:

--- a/opencontractserver/tasks/vector_index_tasks.py
+++ b/opencontractserver/tasks/vector_index_tasks.py
@@ -15,6 +15,7 @@ from django.core.cache import cache
 
 from opencontractserver.constants.search import (
     DIM_TO_FIELD_MAP,
+    EMBEDDABLE_PARENT_KINDS,
     OBJECT_INDEX_COMPACT_LOCK_TIMEOUT_SECONDS,
     OBJECT_INDEX_COMPACT_MIN_WAL_FILES,
 )
@@ -26,18 +27,11 @@ from opencontractserver.vector_search.router import (
 
 logger = logging.getLogger(__name__)
 
-# Mirrors Embedding's parent FK columns -> namespace parent-kind segment.
-# KEEP IN SYNC with PARENT_KIND_BY_MODEL_NAME in
-# opencontractserver/vector_search/router.py — same taxonomy keyed by model
-# name; kind VALUES must match exactly or writes and reads land in different
-# namespaces.
+# Maps Embedding's parent FK columns -> namespace parent-kind segment,
+# derived from the shared EMBEDDABLE_PARENT_KINDS taxonomy (single source of
+# truth with the read-path map in opencontractserver/vector_search/router.py).
 PARENT_FK_TO_KIND = {
-    "document_id": "document",
-    "annotation_id": "annotation",
-    "note_id": "note",
-    "conversation_id": "conversation",
-    "message_id": "message",
-    "relationship_id": "relationship",
+    fk_attr: kind for _model_name, (fk_attr, kind) in EMBEDDABLE_PARENT_KINDS.items()
 }
 
 

--- a/opencontractserver/tasks/vector_index_tasks.py
+++ b/opencontractserver/tasks/vector_index_tasks.py
@@ -76,8 +76,22 @@ def sync_embedding_to_object_index(embedding_id: int, dimension: int) -> str:
     engine.upsert(namespace, [(parent_pk, list(vector))])
 
     if engine.wal_tail_count(namespace) >= OBJECT_INDEX_COMPACT_MIN_WAL_FILES:
-        compact_object_vector_namespace.si(namespace).apply_async()
+        # Pending-marker gate: during a sustained write burst every write past
+        # the threshold would otherwise enqueue its own (no-op) compaction
+        # task. Only the writer that claims the marker enqueues; the marker is
+        # cleared when compaction finishes (or by TTL if the queued task is
+        # lost), letting the next threshold crossing re-trigger.
+        if cache.add(
+            _compact_pending_key(namespace),
+            "1",
+            timeout=OBJECT_INDEX_COMPACT_LOCK_TIMEOUT_SECONDS,
+        ):
+            compact_object_vector_namespace.si(namespace).apply_async()
     return f"upserted {parent_kind} {parent_pk} into {namespace}"
+
+
+def _compact_pending_key(namespace: str) -> str:
+    return f"object-vector-index-compact-pending:{namespace}"
 
 
 @shared_task
@@ -96,3 +110,4 @@ def compact_object_vector_namespace(namespace: str) -> str:
         return f"compacted {namespace}: {stats}"
     finally:
         cache.delete(lock_key)
+        cache.delete(_compact_pending_key(namespace))

--- a/opencontractserver/tests/test_object_storage_vector_backend.py
+++ b/opencontractserver/tests/test_object_storage_vector_backend.py
@@ -192,6 +192,124 @@ class ObjectStorageVectorEngineTests(SimpleTestCase):
         ns_b = build_namespace("annotation", "acme/embedder v1", DIM)
         self.assertNotEqual(ns_a, ns_b)
 
+    def test_search_survives_compaction_between_wal_list_and_manifest_read(self):
+        """
+        Regression for the manifest/WAL read-order race: compaction commits
+        the manifest before GC'ing folded WAL files, so ``search()`` must
+        list the WAL BEFORE reading the manifest. We interleave two full
+        compaction cycles between those two reads (the second cycle GC's the
+        files the first one folded) — with manifest-first ordering the data
+        written before the query would silently vanish from the results.
+        """
+        vectors = clustered_vectors(2, 10)
+        self.engine.upsert(
+            NAMESPACE, [(i, vectors[i].tolist()) for i in range(len(vectors))]
+        )
+        compactor = ObjectStorageVectorEngine(self.store, min_vectors_for_ann=50)
+        real_list_wal = self.engine._list_wal
+
+        def list_then_compact_twice(namespace):
+            compactor.compact(namespace)  # folds the WAL (GC deferred)
+            compactor.compact(namespace)  # GC's the files folded above
+            return real_list_wal(namespace)
+
+        with mock.patch.object(
+            self.engine, "_list_wal", side_effect=list_then_compact_twice
+        ):
+            hits = must(self.engine.search(NAMESPACE, vectors[3].tolist(), 3))
+        self.assertEqual(hits[0][0], 3)
+        self.assertAlmostEqual(hits[0][1], 1.0, places=3)
+
+    def test_partial_gc_failure_cannot_resurrect_tombstoned_ids(self):
+        """
+        A folded WAL file whose (deferred) GC fails must never be replayed:
+        here the lingering file holds an upsert whose id was tombstoned in a
+        file that WAS GC'd — replaying the survivor would resurrect the id.
+        """
+        wal_upsert = self.engine.upsert(NAMESPACE, [(1, sparse_vector((0, 1.0)))])
+        self.engine.upsert(NAMESPACE, [(2, sparse_vector((1, 1.0)))])
+        self.engine.delete(NAMESPACE, [1])
+        self.engine.compact(NAMESPACE)  # gen1: id 1 dead; GC deferred
+        real_delete = self.store.delete
+        with mock.patch.object(
+            self.store,
+            "delete",
+            side_effect=lambda key: (
+                None if key.endswith(wal_upsert) else real_delete(key)
+            ),
+        ):
+            # gen2's deferred GC deletes gen1's folded files — except the
+            # upsert of id 1, whose deletion "fails" and lingers.
+            self.engine.compact(NAMESPACE)
+        hits = must(self.engine.search(NAMESPACE, sparse_vector((0, 1.0)), 5))
+        self.assertEqual([h[0] for h in hits], [2])
+
+    def test_wal_tail_count_ignores_folded_lingering_files(self):
+        self.engine.upsert(NAMESPACE, [(1, sparse_vector((0, 1.0)))])
+        self.engine.upsert(NAMESPACE, [(2, sparse_vector((1, 1.0)))])
+        self.assertEqual(self.engine.wal_tail_count(NAMESPACE), 2)
+        self.engine.compact(NAMESPACE)
+        # GC is deferred: the two folded files still exist in storage, but
+        # they no longer count toward the tail (else auto-compaction would
+        # re-trigger forever).
+        self.assertEqual(len(self.store.list_keys(f"{NAMESPACE}/wal")), 2)
+        self.assertEqual(self.engine.wal_tail_count(NAMESPACE), 0)
+        self.engine.upsert(NAMESPACE, [(3, sparse_vector((2, 1.0)))])
+        self.assertEqual(self.engine.wal_tail_count(NAMESPACE), 1)
+
+    def test_deferred_gc_reclaims_prior_cycle(self):
+        self.engine.upsert(NAMESPACE, [(1, sparse_vector((0, 1.0)))])
+        self.engine.compact(NAMESPACE)  # gen1: folded WAL + no prior gen yet
+        self.engine.upsert(NAMESPACE, [(2, sparse_vector((1, 1.0)))])
+        self.engine.compact(NAMESPACE)  # gen2: GC's gen1's folded WAL
+        self.engine.compact(NAMESPACE)  # gen3: GC's gen1 segments, gen2 WAL
+        wal_files = self.store.list_keys(f"{NAMESPACE}/wal")
+        self.assertEqual(wal_files, [])
+        # gen1 segment blobs are gone; gen2 blobs (prior generation, one
+        # cycle of grace) and gen3 blobs remain.
+        self.assertFalse(
+            self.store.exists(f"{NAMESPACE}/index/segments/000001/centroids.npy")
+        )
+        self.assertTrue(
+            self.store.exists(f"{NAMESPACE}/index/segments/000002/centroids.npy")
+        )
+        self.assertTrue(
+            self.store.exists(f"{NAMESPACE}/index/segments/000003/centroids.npy")
+        )
+        hits = must(self.engine.search(NAMESPACE, sparse_vector((0, 1.0)), 5))
+        self.assertEqual([h[0] for h in hits], [1, 2])
+
+
+class VectorSearchSystemCheckTests(SimpleTestCase):
+    """The opencontracts.E002/W003 settings checks."""
+
+    def test_invalid_backend_value_raises_e002(self):
+        from opencontractserver.shared.checks import check_vector_search_backend
+
+        with override_settings(VECTOR_SEARCH_BACKEND="bogus"):
+            issues = check_vector_search_backend(None)
+        self.assertEqual([issue.id for issue in issues], ["opencontracts.E002"])
+
+    def test_valid_backend_values_pass_e002(self):
+        from opencontractserver.shared.checks import check_vector_search_backend
+
+        for value in ("pgvector", "object_storage"):
+            with override_settings(VECTOR_SEARCH_BACKEND=value):
+                self.assertEqual(check_vector_search_backend(None), [])
+
+    def test_locmem_cache_with_object_backend_warns_w003(self):
+        from opencontractserver.shared.checks import check_vector_search_cache
+
+        locmem = {
+            "default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}
+        }
+        with override_settings(VECTOR_SEARCH_BACKEND="object_storage", CACHES=locmem):
+            issues = check_vector_search_cache(None)
+            self.assertEqual([issue.id for issue in issues], ["opencontracts.W003"])
+        # pgvector (default) never warns, whatever the cache backend.
+        with override_settings(VECTOR_SEARCH_BACKEND="pgvector", CACHES=locmem):
+            self.assertEqual(check_vector_search_cache(None), [])
+
 
 class ObjectStorageBackendIntegrationTests(TestCase):
     """The toggle, write-path fan-out, scoping, fallback, and rebuild."""

--- a/opencontractserver/tests/test_object_storage_vector_backend.py
+++ b/opencontractserver/tests/test_object_storage_vector_backend.py
@@ -723,6 +723,23 @@ class ObjectStorageBackendIntegrationTests(TestCase):
         )
         self.assertGreater(results[0].similarity_score, 0.99)
 
+    def test_sync_task_declares_transient_retry_policy(self):
+        """
+        Write-path resilience: the sync task must carry an autoretry policy
+        so a transient object-store failure re-runs the idempotent upsert
+        instead of silently dropping the embedding from the index. (Eager
+        Celery cannot re-execute retries, so the policy is asserted
+        declaratively — Celery honors these attributes at runtime.)
+        """
+        from opencontractserver.tasks.vector_index_tasks import (
+            sync_embedding_to_object_index,
+        )
+
+        self.assertEqual(sync_embedding_to_object_index.autoretry_for, (Exception,))
+        self.assertEqual(sync_embedding_to_object_index.max_retries, 3)
+        self.assertTrue(sync_embedding_to_object_index.retry_backoff)
+        self.assertTrue(sync_embedding_to_object_index.retry_jitter)
+
     def test_worker_upload_direct_writes_fan_out(self):
         """
         The external-worker upload pipeline writes Embedding rows via

--- a/opencontractserver/tests/test_object_storage_vector_backend.py
+++ b/opencontractserver/tests/test_object_storage_vector_backend.py
@@ -352,6 +352,28 @@ class DjangoStorageObjectStoreTests(SimpleTestCase):
         # No stray uniquified blobs left behind.
         self.assertEqual(self.store.list_keys("ns"), ["manifest.json"])
 
+    def test_put_bytes_raises_when_overwrite_retries_exhausted(self):
+        """
+        Sustained contention (= a breached compaction lock) must fail loudly:
+        a compaction whose manifest never persisted cannot report success.
+        """
+        from django.core.files.base import ContentFile
+
+        from opencontractserver.vector_search.object_store import (
+            ObjectStoreWriteError,
+        )
+
+        real_save = self.storage.save
+
+        def always_racing_save(name, content, *args, **kwargs):
+            if not self.storage.exists(name):
+                real_save(name, ContentFile(b"racer"))
+            return real_save(name, content)
+
+        with mock.patch.object(self.storage, "save", side_effect=always_racing_save):
+            with self.assertRaises(ObjectStoreWriteError):
+                self.store.put_bytes("ns/manifest.json", b"ours")
+
 
 class VectorSearchSystemCheckTests(SimpleTestCase):
     """The opencontracts.E002/W003 settings checks."""
@@ -601,6 +623,88 @@ class ObjectStorageBackendIntegrationTests(TestCase):
             manifest = must(engine._load_manifest(namespace))
             self.assertGreaterEqual(manifest["count"], 2)
             self.assertLessEqual(engine.wal_tail_count(namespace), 1)
+
+    def test_rebuild_command_respects_compaction_lock(self):
+        """
+        The rebuild command must never compact concurrently with an
+        auto-compaction: holding the per-namespace lock makes it replay the
+        WAL but skip compaction (deferred to the next cycle).
+        """
+        import io as io_module
+
+        from opencontractserver.tasks.vector_index_tasks import compact_lock_key
+
+        with self.object_backend_settings():
+            with self.captureOnCommitCallbacks(execute=True):
+                doc = Document.objects.create(title="Locked", creator=self.user)
+                doc.add_embedding(EMBEDDER, sparse_vector((0, 1.0)))
+            namespace = build_namespace("document", EMBEDDER, DIM)
+            cache.add(compact_lock_key(namespace), "1", timeout=60)
+            try:
+                out = io_module.StringIO()
+                call_command("rebuild_object_vector_index", stdout=out)
+                self.assertIn("compaction is already running", out.getvalue())
+                engine = router.get_default_engine()
+                # WAL replayed but no generation committed by the command.
+                self.assertIsNone(engine._load_manifest(namespace))
+                self.assertGreater(engine.wal_tail_count(namespace), 0)
+            finally:
+                cache.delete(compact_lock_key(namespace))
+
+    def test_toggle_serves_core_annotation_vector_store_callers(self):
+        """
+        End-to-end through a real caller (CoreAnnotationVectorStore, the
+        store behind GraphQL semantic search / agents / MCP): with the
+        backend enabled, its vector search is served from the object index
+        without ever touching pgvector's CosineDistance.
+        """
+        from opencontractserver.annotations.models import Annotation
+        from opencontractserver.llms.vector_stores.core_vector_stores import (
+            CoreAnnotationVectorStore,
+            VectorSearchQuery,
+        )
+
+        # Must be a real, loadable embedder class path: the store resolves it
+        # and silently substitutes the default embedder for unknown paths,
+        # which would route the query to a different namespace.
+        embedder_path = (
+            "opencontractserver.pipeline.embedders.test_embedder.TestEmbedder"
+        )
+        with self.object_backend_settings():
+            with self.captureOnCommitCallbacks(execute=True):
+                doc = Document.objects.create(title="Host doc", creator=self.user)
+                anno_hit = Annotation.objects.create(
+                    document=doc, creator=self.user, raw_text="close annotation"
+                )
+                anno_miss = Annotation.objects.create(
+                    document=doc, creator=self.user, raw_text="far annotation"
+                )
+                # Overwrites the signal-created TestEmbedder embeddings with
+                # known sparse vectors (same embedder_path -> same rows).
+                anno_hit.add_embedding(embedder_path, sparse_vector((0, 1.0)))
+                anno_miss.add_embedding(embedder_path, sparse_vector((1, 1.0)))
+
+            store = CoreAnnotationVectorStore(
+                user_id=self.user.id,
+                document_id=doc.id,
+                embedder_path=embedder_path,
+                embed_dim=DIM,
+            )
+            query = VectorSearchQuery(
+                query_embedding=sparse_vector((0, 1.0)),
+                similarity_top_k=2,
+                mode="vector",
+            )
+            with mock.patch(
+                "opencontractserver.shared.mixins.CosineDistance",
+                side_effect=AssertionError("pgvector path must not be used"),
+            ):
+                results = store.search(query)
+        self.assertEqual(
+            [result.annotation.pk for result in results],
+            [anno_hit.pk, anno_miss.pk],
+        )
+        self.assertGreater(results[0].similarity_score, 0.99)
 
     def test_compaction_enqueued_once_per_threshold_crossing(self):
         """

--- a/opencontractserver/tests/test_object_storage_vector_backend.py
+++ b/opencontractserver/tests/test_object_storage_vector_backend.py
@@ -280,6 +280,47 @@ class ObjectStorageVectorEngineTests(SimpleTestCase):
         self.assertEqual([h[0] for h in hits], [1, 2])
 
 
+class DjangoStorageObjectStoreTests(SimpleTestCase):
+    """The overwrite semantics of the blob-store adapter."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmpdir, ignore_errors=True)
+        self.storage = FileSystemStorage(location=self.tmpdir)
+        self.store = DjangoStorageObjectStore(self.storage, prefix="vector-index")
+
+    def test_put_bytes_overwrites_existing_blob(self):
+        self.store.put_bytes("ns/manifest.json", b"one")
+        self.store.put_bytes("ns/manifest.json", b"two")
+        self.assertEqual(self.store.get_bytes("ns/manifest.json"), b"two")
+        self.assertEqual(self.store.list_keys("ns"), ["manifest.json"])
+
+    def test_put_bytes_retries_when_racing_writer_uniquifies_save(self):
+        """
+        Last-writer-wins under contention: a racer re-creates the key between
+        our delete and save, so Django uniquifies our name. put_bytes must
+        discard the stray blob, retry, and leave exactly one blob — ours.
+        """
+        from django.core.files.base import ContentFile
+
+        real_save = self.storage.save
+        calls = {"count": 0}
+
+        def racing_save(name, content, *args, **kwargs):
+            calls["count"] += 1
+            if calls["count"] == 1:
+                # Simulate a concurrent writer landing first: the key exists
+                # again by the time our save runs, forcing uniquification.
+                real_save(name, ContentFile(b"racer"))
+            return real_save(name, content)
+
+        with mock.patch.object(self.storage, "save", side_effect=racing_save):
+            self.store.put_bytes("ns/manifest.json", b"ours")
+        self.assertEqual(self.store.get_bytes("ns/manifest.json"), b"ours")
+        # No stray uniquified blobs left behind.
+        self.assertEqual(self.store.list_keys("ns"), ["manifest.json"])
+
+
 class VectorSearchSystemCheckTests(SimpleTestCase):
     """The opencontracts.E002/W003 settings checks."""
 
@@ -461,3 +502,40 @@ class ObjectStorageBackendIntegrationTests(TestCase):
             manifest = must(engine._load_manifest(namespace))
             self.assertGreaterEqual(manifest["count"], 2)
             self.assertLessEqual(engine.wal_tail_count(namespace), 1)
+
+    def test_filter_shortfall_falls_back_to_pgvector(self):
+        """
+        A heavily-filtered queryset can exhaust the oversampled candidate set
+        without filling top_k (post-ANN filtering's recall cliff). The router
+        must detect the truncated-candidates shortfall and fall back to
+        pgvector, which fills top_k via SQL — keeping "enabling the backend
+        never returns worse results than pgvector" true.
+        """
+        with self.object_backend_settings():
+            with self.captureOnCommitCallbacks(execute=True):
+                # 10 high-similarity docs owned by the OTHER user swamp the
+                # candidate set (fetch_n = top_k 2 * oversample 4 = 8 < 10).
+                for i in range(10):
+                    noise = Document.objects.create(
+                        title=f"Noise {i}", creator=self.other_user
+                    )
+                    noise.add_embedding(
+                        EMBEDDER, sparse_vector((0, 1.0), (i + 2, 0.01))
+                    )
+                # The caller's two docs rank far below all of them.
+                mine_close = Document.objects.create(
+                    title="Mine close", creator=self.user
+                )
+                mine_close.add_embedding(EMBEDDER, sparse_vector((0, 0.3), (1, 0.9)))
+                mine_far = Document.objects.create(title="Mine far", creator=self.user)
+                mine_far.add_embedding(EMBEDDER, sparse_vector((1, 1.0)))
+
+            results = Document.objects.filter(
+                creator=self.user
+                # DocumentQuerySet carries the vector-search mixin at runtime.
+            ).search_by_embedding(  # type: ignore[attr-defined]
+                sparse_vector((0, 1.0)), EMBEDDER, top_k=2
+            )
+        # Without the shortfall rule the object path would return [] here
+        # (all 8 fetched candidates belong to other_user and are filtered).
+        self.assertEqual([doc.pk for doc in results], [mine_close.pk, mine_far.pk])

--- a/opencontractserver/tests/test_object_storage_vector_backend.py
+++ b/opencontractserver/tests/test_object_storage_vector_backend.py
@@ -193,6 +193,37 @@ class ObjectStorageVectorEngineTests(SimpleTestCase):
         ns_b = build_namespace("annotation", "acme/embedder v1", DIM)
         self.assertNotEqual(ns_a, ns_b)
 
+    def test_search_retries_manifest_read_hit_mid_overwrite(self):
+        """
+        put_bytes overwrites the manifest via delete-then-save, so a reader
+        can catch the window where the key is briefly missing. With a
+        non-empty WAL, search() must retry the manifest read instead of
+        proceeding manifest-less (which would silently drop all segment data
+        and misreport the namespace as nearly empty).
+        """
+        from opencontractserver.vector_search.object_store import ObjectNotFound
+
+        vectors = clustered_vectors(2, 10)
+        self.engine.upsert(
+            NAMESPACE, [(i, vectors[i].tolist()) for i in range(len(vectors))]
+        )
+        self.engine.compact(NAMESPACE)  # folded WAL lingers (deferred GC)
+
+        real_get = self.store.get_bytes
+        window = {"open": True}
+
+        def mid_overwrite_get(key):
+            if key.endswith("manifest.json") and window["open"]:
+                window["open"] = False  # the retry lands after the save
+                raise ObjectNotFound(key)
+            return real_get(key)
+
+        with mock.patch.object(self.store, "get_bytes", side_effect=mid_overwrite_get):
+            hits = must(self.engine.search(NAMESPACE, vectors[3].tolist(), 3))
+        self.assertEqual(hits[0][0], 3)
+        self.assertAlmostEqual(hits[0][1], 1.0, places=3)
+        self.assertEqual(len(hits), 3)
+
     def test_search_survives_compaction_between_wal_list_and_manifest_read(self):
         """
         Regression for the manifest/WAL read-order race: compaction commits

--- a/opencontractserver/tests/test_object_storage_vector_backend.py
+++ b/opencontractserver/tests/test_object_storage_vector_backend.py
@@ -351,6 +351,47 @@ class VectorSearchSystemCheckTests(SimpleTestCase):
         with override_settings(VECTOR_SEARCH_BACKEND="pgvector", CACHES=locmem):
             self.assertEqual(check_vector_search_cache(None), [])
 
+    def test_public_storage_signals_warn_w004(self):
+        from opencontractserver.shared.checks import (
+            check_vector_index_storage_exposure,
+        )
+
+        # Each public-read signal triggers the warning on its own.
+        for public_signal in (
+            {"AWS_DEFAULT_ACL": "public-read"},
+            {"AWS_QUERYSTRING_AUTH": False},
+            {"AWS_S3_CUSTOM_DOMAIN": "cdn.example.com"},
+        ):
+            with override_settings(
+                VECTOR_SEARCH_BACKEND="object_storage",
+                STORAGE_BACKEND="AWS",
+                **public_signal,
+            ):
+                issues = check_vector_index_storage_exposure(None)
+                self.assertEqual(
+                    [issue.id for issue in issues],
+                    ["opencontracts.W004"],
+                    public_signal,
+                )
+        # Private signed-URL config passes; so does any non-AWS backend and
+        # the default pgvector backend.
+        with override_settings(
+            VECTOR_SEARCH_BACKEND="object_storage",
+            STORAGE_BACKEND="AWS",
+            AWS_QUERYSTRING_AUTH=True,
+        ):
+            self.assertEqual(check_vector_index_storage_exposure(None), [])
+        with override_settings(
+            VECTOR_SEARCH_BACKEND="object_storage", STORAGE_BACKEND="LOCAL"
+        ):
+            self.assertEqual(check_vector_index_storage_exposure(None), [])
+        with override_settings(
+            VECTOR_SEARCH_BACKEND="pgvector",
+            STORAGE_BACKEND="AWS",
+            AWS_QUERYSTRING_AUTH=False,
+        ):
+            self.assertEqual(check_vector_index_storage_exposure(None), [])
+
 
 class ObjectStorageBackendIntegrationTests(TestCase):
     """The toggle, write-path fan-out, scoping, fallback, and rebuild."""

--- a/opencontractserver/tests/test_object_storage_vector_backend.py
+++ b/opencontractserver/tests/test_object_storage_vector_backend.py
@@ -624,6 +624,23 @@ class ObjectStorageBackendIntegrationTests(TestCase):
             self.assertGreaterEqual(manifest["count"], 2)
             self.assertLessEqual(engine.wal_tail_count(namespace), 1)
 
+    def test_rebuild_command_dry_run_reports_without_writing(self):
+        import io as io_module
+
+        # Backend off during creation: no on_commit hook, so nothing is in
+        # the object store yet — exactly the pre-flip state --dry-run previews.
+        doc = Document.objects.create(title="Dry", creator=self.user)
+        doc.add_embedding(EMBEDDER, sparse_vector((0, 1.0)))
+        with self.object_backend_settings():
+            out = io_module.StringIO()
+            call_command("rebuild_object_vector_index", "--dry-run", stdout=out)
+            namespace = build_namespace("document", EMBEDDER, DIM)
+            self.assertIn(f"[dry-run] {namespace}: would replay 1", out.getvalue())
+            engine = router.get_default_engine()
+            # Nothing written: no WAL files, no manifest.
+            self.assertEqual(engine._list_wal(namespace), [])
+            self.assertIsNone(engine._load_manifest(namespace))
+
     def test_rebuild_command_respects_compaction_lock(self):
         """
         The rebuild command must never compact concurrently with an

--- a/opencontractserver/tests/test_object_storage_vector_backend.py
+++ b/opencontractserver/tests/test_object_storage_vector_backend.py
@@ -723,6 +723,48 @@ class ObjectStorageBackendIntegrationTests(TestCase):
         )
         self.assertGreater(results[0].similarity_score, 0.99)
 
+    def test_non_indexed_parent_kinds_do_not_fan_out(self):
+        """
+        Read/write symmetry (round 12): conversation embeddings' read path
+        bypasses the mixin (own inline pgvector implementation), so their
+        writes must not fan out to the object index — that would be pure
+        write amplification with no read benefit. The hook skips them
+        before any Celery task is queued.
+        """
+        from opencontractserver.annotations.models import Embedding
+        from opencontractserver.conversations.models import Conversation
+
+        with self.object_backend_settings():
+            conversation = Conversation.objects.create(creator=self.user, title="Chat")
+            with mock.patch(
+                "opencontractserver.tasks.vector_index_tasks"
+                ".sync_embedding_to_object_index.si"
+            ) as mock_signature:
+                with self.captureOnCommitCallbacks(execute=True):
+                    Embedding.objects.store_embedding(
+                        creator=self.user,
+                        dimension=DIM,
+                        vector=sparse_vector((0, 1.0)),
+                        embedder_path=EMBEDDER,
+                        conversation_id=conversation.pk,
+                    )
+            mock_signature.assert_not_called()
+            # Document embeddings (an indexed kind) DO fan out.
+            doc = Document.objects.create(title="Indexed", creator=self.user)
+            with mock.patch(
+                "opencontractserver.tasks.vector_index_tasks"
+                ".sync_embedding_to_object_index.si"
+            ) as mock_signature:
+                with self.captureOnCommitCallbacks(execute=True):
+                    Embedding.objects.store_embedding(
+                        creator=self.user,
+                        dimension=DIM,
+                        vector=sparse_vector((0, 1.0)),
+                        embedder_path=EMBEDDER,
+                        document_id=doc.pk,
+                    )
+            mock_signature.assert_called_once()
+
     def test_fetch_cap_binds_for_abusive_top_k(self):
         """
         Regression (round 11): fetch_n must be bounded by

--- a/opencontractserver/tests/test_object_storage_vector_backend.py
+++ b/opencontractserver/tests/test_object_storage_vector_backend.py
@@ -20,6 +20,7 @@ from unittest import mock
 
 import numpy as np
 from django.contrib.auth import get_user_model
+from django.core.cache import cache
 from django.core.files.storage import FileSystemStorage
 from django.core.management import call_command
 from django.test import SimpleTestCase, TestCase, override_settings
@@ -391,6 +392,28 @@ class VectorSearchSystemCheckTests(SimpleTestCase):
             AWS_QUERYSTRING_AUTH=False,
         ):
             self.assertEqual(check_vector_index_storage_exposure(None), [])
+        # GCS public-read signals are covered too.
+        for gcs_signal in (
+            {"GS_DEFAULT_ACL": "publicRead"},
+            {"GS_QUERYSTRING_AUTH": False},
+        ):
+            with override_settings(
+                VECTOR_SEARCH_BACKEND="object_storage",
+                STORAGE_BACKEND="GCP",
+                **gcs_signal,
+            ):
+                issues = check_vector_index_storage_exposure(None)
+                self.assertEqual(
+                    [issue.id for issue in issues],
+                    ["opencontracts.W004"],
+                    gcs_signal,
+                )
+        with override_settings(
+            VECTOR_SEARCH_BACKEND="object_storage",
+            STORAGE_BACKEND="GCP",
+            GS_QUERYSTRING_AUTH=True,
+        ):
+            self.assertEqual(check_vector_index_storage_exposure(None), [])
 
 
 class ObjectStorageBackendIntegrationTests(TestCase):
@@ -401,6 +424,10 @@ class ObjectStorageBackendIntegrationTests(TestCase):
         self.addCleanup(shutil.rmtree, self.tmpdir, ignore_errors=True)
         router.reset_default_engine()
         self.addCleanup(router.reset_default_engine)
+        # Compaction lock/pending markers live in the (locmem) cache and would
+        # otherwise leak between tests sharing a namespace.
+        cache.clear()
+        self.addCleanup(cache.clear)
         self.user = User.objects.create_user(username="owner", password="pw")
         self.other_user = User.objects.create_user(username="other", password="pw")
 
@@ -543,6 +570,26 @@ class ObjectStorageBackendIntegrationTests(TestCase):
             manifest = must(engine._load_manifest(namespace))
             self.assertGreaterEqual(manifest["count"], 2)
             self.assertLessEqual(engine.wal_tail_count(namespace), 1)
+
+    def test_compaction_enqueued_once_per_threshold_crossing(self):
+        """
+        The pending-marker gate: during a write burst past the threshold,
+        only the writer that claims the marker enqueues a compaction task —
+        not every subsequent write (compaction storm).
+        """
+        with self.object_backend_settings():
+            with mock.patch(
+                "opencontractserver.tasks.vector_index_tasks"
+                ".OBJECT_INDEX_COMPACT_MIN_WAL_FILES",
+                1,
+            ), mock.patch(
+                "opencontractserver.tasks.vector_index_tasks"
+                ".compact_object_vector_namespace.si"
+            ) as mock_signature:
+                # Compaction never actually runs (si is mocked), so the WAL
+                # tail stays >= threshold for all three writes.
+                self._make_documents()
+            self.assertEqual(mock_signature.call_count, 1)
 
     def test_filter_shortfall_falls_back_to_pgvector(self):
         """

--- a/opencontractserver/tests/test_object_storage_vector_backend.py
+++ b/opencontractserver/tests/test_object_storage_vector_backend.py
@@ -723,6 +723,58 @@ class ObjectStorageBackendIntegrationTests(TestCase):
         )
         self.assertGreater(results[0].similarity_score, 0.99)
 
+    def test_worker_upload_direct_writes_fan_out(self):
+        """
+        The external-worker upload pipeline writes Embedding rows via
+        bulk_create/update_or_create — bypassing store_embedding — so its
+        explicit enqueue_embedding_index_sync calls are what keep those rows
+        from silently never reaching the object index (round 13).
+        """
+        from opencontractserver.annotations.models import Annotation
+        from opencontractserver.worker_uploads.tasks import (
+            _store_embeddings,
+            _store_single_embedding,
+        )
+
+        with self.object_backend_settings():
+            with self.captureOnCommitCallbacks(execute=True):
+                doc = Document.objects.create(title="Worker doc", creator=self.user)
+                anno = Annotation.objects.create(
+                    document=doc, creator=self.user, raw_text="worker annotation"
+                )
+                _store_single_embedding(
+                    vector=sparse_vector((0, 1.0)),
+                    embedder_path=EMBEDDER,
+                    document=doc,
+                    creator=self.user,
+                )
+                _store_embeddings(
+                    embeddings_data={
+                        "embedder_path": EMBEDDER,
+                        "annotation_embeddings": {"1": sparse_vector((1, 1.0))},
+                    },
+                    corpus_doc=doc,
+                    annot_id_map={"1": anno.pk},
+                    user=self.user,
+                )
+            engine = router.get_default_engine()
+            doc_hits = must(
+                engine.search(
+                    build_namespace("document", EMBEDDER, DIM),
+                    sparse_vector((0, 1.0)),
+                    1,
+                )
+            )
+            self.assertEqual(doc_hits[0][0], doc.pk)
+            anno_hits = must(
+                engine.search(
+                    build_namespace("annotation", EMBEDDER, DIM),
+                    sparse_vector((1, 1.0)),
+                    1,
+                )
+            )
+            self.assertEqual(anno_hits[0][0], anno.pk)
+
     def test_non_indexed_parent_kinds_do_not_fan_out(self):
         """
         Read/write symmetry (round 12): conversation embeddings' read path

--- a/opencontractserver/tests/test_object_storage_vector_backend.py
+++ b/opencontractserver/tests/test_object_storage_vector_backend.py
@@ -1,0 +1,345 @@
+"""
+Tests for the object-storage (turbopuffer-style) vector search backend.
+
+Two layers:
+
+1. ``ObjectStorageVectorEngineTests`` — pure engine tests (no database):
+   WAL-only strong consistency, compaction, centroid-ANN parity with brute
+   force, tombstones, overwrite ordering, and recall on clustered data.
+
+2. ``ObjectStorageBackendIntegrationTests`` — Django integration: the
+   ``VECTOR_SEARCH_BACKEND`` toggle, write-path fan-out from
+   ``store_embedding`` (via transaction.on_commit + eager Celery),
+   queryset-scoping preservation, pgvector fallback, the rebuild management
+   command, and auto-compaction triggering.
+"""
+
+import shutil
+import tempfile
+from unittest import mock
+
+import numpy as np
+from django.contrib.auth import get_user_model
+from django.core.files.storage import FileSystemStorage
+from django.core.management import call_command
+from django.test import SimpleTestCase, TestCase, override_settings
+
+from opencontractserver.documents.models import Document
+from opencontractserver.vector_search import router
+from opencontractserver.vector_search.engine import ObjectStorageVectorEngine
+from opencontractserver.vector_search.object_store import DjangoStorageObjectStore
+from opencontractserver.vector_search.router import build_namespace
+
+User = get_user_model()
+
+DIM = 384
+EMBEDDER = "test/object-storage-embedder"
+NAMESPACE = build_namespace("annotation", EMBEDDER, DIM)
+
+
+def clustered_vectors(
+    n_clusters: int, per_cluster: int, dim: int = DIM, seed: int = 7
+) -> np.ndarray:
+    """Synthetic embeddings with real cluster structure (unlike pure noise)."""
+    rng = np.random.default_rng(seed)
+    centers = rng.normal(size=(n_clusters, dim))
+    points = np.concatenate(
+        [center + 0.05 * rng.normal(size=(per_cluster, dim)) for center in centers]
+    ).astype(np.float32)
+    return points
+
+
+def brute_force_top_ids(vectors: np.ndarray, query: np.ndarray, k: int) -> list[int]:
+    normed = vectors / np.linalg.norm(vectors, axis=1, keepdims=True)
+    query_normed = query / np.linalg.norm(query)
+    return np.argsort(-(normed @ query_normed))[:k].tolist()
+
+
+def sparse_vector(*components: tuple[int, float], dim: int = DIM) -> list[float]:
+    vector = [0.0] * dim
+    for index, value in components:
+        vector[index] = value
+    return vector
+
+
+def must(result):
+    """Narrow Optional engine results for mypy: fail loudly if None."""
+    assert result is not None
+    return result
+
+
+class ObjectStorageVectorEngineTests(SimpleTestCase):
+    """Engine-level behavior against a local filesystem object store."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmpdir, ignore_errors=True)
+        self.store = DjangoStorageObjectStore(
+            FileSystemStorage(location=self.tmpdir), prefix="vector-index"
+        )
+        # min_vectors_for_ann lowered so small fixtures exercise clustering.
+        self.engine = ObjectStorageVectorEngine(self.store, min_vectors_for_ann=50)
+        # Full-probe twin: visits every cluster, so results must be exact.
+        self.full_probe = ObjectStorageVectorEngine(
+            self.store,
+            min_vectors_for_ann=50,
+            nprobe_ratio=1.0,
+            nprobe_min=10_000,
+        )
+
+    def test_unknown_namespace_returns_none(self):
+        self.assertIsNone(self.engine.search(NAMESPACE, [1.0] * DIM, 5))
+
+    def test_wal_only_search_is_strongly_consistent(self):
+        """Writes are searchable immediately, before any compaction/index."""
+        vectors = clustered_vectors(2, 10)
+        self.engine.upsert(
+            NAMESPACE, [(i, vectors[i].tolist()) for i in range(len(vectors))]
+        )
+        hits = must(self.engine.search(NAMESPACE, vectors[3].tolist(), 3))
+        self.assertEqual(hits[0][0], 3)
+        self.assertAlmostEqual(hits[0][1], 1.0, places=3)
+
+    def test_later_wal_upsert_wins(self):
+        self.engine.upsert(NAMESPACE, [(1, sparse_vector((0, 1.0)))])
+        self.engine.upsert(NAMESPACE, [(1, sparse_vector((1, 1.0)))])
+        hits = must(self.engine.search(NAMESPACE, sparse_vector((0, 1.0)), 1))
+        # Old value replaced: similarity against the new orthogonal vector is 0.
+        self.assertEqual(hits[0][0], 1)
+        self.assertAlmostEqual(hits[0][1], 0.0, places=5)
+
+    def test_compaction_folds_wal_and_matches_brute_force(self):
+        vectors = clustered_vectors(6, 50)  # 300 vectors -> k-means path
+        for start in range(0, len(vectors), 40):
+            batch = [
+                (i, vectors[i].tolist())
+                for i in range(start, min(start + 40, len(vectors)))
+            ]
+            self.engine.upsert(NAMESPACE, batch)
+        stats = self.engine.compact(NAMESPACE)
+        self.assertEqual(stats["count"], len(vectors))
+        self.assertGreater(stats["cluster_count"], 1)
+        self.assertEqual(self.engine.wal_tail_count(NAMESPACE), 0)
+
+        query = clustered_vectors(1, 1, seed=99)[0]
+        expected = brute_force_top_ids(vectors, query, 10)
+        hits = [
+            h[0] for h in must(self.full_probe.search(NAMESPACE, query.tolist(), 10))
+        ]
+        self.assertEqual(hits, expected)
+
+    def test_default_nprobe_recall_on_clustered_data(self):
+        vectors = clustered_vectors(8, 40)
+        self.engine.upsert(
+            NAMESPACE, [(i, vectors[i].tolist()) for i in range(len(vectors))]
+        )
+        self.engine.compact(NAMESPACE)
+        # Query near an existing point: its cluster must be probed.
+        query = vectors[123] + 0.01
+        expected = set(brute_force_top_ids(vectors, query, 10))
+        hits = {h[0] for h in must(self.engine.search(NAMESPACE, query.tolist(), 10))}
+        recall = len(hits & expected) / 10
+        self.assertGreaterEqual(recall, 0.9)
+
+    def test_wal_tail_overrides_segments(self):
+        """Post-compaction writes are visible without waiting for recompaction."""
+        vectors = clustered_vectors(4, 30)
+        self.engine.upsert(
+            NAMESPACE, [(i, vectors[i].tolist()) for i in range(len(vectors))]
+        )
+        self.engine.compact(NAMESPACE)
+
+        probe = self.full_probe
+        target = brute_force_top_ids(vectors, vectors[5], 2)
+        # Tombstone the best hit, flip the runner-up to the opposite direction.
+        probe.delete(NAMESPACE, [target[0]])
+        probe.upsert(NAMESPACE, [(target[1], (-vectors[target[1]]).tolist())])
+
+        hits = [h[0] for h in must(probe.search(NAMESPACE, vectors[5].tolist(), 5))]
+        self.assertNotIn(target[0], hits)
+        self.assertNotIn(target[1], hits)
+
+        # Compaction preserves exactly that state.
+        stats = probe.compact(NAMESPACE)
+        self.assertEqual(stats["count"], len(vectors) - 1)
+        hits_after = [
+            h[0] for h in must(probe.search(NAMESPACE, vectors[5].tolist(), 5))
+        ]
+        self.assertEqual(hits, hits_after)
+
+    def test_compaction_is_deterministic(self):
+        vectors = clustered_vectors(4, 30)
+        self.engine.upsert(
+            NAMESPACE, [(i, vectors[i].tolist()) for i in range(len(vectors))]
+        )
+        self.engine.compact(NAMESPACE)
+        first = self.full_probe.search(NAMESPACE, vectors[0].tolist(), 10)
+        self.engine.compact(NAMESPACE)
+        self.full_probe.clear_caches()
+        second = self.full_probe.search(NAMESPACE, vectors[0].tolist(), 10)
+        self.assertEqual(first, second)
+
+    def test_mixed_dimension_batch_rejected(self):
+        with self.assertRaises(ValueError):
+            self.engine.upsert(NAMESPACE, [(1, [1.0] * 384), (2, [1.0] * 768)])
+
+    def test_invalid_dimension_rejected(self):
+        with self.assertRaises(ValueError):
+            self.engine.upsert(NAMESPACE, [(1, [1.0] * 3)])
+
+    def test_namespace_slug_collisions_disambiguated(self):
+        ns_a = build_namespace("annotation", "acme/embedder:v1", DIM)
+        ns_b = build_namespace("annotation", "acme/embedder v1", DIM)
+        self.assertNotEqual(ns_a, ns_b)
+
+
+class ObjectStorageBackendIntegrationTests(TestCase):
+    """The toggle, write-path fan-out, scoping, fallback, and rebuild."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmpdir, ignore_errors=True)
+        router.reset_default_engine()
+        self.addCleanup(router.reset_default_engine)
+        self.user = User.objects.create_user(username="owner", password="pw")
+        self.other_user = User.objects.create_user(username="other", password="pw")
+
+    def object_backend_settings(self):
+        """Route default storage to a per-test tmpdir + enable the backend."""
+        return override_settings(
+            VECTOR_SEARCH_BACKEND="object_storage",
+            STORAGES={
+                "default": {
+                    "BACKEND": "django.core.files.storage.FileSystemStorage",
+                    "OPTIONS": {"location": self.tmpdir},
+                },
+                "staticfiles": {
+                    "BACKEND": ("django.contrib.staticfiles.storage.StaticFilesStorage")
+                },
+            },
+        )
+
+    def _make_documents(self) -> tuple[Document, Document, Document]:
+        """Three docs whose vectors rank a > b > c against ``sparse (0, 1.0)``."""
+        doc_a = Document.objects.create(title="A", creator=self.user, is_public=True)
+        doc_b = Document.objects.create(title="B", creator=self.user, is_public=True)
+        doc_c = Document.objects.create(title="C", creator=self.user, is_public=True)
+        with self.captureOnCommitCallbacks(execute=True):
+            doc_a.add_embedding(EMBEDDER, sparse_vector((0, 1.0)))
+            doc_b.add_embedding(EMBEDDER, sparse_vector((0, 0.8), (1, 0.6)))
+            doc_c.add_embedding(EMBEDDER, sparse_vector((1, 1.0)))
+        return doc_a, doc_b, doc_c
+
+    def test_default_backend_is_pgvector_and_object_path_untouched(self):
+        with mock.patch.object(
+            router, "search_via_object_index", side_effect=AssertionError
+        ):
+            doc_a, doc_b, _ = self._make_documents()
+            results = Document.objects.search_by_embedding(
+                sparse_vector((0, 1.0)), EMBEDDER, top_k=2
+            )
+        self.assertEqual([doc.pk for doc in results], [doc_a.pk, doc_b.pk])
+        self.assertAlmostEqual(results[0].similarity_score, 1.0, places=3)
+
+    def test_toggle_on_serves_ranking_from_object_index(self):
+        with self.object_backend_settings():
+            doc_a, doc_b, doc_c = self._make_documents()
+            # pgvector must not be touched when the object index serves the hit.
+            with mock.patch(
+                "opencontractserver.shared.mixins.CosineDistance",
+                side_effect=AssertionError("pgvector path used"),
+            ):
+                results = Document.objects.search_by_embedding(
+                    sparse_vector((0, 1.0)), EMBEDDER, top_k=3
+                )
+        self.assertEqual([doc.pk for doc in results], [doc_a.pk, doc_b.pk, doc_c.pk])
+        self.assertAlmostEqual(results[0].similarity_score, 1.0, places=3)
+        self.assertAlmostEqual(results[1].similarity_score, 0.8, places=3)
+        self.assertAlmostEqual(results[2].similarity_score, 0.0, places=3)
+
+    def test_queryset_scoping_is_preserved(self):
+        """Ids come from the shared index, but the caller's queryset filters."""
+        with self.object_backend_settings():
+            doc_a, doc_b, doc_c = self._make_documents()
+            doc_other = Document.objects.create(
+                title="Other", creator=self.other_user, is_public=False
+            )
+            with self.captureOnCommitCallbacks(execute=True):
+                doc_other.add_embedding(EMBEDDER, sparse_vector((0, 0.9)))
+
+            results = Document.objects.filter(
+                creator=self.user
+                # DocumentQuerySet carries the vector-search mixin at runtime.
+            ).search_by_embedding(  # type: ignore[attr-defined]
+                sparse_vector((0, 1.0)), EMBEDDER, top_k=3
+            )
+        result_pks = [doc.pk for doc in results]
+        self.assertNotIn(doc_other.pk, result_pks)
+        # doc_c (similarity 0, but owned by self.user) fills the freed slot —
+        # exactly what the pgvector path would return for this queryset.
+        self.assertEqual(result_pks, [doc_a.pk, doc_b.pk, doc_c.pk])
+
+    def test_deleted_rows_dropped_by_orm_refilter(self):
+        with self.object_backend_settings():
+            doc_a, doc_b, _ = self._make_documents()
+            doc_a.delete()  # index still holds doc_a's vector (stale)
+            results = Document.objects.search_by_embedding(
+                sparse_vector((0, 1.0)), EMBEDDER, top_k=2
+            )
+        self.assertEqual(results[0].pk, doc_b.pk)
+
+    def test_unindexed_namespace_falls_back_to_pgvector(self):
+        # Embeddings created while the toggle is OFF -> no object index.
+        doc_a, doc_b, _ = self._make_documents()
+        with self.object_backend_settings():
+            results = Document.objects.search_by_embedding(
+                sparse_vector((0, 1.0)), EMBEDDER, top_k=2
+            )
+        self.assertEqual([doc.pk for doc in results], [doc_a.pk, doc_b.pk])
+
+    def test_engine_error_falls_back_to_pgvector(self):
+        doc_a, _, _ = self._make_documents()
+        with self.object_backend_settings():
+            with mock.patch.object(
+                ObjectStorageVectorEngine, "search", side_effect=RuntimeError("boom")
+            ):
+                results = Document.objects.search_by_embedding(
+                    sparse_vector((0, 1.0)), EMBEDDER, top_k=1
+                )
+        self.assertEqual(results[0].pk, doc_a.pk)
+
+    def test_rebuild_command_indexes_preexisting_embeddings(self):
+        # Create embeddings with the backend disabled...
+        doc_a, doc_b, doc_c = self._make_documents()
+        with self.object_backend_settings():
+            call_command("rebuild_object_vector_index", "--embedder-path", EMBEDDER)
+            with mock.patch(
+                "opencontractserver.shared.mixins.CosineDistance",
+                side_effect=AssertionError("pgvector path used"),
+            ):
+                results = Document.objects.search_by_embedding(
+                    sparse_vector((0, 1.0)), EMBEDDER, top_k=3
+                )
+        self.assertEqual([doc.pk for doc in results], [doc_a.pk, doc_b.pk, doc_c.pk])
+        # Rebuild always compacts: the namespace has an indexed generation.
+        namespace = build_namespace("document", EMBEDDER, DIM)
+        engine = router.get_default_engine()
+        with self.object_backend_settings():
+            self.assertEqual(engine.wal_tail_count(namespace), 0)
+
+    def test_auto_compaction_triggers_at_wal_threshold(self):
+        with self.object_backend_settings():
+            with mock.patch(
+                "opencontractserver.tasks.vector_index_tasks"
+                ".OBJECT_INDEX_COMPACT_MIN_WAL_FILES",
+                2,
+            ):
+                self._make_documents()  # 3 upserts -> threshold crossed at #2
+            namespace = build_namespace("document", EMBEDDER, DIM)
+            engine = router.get_default_engine()
+            # Compaction fired mid-stream: an indexed generation exists with at
+            # least the first two vectors, and only the post-compaction write
+            # can remain in the WAL tail.
+            manifest = must(engine._load_manifest(namespace))
+            self.assertGreaterEqual(manifest["count"], 2)
+            self.assertLessEqual(engine.wal_tail_count(namespace), 1)

--- a/opencontractserver/tests/test_object_storage_vector_backend.py
+++ b/opencontractserver/tests/test_object_storage_vector_backend.py
@@ -723,6 +723,40 @@ class ObjectStorageBackendIntegrationTests(TestCase):
         )
         self.assertGreater(results[0].similarity_score, 0.99)
 
+    def test_fetch_cap_binds_for_abusive_top_k(self):
+        """
+        Regression (round 11): fetch_n must be bounded by
+        OBJECT_INDEX_MAX_FETCH_CANDIDATES even when top_k exceeds the cap —
+        the earlier max(top_k, CAP) formulation collapsed the cap to top_k
+        exactly when the cap was needed (caller-controlled top_k reaches this
+        path unbounded, e.g. from GraphQL search resolvers).
+        """
+        from opencontractserver.constants.search import (
+            OBJECT_INDEX_MAX_FETCH_CANDIDATES,
+        )
+
+        with self.object_backend_settings():
+            with self.captureOnCommitCallbacks(execute=True):
+                self._make_documents()
+            engine = router.get_default_engine()
+            requested: dict[str, int] = {}
+            real_search = engine.search
+
+            def spying_search(namespace, query_vector, top_k):
+                requested["fetch_n"] = top_k
+                return real_search(namespace, query_vector, top_k)
+
+            with mock.patch.object(engine, "search", side_effect=spying_search):
+                results = Document.objects.search_by_embedding(
+                    sparse_vector((0, 1.0)),
+                    EMBEDDER,
+                    top_k=OBJECT_INDEX_MAX_FETCH_CANDIDATES * 10,
+                )
+        self.assertEqual(requested["fetch_n"], OBJECT_INDEX_MAX_FETCH_CANDIDATES)
+        # Only 3 documents exist (< fetch_n): the namespace was exhausted, so
+        # the short result set is complete — served without fallback.
+        self.assertEqual(len(results), 3)
+
     def test_compaction_enqueued_once_per_threshold_crossing(self):
         """
         The pending-marker gate: during a write burst past the threshold,

--- a/opencontractserver/vector_search/__init__.py
+++ b/opencontractserver/vector_search/__init__.py
@@ -1,0 +1,16 @@
+"""
+Pluggable vector-search backends for OpenContracts.
+
+The default backend is pgvector (Postgres HNSW via
+``VectorSearchViaEmbeddingMixin``). This package adds an optional,
+turbopuffer-style backend that keeps its index entirely in object storage
+(S3 / GCS / local filesystem via django-storages):
+
+- ``object_store``  — minimal blob-store adapter over a Django Storage
+- ``engine``        — WAL + segment + centroid-ANN search engine
+- ``router``        — backend selection + queryset integration
+- ``hooks``         — write-path fan-out from ``Embedding.objects.store_embedding``
+
+Enable with ``VECTOR_SEARCH_BACKEND=object_storage``. See
+``docs/architecture/object_storage_vector_search.md`` for the design.
+"""

--- a/opencontractserver/vector_search/engine.py
+++ b/opencontractserver/vector_search/engine.py
@@ -1,0 +1,420 @@
+"""
+Turbopuffer-style vector search engine on object storage.
+
+Design (see ``docs/architecture/object_storage_vector_search.md``):
+
+- Object storage is the **source of truth for the index**; Postgres remains
+  the source of truth for the vectors themselves (``Embedding`` rows), so the
+  index can always be rebuilt (``manage.py rebuild_object_vector_index``).
+- Each **namespace** (one per parent-kind + embedder + dimension) owns a key
+  prefix::
+
+      <namespace>/wal/<seq>.jsonl                     append-only write batches
+      <namespace>/index/manifest.json                 current generation pointer
+      <namespace>/index/segments/<gen>/centroids.npy  (k, d) float32, unit norm
+      <namespace>/index/segments/<gen>/cluster_<i>.npz ids:int64 + vectors:float32
+
+- **Writes** append a WAL file (one PUT, durable on return). Vectors are
+  unit-normalised so cosine similarity is a dot product.
+- **Reads** are strongly consistent: load the manifest (one roundtrip), probe
+  the ``nprobe`` nearest centroid clusters, then exhaustively scan the WAL
+  tail (files not yet folded into segments) as an overlay — newest write or
+  tombstone for an id wins over any segment entry.
+- **Compaction** folds segments + WAL into a new generation: k-means clusters
+  the vectors, writes new segment blobs, atomically swaps the manifest (single
+  PUT, last-writer-wins), then deletes the folded WAL files and the previous
+  generation's blobs. Callers must serialise compaction per namespace (the
+  Celery task uses a cache lock).
+
+The engine is deliberately framework-free: it depends only on numpy and the
+blob-store primitives in ``object_store.py``, so it is unit-testable without
+Django models or a database.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+import math
+import threading
+import time
+import uuid
+from collections import OrderedDict
+
+import numpy as np
+
+from opencontractserver.constants.search import (
+    OBJECT_INDEX_CACHE_MAX_ENTRIES,
+    OBJECT_INDEX_KMEANS_ITERATIONS,
+    OBJECT_INDEX_KMEANS_SEED,
+    OBJECT_INDEX_MAX_CENTROIDS,
+    OBJECT_INDEX_MIN_VECTORS_FOR_ANN,
+    OBJECT_INDEX_NPROBE_MIN,
+    OBJECT_INDEX_NPROBE_RATIO,
+    VALID_EMBEDDING_DIMS,
+)
+
+from .object_store import DjangoStorageObjectStore, ObjectNotFound
+
+logger = logging.getLogger(__name__)
+
+# WAL ops
+_OP_UPSERT = "upsert"
+_OP_DELETE = "delete"
+
+
+class _LRUCache:
+    """Tiny thread-safe LRU for immutable index artifacts (keyed by generation)."""
+
+    def __init__(self, max_entries: int):
+        self._max = max_entries
+        self._data: OrderedDict = OrderedDict()
+        self._lock = threading.Lock()
+
+    def get(self, key):
+        with self._lock:
+            if key not in self._data:
+                return None
+            self._data.move_to_end(key)
+            return self._data[key]
+
+    def put(self, key, value) -> None:
+        with self._lock:
+            self._data[key] = value
+            self._data.move_to_end(key)
+            while len(self._data) > self._max:
+                self._data.popitem(last=False)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._data.clear()
+
+
+def _normalize(matrix: np.ndarray) -> np.ndarray:
+    """Unit-normalise rows; zero rows stay zero (cosine sim 0 against anything)."""
+    norms = np.linalg.norm(matrix, axis=-1, keepdims=True)
+    norms[norms == 0] = 1.0
+    return matrix / norms
+
+
+def _kmeans(vectors: np.ndarray, k: int, iterations: int, seed: int) -> np.ndarray:
+    """
+    Plain Lloyd's k-means over unit vectors, deterministic via ``seed``.
+    Returns (k, d) unit-normalised centroids. Empty clusters are re-seeded
+    from the points furthest from their assigned centroid.
+    """
+    rng = np.random.default_rng(seed)
+    n = vectors.shape[0]
+    centroids = vectors[rng.choice(n, size=k, replace=False)].copy()
+    for _ in range(iterations):
+        # Cosine assignment: vectors and centroids are unit norm.
+        sims = vectors @ centroids.T  # (n, k)
+        assignment = np.argmax(sims, axis=1)
+        best_sims = sims[np.arange(n), assignment]
+        for cluster_idx in range(k):
+            members = vectors[assignment == cluster_idx]
+            if len(members) == 0:
+                # Re-seed from the globally worst-fit point.
+                centroids[cluster_idx] = vectors[np.argmin(best_sims)]
+            else:
+                centroids[cluster_idx] = members.mean(axis=0)
+        centroids = _normalize(centroids)
+    return centroids
+
+
+class ObjectStorageVectorEngine:
+    """WAL + segment + centroid-ANN engine over an object store."""
+
+    def __init__(
+        self,
+        store: DjangoStorageObjectStore,
+        *,
+        nprobe_min: int = OBJECT_INDEX_NPROBE_MIN,
+        nprobe_ratio: float = OBJECT_INDEX_NPROBE_RATIO,
+        kmeans_iterations: int = OBJECT_INDEX_KMEANS_ITERATIONS,
+        max_centroids: int = OBJECT_INDEX_MAX_CENTROIDS,
+        min_vectors_for_ann: int = OBJECT_INDEX_MIN_VECTORS_FOR_ANN,
+        cache_max_entries: int = OBJECT_INDEX_CACHE_MAX_ENTRIES,
+    ):
+        self.store = store
+        self.nprobe_min = nprobe_min
+        self.nprobe_ratio = nprobe_ratio
+        self.kmeans_iterations = kmeans_iterations
+        self.max_centroids = max_centroids
+        self.min_vectors_for_ann = min_vectors_for_ann
+        self._cache = _LRUCache(cache_max_entries)
+
+    # ------------------------------------------------------------------ keys
+    @staticmethod
+    def _wal_dir(namespace: str) -> str:
+        return f"{namespace}/wal"
+
+    @staticmethod
+    def _manifest_key(namespace: str) -> str:
+        return f"{namespace}/index/manifest.json"
+
+    @staticmethod
+    def _segment_prefix(namespace: str, generation: int) -> str:
+        return f"{namespace}/index/segments/{generation:06d}"
+
+    # ------------------------------------------------------------- write path
+    def upsert(self, namespace: str, docs: list[tuple[int, list[float]]]) -> str:
+        """
+        Durably append one WAL batch of ``(id, vector)`` upserts.
+        Returns the WAL file name written.
+        """
+        if not docs:
+            raise ValueError("upsert requires at least one (id, vector) pair")
+        dims = {len(vector) for _, vector in docs}
+        if len(dims) != 1 or next(iter(dims)) not in VALID_EMBEDDING_DIMS:
+            raise ValueError(f"Invalid or mixed vector dimensions in batch: {dims}")
+        entries = [
+            {"op": _OP_UPSERT, "id": int(doc_id), "v": [float(x) for x in vector]}
+            for doc_id, vector in docs
+        ]
+        return self._append_wal(namespace, entries)
+
+    def delete(self, namespace: str, ids: list[int]) -> str:
+        """Durably append tombstones for ``ids``. Returns the WAL file name."""
+        if not ids:
+            raise ValueError("delete requires at least one id")
+        entries = [{"op": _OP_DELETE, "id": int(doc_id)} for doc_id in ids]
+        return self._append_wal(namespace, entries)
+
+    def _append_wal(self, namespace: str, entries: list[dict]) -> str:
+        # Time-ordered, collision-free name: WAL files replay in name order.
+        name = f"{time.time_ns():020d}-{uuid.uuid4().hex[:8]}.jsonl"
+        payload = "\n".join(json.dumps(entry) for entry in entries).encode("utf-8")
+        self.store.put_bytes(f"{self._wal_dir(namespace)}/{name}", payload)
+        return name
+
+    # -------------------------------------------------------------- read path
+    def namespace_exists(self, namespace: str) -> bool:
+        return (
+            self.store.exists(self._manifest_key(namespace))
+            or len(self._list_wal(namespace)) > 0
+        )
+
+    def wal_tail_count(self, namespace: str) -> int:
+        return len(self._list_wal(namespace))
+
+    def search(
+        self, namespace: str, query_vector: list[float], top_k: int
+    ) -> list[tuple[int, float]] | None:
+        """
+        Return up to ``top_k`` ``(id, cosine_similarity)`` pairs, best first,
+        or ``None`` if the namespace has never been written (callers fall back
+        to another backend in that case).
+
+        Strong consistency: WAL entries not yet folded into segments are
+        scanned exhaustively and override segment data per id.
+        """
+        manifest = self._load_manifest(namespace)
+        wal_names = self._list_wal(namespace)
+        if manifest is None and not wal_names:
+            return None
+
+        query = _normalize(np.asarray(query_vector, dtype=np.float32))
+        overlay = self._load_wal_overlay(namespace, wal_names)
+
+        scored: dict[int, float] = {}
+        if manifest is not None and manifest["cluster_count"] > 0:
+            generation = manifest["generation"]
+            centroids = self._load_centroids(namespace, generation)
+            cluster_sims = centroids @ query
+            nprobe = self._effective_nprobe(len(centroids))
+            probe_order = np.argsort(-cluster_sims)[:nprobe]
+            for cluster_idx in probe_order:
+                ids, vectors = self._load_cluster(
+                    namespace, generation, int(cluster_idx)
+                )
+                sims = vectors @ query
+                for doc_id, sim in zip(ids.tolist(), sims.tolist()):
+                    if doc_id in overlay:
+                        continue  # superseded by a newer WAL upsert/tombstone
+                    scored[doc_id] = sim
+
+        for doc_id, vector in overlay.items():
+            if vector is not None:
+                scored[doc_id] = float(vector @ query)
+
+        ranked = sorted(scored.items(), key=lambda kv: (-kv[1], kv[0]))
+        return ranked[:top_k]
+
+    def _effective_nprobe(self, cluster_count: int) -> int:
+        by_ratio = math.ceil(cluster_count * self.nprobe_ratio)
+        return max(1, min(cluster_count, max(self.nprobe_min, by_ratio)))
+
+    # -------------------------------------------------------------- compaction
+    def compact(self, namespace: str) -> dict:
+        """
+        Fold current segments + WAL tail into a new generation.
+
+        NOT concurrency-safe with itself: callers must hold a per-namespace
+        lock (see ``compact_object_vector_namespace``). Concurrent *writes*
+        are safe — WAL files that appear after the listing below simply stay
+        in the tail for the next compaction.
+        """
+        manifest = self._load_manifest(namespace)
+        wal_names = self._list_wal(namespace)
+        if manifest is None and not wal_names:
+            return {"namespace": namespace, "skipped": True, "reason": "empty"}
+
+        # Materialise current state: segments first, then WAL overlay in order.
+        state: dict[int, np.ndarray] = {}
+        dimension = manifest["dimension"] if manifest else None
+        if manifest is not None:
+            generation = manifest["generation"]
+            for cluster_idx in range(manifest["cluster_count"]):
+                ids, vectors = self._load_cluster(namespace, generation, cluster_idx)
+                for pos, doc_id in enumerate(ids.tolist()):
+                    state[doc_id] = vectors[pos]
+        overlay = self._load_wal_overlay(namespace, wal_names)
+        for doc_id, vector in overlay.items():
+            if vector is None:
+                state.pop(doc_id, None)
+            else:
+                state[doc_id] = vector
+                dimension = int(vector.shape[0])
+
+        new_generation = (manifest["generation"] + 1) if manifest else 1
+        segment_prefix = self._segment_prefix(namespace, new_generation)
+
+        if state:
+            ids = np.asarray(sorted(state.keys()), dtype=np.int64)
+            vectors = np.stack([state[doc_id] for doc_id in ids.tolist()]).astype(
+                np.float32
+            )
+            count = len(ids)
+            if count < self.min_vectors_for_ann:
+                k = 1
+            else:
+                k = min(self.max_centroids, max(1, int(math.sqrt(count))))
+            if k == 1:
+                centroids = _normalize(vectors.mean(axis=0, keepdims=True))
+                assignment = np.zeros(count, dtype=np.int64)
+            else:
+                centroids = _kmeans(
+                    vectors, k, self.kmeans_iterations, OBJECT_INDEX_KMEANS_SEED
+                )
+                assignment = np.argmax(vectors @ centroids.T, axis=1)
+            for cluster_idx in range(k):
+                mask = assignment == cluster_idx
+                self._put_cluster(segment_prefix, cluster_idx, ids[mask], vectors[mask])
+            buf = io.BytesIO()
+            np.save(buf, centroids)
+            self.store.put_bytes(f"{segment_prefix}/centroids.npy", buf.getvalue())
+            cluster_count = k
+        else:
+            count = 0
+            cluster_count = 0
+
+        new_manifest = {
+            "generation": new_generation,
+            "dimension": dimension,
+            "count": count,
+            "cluster_count": cluster_count,
+        }
+        # Single PUT = the atomic commit point of the new generation.
+        self.store.put_bytes(
+            self._manifest_key(namespace),
+            json.dumps(new_manifest).encode("utf-8"),
+        )
+
+        # Best-effort garbage collection: folded WAL files + old generation.
+        # Failures leave harmless duplicates (upserts are idempotent; see doc).
+        for name in wal_names:
+            self.store.delete(f"{self._wal_dir(namespace)}/{name}")
+        if manifest is not None:
+            old_prefix = self._segment_prefix(namespace, manifest["generation"])
+            self.store.delete(f"{old_prefix}/centroids.npy")
+            for cluster_idx in range(manifest["cluster_count"]):
+                self.store.delete(f"{old_prefix}/cluster_{cluster_idx:05d}.npz")
+
+        return {
+            "namespace": namespace,
+            "generation": new_generation,
+            "count": count,
+            "cluster_count": cluster_count,
+            "folded_wal_files": len(wal_names),
+        }
+
+    # ---------------------------------------------------------------- loaders
+    def _list_wal(self, namespace: str) -> list[str]:
+        return self.store.list_keys(self._wal_dir(namespace))
+
+    def _load_manifest(self, namespace: str) -> dict | None:
+        try:
+            raw = self.store.get_bytes(self._manifest_key(namespace))
+        except ObjectNotFound:
+            return None
+        return json.loads(raw)
+
+    def _load_wal_overlay(
+        self, namespace: str, wal_names: list[str]
+    ) -> dict[int, np.ndarray | None]:
+        """
+        Replay WAL files in name (= time) order into ``id -> unit vector`` with
+        ``None`` marking tombstones. Later entries win.
+        """
+        overlay: dict[int, np.ndarray | None] = {}
+        for name in wal_names:
+            try:
+                raw = self.store.get_bytes(f"{self._wal_dir(namespace)}/{name}")
+            except ObjectNotFound:
+                continue  # deleted by a concurrent compaction; its data is in segments
+            for line in raw.decode("utf-8").splitlines():
+                if not line.strip():
+                    continue
+                entry = json.loads(line)
+                if entry["op"] == _OP_DELETE:
+                    overlay[entry["id"]] = None
+                else:
+                    vector = np.asarray(entry["v"], dtype=np.float32)
+                    overlay[entry["id"]] = _normalize(vector)
+        return overlay
+
+    def _load_centroids(self, namespace: str, generation: int) -> np.ndarray:
+        cache_key = (self.store.prefix, namespace, generation, "centroids")
+        cached = self._cache.get(cache_key)
+        if cached is not None:
+            return cached
+        raw = self.store.get_bytes(
+            f"{self._segment_prefix(namespace, generation)}/centroids.npy"
+        )
+        centroids = np.load(io.BytesIO(raw))
+        self._cache.put(cache_key, centroids)
+        return centroids
+
+    def _load_cluster(
+        self, namespace: str, generation: int, cluster_idx: int
+    ) -> tuple[np.ndarray, np.ndarray]:
+        cache_key = (self.store.prefix, namespace, generation, cluster_idx)
+        cached = self._cache.get(cache_key)
+        if cached is not None:
+            return cached
+        raw = self.store.get_bytes(
+            f"{self._segment_prefix(namespace, generation)}"
+            f"/cluster_{cluster_idx:05d}.npz"
+        )
+        data = np.load(io.BytesIO(raw))
+        result = (data["ids"], data["vectors"])
+        self._cache.put(cache_key, result)
+        return result
+
+    def _put_cluster(
+        self,
+        segment_prefix: str,
+        cluster_idx: int,
+        ids: np.ndarray,
+        vectors: np.ndarray,
+    ) -> None:
+        buf = io.BytesIO()
+        np.savez(buf, ids=ids, vectors=vectors)
+        self.store.put_bytes(
+            f"{segment_prefix}/cluster_{cluster_idx:05d}.npz", buf.getvalue()
+        )
+
+    def clear_caches(self) -> None:
+        self._cache.clear()

--- a/opencontractserver/vector_search/engine.py
+++ b/opencontractserver/vector_search/engine.py
@@ -114,11 +114,16 @@ def _kmeans(vectors: np.ndarray, k: int, iterations: int, seed: int) -> np.ndarr
         sims = vectors @ centroids.T  # (n, k)
         assignment = np.argmax(sims, axis=1)
         best_sims = sims[np.arange(n), assignment]
+        # Ascending: worst-fit points first, for empty-cluster reseeding.
+        worst_fit_order = np.argsort(best_sims)
+        reseed_cursor = 0
         for cluster_idx in range(k):
             members = vectors[assignment == cluster_idx]
             if len(members) == 0:
-                # Re-seed from the globally worst-fit point.
-                centroids[cluster_idx] = vectors[np.argmin(best_sims)]
+                # Re-seed from successive worst-fit points so multiple empty
+                # clusters in one iteration don't collapse onto one seed.
+                centroids[cluster_idx] = vectors[worst_fit_order[reseed_cursor]]
+                reseed_cursor += 1
             else:
                 centroids[cluster_idx] = members.mean(axis=0)
         centroids = _normalize(centroids)

--- a/opencontractserver/vector_search/engine.py
+++ b/opencontractserver/vector_search/engine.py
@@ -16,15 +16,17 @@ Design (see ``docs/architecture/object_storage_vector_search.md``):
 
 - **Writes** append a WAL file (one PUT, durable on return). Vectors are
   unit-normalised so cosine similarity is a dot product.
-- **Reads** are strongly consistent: load the manifest (one roundtrip), probe
-  the ``nprobe`` nearest centroid clusters, then exhaustively scan the WAL
-  tail (files not yet folded into segments) as an overlay — newest write or
-  tombstone for an id wins over any segment entry.
+- **Reads** are strongly consistent: list the WAL, then load the manifest
+  (WAL-first ordering is load-bearing — see ``search()``), probe the
+  ``nprobe`` nearest centroid clusters, then exhaustively scan the WAL tail
+  (files not folded into the manifest's generation) as an overlay — newest
+  write or tombstone for an id wins over any segment entry.
 - **Compaction** folds segments + WAL into a new generation: k-means clusters
   the vectors, writes new segment blobs, atomically swaps the manifest (single
-  PUT, last-writer-wins), then deletes the folded WAL files and the previous
-  generation's blobs. Callers must serialise compaction per namespace (the
-  Celery task uses a cache lock).
+  PUT, last-writer-wins). GC is deferred one cycle: committing generation
+  N+1 deletes only what generation N superseded, so readers holding manifest
+  N can still fetch everything it references. Callers must serialise
+  compaction per namespace (the Celery task uses a cache lock).
 
 The engine is deliberately framework-free: it depends only on numpy and the
 blob-store primitives in ``object_store.py``, so it is unit-testable without
@@ -197,7 +199,16 @@ class ObjectStorageVectorEngine:
         )
 
     def wal_tail_count(self, namespace: str) -> int:
-        return len(self._list_wal(namespace))
+        """
+        Number of WAL files NOT yet folded into the current generation.
+        Folded-but-not-yet-GC'd files (GC is deferred one compaction cycle)
+        don't count — they'd otherwise re-trigger auto-compaction forever.
+        """
+        wal_names = self._list_wal(namespace)
+        if not wal_names:
+            return 0
+        folded = self._folded_wals(self._load_manifest(namespace))
+        return len([name for name in wal_names if name not in folded])
 
     def search(
         self, namespace: str, query_vector: list[float], top_k: int
@@ -210,13 +221,25 @@ class ObjectStorageVectorEngine:
         Strong consistency: WAL entries not yet folded into segments are
         scanned exhaustively and override segment data per id.
         """
-        manifest = self._load_manifest(namespace)
+        # ORDERING MATTERS: list the WAL BEFORE reading the manifest.
+        # Compaction commits the new manifest strictly before GC'ing the WAL
+        # files it folded, so a reader that lists the WAL first sees either
+        # (a) the folded files still present (their data is served from the
+        # overlay, and the manifest's folded_wals list prevents replaying
+        # them over the newer segments), or (b) the files already gone, in
+        # which case the manifest it reads next must already include the
+        # generation that folded them. Reading manifest-first would open a
+        # window where an old manifest is paired with an already-GC'd WAL
+        # tail — silently dropping those writes.
         wal_names = self._list_wal(namespace)
+        manifest = self._load_manifest(namespace)
         if manifest is None and not wal_names:
             return None
 
         query = _normalize(np.asarray(query_vector, dtype=np.float32))
-        overlay = self._load_wal_overlay(namespace, wal_names)
+        overlay = self._load_wal_overlay(
+            namespace, wal_names, exclude=self._folded_wals(manifest)
+        )
 
         scored: dict[int, float] = {}
         if manifest is not None and manifest["cluster_count"] > 0:
@@ -256,10 +279,16 @@ class ObjectStorageVectorEngine:
         are safe — WAL files that appear after the listing below simply stay
         in the tail for the next compaction.
         """
-        manifest = self._load_manifest(namespace)
         wal_names = self._list_wal(namespace)
+        manifest = self._load_manifest(namespace)
         if manifest is None and not wal_names:
             return {"namespace": namespace, "skipped": True, "reason": "empty"}
+
+        # WAL files already folded into the current generation but whose GC
+        # failed must NOT be replayed: their entries are older than the
+        # segment state and would roll ids back (or resurrect tombstoned
+        # ones). They are re-listed in the new manifest and re-GC'd below.
+        folded_prior = self._folded_wals(manifest)
 
         # Materialise current state: segments first, then WAL overlay in order.
         state: dict[int, np.ndarray] = {}
@@ -270,7 +299,7 @@ class ObjectStorageVectorEngine:
                 ids, vectors = self._load_cluster(namespace, generation, cluster_idx)
                 for pos, doc_id in enumerate(ids.tolist()):
                     state[doc_id] = vectors[pos]
-        overlay = self._load_wal_overlay(namespace, wal_names)
+        overlay = self._load_wal_overlay(namespace, wal_names, exclude=folded_prior)
         for doc_id, vector in overlay.items():
             if vector is None:
                 state.pop(doc_id, None)
@@ -315,6 +344,21 @@ class ObjectStorageVectorEngine:
             "dimension": dimension,
             "count": count,
             "cluster_count": cluster_count,
+            # Every WAL file whose data is reflected in this generation.
+            # Readers skip these when building the overlay so their stale
+            # entries are never replayed over newer segment state (and racing
+            # readers that listed the WAL just before this commit don't
+            # double-apply them).
+            "folded_wals": wal_names,
+            # Segment blobs superseded by this commit; GC'd one cycle later.
+            "prior_generation": (
+                {
+                    "generation": manifest["generation"],
+                    "cluster_count": manifest["cluster_count"],
+                }
+                if manifest is not None
+                else None
+            ),
         }
         # Single PUT = the atomic commit point of the new generation.
         self.store.put_bytes(
@@ -322,14 +366,22 @@ class ObjectStorageVectorEngine:
             json.dumps(new_manifest).encode("utf-8"),
         )
 
-        # Best-effort garbage collection: folded WAL files + old generation.
-        # Failures leave harmless duplicates (upserts are idempotent; see doc).
-        for name in wal_names:
+        # DEFERRED garbage collection: delete only what the *previous*
+        # manifest superseded (its folded WAL files and its prior
+        # generation's segment blobs), not what this commit just superseded.
+        # In-flight readers holding the previous manifest can therefore still
+        # fetch every blob it references — one full compaction cycle of grace
+        # — instead of hitting ObjectNotFound and burning a pgvector fallback
+        # per racing query. Deletion failures are harmless: folded WAL files
+        # are skipped by readers via folded_wals, and orphaned segment blobs
+        # of dead generations are never referenced again.
+        for name in folded_prior:
             self.store.delete(f"{self._wal_dir(namespace)}/{name}")
-        if manifest is not None:
-            old_prefix = self._segment_prefix(namespace, manifest["generation"])
+        prior_generation = manifest.get("prior_generation") if manifest else None
+        if prior_generation:
+            old_prefix = self._segment_prefix(namespace, prior_generation["generation"])
             self.store.delete(f"{old_prefix}/centroids.npy")
-            for cluster_idx in range(manifest["cluster_count"]):
+            for cluster_idx in range(prior_generation["cluster_count"]):
                 self.store.delete(f"{old_prefix}/cluster_{cluster_idx:05d}.npz")
 
         return {
@@ -337,7 +389,9 @@ class ObjectStorageVectorEngine:
             "generation": new_generation,
             "count": count,
             "cluster_count": cluster_count,
-            "folded_wal_files": len(wal_names),
+            "folded_wal_files": len(
+                [name for name in wal_names if name not in folded_prior]
+            ),
         }
 
     # ---------------------------------------------------------------- loaders
@@ -351,15 +405,29 @@ class ObjectStorageVectorEngine:
             return None
         return json.loads(raw)
 
+    @staticmethod
+    def _folded_wals(manifest: dict | None) -> set[str]:
+        """WAL file names already folded into the manifest's generation."""
+        if manifest is None:
+            return set()
+        return set(manifest.get("folded_wals", []))
+
     def _load_wal_overlay(
-        self, namespace: str, wal_names: list[str]
+        self,
+        namespace: str,
+        wal_names: list[str],
+        exclude: set[str] | None = None,
     ) -> dict[int, np.ndarray | None]:
         """
         Replay WAL files in name (= time) order into ``id -> unit vector`` with
-        ``None`` marking tombstones. Later entries win.
+        ``None`` marking tombstones. Later entries win. Files in ``exclude``
+        (already folded into the current generation) are skipped — replaying
+        them would apply stale entries over newer segment state.
         """
         overlay: dict[int, np.ndarray | None] = {}
         for name in wal_names:
+            if exclude and name in exclude:
+                continue
             try:
                 raw = self.store.get_bytes(f"{self._wal_dir(namespace)}/{name}")
             except ObjectNotFound:

--- a/opencontractserver/vector_search/engine.py
+++ b/opencontractserver/vector_search/engine.py
@@ -50,6 +50,7 @@ from opencontractserver.constants.search import (
     OBJECT_INDEX_CACHE_MAX_ENTRIES,
     OBJECT_INDEX_KMEANS_ITERATIONS,
     OBJECT_INDEX_KMEANS_SEED,
+    OBJECT_INDEX_MANIFEST_RETRY_DELAY_SECONDS,
     OBJECT_INDEX_MAX_CENTROIDS,
     OBJECT_INDEX_MIN_VECTORS_FOR_ANN,
     OBJECT_INDEX_NPROBE_MIN,
@@ -212,7 +213,7 @@ class ObjectStorageVectorEngine:
         wal_names = self._list_wal(namespace)
         if not wal_names:
             return 0
-        folded = self._folded_wals(self._load_manifest(namespace))
+        folded = self._folded_wals(self._load_manifest_expecting_data(namespace))
         return len([name for name in wal_names if name not in folded])
 
     def search(
@@ -237,7 +238,14 @@ class ObjectStorageVectorEngine:
         # window where an old manifest is paired with an already-GC'd WAL
         # tail — silently dropping those writes.
         wal_names = self._list_wal(namespace)
-        manifest = self._load_manifest(namespace)
+        if wal_names:
+            # Non-empty WAL: a missing manifest here is either a namespace
+            # awaiting its first compaction or a manifest mid-overwrite, so
+            # read with the retry guard — proceeding with manifest=None
+            # would silently drop all segment data.
+            manifest = self._load_manifest_expecting_data(namespace)
+        else:
+            manifest = self._load_manifest(namespace)
         if manifest is None and not wal_names:
             return None
 
@@ -409,6 +417,22 @@ class ObjectStorageVectorEngine:
         except ObjectNotFound:
             return None
         return json.loads(raw)
+
+    def _load_manifest_expecting_data(self, namespace: str) -> dict | None:
+        """
+        Manifest read for namespaces that demonstrably hold data (non-empty
+        WAL). ``put_bytes`` overwrites the manifest via delete-then-save, so
+        a reader can catch the sub-second window between the two operations
+        and see the key missing even though a generation is committed —
+        structurally indistinguishable from "never compacted." Retry once
+        after a short delay before accepting None; a genuinely
+        pre-first-compaction namespace just pays one extra GET.
+        """
+        manifest = self._load_manifest(namespace)
+        if manifest is None:
+            time.sleep(OBJECT_INDEX_MANIFEST_RETRY_DELAY_SECONDS)
+            manifest = self._load_manifest(namespace)
+        return manifest
 
     @staticmethod
     def _folded_wals(manifest: dict | None) -> set[str]:

--- a/opencontractserver/vector_search/engine.py
+++ b/opencontractserver/vector_search/engine.py
@@ -198,12 +198,6 @@ class ObjectStorageVectorEngine:
         return name
 
     # -------------------------------------------------------------- read path
-    def namespace_exists(self, namespace: str) -> bool:
-        return (
-            self.store.exists(self._manifest_key(namespace))
-            or len(self._list_wal(namespace)) > 0
-        )
-
     def wal_tail_count(self, namespace: str) -> int:
         """
         Number of WAL files NOT yet folded into the current generation.

--- a/opencontractserver/vector_search/hooks.py
+++ b/opencontractserver/vector_search/hooks.py
@@ -1,0 +1,44 @@
+"""
+Write-path fan-out: mirror every stored embedding into the object-storage
+index when the backend is enabled.
+
+``Embedding.objects.store_embedding`` is the single chokepoint through which
+ALL embedding writes flow (Celery embedding tasks, ``HasEmbeddingMixin
+.add_embedding``, backfill commands), so hooking here covers every producer.
+
+The sync is queued on transaction commit so the Celery task can always load
+the committed ``Embedding`` row, and it is fire-and-forget: an object-index
+sync failure never breaks the Postgres write (pgvector data is ground truth
+and the index can be rebuilt).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from django.db import transaction
+
+from .router import object_storage_backend_enabled
+
+logger = logging.getLogger(__name__)
+
+
+def enqueue_embedding_index_sync(embedding, dimension: int) -> None:
+    """
+    Queue the object-index upsert for ``embedding`` after the surrounding
+    transaction commits. No-op when the object-storage backend is disabled.
+    """
+    if not object_storage_backend_enabled():
+        return
+    if embedding is None or embedding.pk is None:
+        return
+    embedding_pk = embedding.pk
+    # Late import: opencontractserver.tasks imports models which import
+    # shared.Managers which imports this module.
+    from opencontractserver.tasks.vector_index_tasks import (
+        sync_embedding_to_object_index,
+    )
+
+    transaction.on_commit(
+        lambda: sync_embedding_to_object_index.si(embedding_pk, dimension).apply_async()
+    )

--- a/opencontractserver/vector_search/hooks.py
+++ b/opencontractserver/vector_search/hooks.py
@@ -18,19 +18,32 @@ import logging
 
 from django.db import transaction
 
+from opencontractserver.constants.search import EMBEDDABLE_PARENT_KINDS
+
 from .router import object_storage_backend_enabled
 
 logger = logging.getLogger(__name__)
+
+_INDEXED_PARENT_FK_ATTRS = tuple(
+    fk_attr for fk_attr, _kind in EMBEDDABLE_PARENT_KINDS.values()
+)
 
 
 def enqueue_embedding_index_sync(embedding, dimension: int) -> None:
     """
     Queue the object-index upsert for ``embedding`` after the surrounding
-    transaction commits. No-op when the object-storage backend is disabled.
+    transaction commits. No-op when the object-storage backend is disabled
+    or when the embedding's parent kind is not served by the object index
+    (conversation/message/relationship reads still use their own pgvector
+    paths — indexing their writes would be pure write amplification).
     """
     if not object_storage_backend_enabled():
         return
     if embedding is None or embedding.pk is None:
+        return
+    if not any(
+        getattr(embedding, fk_attr, None) for fk_attr in _INDEXED_PARENT_FK_ATTRS
+    ):
         return
     embedding_pk = embedding.pk
     # Late import: opencontractserver.tasks imports models which import

--- a/opencontractserver/vector_search/hooks.py
+++ b/opencontractserver/vector_search/hooks.py
@@ -2,9 +2,15 @@
 Write-path fan-out: mirror every stored embedding into the object-storage
 index when the backend is enabled.
 
-``Embedding.objects.store_embedding`` is the single chokepoint through which
-ALL embedding writes flow (Celery embedding tasks, ``HasEmbeddingMixin
-.add_embedding``, backfill commands), so hooking here covers every producer.
+``Embedding.objects.store_embedding`` is the chokepoint through which the
+in-app embedding pipeline flows (Celery embedding tasks,
+``HasEmbeddingMixin.add_embedding``, backfill commands). ONE producer
+bypasses it for performance — ``opencontractserver/worker_uploads/tasks.py``
+writes rows via ``bulk_create``/``update_or_create`` and calls
+``enqueue_embedding_index_sync`` explicitly. Any new code path that writes
+``Embedding`` rows directly must do the same, or its rows silently never
+reach the object index (Postgres stays correct; only the index goes stale
+until the next ``rebuild_object_vector_index``).
 
 The sync is queued on transaction commit so the Celery task can always load
 the committed ``Embedding`` row, and it is fire-and-forget: an object-index

--- a/opencontractserver/vector_search/object_store.py
+++ b/opencontractserver/vector_search/object_store.py
@@ -1,0 +1,97 @@
+"""
+Minimal object-store adapter used by the object-storage vector search engine.
+
+The engine only needs five blob primitives (put/get/list/delete/exists), so we
+adapt Django's Storage API rather than talking to boto3 directly. That means
+the index transparently lives wherever ``STORAGE_BACKEND`` points it:
+
+- ``LOCAL``  -> ``FileSystemStorage`` under ``MEDIA_ROOT`` (dev / CI)
+- ``AWS``    -> S3 (or any S3-compatible store such as MinIO)
+- ``GCP``    -> Google Cloud Storage
+
+All keys are namespaced under ``settings.VECTOR_INDEX_STORAGE_PREFIX``.
+"""
+
+from __future__ import annotations
+
+import posixpath
+
+from django.conf import settings
+from django.core.files.base import ContentFile
+from django.core.files.storage import Storage, default_storage
+
+
+class ObjectNotFound(Exception):
+    """Raised when a requested key does not exist in the object store."""
+
+
+class DjangoStorageObjectStore:
+    """
+    Blob-store primitives over a Django ``Storage`` instance.
+
+    ``storage`` may be a lazy proxy (e.g. ``default_storage``) so that test
+    overrides of ``STORAGES`` are honoured. ``prefix`` is resolved lazily from
+    settings when not given explicitly, for the same reason.
+    """
+
+    def __init__(self, storage: Storage | None = None, prefix: str | None = None):
+        self._storage = storage if storage is not None else default_storage
+        self._prefix = prefix
+
+    @property
+    def prefix(self) -> str:
+        if self._prefix is not None:
+            return self._prefix
+        return settings.VECTOR_INDEX_STORAGE_PREFIX
+
+    def _full(self, key: str) -> str:
+        return posixpath.join(self.prefix, key)
+
+    def put_bytes(self, key: str, data: bytes) -> None:
+        """
+        Write ``data`` at ``key``, overwriting any existing blob.
+
+        Django's ``Storage.save`` never overwrites (it uniquifies the name),
+        so delete-then-save is required for mutable keys (the manifest). WAL
+        and segment keys are unique by construction, making the pattern safe.
+        """
+        name = self._full(key)
+        if self._storage.exists(name):
+            self._storage.delete(name)
+        saved_as = self._storage.save(name, ContentFile(data))
+        if saved_as != name:
+            # A concurrent writer raced us between delete() and save() and the
+            # backend uniquified our name. Last-writer-wins for mutable keys:
+            # replace the existing blob with ours.
+            self._storage.delete(name)
+            with self._storage.open(saved_as, "rb") as fh:
+                payload = fh.read()
+            self._storage.delete(saved_as)
+            self._storage.save(name, ContentFile(payload))
+
+    def get_bytes(self, key: str) -> bytes:
+        name = self._full(key)
+        try:
+            with self._storage.open(name, "rb") as fh:
+                return fh.read()
+        except FileNotFoundError as exc:
+            raise ObjectNotFound(key) from exc
+
+    def list_keys(self, dir_key: str) -> list[str]:
+        """Return sorted file names (not full paths) directly under ``dir_key``."""
+        name = self._full(dir_key)
+        try:
+            _dirs, files = self._storage.listdir(name)
+        except FileNotFoundError:
+            return []
+        return sorted(files)
+
+    def delete(self, key: str) -> None:
+        name = self._full(key)
+        try:
+            self._storage.delete(name)
+        except FileNotFoundError:
+            pass
+
+    def exists(self, key: str) -> bool:
+        return self._storage.exists(self._full(key))

--- a/opencontractserver/vector_search/object_store.py
+++ b/opencontractserver/vector_search/object_store.py
@@ -32,6 +32,10 @@ class ObjectNotFound(Exception):
     """Raised when a requested key does not exist in the object store."""
 
 
+class ObjectStoreWriteError(Exception):
+    """Raised when an overwrite could not be committed (race retries exhausted)."""
+
+
 class DjangoStorageObjectStore:
     """
     Blob-store primitives over a Django ``Storage`` instance.
@@ -66,8 +70,10 @@ class DjangoStorageObjectStore:
         bounded — the only mutable key is the manifest, whose writers are
         serialised by the compaction cache-lock, so contention here means
         that lock was breached (e.g. it expired mid-compaction); after the
-        bound we concede last-writer-wins to the racing writer and log,
-        leaving a valid (their) manifest in place.
+        bound we raise ``ObjectStoreWriteError`` so the caller fails visibly
+        (a compaction whose manifest never persisted must not report
+        success) — the racing writer's blob, itself a valid manifest,
+        remains in place.
         """
         name = self._full(key)
         for _ in range(OBJECT_STORE_PUT_OVERWRITE_MAX_ATTEMPTS):
@@ -77,11 +83,10 @@ class DjangoStorageObjectStore:
             if saved_as == name:
                 return
             self._storage.delete(saved_as)
-        logger.warning(
-            "put_bytes lost the overwrite race for %s after %d attempts; "
-            "keeping the racing writer's blob.",
-            name,
-            OBJECT_STORE_PUT_OVERWRITE_MAX_ATTEMPTS,
+        raise ObjectStoreWriteError(
+            f"Lost the overwrite race for {name} "
+            f"{OBJECT_STORE_PUT_OVERWRITE_MAX_ATTEMPTS} times; the racing "
+            "writer's blob was kept and this write was NOT committed."
         )
 
     def get_bytes(self, key: str) -> bytes:

--- a/opencontractserver/vector_search/object_store.py
+++ b/opencontractserver/vector_search/object_store.py
@@ -14,11 +14,18 @@ All keys are namespaced under ``settings.VECTOR_INDEX_STORAGE_PREFIX``.
 
 from __future__ import annotations
 
+import logging
 import posixpath
 
 from django.conf import settings
 from django.core.files.base import ContentFile
 from django.core.files.storage import Storage, default_storage
+
+from opencontractserver.constants.search import (
+    OBJECT_STORE_PUT_OVERWRITE_MAX_ATTEMPTS,
+)
+
+logger = logging.getLogger(__name__)
 
 
 class ObjectNotFound(Exception):
@@ -52,27 +59,30 @@ class DjangoStorageObjectStore:
         Write ``data`` at ``key``, overwriting any existing blob.
 
         Django's ``Storage.save`` never overwrites (it uniquifies the name),
-        so delete-then-save is required for mutable keys (the manifest). WAL
-        and segment keys are unique by construction, making the pattern safe.
+        so overwrite = delete-then-save. If a concurrent writer re-creates
+        ``key`` between our delete and save, our blob lands under a
+        uniquified stray name: discard the stray and retry the overwrite, so
+        the terminal state is always exactly one blob at ``key``. Retries are
+        bounded — the only mutable key is the manifest, whose writers are
+        serialised by the compaction cache-lock, so contention here means
+        that lock was breached (e.g. it expired mid-compaction); after the
+        bound we concede last-writer-wins to the racing writer and log,
+        leaving a valid (their) manifest in place.
         """
         name = self._full(key)
-        if self._storage.exists(name):
-            self._storage.delete(name)
-        saved_as = self._storage.save(name, ContentFile(data))
-        if saved_as != name:
-            # A concurrent writer raced us between delete() and save() and the
-            # backend uniquified our name. Last-writer-wins for mutable keys:
-            # replace the existing blob with ours. If yet another racer
-            # deletes our uniquified blob mid-recovery, fall back to writing
-            # the payload we still hold — same last-writer-wins outcome.
-            self._storage.delete(name)
-            try:
-                with self._storage.open(saved_as, "rb") as fh:
-                    payload = fh.read()
-                self._storage.delete(saved_as)
-            except FileNotFoundError:
-                payload = data
-            self._storage.save(name, ContentFile(payload))
+        for _ in range(OBJECT_STORE_PUT_OVERWRITE_MAX_ATTEMPTS):
+            if self._storage.exists(name):
+                self._storage.delete(name)
+            saved_as = self._storage.save(name, ContentFile(data))
+            if saved_as == name:
+                return
+            self._storage.delete(saved_as)
+        logger.warning(
+            "put_bytes lost the overwrite race for %s after %d attempts; "
+            "keeping the racing writer's blob.",
+            name,
+            OBJECT_STORE_PUT_OVERWRITE_MAX_ATTEMPTS,
+        )
 
     def get_bytes(self, key: str) -> bytes:
         name = self._full(key)

--- a/opencontractserver/vector_search/object_store.py
+++ b/opencontractserver/vector_search/object_store.py
@@ -62,11 +62,16 @@ class DjangoStorageObjectStore:
         if saved_as != name:
             # A concurrent writer raced us between delete() and save() and the
             # backend uniquified our name. Last-writer-wins for mutable keys:
-            # replace the existing blob with ours.
+            # replace the existing blob with ours. If yet another racer
+            # deletes our uniquified blob mid-recovery, fall back to writing
+            # the payload we still hold — same last-writer-wins outcome.
             self._storage.delete(name)
-            with self._storage.open(saved_as, "rb") as fh:
-                payload = fh.read()
-            self._storage.delete(saved_as)
+            try:
+                with self._storage.open(saved_as, "rb") as fh:
+                    payload = fh.read()
+                self._storage.delete(saved_as)
+            except FileNotFoundError:
+                payload = data
             self._storage.save(name, ContentFile(payload))
 
     def get_bytes(self, key: str) -> bytes:

--- a/opencontractserver/vector_search/object_store.py
+++ b/opencontractserver/vector_search/object_store.py
@@ -91,6 +91,8 @@ class DjangoStorageObjectStore:
         try:
             self._storage.delete(name)
         except FileNotFoundError:
+            # Delete is idempotent: a missing key is already deleted (e.g. a
+            # concurrent compaction GC'd the same WAL file first).
             pass
 
     def exists(self, key: str) -> bool:

--- a/opencontractserver/vector_search/router.py
+++ b/opencontractserver/vector_search/router.py
@@ -24,6 +24,7 @@ from typing import Any
 from django.conf import settings
 
 from opencontractserver.constants.search import (
+    EMBEDDABLE_PARENT_KINDS,
     OBJECT_INDEX_FILTER_OVERSAMPLE,
     OBJECT_INDEX_MAX_FETCH_CANDIDATES,
     VECTOR_SEARCH_BACKEND_OBJECT_STORAGE,
@@ -35,20 +36,12 @@ from .object_store import DjangoStorageObjectStore
 
 logger = logging.getLogger(__name__)
 
-# Maps Django model_name -> namespace parent-kind segment. Only models that
-# can own Embedding rows (Embedding's parent FKs) are searchable.
-# KEEP IN SYNC with PARENT_FK_TO_KIND in
-# opencontractserver/tasks/vector_index_tasks.py — same taxonomy keyed by
-# Embedding FK attribute instead of model name; adding an embeddable parent
-# type requires updating both (kind VALUES must match exactly, or writes and
-# reads land in different namespaces).
+# Maps Django model_name -> namespace parent-kind segment, derived from the
+# shared EMBEDDABLE_PARENT_KINDS taxonomy (single source of truth with the
+# write-path map in opencontractserver/tasks/vector_index_tasks.py). Only
+# models that can own Embedding rows (Embedding's parent FKs) are searchable.
 PARENT_KIND_BY_MODEL_NAME: dict[str, str] = {
-    "annotation": "annotation",
-    "document": "document",
-    "note": "note",
-    "conversation": "conversation",
-    "chatmessage": "message",
-    "relationship": "relationship",
+    model_name: kind for model_name, (_fk_attr, kind) in EMBEDDABLE_PARENT_KINDS.items()
 }
 
 _default_engine: ObjectStorageVectorEngine | None = None

--- a/opencontractserver/vector_search/router.py
+++ b/opencontractserver/vector_search/router.py
@@ -25,6 +25,7 @@ from django.conf import settings
 
 from opencontractserver.constants.search import (
     OBJECT_INDEX_FILTER_OVERSAMPLE,
+    OBJECT_INDEX_MAX_FETCH_CANDIDATES,
     VECTOR_SEARCH_BACKEND_OBJECT_STORAGE,
     VECTOR_SEARCH_BACKEND_PGVECTOR,
 )
@@ -36,6 +37,11 @@ logger = logging.getLogger(__name__)
 
 # Maps Django model_name -> namespace parent-kind segment. Only models that
 # can own Embedding rows (Embedding's parent FKs) are searchable.
+# KEEP IN SYNC with PARENT_FK_TO_KIND in
+# opencontractserver/tasks/vector_index_tasks.py — same taxonomy keyed by
+# Embedding FK attribute instead of model name; adding an embeddable parent
+# type requires updating both (kind VALUES must match exactly, or writes and
+# reads land in different namespaces).
 PARENT_KIND_BY_MODEL_NAME: dict[str, str] = {
     "annotation": "annotation",
     "document": "document",
@@ -124,7 +130,13 @@ def search_via_object_index(
         return None
     try:
         engine = get_default_engine()
-        fetch_n = top_k * OBJECT_INDEX_FILTER_OVERSAMPLE
+        # Capped independent of caller top_k: bounds the in-memory ranking
+        # and the pk__in re-filter. A cap-truncated candidate set that can't
+        # fill top_k takes the shortfall fallback below.
+        fetch_n = min(
+            top_k * OBJECT_INDEX_FILTER_OVERSAMPLE,
+            max(top_k, OBJECT_INDEX_MAX_FETCH_CANDIDATES),
+        )
         hits = engine.search(namespace, query_vector, fetch_n)
     except Exception:
         logger.exception(
@@ -162,7 +174,10 @@ def search_via_object_index(
     # engine returned fewer than fetch_n hits it exhausted the namespace, so
     # a short result list is genuinely complete and is returned as-is. This
     # keeps "enabling the backend never returns worse results than pgvector"
-    # true even for heavily-filtered querysets.
+    # true even for heavily-filtered querysets. Accepted false positive: a
+    # namespace holding EXACTLY fetch_n matching vectors is indistinguishable
+    # from a truncated set, so that boundary pays one unnecessary (harmless)
+    # pgvector fallback.
     if len(results) < top_k and len(hits) >= fetch_n:
         logger.info(
             "Object-storage candidates for namespace %s were exhausted by "

--- a/opencontractserver/vector_search/router.py
+++ b/opencontractserver/vector_search/router.py
@@ -1,0 +1,152 @@
+"""
+Backend selection and queryset integration for pluggable vector search.
+
+``VectorSearchViaEmbeddingMixin.search_by_embedding`` (the single pgvector
+similarity call site) consults this module first. When
+``settings.VECTOR_SEARCH_BACKEND == "object_storage"`` the similarity ranking
+is served from the object-storage engine and the resulting candidate ids are
+re-filtered through the *caller's own queryset* — so every permission /
+visibility / corpus-scoping rule already applied to that queryset (e.g. by
+``CoreAnnotationVectorStore._build_base_queryset``) is preserved verbatim.
+
+Any engine failure, or a namespace that has never been indexed, falls back to
+the pgvector path — flipping the flag on can never make search *worse* than
+pgvector, only faster/cheaper at scale.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+from typing import Any
+
+from django.conf import settings
+
+from opencontractserver.constants.search import (
+    OBJECT_INDEX_FILTER_OVERSAMPLE,
+    VECTOR_SEARCH_BACKEND_OBJECT_STORAGE,
+    VECTOR_SEARCH_BACKEND_PGVECTOR,
+)
+
+from .engine import ObjectStorageVectorEngine
+from .object_store import DjangoStorageObjectStore
+
+logger = logging.getLogger(__name__)
+
+# Maps Django model_name -> namespace parent-kind segment. Only models that
+# can own Embedding rows (Embedding's parent FKs) are searchable.
+PARENT_KIND_BY_MODEL_NAME: dict[str, str] = {
+    "annotation": "annotation",
+    "document": "document",
+    "note": "note",
+    "conversation": "conversation",
+    "chatmessage": "message",
+    "relationship": "relationship",
+}
+
+_default_engine: ObjectStorageVectorEngine | None = None
+
+
+def get_vector_search_backend() -> str:
+    return getattr(settings, "VECTOR_SEARCH_BACKEND", VECTOR_SEARCH_BACKEND_PGVECTOR)
+
+
+def object_storage_backend_enabled() -> bool:
+    return get_vector_search_backend() == VECTOR_SEARCH_BACKEND_OBJECT_STORAGE
+
+
+def get_default_engine() -> ObjectStorageVectorEngine:
+    """
+    Process-wide engine over the default Django storage (lazy proxy, so test
+    ``override_settings(STORAGES=...)`` is honoured). Shared so that the
+    artifact LRU cache survives across requests.
+    """
+    global _default_engine
+    if _default_engine is None:
+        _default_engine = ObjectStorageVectorEngine(DjangoStorageObjectStore())
+    return _default_engine
+
+
+def reset_default_engine() -> None:
+    """Drop the cached engine (tests switching storage locations)."""
+    global _default_engine
+    _default_engine = None
+
+
+def build_namespace(parent_kind: str, embedder_path: str, dimension: int) -> str:
+    """
+    One namespace per (parent kind, embedder, dimension) — mirroring the
+    filters the pgvector path applies (embedder_path + vector_<dim> column).
+    The embedder slug is suffixed with a short digest so distinct embedder
+    paths can never collide after sanitisation.
+    """
+    slug = re.sub(r"[^a-zA-Z0-9_-]+", "-", embedder_path).strip("-").lower()[:80]
+    digest = hashlib.md5(
+        embedder_path.encode("utf-8"), usedforsecurity=False
+    ).hexdigest()[:8]
+    return f"{parent_kind}/{slug}-{digest}/{dimension}"
+
+
+def namespace_for_queryset(queryset, embedder_path: str, dimension: int) -> str | None:
+    parent_kind = PARENT_KIND_BY_MODEL_NAME.get(queryset.model._meta.model_name)
+    if parent_kind is None:
+        return None
+    return build_namespace(parent_kind, embedder_path, dimension)
+
+
+def search_via_object_index(
+    queryset,
+    query_vector: list[float],
+    embedder_path: str,
+    top_k: int,
+) -> list[Any] | None:
+    """
+    Serve ``search_by_embedding`` from the object-storage index.
+
+    Returns a list of model instances annotated with ``similarity_score``
+    (same contract as the pgvector path), or ``None`` to signal the caller to
+    fall back to pgvector (unsupported model, unindexed namespace, or any
+    engine error).
+
+    Because permission filtering happens *after* ANN retrieval here (post-ANN
+    filtering), the engine is asked for ``top_k * OBJECT_INDEX_FILTER_OVERSAMPLE``
+    candidates so heavily-filtered querysets still fill ``top_k`` results.
+    """
+    namespace = namespace_for_queryset(queryset, embedder_path, len(query_vector))
+    if namespace is None:
+        return None
+    try:
+        engine = get_default_engine()
+        fetch_n = max(top_k, top_k * OBJECT_INDEX_FILTER_OVERSAMPLE)
+        hits = engine.search(namespace, query_vector, fetch_n)
+    except Exception:
+        logger.exception(
+            "Object-storage vector search failed for namespace %s; "
+            "falling back to pgvector.",
+            namespace,
+        )
+        return None
+    if hits is None:
+        logger.info(
+            "Namespace %s has no object-storage index yet; falling back to "
+            "pgvector. Run `manage.py rebuild_object_vector_index` to build it.",
+            namespace,
+        )
+        return None
+
+    # Re-filter candidates through the caller's queryset: this re-applies all
+    # visibility/corpus scoping AND drops ids whose rows were deleted after
+    # indexing (the index tolerates staleness; Postgres is ground truth).
+    candidate_ids = [doc_id for doc_id, _ in hits]
+    instances_by_id = {obj.pk: obj for obj in queryset.filter(pk__in=candidate_ids)}
+    results: list[Any] = []
+    for doc_id, similarity in hits:
+        instance = instances_by_id.get(doc_id)
+        if instance is None:
+            continue
+        instance.similarity_score = max(0.0, min(1.0, similarity))
+        results.append(instance)
+        if len(results) >= top_k:
+            break
+    return results

--- a/opencontractserver/vector_search/router.py
+++ b/opencontractserver/vector_search/router.py
@@ -128,11 +128,12 @@ def search_via_object_index(
     try:
         engine = get_default_engine()
         # Capped independent of caller top_k: bounds the in-memory ranking
-        # and the pk__in re-filter. A cap-truncated candidate set that can't
-        # fill top_k takes the shortfall fallback below.
+        # and the pk__in re-filter even for abusive top_k values. When the
+        # cap truncates below top_k, a result set that can't fill top_k takes
+        # the shortfall fallback below (pgvector fills via SQL LIMIT).
         fetch_n = min(
             top_k * OBJECT_INDEX_FILTER_OVERSAMPLE,
-            max(top_k, OBJECT_INDEX_MAX_FETCH_CANDIDATES),
+            OBJECT_INDEX_MAX_FETCH_CANDIDATES,
         )
         hits = engine.search(namespace, query_vector, fetch_n)
     except Exception:

--- a/opencontractserver/vector_search/router.py
+++ b/opencontractserver/vector_search/router.py
@@ -115,14 +115,16 @@ def search_via_object_index(
 
     Because permission filtering happens *after* ANN retrieval here (post-ANN
     filtering), the engine is asked for ``top_k * OBJECT_INDEX_FILTER_OVERSAMPLE``
-    candidates so heavily-filtered querysets still fill ``top_k`` results.
+    candidates so heavily-filtered querysets still fill ``top_k`` results —
+    and if even that is not enough (see the shortfall rule below), the caller
+    falls back to pgvector rather than under-filling.
     """
     namespace = namespace_for_queryset(queryset, embedder_path, len(query_vector))
     if namespace is None:
         return None
     try:
         engine = get_default_engine()
-        fetch_n = max(top_k, top_k * OBJECT_INDEX_FILTER_OVERSAMPLE)
+        fetch_n = top_k * OBJECT_INDEX_FILTER_OVERSAMPLE
         hits = engine.search(namespace, query_vector, fetch_n)
     except Exception:
         logger.exception(
@@ -153,4 +155,21 @@ def search_via_object_index(
         results.append(instance)
         if len(results) >= top_k:
             break
+
+    # Shortfall rule: if filtering consumed a TRUNCATED candidate set without
+    # filling top_k, deeper matches may exist beyond fetch_n — fall back to
+    # pgvector, whose SQL filter+limit has no such recall cliff. If the
+    # engine returned fewer than fetch_n hits it exhausted the namespace, so
+    # a short result list is genuinely complete and is returned as-is. This
+    # keeps "enabling the backend never returns worse results than pgvector"
+    # true even for heavily-filtered querysets.
+    if len(results) < top_k and len(hits) >= fetch_n:
+        logger.info(
+            "Object-storage candidates for namespace %s were exhausted by "
+            "filtering (%d/%d after re-filter); falling back to pgvector.",
+            namespace,
+            len(results),
+            top_k,
+        )
+        return None
     return results

--- a/opencontractserver/vector_search/router.py
+++ b/opencontractserver/vector_search/router.py
@@ -118,6 +118,10 @@ def search_via_object_index(
     and if even that is not enough (see the shortfall rule below), the caller
     falls back to pgvector rather than under-filling.
     """
+    if top_k <= 0:
+        # Degenerate input: defer to the pgvector path so behavior stays
+        # byte-identical to the default backend for any caller quirk.
+        return None
     namespace = namespace_for_queryset(queryset, embedder_path, len(query_vector))
     if namespace is None:
         return None

--- a/opencontractserver/vector_search/router.py
+++ b/opencontractserver/vector_search/router.py
@@ -61,6 +61,10 @@ def get_default_engine() -> ObjectStorageVectorEngine:
     Process-wide engine over the default Django storage (lazy proxy, so test
     ``override_settings(STORAGES=...)`` is honoured). Shared so that the
     artifact LRU cache survives across requests.
+
+    Deliberately unlocked lazy init: a racing double-construction just makes
+    one engine's (empty) LRU cache unreachable — the engine holds no other
+    state. Revisit if the engine ever grows stateful fields.
     """
     global _default_engine
     if _default_engine is None:

--- a/opencontractserver/worker_uploads/tasks.py
+++ b/opencontractserver/worker_uploads/tasks.py
@@ -50,6 +50,7 @@ from opencontractserver.utils.importing import (
 from opencontractserver.utils.permissioning import set_permissions_for_obj_to_user
 from opencontractserver.utils.structural_sets import create_structural_annotation_set
 from opencontractserver.utils.subtree_groups import build_subtree_groups_for_document
+from opencontractserver.vector_search.hooks import enqueue_embedding_index_sync
 from opencontractserver.worker_uploads.models import (
     UploadStatus,
     WorkerDocumentUpload,
@@ -529,10 +530,16 @@ def _store_embeddings(
             creator_id=user.id,
         )
         setattr(emb, field_name, vector)
-        embeddings_to_create.append(emb)
+        embeddings_to_create.append((emb, len(vector)))
 
     if embeddings_to_create:
-        Embedding.objects.bulk_create(embeddings_to_create)
+        Embedding.objects.bulk_create([emb for emb, _dim in embeddings_to_create])
+        # bulk_create bypasses EmbeddingManager.store_embedding, so the
+        # object-storage index fan-out must be invoked explicitly here (it is
+        # a no-op unless VECTOR_SEARCH_BACKEND=object_storage). Any new code
+        # path that writes Embedding rows directly must do the same.
+        for emb, dimension in embeddings_to_create:
+            enqueue_embedding_index_sync(emb, dimension)
         logger.info(
             f"Stored {len(embeddings_to_create)} annotation embeddings "
             f"(embedder={embedder_path})"
@@ -563,6 +570,10 @@ def _store_single_embedding(
         annotation=annotation,
         defaults=defaults,
     )
+    # update_or_create bypasses EmbeddingManager.store_embedding, so invoke
+    # the object-storage index fan-out explicitly (no-op unless
+    # VECTOR_SEARCH_BACKEND=object_storage).
+    enqueue_embedding_index_sync(emb, len(vector))
     return emb
 
 


### PR DESCRIPTION
# Overview

Adds an **opt-in, reversible** vector search backend that keeps its index entirely in object storage, following [turbopuffer's architecture](https://turbopuffer.com/architecture): object storage as index source of truth, per-namespace WAL with strongly consistent reads (unindexed tail scanned as an overlay), async compaction into immutable centroid-ANN segment generations, and tiered caching for warm queries. **Default behavior is unchanged** — `VECTOR_SEARCH_BACKEND=pgvector` remains the default, and the object-storage path falls back to pgvector on unindexed namespaces, engine errors, or post-filter shortfalls.

Design doc: `docs/architecture/object_storage_vector_search.md` (includes the build-on-turbopuffer vs from-scratch analysis and prior-art comparison — OpenSearch searchable snapshots, Quickwit — from the referenced HN discussion).

**Flag on feasibility (as requested):** turbopuffer is closed-source SaaS, so there is nothing to self-host; this is a from-scratch implementation of the same architecture (~500 lines of numpy over blob-store primitives). A hosted-turbopuffer API driver could later slot into the same `search_via_object_index()` / `enqueue_embedding_index_sync()` seam.

## How it works

```
Embedding.objects.store_embedding()  ── on_commit ──▶ Celery WAL append (one PUT)
  (+ worker_uploads bulk writes, hooked explicitly)
<prefix>/<ns>/wal/*.jsonl  ── auto-compaction (cache-lock, k-means, k=√n) ──▶
<prefix>/<ns>/index/segments/<gen>/{centroids.npy, cluster_*.npz} + manifest.json
VectorSearchViaEmbeddingMixin.search_by_embedding()  ◀── router probes nprobe
clusters + WAL tail, then RE-FILTERS candidate ids through the caller's queryset
```

- **Integration seam**: `VectorSearchViaEmbeddingMixin.search_by_embedding` (`opencontractserver/shared/mixins.py`). **Scope: document, annotation, and note search** — the parent kinds whose querysets inherit the mixin — so GraphQL semantic search, Discover, MCP `search_corpus` passages, agent tools, and hybrid RRF over those kinds inherit the toggle with zero caller changes. Conversation/ChatMessage/Relationship vector search deliberately stays on pgvector for now (their reads use separate inline implementations with a different result contract; documented follow-up — see `EMBEDDABLE_PARENT_KINDS`), and their writes are correspondingly not fanned out to the index.
- **Permissions preserved by construction**: the engine stores only `(parent_pk, vector)`; candidate ids are re-filtered through the caller's already-scoped queryset (`visible_to_user`, MIN(document, corpus), structural rules), with capped oversampling and a shortfall rule that falls back to pgvector rather than under-filling. Deleted rows drop out at the same re-filter. The index blobs carry no ACL — system check `opencontracts.W004` warns when the backend is enabled over storage with public-read signals (AWS + GCS).
- **Write path**: fan-out from `Embedding.objects.store_embedding` (the in-app pipeline chokepoint) plus explicit hooks in `worker_uploads/tasks.py`'s bulk writes, via `opencontractserver/tasks/vector_index_tasks.py`, with autoretry and pending-marker-gated auto-compaction (cache-lock serialised, deferred GC by one generation); fire-and-forget — an index sync failure never breaks the Postgres write.
- **Ops**: `manage.py rebuild_object_vector_index` (batched, `--dry-run`, progress, lock-aware) replays Postgres embeddings into the index; system checks `opencontracts.E002` (invalid backend value) and `W003` (process-local cache vs compaction lock); tuning constants in `opencontractserver/constants/search.py`.

## Testing

- **38 tests** (`opencontractserver/tests/test_object_storage_vector_backend.py`): engine-level (WAL-only strong consistency, compaction parity with numpy brute force, tombstones, overwrite ordering, determinism, recall, manifest mid-overwrite retry, WAL/manifest read-ordering race, deferred/partial GC, put_bytes overwrite races) and Django integration (toggle both ways, queryset scoping, all fallback paths incl. filter shortfall and fetch-cap, end-to-end `CoreAnnotationVectorStore` caller, worker-upload direct-write fan-out, rebuild command incl. dry-run + lock contention, auto-compaction gating, read/write kind symmetry, E002/W003/W004 checks).
- **Regression**: existing search/embedding suites (incl. conversation, subtree-group, and worker-upload suites) and the 92 architecture-invariant tests — all pass.
- **Real object-storage verification**: engine exercised end-to-end against **MinIO via the S3 API** (`docs/test_scripts/object_storage_vector_backend_minio.md`) and **fake-gcs-server via the GCS JSON API** through django-storages `GoogleCloudStorage` (`docs/test_scripts/object_storage_vector_backend_gcs.md`) — all three supported storage backends (LOCAL/AWS/GCP) verified.

## Limitations / future work (documented in the design doc)

Vector arm only (FTS/hybrid RRF unchanged in Postgres); document/annotation/note kinds only (conversation/message/relationship read paths are the named follow-up); async write-visibility window (Celery lag vs turbopuffer's synchronous ack); no group commit (~3 object-store roundtrips per online write — bulk jobs should use the rebuild command); lazy deletes; wall-clock WAL ordering under worker clock skew; non-atomic manifest overwrite (retry-mitigated; S3 conditional PUT named as the permanent fix); full recluster per compaction; per-process cache only; deployment-wide (not corpus-sharded) namespaces.