### PR TITLE
Close review gaps in graphene→strawberry migration (FK-traversal IDOR, rate bucket, served-validation test)

### DIFF
--- a/changelog.d/2139-fk-traversal-idor.security.md
+++ b/changelog.d/2139-fk-traversal-idor.security.md
@@ -1,0 +1,31 @@
+- Closed a systematic cross-boundary information-disclosure regression in the
+  graphene→strawberry migration: **singular to-one FK object fields lost their
+  per-row visibility filter.** graphene-django auto-converted a FK whose target
+  type overrode `get_queryset` into a permission-filtered resolver
+  (`convert_field_to_djangomodel` → `target.get_node`), so an invisible FK
+  target resolved to `null`. The strawberry port declared these as plain
+  getattr fields, leaking the target row's fields across a permission boundary.
+  Added `config/graphql/core/relay.py::resolve_visible_fk` (applies the target
+  type's registered `get_node`/`get_queryset` hook) and routed the affected
+  **nullable** FK fields through it, restoring the graphene contract. Fields
+  fixed include the confirmed-exploitable cross-boundary edges —
+  `AnnotationType.corpus`, `RelationshipType.corpus`/`document`,
+  `CorpusReferenceType.targetDocument`/`targetCorpus`/`targetAnnotation`,
+  `ConversationType.chatWithCorpus`/`chatWithDocument`,
+  `MessageType.sourceDocument`, `DocumentType.parent`/`sourceDocument`,
+  `CorpusType.parent`/`memoryDocument` — plus the lower-severity theoretical
+  edges on `agent_types`/`extract_types`/`social_types`/`user_types`/
+  `research_types`/`document_types` for consistency.
+- `config/graphql/document_types.py::_get_queryset_DocumentPathType`: the
+  **non-null** `DocumentPathType.document` FK cannot resolve to `null`, so its
+  leak (DocumentPath membership is corpus-as-gate — a public/shared corpus
+  lists paths for its *private* documents too) is closed at the list level by
+  adding a `document_id__in=<visible documents>` MIN(document, corpus) filter,
+  the same semantic `CorpusType.documents` uses (issue #1682).
+- FK edges whose source-row visibility already implies READ on the target
+  (e.g. `NoteType.corpus`/`document`, `DocumentRelationshipType.*`, corpus-gated
+  `*.corpus`, same-parent `parent`) are left as fast plain fields — filtering
+  them is a no-op that only adds per-row queries.
+- Regression coverage: `opencontractserver/tests/test_fk_visibility_traversal.py`
+  pins both branches of `resolve_visible_fk`, the DocumentPath MIN filter, and an
+  end-to-end schema query (`CorpusType.parent` → `null` for a non-owner).

--- a/changelog.d/2139-review-followups.fixed.md
+++ b/changelog.d/2139-review-followups.fixed.md
@@ -1,0 +1,34 @@
+- Review follow-ups to the graphene→strawberry migration:
+  - `config/graphql/core/mutations.py`: `drf_mutation`/`drf_deletion` now pass
+    `group="mutate"` to `graphql_ratelimit`. The decorator was applied to a
+    `lambda`, so it derived the rate-limit cache group from `func.__name__`
+    (`"<lambda>"`), splitting the ~9 DRF-routed mutations (`updateAnnotation`,
+    `deleteNote`, `createCorpus`, `updateCorpus`, `deleteCorpusAction`,
+    `updateDocument`, `deleteDocument`, `deleteExport`, `deleteExtract`) into a
+    separate write bucket and roughly doubling a user's combined write budget.
+    They now share the single `"mutate"` fixed-window counter, matching the
+    graphene baseline and every hand-ported mutation.
+  - `config/graphql/core/relay.py::get_node_from_global_id`: the `entry.get_node`
+    hook path is now wrapped in the same `(ValueError, TypeError, OverflowError)`
+    guard the default queryset path already had, so a malformed pk reaching an
+    `int(pk)` hook (e.g. `researchReport(id: base64("ResearchReportType:xyz"))`)
+    returns the unified IDOR-safe not-found instead of surfacing a raw
+    `ValueError`.
+  - `opencontractserver/tests/test_security_hardening.py`: added
+    `TestServedSchemaExecutesValidationRules`, which drives a too-deep query and
+    an introspection query through `schema.execute_sync` (the real
+    `AddValidationRules` extension path). The pre-existing depth/introspection
+    tests only call graphql-core's `validate(..., validation_rules)` against the
+    exported list, so they would keep passing even if `AddValidationRules` were
+    dropped from the schema's `extensions` (depth-limiting / prod
+    introspection-blocking silently disabled on the endpoint). This closes that
+    coverage gap.
+  - `config/settings/base.py`: removed the dead `ALLOW_GRAPHQL_DEBUG` setting —
+    its only consumer, `graphene_django.debug.DjangoDebugMiddleware`, was deleted
+    with the graphene stack.
+  - Corrected the stale relay/`MessageType` note in
+    `config/graphql/core/relay.py` and `docs/architecture/graphql_strawberry_migration.md`,
+    which described singular node resolution as unfiltered-by-pk for
+    `MessageType`/`chatMessage`; the migration's own IDOR fix registered a
+    permission-aware `get_node` hook, and the doc now documents the
+    `resolve_visible_fk` FK-traversal path as well.

--- a/config/graphql/agent_types.py
+++ b/config/graphql/agent_types.py
@@ -41,6 +41,7 @@ from config.graphql.core.relay import (
     make_connection_types,
     register_type,
     resolve_django_connection,
+    resolve_visible_fk,
 )
 from config.graphql.core.scalars import GenericScalar, JSONString
 from config.graphql.filters import AnnotationFilter
@@ -550,22 +551,31 @@ class CorpusActionExecutionType(Node):
         description="The corpus action configuration that was executed",
         default=None,
     )
-    document: None | (
-        Annotated[DocumentType, strawberry.lazy("config.graphql.document_types")]
-    ) = strawberry.field(
+
+    @strawberry.field(
         name="document",
         description="The document this action was executed on (null for thread-based actions)",
-        default=None,
     )
-    conversation: None | (
+    def document(
+        self, info: strawberry.Info
+    ) -> None | (
+        Annotated[DocumentType, strawberry.lazy("config.graphql.document_types")]
+    ):
+        return resolve_visible_fk(self, info, "document_id", "DocumentType")
+
+    @strawberry.field(
+        name="conversation",
+        description="The thread that triggered this execution (for thread-based actions)",
+    )
+    def conversation(
+        self, info: strawberry.Info
+    ) -> None | (
         Annotated[
             ConversationType, strawberry.lazy("config.graphql.conversation_types")
         ]
-    ) = strawberry.field(
-        name="conversation",
-        description="The thread that triggered this execution (for thread-based actions)",
-        default=None,
-    )
+    ):
+        return resolve_visible_fk(self, info, "conversation_id", "ConversationType")
+
     message: None | (
         Annotated[MessageType, strawberry.lazy("config.graphql.conversation_types")]
     ) = strawberry.field(
@@ -804,13 +814,15 @@ class AgentConfigurationType(Node):
             enums.AgentsAgentConfigurationScopeChoices, getattr(self, "scope", None)
         )
 
-    corpus: None | (
-        Annotated[CorpusType, strawberry.lazy("config.graphql.corpus_types")]
-    ) = strawberry.field(
+    @strawberry.field(
         name="corpus",
         description="Corpus this agent belongs to (if scope=CORPUS)",
-        default=None,
     )
+    def corpus(
+        self, info: strawberry.Info
+    ) -> None | (Annotated[CorpusType, strawberry.lazy("config.graphql.corpus_types")]):
+        return resolve_visible_fk(self, info, "corpus_id", "CorpusType")
+
     is_active: bool = strawberry.field(
         name="isActive",
         description="Whether this agent is active and can be used",
@@ -905,31 +917,46 @@ class AgentActionResultType(Node):
         description="The corpus action that triggered this execution",
         default=None,
     )
-    document: None | (
-        Annotated[DocumentType, strawberry.lazy("config.graphql.document_types")]
-    ) = strawberry.field(
+
+    @strawberry.field(
         name="document",
         description="The document this action was run on (null for thread-based actions)",
-        default=None,
     )
-    conversation: None | (
-        Annotated[
-            ConversationType, strawberry.lazy("config.graphql.conversation_types")
-        ]
-    ) = strawberry.field(
+    def document(
+        self, info: strawberry.Info
+    ) -> None | (
+        Annotated[DocumentType, strawberry.lazy("config.graphql.document_types")]
+    ):
+        return resolve_visible_fk(self, info, "document_id", "DocumentType")
+
+    @strawberry.field(
         name="conversation",
         description="Conversation record containing the full agent interaction",
-        default=None,
     )
-    triggering_conversation: None | (
+    def conversation(
+        self, info: strawberry.Info
+    ) -> None | (
         Annotated[
             ConversationType, strawberry.lazy("config.graphql.conversation_types")
         ]
-    ) = strawberry.field(
+    ):
+        return resolve_visible_fk(self, info, "conversation_id", "ConversationType")
+
+    @strawberry.field(
         name="triggeringConversation",
         description="Thread that triggered this agent action (for thread-based triggers)",
-        default=None,
     )
+    def triggering_conversation(
+        self, info: strawberry.Info
+    ) -> None | (
+        Annotated[
+            ConversationType, strawberry.lazy("config.graphql.conversation_types")
+        ]
+    ):
+        return resolve_visible_fk(
+            self, info, "triggering_conversation_id", "ConversationType"
+        )
+
     triggering_message: None | (
         Annotated[MessageType, strawberry.lazy("config.graphql.conversation_types")]
     ) = strawberry.field(

--- a/config/graphql/annotation_types.py
+++ b/config/graphql/annotation_types.py
@@ -44,6 +44,7 @@ from config.graphql.core.relay import (
     make_connection_types,
     register_type,
     resolve_django_connection,
+    resolve_visible_fk,
 )
 from config.graphql.core.scalars import GenericScalar
 from config.graphql.filters import (
@@ -361,9 +362,16 @@ class AnnotationType(Node):
         kwargs = strip_unset({})
         return _resolve_AnnotationType_document(self, info, **kwargs)
 
-    corpus: None | (
-        Annotated[CorpusType, strawberry.lazy("config.graphql.corpus_types")]
-    ) = strawberry.field(name="corpus", default=None)
+    @strawberry.field(name="corpus")
+    def corpus(
+        self, info: strawberry.Info
+    ) -> None | (Annotated[CorpusType, strawberry.lazy("config.graphql.corpus_types")]):
+        # Permission-filtered FK traversal (graphene routed auto-converted FKs
+        # to CorpusType through CorpusType.get_queryset). A structural
+        # annotation reachable via one corpus must not leak a different,
+        # private corpus via its ``corpus_id``.
+        return resolve_visible_fk(self, info, "corpus_id", "CorpusType")
+
     analysis: None | (
         Annotated[AnalysisType, strawberry.lazy("config.graphql.extract_types")]
     ) = strawberry.field(name="analysis", default=None)
@@ -1736,12 +1744,20 @@ class RelationshipType(Node):
     relationship_label: AnnotationLabelType | None = strawberry.field(
         name="relationshipLabel", default=None
     )
-    corpus: None | (
-        Annotated[CorpusType, strawberry.lazy("config.graphql.corpus_types")]
-    ) = strawberry.field(name="corpus", default=None)
-    document: None | (
+
+    @strawberry.field(name="corpus")
+    def corpus(
+        self, info: strawberry.Info
+    ) -> None | (Annotated[CorpusType, strawberry.lazy("config.graphql.corpus_types")]):
+        return resolve_visible_fk(self, info, "corpus_id", "CorpusType")
+
+    @strawberry.field(name="document")
+    def document(
+        self, info: strawberry.Info
+    ) -> None | (
         Annotated[DocumentType, strawberry.lazy("config.graphql.document_types")]
-    ) = strawberry.field(name="document", default=None)
+    ):
+        return resolve_visible_fk(self, info, "document_id", "DocumentType")
 
     @strawberry.field(name="sourceAnnotations")
     def source_annotations(
@@ -2110,15 +2126,27 @@ class CorpusReferenceType(Node):
     source_annotation: AnnotationType = strawberry.field(
         name="sourceAnnotation", default=None
     )
-    target_annotation: AnnotationType | None = strawberry.field(
-        name="targetAnnotation", default=None
-    )
-    target_document: None | (
+
+    @strawberry.field(name="targetAnnotation")
+    def target_annotation(self, info: strawberry.Info) -> AnnotationType | None:
+        return resolve_visible_fk(self, info, "target_annotation_id", "AnnotationType")
+
+    @strawberry.field(name="targetDocument")
+    def target_document(
+        self, info: strawberry.Info
+    ) -> None | (
         Annotated[DocumentType, strawberry.lazy("config.graphql.document_types")]
-    ) = strawberry.field(name="targetDocument", default=None)
-    target_corpus: None | (
-        Annotated[CorpusType, strawberry.lazy("config.graphql.corpus_types")]
-    ) = strawberry.field(name="targetCorpus", default=None)
+    ):
+        # Cross-corpus enrichment references point at documents in corpora the
+        # caller may not see (the governance graph degrades these to "ghost"
+        # nodes). graphene returned null for an invisible target; preserve that.
+        return resolve_visible_fk(self, info, "target_document_id", "DocumentType")
+
+    @strawberry.field(name="targetCorpus")
+    def target_corpus(
+        self, info: strawberry.Info
+    ) -> None | (Annotated[CorpusType, strawberry.lazy("config.graphql.corpus_types")]):
+        return resolve_visible_fk(self, info, "target_corpus_id", "CorpusType")
 
     @strawberry.field(name="canonicalKey")
     def canonical_key(self, info: strawberry.Info) -> str | None:
@@ -2558,9 +2586,13 @@ class AuthorityNamespaceNode(Node):
         return coerce_str(getattr(self, "baseline_origin", None))
 
     is_global: bool = strawberry.field(name="isGlobal", default=None)
-    authority_corpus: None | (
-        Annotated[CorpusType, strawberry.lazy("config.graphql.corpus_types")]
-    ) = strawberry.field(name="authorityCorpus", default=None)
+
+    @strawberry.field(name="authorityCorpus")
+    def authority_corpus(
+        self, info: strawberry.Info
+    ) -> None | (Annotated[CorpusType, strawberry.lazy("config.graphql.corpus_types")]):
+        return resolve_visible_fk(self, info, "authority_corpus_id", "CorpusType")
+
     created: datetime.datetime = strawberry.field(name="created", default=None)
     modified: datetime.datetime = strawberry.field(name="modified", default=None)
 

--- a/config/graphql/conversation_types.py
+++ b/config/graphql/conversation_types.py
@@ -44,6 +44,7 @@ from config.graphql.core.relay import (
     make_connection_types,
     register_type,
     resolve_django_connection,
+    resolve_visible_fk,
 )
 from config.graphql.core.scalars import BigInt, GenericScalar
 from config.graphql.filters import AnnotationFilter
@@ -494,20 +495,28 @@ class ConversationType(Node):
         description="Cached count of downvotes for this conversation/thread",
         default=None,
     )
-    chat_with_corpus: None | (
-        Annotated[CorpusType, strawberry.lazy("config.graphql.corpus_types")]
-    ) = strawberry.field(
+
+    @strawberry.field(
         name="chatWithCorpus",
         description="The corpus to which this conversation belongs",
-        default=None,
     )
-    chat_with_document: None | (
-        Annotated[DocumentType, strawberry.lazy("config.graphql.document_types")]
-    ) = strawberry.field(
+    def chat_with_corpus(
+        self, info: strawberry.Info
+    ) -> None | (Annotated[CorpusType, strawberry.lazy("config.graphql.corpus_types")]):
+        # A public/shared conversation must not leak the private corpus it is
+        # attached to (conversation visibility is not gated on corpus READ).
+        return resolve_visible_fk(self, info, "chat_with_corpus_id", "CorpusType")
+
+    @strawberry.field(
         name="chatWithDocument",
         description="The document to which this conversation belongs",
-        default=None,
     )
+    def chat_with_document(
+        self, info: strawberry.Info
+    ) -> None | (
+        Annotated[DocumentType, strawberry.lazy("config.graphql.document_types")]
+    ):
+        return resolve_visible_fk(self, info, "chat_with_document_id", "DocumentType")
 
     @strawberry.field(
         name="compactionSummary",
@@ -1194,13 +1203,17 @@ class MessageType(Node):
         description="Timestamp when the message was soft-deleted",
         default=None,
     )
-    source_document: None | (
-        Annotated[DocumentType, strawberry.lazy("config.graphql.document_types")]
-    ) = strawberry.field(
+
+    @strawberry.field(
         name="sourceDocument",
         description="A document that this chat message is based on",
-        default=None,
     )
+    def source_document(
+        self, info: strawberry.Info
+    ) -> None | (
+        Annotated[DocumentType, strawberry.lazy("config.graphql.document_types")]
+    ):
+        return resolve_visible_fk(self, info, "source_document_id", "DocumentType")
 
     @strawberry.field(
         name="sourceAnnotations",
@@ -1997,11 +2010,14 @@ def _resolve_ModerationActionType_can_rollback(root, info, **kwargs):
 class ModerationActionType(Node):
     created: datetime.datetime = strawberry.field(name="created", default=None)
     modified: datetime.datetime = strawberry.field(name="modified", default=None)
-    conversation: ConversationType | None = strawberry.field(
+
+    @strawberry.field(
         name="conversation",
         description="The conversation that was moderated",
-        default=None,
     )
+    def conversation(self, info: strawberry.Info) -> ConversationType | None:
+        return resolve_visible_fk(self, info, "conversation_id", "ConversationType")
+
     message: MessageType | None = strawberry.field(
         name="message", description="The message that was moderated", default=None
     )

--- a/config/graphql/core/mutations.py
+++ b/config/graphql/core/mutations.py
@@ -59,7 +59,13 @@ def drf_mutation(
 ) -> Any:
     """Port of ``DRFMutation.mutate`` (create/update via DRF serializer)."""
     _require_login(info)
-    _ratelimited = graphql_ratelimit(rate=RateLimits.WRITE_MEDIUM)(
+    # ``group="mutate"`` keeps DRF-routed mutations in the SAME fixed-window
+    # rate bucket as every hand-ported ``mutate`` resolver. Without it the
+    # decorator derives the group from ``func.__name__`` — here a ``lambda``,
+    # i.e. ``"<lambda>"`` — splitting these off into a separate counter and
+    # roughly doubling a user's combined write budget. Matches the graphene
+    # baseline, where all mutations shared the one ``"mutate"`` group.
+    _ratelimited = graphql_ratelimit(rate=RateLimits.WRITE_MEDIUM, group="mutate")(
         lambda _root, _info, **kw: _drf_mutation_body(
             payload_cls=payload_cls,
             model=model,
@@ -185,7 +191,9 @@ def drf_deletion(
 ) -> Any:
     """Port of ``DRFDeletion.mutate`` — errors intentionally propagate raw."""
     _require_login(info)
-    _ratelimited = graphql_ratelimit(rate=RateLimits.WRITE_LIGHT)(
+    # See ``drf_mutation``: pin the shared ``"mutate"`` rate bucket rather than
+    # inheriting the lambda's ``"<lambda>"`` group.
+    _ratelimited = graphql_ratelimit(rate=RateLimits.WRITE_LIGHT, group="mutate")(
         lambda _root, _info, **kw: _drf_deletion_body(
             payload_cls=payload_cls,
             model=model,

--- a/config/graphql/core/relay.py
+++ b/config/graphql/core/relay.py
@@ -218,12 +218,18 @@ def get_node_from_global_id(
       ``get_queryset`` (the permission filter for types that define one; the
       identity manager for types that don't) and fetches by pk — **exactly**
       graphene-django's ``cls.get_queryset(model._default_manager, info)
-      .get(pk=id)``. This is deliberately NOT ``BaseService.get_or_none``:
-      graphene left types without a ``get_queryset`` (e.g. ``MessageType``)
-      resolving unfiltered by pk, with per-field resolvers enforcing
-      visibility (e.g. ``mentionedResources``). Over-filtering here silently
+      .get(pk=id)``. This is deliberately NOT a blanket
+      ``BaseService.get_or_none``: graphene left types WITHOUT a
+      ``get_queryset`` resolving unfiltered by pk here, with per-field
+      resolvers enforcing visibility, and over-filtering this path silently
       changed that contract (issue surfaced by
-      ``test_mentions.test_permission_enforcement_corpus``).
+      ``test_mentions.test_permission_enforcement_corpus``). Types whose
+      *singular* ``xxx(id:)`` lookup must stay permission-scoped instead
+      register an explicit ``get_node`` hook (the first bullet) — e.g.
+      ``MessageType`` now routes ``chatMessage(id:)`` through
+      ``BaseService.get_or_none`` (``_get_node_MessageType``), closing a
+      pre-existing unfiltered-``.get(pk)`` IDOR; ``test_singular_node_idor``
+      asserts every model-backed singular target carries such a hook.
 
     Returns the instance, or raises the model's ``DoesNotExist`` with a
     unified (IDOR-safe) message. Malformed pks (a global id passed where a
@@ -251,7 +257,14 @@ def get_node_from_global_id(
     )
 
     if entry.get_node is not None:
-        node = entry.get_node(info, _pk)
+        try:
+            node = entry.get_node(info, _pk)
+        except (ValueError, TypeError, OverflowError):
+            # Malformed / out-of-range pk from untrusted input reaching a
+            # ``get_node`` hook that casts it (e.g. ``int(pk)``) — treat as
+            # not-found, the same IDOR-safe branch the default path takes
+            # below, rather than surfacing a raw ``ValueError``.
+            raise not_found
         if node is None:
             raise not_found
         return node
@@ -579,3 +592,54 @@ def resolve_django_list(root: Any, info: Any, value: Any, node_type_name: str) -
             apply_type_get_queryset(node_type_name, queryset, info)
         )
     return queryset
+
+
+def resolve_visible_fk(
+    root: Any, info: Any, fk_id_attr: str, node_type_name: str
+) -> Any:
+    """Resolve a to-one FK field through the target type's visibility hook.
+
+    Ports graphene-django's ``convert_field_to_djangomodel`` behaviour: an
+    auto-generated FK / 1:1 field whose target ``DjangoObjectType`` overrode
+    ``get_queryset`` was resolved via ``target.get_node(info, fk_pk)`` →
+    ``get_queryset(...).get(pk)``, i.e. **permission-filtered per row**,
+    resolving to ``None`` when the FK target was not visible to the caller.
+
+    Strawberry's stock getattr resolver skips that filter — the connection /
+    list / relay-node paths funnel through ``apply_type_get_queryset`` but a
+    plain ``foo: T = strawberry.field(...)`` singular FK field does not — so
+    such a field would leak the target row's fields across a permission
+    boundary (e.g. an ``AnnotationType.corpus`` pointing at a private corpus,
+    or a ``CorpusReferenceType.targetDocument`` in another corpus). This helper
+    reinstates the target type's visibility filter.
+
+    ``fk_id_attr`` is the raw id column (e.g. ``"corpus_id"``) so the pk is
+    read off the already-loaded row without a DB hit. Returns ``None`` for a
+    missing/invisible target — only valid on a **nullable** FK field — or a
+    malformed stored id.
+    """
+    fk_pk = getattr(root, fk_id_attr, None)
+    if fk_pk is None:
+        return None
+    entry = _TYPE_REGISTRY.get(node_type_name)
+    if entry is None or entry.model is None:
+        # Unregistered / non-model target — fall back to the plain attribute.
+        return getattr(
+            root, fk_id_attr[:-3] if fk_id_attr.endswith("_id") else fk_id_attr, None
+        )
+    try:
+        if entry.get_node is not None:
+            # Permission-aware hook (e.g. ``BaseService.get_or_none``), which
+            # engages the request-scoped permission cache when passed the
+            # request via ``info.context``.
+            return entry.get_node(info, fk_pk)
+        if entry.get_queryset is not None:
+            queryset = apply_type_get_queryset(
+                node_type_name, entry.model._default_manager.get_queryset(), info
+            )
+            return queryset.filter(pk=fk_pk).first()
+        # No visibility hook on the target — parity with graphene's unfiltered
+        # default resolver.
+        return entry.model._default_manager.filter(pk=fk_pk).first()
+    except (ValueError, TypeError, OverflowError):
+        return None

--- a/config/graphql/corpus_types.py
+++ b/config/graphql/corpus_types.py
@@ -46,6 +46,7 @@ from config.graphql.core.relay import (
     make_connection_types,
     register_type,
     resolve_django_connection,
+    resolve_visible_fk,
 )
 from config.graphql.core.scalars import GenericScalar, JSONString
 from config.graphql.filters import AnnotationFilter
@@ -353,7 +354,9 @@ def _resolve_CorpusType_annotation_count(root, info):
 
 @strawberry.type(name="CorpusType")
 class CorpusType(Node):
-    parent: CorpusType | None = strawberry.field(name="parent", default=None)
+    @strawberry.field(name="parent")
+    def parent(self, info: strawberry.Info) -> CorpusType | None:
+        return resolve_visible_fk(self, info, "parent_id", "CorpusType")
 
     @strawberry.field(name="title")
     def title(self, info: strawberry.Info) -> str:
@@ -469,13 +472,17 @@ class CorpusType(Node):
         description="Enable agent memory system for this corpus. When enabled, agents accumulate reusable insights from conversations into a memory document.",
         default=None,
     )
-    memory_document: None | (
-        Annotated[DocumentType, strawberry.lazy("config.graphql.document_types")]
-    ) = strawberry.field(
+
+    @strawberry.field(
         name="memoryDocument",
         description="The Document storing accumulated agent memory for this corpus.",
-        default=None,
     )
+    def memory_document(
+        self, info: strawberry.Info
+    ) -> None | (
+        Annotated[DocumentType, strawberry.lazy("config.graphql.document_types")]
+    ):
+        return resolve_visible_fk(self, info, "memory_document_id", "DocumentType")
 
     @strawberry.field(
         name="license",

--- a/config/graphql/document_types.py
+++ b/config/graphql/document_types.py
@@ -47,6 +47,7 @@ from config.graphql.core.relay import (
     make_connection_types,
     register_type,
     resolve_django_connection,
+    resolve_visible_fk,
 )
 from config.graphql.core.scalars import GenericScalar, JSONString
 from config.graphql.custom_resolvers import resolve_doc_annotations_optimized
@@ -1022,7 +1023,10 @@ def _resolve_DocumentType_folder_in_corpus(root, info, corpus_id):
 
 @strawberry.type(name="DocumentType")
 class DocumentType(Node):
-    parent: DocumentType | None = strawberry.field(name="parent", default=None)
+    @strawberry.field(name="parent")
+    def parent(self, info: strawberry.Info) -> DocumentType | None:
+        return resolve_visible_fk(self, info, "parent_id", "DocumentType")
+
     user_lock: None | (
         Annotated[UserType, strawberry.lazy("config.graphql.user_types")]
     ) = strawberry.field(name="userLock", default=None)
@@ -1108,11 +1112,16 @@ class DocumentType(Node):
         description="True for newest content in this version tree. Implements Rule C3.",
         default=None,
     )
-    source_document: DocumentType | None = strawberry.field(
+
+    @strawberry.field(
         name="sourceDocument",
         description="Original document this was copied from (cross-corpus provenance). Implements Rule I2.",
-        default=None,
     )
+    def source_document(self, info: strawberry.Info) -> DocumentType | None:
+        # Cross-corpus provenance: a copied document must not leak its private
+        # origin document to a caller who lacks READ on the source.
+        return resolve_visible_fk(self, info, "source_document_id", "DocumentType")
+
     processing_started: datetime.datetime | None = strawberry.field(
         name="processingStarted", default=None
     )
@@ -2917,7 +2926,10 @@ def _resolve_DocumentPathType_action(root, info):
     description="GraphQL type for DocumentPath model - represents filesystem lifecycle events.",
 )
 class DocumentPathType(Node):
-    parent: DocumentPathType | None = strawberry.field(name="parent", default=None)
+    @strawberry.field(name="parent")
+    def parent(self, info: strawberry.Info) -> DocumentPathType | None:
+        return resolve_visible_fk(self, info, "parent_id", "DocumentPathType")
+
     user_lock: None | (
         Annotated[UserType, strawberry.lazy("config.graphql.user_types")]
     ) = strawberry.field(name="userLock", default=None)
@@ -2938,13 +2950,17 @@ class DocumentPathType(Node):
             name="corpus", description="Corpus owning this path", default=None
         )
     )
-    folder: None | (
-        Annotated[CorpusFolderType, strawberry.lazy("config.graphql.corpus_types")]
-    ) = strawberry.field(
+
+    @strawberry.field(
         name="folder",
         description="Current folder (null if folder deleted or at root)",
-        default=None,
     )
+    def folder(
+        self, info: strawberry.Info
+    ) -> None | (
+        Annotated[CorpusFolderType, strawberry.lazy("config.graphql.corpus_types")]
+    ):
+        return resolve_visible_fk(self, info, "folder_id", "CorpusFolderType")
 
     @strawberry.field(name="path", description="Full path in corpus filesystem")
     def path(self, info: strawberry.Info) -> str:
@@ -2963,11 +2979,15 @@ class DocumentPathType(Node):
         description="True for current filesystem state (Rule P3)",
         default=None,
     )
-    ingestion_source: IngestionSourceType | None = strawberry.field(
+
+    @strawberry.field(
         name="ingestionSource",
         description="Source integration that produced this version (null = manual upload)",
-        default=None,
     )
+    def ingestion_source(self, info: strawberry.Info) -> IngestionSourceType | None:
+        return resolve_visible_fk(
+            self, info, "ingestion_source_id", "IngestionSourceType"
+        )
 
     @strawberry.field(
         name="externalId",
@@ -3038,18 +3058,37 @@ class DocumentPathType(Node):
 
 
 def _get_queryset_DocumentPathType(queryset, info):
-    """Filter paths to current, non-deleted paths in visible corpuses."""
+    """Filter paths to current, non-deleted paths in visible corpuses whose
+    target document is also visible to the user.
+
+    The ``document_id`` filter enforces MIN(document, corpus) and closes a
+    cross-document leak: DocumentPath membership is corpus-gated, so a public
+    (or merely shared) corpus lists paths for its *private* documents too.
+    graphene filtered the **non-null** ``document`` FK through
+    ``DocumentType.get_queryset`` per row (an invisible target surfaced as a
+    non-null-violation error, never real data); strawberry's plain field
+    cannot resolve non-null to null, so the exclusion moves up to the list
+    level — the same MIN semantic ``CorpusType.documents`` already uses
+    (issue #1682).
+    """
+    from opencontractserver.documents.models import Document
+
     visible_corpus_ids = _docpath_visible_corpus_ids(info)
+    visible_document_ids = BaseService.filter_visible(
+        Document, info.context.user, request=info.context
+    ).values("id")
 
     if issubclass(type(queryset), QuerySet):
         return queryset.filter(
             corpus_id__in=visible_corpus_ids,
+            document_id__in=visible_document_ids,
             is_current=True,
             is_deleted=False,
         )
     elif "RelatedManager" in str(type(queryset)):
         return queryset.all().filter(
             corpus_id__in=visible_corpus_ids,
+            document_id__in=visible_document_ids,
             is_current=True,
             is_deleted=False,
         )

--- a/config/graphql/extract_types.py
+++ b/config/graphql/extract_types.py
@@ -42,6 +42,7 @@ from config.graphql.core.relay import (
     make_connection_types,
     register_type,
     resolve_django_connection,
+    resolve_visible_fk,
 )
 from config.graphql.core.scalars import GenericScalar
 from config.graphql.filters import AnnotationFilter
@@ -674,9 +675,12 @@ class ExtractType(Node):
         strawberry.field(name="creator", default=None)
     )
     modified: datetime.datetime = strawberry.field(name="modified", default=None)
-    corpus: None | (
-        Annotated[CorpusType, strawberry.lazy("config.graphql.corpus_types")]
-    ) = strawberry.field(name="corpus", default=None)
+
+    @strawberry.field(name="corpus")
+    def corpus(
+        self, info: strawberry.Info
+    ) -> None | (Annotated[CorpusType, strawberry.lazy("config.graphql.corpus_types")]):
+        return resolve_visible_fk(self, info, "corpus_id", "CorpusType")
 
     @strawberry.field(name="documents")
     def documents(
@@ -1280,13 +1284,14 @@ class FieldsetType(Node):
     def description(self, info: strawberry.Info) -> str:
         return coerce_str(getattr(self, "description", None))
 
-    corpus: None | (
-        Annotated[CorpusType, strawberry.lazy("config.graphql.corpus_types")]
-    ) = strawberry.field(
+    @strawberry.field(
         name="corpus",
         description="If set, this fieldset defines the metadata schema for the corpus",
-        default=None,
     )
+    def corpus(
+        self, info: strawberry.Info
+    ) -> None | (Annotated[CorpusType, strawberry.lazy("config.graphql.corpus_types")]):
+        return resolve_visible_fk(self, info, "corpus_id", "CorpusType")
 
     @strawberry.field(name="corpusactionSet")
     def corpusaction_set(
@@ -1993,9 +1998,12 @@ class AnalysisType(Node):
     def received_callback_file(self, info: strawberry.Info) -> str | None:
         return coerce_str(getattr(self, "received_callback_file", None))
 
-    analyzed_corpus: None | (
-        Annotated[CorpusType, strawberry.lazy("config.graphql.corpus_types")]
-    ) = strawberry.field(name="analyzedCorpus", default=None)
+    @strawberry.field(name="analyzedCorpus")
+    def analyzed_corpus(
+        self, info: strawberry.Info
+    ) -> None | (Annotated[CorpusType, strawberry.lazy("config.graphql.corpus_types")]):
+        return resolve_visible_fk(self, info, "analyzed_corpus_id", "CorpusType")
+
     corpus_action: None | (
         Annotated[CorpusActionType, strawberry.lazy("config.graphql.agent_types")]
     ) = strawberry.field(name="corpusAction", default=None)

--- a/config/graphql/research_types.py
+++ b/config/graphql/research_types.py
@@ -40,6 +40,7 @@ from config.graphql.core.relay import (
     make_connection_types,
     register_type,
     resolve_django_connection,
+    resolve_visible_fk,
 )
 from config.graphql.core.scalars import GenericScalar, JSONString
 from config.graphql.filters import AnnotationFilter
@@ -337,15 +338,19 @@ class ResearchReportType(Node):
             node_type_name="DocumentType",
         )
 
-    conversation: None | (
+    @strawberry.field(
+        name="conversation",
+        description="Chat conversation that kicked this off, if any",
+    )
+    def conversation(
+        self, info: strawberry.Info
+    ) -> None | (
         Annotated[
             ConversationType, strawberry.lazy("config.graphql.conversation_types")
         ]
-    ) = strawberry.field(
-        name="conversation",
-        description="Chat conversation that kicked this off, if any",
-        default=None,
-    )
+    ):
+        return resolve_visible_fk(self, info, "conversation_id", "ConversationType")
+
     originating_message: None | (
         Annotated[MessageType, strawberry.lazy("config.graphql.conversation_types")]
     ) = strawberry.field(

--- a/config/graphql/social_types.py
+++ b/config/graphql/social_types.py
@@ -39,6 +39,7 @@ from config.graphql.core.relay import (
     Node,
     make_connection_types,
     register_type,
+    resolve_visible_fk,
 )
 from config.graphql.core.scalars import GenericScalar, JSONString
 from opencontractserver.badges.models import Badge, UserBadge
@@ -264,13 +265,15 @@ class BadgeType(Node):
     def color(self, info: strawberry.Info) -> str:
         return coerce_str(getattr(self, "color", None))
 
-    corpus: None | (
-        Annotated[CorpusType, strawberry.lazy("config.graphql.corpus_types")]
-    ) = strawberry.field(
+    @strawberry.field(
         name="corpus",
         description="If badge_type is CORPUS, the corpus this badge belongs to",
-        default=None,
     )
+    def corpus(
+        self, info: strawberry.Info
+    ) -> None | (Annotated[CorpusType, strawberry.lazy("config.graphql.corpus_types")]):
+        return resolve_visible_fk(self, info, "corpus_id", "CorpusType")
+
     is_auto_awarded: bool = strawberry.field(
         name="isAutoAwarded",
         description="Whether this badge is automatically awarded based on criteria",
@@ -337,13 +340,15 @@ class UserBadgeType(Node):
         description="User who awarded the badge (null for auto-awards)",
         default=None,
     )
-    corpus: None | (
-        Annotated[CorpusType, strawberry.lazy("config.graphql.corpus_types")]
-    ) = strawberry.field(
+
+    @strawberry.field(
         name="corpus",
         description="For corpus-specific badges, the context in which it was awarded",
-        default=None,
     )
+    def corpus(
+        self, info: strawberry.Info
+    ) -> None | (Annotated[CorpusType, strawberry.lazy("config.graphql.corpus_types")]):
+        return resolve_visible_fk(self, info, "corpus_id", "CorpusType")
 
     @strawberry.field(name="myPermissions")
     def my_permissions(self, info: strawberry.Info) -> GenericScalar | None:

--- a/config/graphql/user_types.py
+++ b/config/graphql/user_types.py
@@ -42,6 +42,7 @@ from config.graphql.core.relay import (
     make_connection_types,
     register_type,
     resolve_django_connection,
+    resolve_visible_fk,
 )
 from config.graphql.core.scalars import GenericScalar, JSONString
 from config.graphql.filters import AnnotationFilter
@@ -4487,9 +4488,12 @@ class AssignmentType(Node):
     document: Annotated[
         DocumentType, strawberry.lazy("config.graphql.document_types")
     ] = strawberry.field(name="document", default=None)
-    corpus: None | (
-        Annotated[CorpusType, strawberry.lazy("config.graphql.corpus_types")]
-    ) = strawberry.field(name="corpus", default=None)
+
+    @strawberry.field(name="corpus")
+    def corpus(
+        self, info: strawberry.Info
+    ) -> None | (Annotated[CorpusType, strawberry.lazy("config.graphql.corpus_types")]):
+        return resolve_visible_fk(self, info, "corpus_id", "CorpusType")
 
     @strawberry.field(name="resultingAnnotations")
     def resulting_annotations(
@@ -4731,9 +4735,16 @@ class UserFeedbackType(Node):
         return coerce_str(getattr(self, "markdown", None))
 
     metadata: JSONString | None = strawberry.field(name="metadata", default=None)
-    commented_annotation: None | (
+
+    @strawberry.field(name="commentedAnnotation")
+    def commented_annotation(
+        self, info: strawberry.Info
+    ) -> None | (
         Annotated[AnnotationType, strawberry.lazy("config.graphql.annotation_types")]
-    ) = strawberry.field(name="commentedAnnotation", default=None)
+    ):
+        return resolve_visible_fk(
+            self, info, "commented_annotation_id", "AnnotationType"
+        )
 
     @strawberry.field(name="myPermissions")
     def my_permissions(self, info: strawberry.Info) -> GenericScalar | None:

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -72,10 +72,6 @@ if env.bool("USE_AWS", default=None) is not None:
 USE_ANALYZER = env.bool("USE_ANALYZER", False)
 CALLBACK_ROOT_URL_FOR_ANALYZER = env.str("CALLBACK_ROOT_URL_FOR_ANALYZER", None)
 
-# Allow Graphene Django Debug Toolbar middleware
-# Default to False for performance - only enable when actually debugging
-ALLOW_GRAPHQL_DEBUG = env.bool("ALLOW_GRAPHQL_DEBUG", default=False)
-
 # Set max file upload size to 5 GB for large corpuses
 DATA_UPLOAD_MAX_MEMORY_SIZE = MAX_FILE_UPLOAD_SIZE_BYTES
 # Local time zone. Choices are

--- a/docs/architecture/graphql_strawberry_migration.md
+++ b/docs/architecture/graphql_strawberry_migration.md
@@ -30,11 +30,23 @@ Reproduces graphene / graphene-django behaviours on top of strawberry:
   `offset`→`after`, `RELAY_CONNECTION_MAX_LIMIT = 100`).
   - **Node resolution matches graphene-django's default `get_node`**
     (`type.get_queryset(model._default_manager, info).get(pk=id)`), NOT a
-    blanket permission filter: types without a `get_queryset` resolve
-    unfiltered by pk with per-field resolvers enforcing visibility
-    (e.g. `MessageType` / `chatMessage`); types with one filter. `CorpusType`
-    keeps a permission-aware custom `get_node` (the ported `OpenContractsNode`).
-    Pinned by `test_mentions.test_permission_enforcement_corpus`.
+    blanket permission filter: a type without a `get_queryset` resolves
+    unfiltered by pk on the DEFAULT path, with per-field resolvers enforcing
+    visibility; a type with one filters. Pinned by
+    `test_mentions.test_permission_enforcement_corpus`.
+  - A type whose singular `xxx(id:)` lookup must stay permission-scoped
+    registers an explicit `get_node` hook instead (`CorpusType` ported
+    `OpenContractsNode`; `MessageType`/`chatMessage`, `datacell`, `badge`,
+    `userexport`, … route through `BaseService.get_or_none` / a service). This
+    closed a class of pre-existing unfiltered-`.get(pk)` IDORs;
+    `test_singular_node_idor` asserts every model-backed singular target has a
+    hook so the fallback can never silently re-expose one.
+  - **Singular to-one FK object fields** (e.g. `AnnotationType.corpus`,
+    `CorpusReferenceType.targetDocument`) resolve through
+    `core/relay.py::resolve_visible_fk`, which applies the *target* type's
+    `get_node`/`get_queryset` visibility hook — reproducing graphene-django's
+    auto-converted-FK `CustomField`, so an invisible FK target resolves to
+    `null` rather than leaking its fields across a permission boundary.
   - `register_type` also installs graphene-compat `resolve_<field>`
     staticmethod aliases (delegating to the `_resolve_<Type>_<field>` module
     functions) so unit tests that call resolvers directly keep working. These

--- a/opencontractserver/tests/test_fk_visibility_traversal.py
+++ b/opencontractserver/tests/test_fk_visibility_traversal.py
@@ -1,0 +1,274 @@
+"""Regression tests for permission-filtered singular FK object traversal.
+
+graphene-django auto-converted a to-one FK whose target ``DjangoObjectType``
+overrode ``get_queryset`` into a permission-filtered resolver
+(``convert_field_to_djangomodel``): an invisible FK target resolved to
+``null``. The strawberry port initially declared these FKs as plain getattr
+fields, which leaked the target row's fields across a permission boundary
+(e.g. ``AnnotationType.corpus`` / ``CorpusReferenceType.targetDocument`` /
+``ConversationType.chatWithCorpus`` pointing at a private corpus/document).
+
+``config.graphql.core.relay.resolve_visible_fk`` reinstates the target type's
+visibility hook for singular FK fields; these tests pin both branches of it
+(``get_queryset`` and ``get_node``), the non-null ``DocumentPathType.document``
+list-level MIN filter that closes the same leak where the field cannot be
+null, and one end-to-end schema query.
+"""
+
+from __future__ import annotations
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from graphql_relay import to_global_id
+
+from config.graphql.core.relay import resolve_visible_fk
+from config.graphql.schema import schema
+from config.graphql.testing import Client
+from opencontractserver.conversations.models import Conversation
+from opencontractserver.corpuses.models import Corpus
+from opencontractserver.documents.models import Document, DocumentPath
+from opencontractserver.types.enums import PermissionTypes
+from opencontractserver.utils.permissioning import set_permissions_for_obj_to_user
+
+User = get_user_model()
+
+
+class _Ctx:
+    """Minimal Django-request-like GraphQL context (carries ``user``)."""
+
+    def __init__(self, user):
+        self.user = user
+        self.META = {}
+
+
+class _Info:
+    """Minimal ``strawberry.Info``-like stand-in for direct resolver calls."""
+
+    def __init__(self, user):
+        self.context = _Ctx(user)
+
+
+class _Row:
+    """Lightweight stand-in for a Django row exposing only FK id columns."""
+
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+class FkVisibilityHelperTests(TestCase):
+    """``resolve_visible_fk`` filters through the target type's visibility hook."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.owner = User.objects.create_user(username="fk_owner", password="pw")
+        cls.outsider = User.objects.create_user(username="fk_outsider", password="pw")
+
+        cls.private_corpus = Corpus.objects.create(
+            title="Private Corpus", creator=cls.owner, is_public=False
+        )
+        set_permissions_for_obj_to_user(
+            cls.owner, cls.private_corpus, [PermissionTypes.CRUD]
+        )
+
+        cls.private_doc = Document.objects.create(
+            title="Private Doc", creator=cls.owner, is_public=False
+        )
+        set_permissions_for_obj_to_user(
+            cls.owner, cls.private_doc, [PermissionTypes.CRUD]
+        )
+
+        # Private conversations whose FKs point at the private corpus/document.
+        # A Conversation may attach to a corpus OR a document, not both
+        # (``chat_type_mutual_exclusivity_constraint``), so use two rows.
+        cls.conversation = Conversation.objects.create(
+            title="Conv-corpus",
+            creator=cls.owner,
+            is_public=False,
+            chat_with_corpus=cls.private_corpus,
+        )
+        cls.conversation_doc = Conversation.objects.create(
+            title="Conv-doc",
+            creator=cls.owner,
+            is_public=False,
+            chat_with_document=cls.private_doc,
+        )
+
+    # --- get_queryset branch (CorpusType / DocumentType) ------------------- #
+
+    def test_get_queryset_target_hidden_for_outsider(self) -> None:
+        info = _Info(self.outsider)
+        self.assertIsNone(
+            resolve_visible_fk(
+                self.conversation, info, "chat_with_corpus_id", "CorpusType"
+            ),
+            "private corpus leaked through a plain FK field",
+        )
+        self.assertIsNone(
+            resolve_visible_fk(
+                self.conversation_doc, info, "chat_with_document_id", "DocumentType"
+            ),
+            "private document leaked through a plain FK field",
+        )
+
+    def test_get_queryset_target_visible_for_owner(self) -> None:
+        info = _Info(self.owner)
+        self.assertEqual(
+            resolve_visible_fk(
+                self.conversation, info, "chat_with_corpus_id", "CorpusType"
+            ),
+            self.private_corpus,
+        )
+        self.assertEqual(
+            resolve_visible_fk(
+                self.conversation_doc, info, "chat_with_document_id", "DocumentType"
+            ),
+            self.private_doc,
+        )
+
+    # --- get_node branch (ConversationType) -------------------------------- #
+
+    def test_get_node_target_hidden_for_outsider(self) -> None:
+        row = _Row(conversation_id=self.conversation.pk)
+        self.assertIsNone(
+            resolve_visible_fk(
+                row, _Info(self.outsider), "conversation_id", "ConversationType"
+            ),
+            "private conversation leaked through a plain FK field",
+        )
+
+    def test_get_node_target_visible_for_owner(self) -> None:
+        row = _Row(conversation_id=self.conversation.pk)
+        self.assertEqual(
+            resolve_visible_fk(
+                row, _Info(self.owner), "conversation_id", "ConversationType"
+            ),
+            self.conversation,
+        )
+
+    # --- edge cases -------------------------------------------------------- #
+
+    def test_null_fk_returns_none(self) -> None:
+        self.assertIsNone(
+            resolve_visible_fk(
+                _Row(corpus_id=None), _Info(self.owner), "corpus_id", "CorpusType"
+            )
+        )
+
+    def test_malformed_fk_returns_none(self) -> None:
+        # A non-numeric id reaching an ``int(pk)`` hook must not raise.
+        self.assertIsNone(
+            resolve_visible_fk(
+                _Row(conversation_id="not-a-pk"),
+                _Info(self.owner),
+                "conversation_id",
+                "ConversationType",
+            )
+        )
+
+
+class DocumentPathMinVisibilityTests(TestCase):
+    """DocumentPath list enforces MIN(document, corpus) — the non-null
+    ``DocumentPathType.document`` cannot resolve to null, so paths pointing at
+    documents the caller may not see are excluded at the list level."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.owner = User.objects.create_user(username="dp_owner", password="pw")
+        cls.viewer = User.objects.create_user(username="dp_viewer", password="pw")
+
+        # Public corpus: readable by anyone (corpus-as-gate would surface all
+        # of its paths).
+        cls.corpus = Corpus.objects.create(
+            title="Public Corpus", creator=cls.owner, is_public=True
+        )
+        cls.public_doc = Document.objects.create(
+            title="Public Doc", creator=cls.owner, is_public=True
+        )
+        cls.private_doc = Document.objects.create(
+            title="Private Doc", creator=cls.owner, is_public=False
+        )
+        set_permissions_for_obj_to_user(
+            cls.owner, cls.private_doc, [PermissionTypes.CRUD]
+        )
+        for doc in (cls.public_doc, cls.private_doc):
+            DocumentPath.objects.create(
+                document=doc,
+                corpus=cls.corpus,
+                folder=None,
+                path=f"/{doc.title}",
+                version_number=1,
+                parent=None,
+                is_current=True,
+                is_deleted=False,
+                creator=cls.owner,
+                backend_lock=False,
+                is_public=doc.is_public,
+            )
+
+    def _visible_document_ids(self, user):
+        from config.graphql.document_types import _get_queryset_DocumentPathType
+
+        qs = _get_queryset_DocumentPathType(DocumentPath.objects.all(), _Info(user))
+        return set(qs.values_list("document_id", flat=True))
+
+    def test_private_document_path_excluded_for_non_owner(self) -> None:
+        doc_ids = self._visible_document_ids(self.viewer)
+        self.assertIn(self.public_doc.id, doc_ids)
+        self.assertNotIn(
+            self.private_doc.id,
+            doc_ids,
+            "a private document's path is listed in a public corpus (leak)",
+        )
+
+    def test_owner_sees_all_paths(self) -> None:
+        doc_ids = self._visible_document_ids(self.owner)
+        self.assertIn(self.public_doc.id, doc_ids)
+        self.assertIn(self.private_doc.id, doc_ids)
+
+
+class FkVisibilitySchemaTests(TestCase):
+    """End-to-end: a nullable FK to an invisible target resolves to ``null``
+    through the served schema (``CorpusType.parent``)."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.owner = User.objects.create_user(username="s_owner", password="pw")
+        cls.outsider = User.objects.create_user(username="s_outsider", password="pw")
+
+        cls.private_parent = Corpus.objects.create(
+            title="Secret Parent", creator=cls.owner, is_public=False
+        )
+        set_permissions_for_obj_to_user(
+            cls.owner, cls.private_parent, [PermissionTypes.CRUD]
+        )
+        cls.public_child = Corpus.objects.create(
+            title="Public Child",
+            creator=cls.owner,
+            is_public=True,
+            parent=cls.private_parent,
+        )
+
+    def _query_parent_as(self, user):
+        return Client(schema).execute(
+            "query($id: ID!) { corpus(id: $id) { id parent { id title } } }",
+            variables={"id": to_global_id("CorpusType", self.public_child.id)},
+            context_value=_Ctx(user),
+        )
+
+    def test_outsider_cannot_see_private_parent_corpus(self) -> None:
+        result = self._query_parent_as(self.outsider)
+        node = result["data"]["corpus"]
+        self.assertIsNotNone(node, f"public child not visible: {result}")
+        self.assertIsNone(
+            node["parent"],
+            "private parent corpus leaked via CorpusType.parent traversal",
+        )
+
+    def test_owner_sees_private_parent_corpus(self) -> None:
+        result = self._query_parent_as(self.owner)
+        node = result["data"]["corpus"]
+        self.assertIsNotNone(node["parent"], f"owner denied their own parent: {result}")
+        self.assertEqual(
+            node["parent"]["id"],
+            to_global_id("CorpusType", self.private_parent.id),
+        )

--- a/opencontractserver/tests/test_security_hardening.py
+++ b/opencontractserver/tests/test_security_hardening.py
@@ -2053,3 +2053,52 @@ class TestServedValidationRulesIncludeSpecRules(TestCase):
         document = parse(f"query {{ corpuses {{ edges {{ node {{ {inner} }} }} }} }}")
         errors = validate(schema.graphql_schema, document, validation_rules)
         self.assertTrue(any("depth" in str(e).lower() for e in errors))
+
+
+class TestServedSchemaExecutesValidationRules(TestCase):
+    """The security rules must be wired into the SERVED schema, not merely
+    present in the exported ``validation_rules`` list.
+
+    Strawberry enforces them via the ``AddValidationRules`` schema extension
+    (``config/graphql/schema.py``); ``validation_rules`` itself is exported only
+    for tooling/tests and is NOT what the endpoint consults. The tests above
+    call graphql-core's ``validate(..., validation_rules)`` directly, so they
+    would keep passing even if ``AddValidationRules`` were dropped from the
+    schema's ``extensions`` (depth-limiting / prod introspection-blocking
+    silently disabled on the live endpoint). These exercise the real path —
+    ``schema.execute_sync`` runs the extension stack — so removing the
+    extension makes them fail.
+    """
+
+    def test_deep_query_rejected_through_served_execution(self):
+        from config.graphql.schema import schema
+
+        # Corpus.parent recursion: spec-valid but deeper than the cap.
+        inner = "id"
+        for _ in range(30):
+            inner = f"parent {{ {inner} }}"
+        query = f"query {{ corpuses {{ edges {{ node {{ {inner} }} }} }} }}"
+        result = schema.execute_sync(query)
+        self.assertIsNotNone(
+            result.errors,
+            "depth-limit rule is not wired into the served schema (AddValidationRules)",
+        )
+        self.assertTrue(any("depth" in str(e).lower() for e in result.errors))
+
+    def test_introspection_blocked_through_served_execution(self):
+        from django.conf import settings
+
+        from config.graphql.schema import schema
+
+        if settings.DEBUG:
+            self.skipTest("introspection is intentionally allowed when DEBUG=True")
+
+        result = schema.execute_sync("{ __schema { types { name } } }")
+        self.assertIsNotNone(
+            result.errors,
+            "introspection is not blocked on the served schema outside DEBUG",
+        )
+        self.assertTrue(
+            any("introspection" in str(e).lower() for e in result.errors),
+            f"unexpected errors: {result.errors}",
+        )

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -73,6 +73,7 @@ django-guardian
 # GraphQL
 # ------------------------------------------------------------------------------
 strawberry-graphql==0.320.3  # code-first GraphQL; replaced graphene-django (schema parity pinned by config/graphql/schema.graphql)
+graphql-relay==3.2.0  # relay global-id / connection helpers imported directly by config/graphql/* (to_global_id, from_global_id, connection_from_array_slice); pinned explicitly rather than relying on the transitive pull via django-graphql-jwt
 django-graphql-jwt==0.4.0  # JWT signing/backends + refresh-token utilities only — its graphene middleware/mutations are replaced by strawberry ports (config/graphql/views.py, jwt_auth.py, user_mutations.py)
 
 # Telemetry


### PR DESCRIPTION
Stacks on top of the migration branch (`claude/graphene-strawberry-migration-eyvj57`, PR #2139) and closes the gaps found reviewing that migration. Base is the migration branch so this diff is only the fixes.

## 1. High — singular FK-object traversal lost its visibility filter (systematic)

graphene-django auto-converted a to-one FK whose target type overrode `get_queryset` into a permission-filtered resolver (`convert_field_to_djangomodel` → `target.get_node`), so an invisible FK target resolved to `null`. The strawberry port declared these as plain getattr fields, leaking the target row's fields across a permission boundary. Node/connection/list paths already funnel through `apply_type_get_queryset`; **singular FK fields never did.**

- Added `config/graphql/core/relay.py::resolve_visible_fk`, which applies the target type's registered `get_node`/`get_queryset` hook (returns `None` for an invisible/missing/malformed target).
- Routed the affected **nullable** FK fields through it across `annotation`/`agent`/`conversation`/`corpus`/`document`/`extract`/`research`/`social`/`user` types — including the confirmed-exploitable edges: `AnnotationType.corpus`, `RelationshipType.corpus`/`document`, `CorpusReferenceType.targetDocument`/`targetCorpus`/`targetAnnotation`, `ConversationType.chatWithCorpus`/`chatWithDocument`, `MessageType.sourceDocument`, `DocumentType.parent`/`sourceDocument`, `CorpusType.parent`/`memoryDocument`.
- **Non-null `DocumentPathType.document`** can't resolve to `null`, so its leak (DocumentPath membership is corpus-as-gate — a public corpus lists paths for its *private* documents too) is closed at the list level: `_get_queryset_DocumentPathType` now enforces `MIN(document, corpus)`, matching `CorpusType.documents` (issue #1682).
- FK edges whose source visibility already implies READ on the target (`NoteType.*`, `DocumentRelationshipType.*`, corpus-gated `*.corpus`, same-parent `parent`) are intentionally left as fast plain fields — filtering them is a no-op that only adds per-row queries.

## 2. Major — served-schema validation wiring was untested

Depth-limiting and prod introspection-blocking are enforced by the `AddValidationRules` extension in `schema.py`, but the existing tests only call graphql-core's `validate(..., validation_rules)` against the exported (decorative) list — they'd stay green if the extension were dropped. Added `TestServedSchemaExecutesValidationRules`, which drives a too-deep query and an introspection query through `schema.execute_sync` (the real extension path).

## 3. Minor

- `drf_mutation`/`drf_deletion` now pass `group="mutate"` — the ratelimit decorator was wrapping a `lambda`, so the ~9 DRF-routed mutations bucketed under `"<lambda>"` instead of the shared `"mutate"` write counter (roughly doubling combined write budget). No guard was dropped.
- `get_node_from_global_id` wraps the `get_node` hook path in the same malformed-pk guard as the default path, so `int(pk)` hooks return the unified not-found instead of a raw `ValueError`.
- Declared `graphql-relay==3.2.0` explicitly (imported directly by ~20 modules, previously only transitive via `django-graphql-jwt`).
- Removed the dead `ALLOW_GRAPHQL_DEBUG` setting; corrected the stale `MessageType` relay docstring + migration doc, which described singular node resolution as unfiltered despite the shipped IDOR hook.

## Verification

Run in-container against the strawberry schema:

- `test_fk_visibility_traversal` (new, 10 tests) — both `resolve_visible_fk` branches, the DocumentPath MIN filter, and an end-to-end `CorpusType.parent` → `null` for a non-owner.
- `test_schema_parity` — green (zero schema-shape change from the ~32 field conversions).
- `test_singular_node_idor`, served-validation classes — green.
- Regression: `test_document_versioning_graphql`, `test_corpus_cards_structural_document_resolution`, `test_versioning_paths_audit`, `test_mentions` — 95 tests green.
- `black`, `isort`, `flake8` clean; no inline Tier-0 introduced (E001 unaffected).

Two changelog fragments added (`2139-fk-traversal-idor.security.md`, `2139-review-followups.fixed.md`).

---
_Generated by [Claude Code](https://claude.ai/code/session_018fEb1ZFb8M9PS8opd1286g)_