### PR TITLE
Remove the dead vcrpy/aiohttp compat shim (closes #2140)

### DIFF
--- a/changelog.d/2140-vcr-aiohttp-shim.removed.md
+++ b/changelog.d/2140-vcr-aiohttp-shim.removed.md
@@ -1,0 +1,14 @@
+- Removed the now-dead `ensure_aiohttp_vcr_compat()` aiohttp/vcrpy compat shim
+  (`opencontractserver/utils/vcr_replay.py`) and its call sites in `conftest.py`
+  and `maybe_vcr_cassette()`. The shim restored
+  `aiohttp.streams.AsyncStreamReaderMixin`, a symbol aiohttp 3.14 removed and
+  vcrpy 8.1.1's aiohttp stub subclassed at import time (issue #1920). vcrpy
+  8.2.0 fixed the stub upstream (kevin1024/vcrpy#996) — `MockStream` no longer
+  inherits the mixin — so the shim has been a no-op since the pin moved to
+  8.2.1. Verified empirically against `vcrpy==8.3.0` + `aiohttp==3.14.1`:
+  entering a cassette with no shim applied succeeds. The `aiohttp>=3.13,<3.14`
+  cap this was paired with had already been lifted. The
+  `EnsureAiohttpVcrCompatTests` shim unit tests are replaced by
+  `VcrCassetteEntryTests` in `opencontractserver/tests/test_vcr_replay.py`,
+  which keeps the meaningful regression guard: entering a cassette (and thus
+  lazily importing `vcr/stubs/aiohttp_stubs.py`) must not raise. Closes #2140.

--- a/conftest.py
+++ b/conftest.py
@@ -11,17 +11,6 @@ import os
 import pytest
 from django import db
 
-from opencontractserver.utils.vcr_replay import ensure_aiohttp_vcr_compat
-
-# Many integration tests record/replay VCR cassettes. vcrpy 8.1.1 imports its
-# aiohttp stub lazily when a cassette is entered, and that stub subclasses
-# ``aiohttp.streams.AsyncStreamReaderMixin`` — a symbol aiohttp 3.14 removed — at
-# module-evaluation time. A fresh CI resolution that picks up aiohttp >= 3.14
-# would therefore make every VCR-using test raise AttributeError. Apply the
-# compat shim here, at conftest import, so the symbol exists before any test
-# runs. See opencontractserver/utils/vcr_replay.py and issue #1920.
-ensure_aiohttp_vcr_compat()
-
 
 @pytest.fixture(scope="session", autouse=True)
 def make_create_permissions_xdist_safe():

--- a/opencontractserver/tests/test_vcr_replay.py
+++ b/opencontractserver/tests/test_vcr_replay.py
@@ -34,7 +34,6 @@ from opencontractserver.utils.vcr_replay import (
     _VOLATILE_PATTERNS,
     _match_llm_body,
     _normalize_body,
-    ensure_aiohttp_vcr_compat,
     maybe_vcr_cassette,
 )
 
@@ -323,69 +322,37 @@ class MaybeVcrCassetteTests(TestCase):
                     self.assertIsNotNone(ctx)
 
 
-class EnsureAiohttpVcrCompatTests(TestCase):
-    """Regression for issue #1920 / kevin1024/vcrpy#995.
+class VcrCassetteEntryTests(TestCase):
+    """Guard the vcrpy <-> aiohttp import contract (issue #1920, #2140).
 
-    aiohttp 3.14 removed ``aiohttp.streams.AsyncStreamReaderMixin``, which the
-    pinned vcrpy 8.1.1 aiohttp stub subclasses at module-evaluation time. vcrpy
-    imports that stub lazily when a cassette is entered, so under aiohttp >= 3.14
-    every VCR cassette entry raises ``AttributeError``. The compat shim restores
-    the symbol so cassette entry works again.
+    Entering a cassette makes ``vcr/patch.py`` build its patchers, which imports
+    ``vcr/stubs/aiohttp_stubs.py`` — a module vcrpy evaluates lazily and that
+    this codebase never otherwise touches (we only record/replay *httpx* LLM
+    traffic; aiohttp is merely importable, transitively via llama-index-core).
+    That lazy import is exactly where vcrpy 8.1.1 blew up under aiohttp 3.14,
+    which had removed ``aiohttp.streams.AsyncStreamReaderMixin``: every cassette
+    entry raised ``AttributeError`` and aborted whole test runs.
+
+    vcrpy 8.2.0 fixed the stub upstream (kevin1024/vcrpy#996), so the local
+    compat shim was deleted in #2140. This test is what remains of that
+    regression guard: it fails if a future vcrpy/aiohttp pair reintroduces an
+    import-time incompatibility. ``import vcr`` alone does NOT trigger the stub,
+    which is why this enters a cassette rather than just importing.
     """
 
-    def test_mixin_symbol_present_after_shim(self):
-        try:
-            from aiohttp import streams
-        except ModuleNotFoundError:  # pragma: no cover - aiohttp always present
-            self.skipTest("aiohttp not installed")
-
-        had_real_symbol = hasattr(streams, "AsyncStreamReaderMixin")
-        original = getattr(streams, "AsyncStreamReaderMixin", None)
-
-        # Keep the test self-contained: restore the module to whatever state it
-        # was in before this test ran (the shim may add the symbol below).
-        def _restore() -> None:
-            if had_real_symbol:
-                setattr(streams, "AsyncStreamReaderMixin", original)
-            elif hasattr(streams, "AsyncStreamReaderMixin"):
-                delattr(streams, "AsyncStreamReaderMixin")
-
-        self.addCleanup(_restore)
-
-        ensure_aiohttp_vcr_compat()
-
-        # Whichever aiohttp is installed, the symbol must exist afterward so
-        # vcrpy's MockStream class statement can evaluate.
-        self.assertTrue(hasattr(streams, "AsyncStreamReaderMixin"))
-        if had_real_symbol:
-            # Under aiohttp < 3.14 the real mixin must be left untouched.
-            self.assertIs(getattr(streams, "AsyncStreamReaderMixin"), original)
-
-    def test_shim_is_idempotent(self):
-        # Called twice (conftest + maybe_vcr_cassette both invoke it) must not
-        # raise or swap the symbol out from under a prior call.
-        ensure_aiohttp_vcr_compat()
-        try:
-            from aiohttp import streams
-        except ModuleNotFoundError:  # pragma: no cover - aiohttp always present
-            self.skipTest("aiohttp not installed")
-        first = getattr(streams, "AsyncStreamReaderMixin")
-        ensure_aiohttp_vcr_compat()
-        self.assertIs(getattr(streams, "AsyncStreamReaderMixin"), first)
-
     def test_vcr_cassette_entry_works(self):
-        # The real contract: vcrpy imports its aiohttp stub lazily when a
-        # cassette is entered (vcr/patch.py builds its patchers). Under aiohttp
-        # >= 3.14 that stub subclasses the removed AsyncStreamReaderMixin and
-        # raises AttributeError. With the shim applied, entering an (empty)
-        # cassette must succeed. (`import vcr` alone does NOT trigger the stub,
-        # which is why this enters a cassette rather than just importing.)
-        ensure_aiohttp_vcr_compat()
         import vcr
 
         with tempfile.TemporaryDirectory() as td:
             with vcr.VCR().use_cassette(os.path.join(td, "regression.yaml")):
                 pass
+
+    def test_aiohttp_stub_is_importable(self):
+        # Pin the specific failure mode directly: the stub module must evaluate
+        # against the installed aiohttp without any shim in place.
+        import vcr.stubs.aiohttp_stubs as aiohttp_stubs
+
+        self.assertTrue(hasattr(aiohttp_stubs, "MockStream"))
 
 
 class LlmHostsTests(TestCase):

--- a/opencontractserver/utils/vcr_replay.py
+++ b/opencontractserver/utils/vcr_replay.py
@@ -42,52 +42,6 @@ from contextlib import contextmanager
 logger = logging.getLogger(__name__)
 
 
-def ensure_aiohttp_vcr_compat() -> None:
-    """Make vcrpy 8.1.1's aiohttp stub importable under aiohttp >= 3.14.
-
-    vcrpy 8.1.1 (the latest release) defines
-    ``class MockStream(asyncio.StreamReader, streams.AsyncStreamReaderMixin)``
-    in ``vcr/stubs/aiohttp_stubs.py``. aiohttp 3.14 removed
-    ``aiohttp.streams.AsyncStreamReaderMixin`` (its helpers were folded onto the
-    stream classes). vcrpy imports that stub lazily — when a cassette is entered
-    and ``vcr/patch.py`` builds its patchers — so under aiohttp >= 3.14 every VCR
-    cassette entry raises ``AttributeError`` (issue #1920; upstream
-    kevin1024/vcrpy#995, fix proposed in the unreleased PR #996).
-
-    This codebase only records/replays *httpx* (LLM provider) cassettes — the
-    aiohttp stub is pulled in incidentally because aiohttp is importable
-    (transitive via llama-index-core). ``MockStream`` is therefore never
-    instantiated here, so restoring the removed name as an empty mixin is enough
-    to let the stub's class body evaluate; none of the mixin's (now-removed)
-    helper methods are exercised.
-
-    Idempotent, and a no-op under aiohttp < 3.14 (where the real mixin is still
-    present — it is left untouched). Delete this shim, and bump ``vcrpy`` in
-    requirements/local.txt, once vcrpy ships a release that supports the aiohttp
-    3.14 stream API.
-    """
-    try:
-        from aiohttp import streams
-    except ModuleNotFoundError:
-        # aiohttp isn't installed → vcrpy won't load its aiohttp stub anyway.
-        return
-
-    if hasattr(streams, "AsyncStreamReaderMixin"):
-        return
-
-    class AsyncStreamReaderMixin:
-        """Empty stand-in for the base class aiohttp 3.14 removed.
-
-        Only needs to exist so vcrpy's ``MockStream`` class statement can
-        evaluate; its methods are never called (we never replay aiohttp
-        cassettes).
-        """
-
-    # setattr (string name) rather than attribute assignment so mypy does not
-    # flag a member aiohttp 3.14 removed from the ``streams`` module.
-    setattr(streams, "AsyncStreamReaderMixin", AsyncStreamReaderMixin)
-
-
 # These hostnames are the LLM provider endpoints VCR should intercept.
 # Other hosts (LlamaParse, embedder microservice, S3) bypass VCR.
 _LLM_HOSTS = {"api.openai.com", "api.anthropic.com"}
@@ -248,11 +202,6 @@ def maybe_vcr_cassette() -> Iterator[object | None]:
         yield None
         return
 
-    # vcrpy 8.1.1's aiohttp stub references a symbol aiohttp 3.14 removed;
-    # restore it before importing vcr so the live E2E record/replay harness
-    # (which runs outside pytest, where conftest isn't loaded) also works under
-    # aiohttp >= 3.14. See ensure_aiohttp_vcr_compat above and issue #1920.
-    ensure_aiohttp_vcr_compat()
     import vcr  # local import keeps prod paths free of vcr cost
 
     cassette_dir = os.path.dirname(os.path.abspath(cassette_path))

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -14,14 +14,11 @@ pytest-xdist==3.8.0  # https://github.com/pytest-dev/pytest-xdist (parallel test
 pytest-timeout==2.4.0  # https://github.com/pytest-dev/pytest-timeout (per-test hang guard in CI)
 djangorestframework-stubs==3.17.0  # https://github.com/typeddjango/djangorestframework-stubs
 responses==0.26.2  # https://github.com/getsentry/responses
-# vcrpy 8.1.1 is the latest release and is NOT yet compatible with aiohttp
-# >=3.14: its aiohttp stub subclasses aiohttp.streams.AsyncStreamReaderMixin at
-# import time, a symbol aiohttp 3.14 removed (kevin1024/vcrpy#995; fix proposed
-# in the unreleased PR #996). aiohttp is an unpinned transitive dep, so a fresh
-# CI resolution picks up 3.14+. ensure_aiohttp_vcr_compat() in
-# opencontractserver/utils/vcr_replay.py restores that symbol so vcrpy works
-# under aiohttp >=3.14. Bump vcrpy here and delete the shim once a release ships
-# the vcrpy#996 fix. See issue #1920.
+# Keep at >=8.2.0. Earlier releases' aiohttp stub subclasses
+# aiohttp.streams.AsyncStreamReaderMixin at import time, a symbol aiohttp 3.14
+# removed, which breaks every VCR cassette entry (issues #1920 / #2140,
+# kevin1024/vcrpy#995, fixed upstream in #996). aiohttp is an unpinned
+# transitive dep, so a fresh CI resolution picks up 3.14+.
 vcrpy==8.3.0
 
 # Profiling


### PR DESCRIPTION
Closes #2140.

## Finding: the shim is dead, and confirmed so

aiohttp 3.14 removed `aiohttp.streams.AsyncStreamReaderMixin`, which vcrpy 8.1.1's `vcr/stubs/aiohttp_stubs.py` subclassed at import time. vcrpy loads that stub lazily when a cassette is entered, so every VCR cassette entry raised `AttributeError` (issue #1920). The workaround was `ensure_aiohttp_vcr_compat()`, which re-injected the removed name as an empty class.

vcrpy 8.2.0 fixed the stub upstream (kevin1024/vcrpy#996). In 8.2.1 and 8.3.0, `MockStream` inherits only from `asyncio.StreamReader` and handles the aiohttp 3.14 `stream_writer` argument itself. The pin has been at 8.2.1 or later since then, so the issue's hypothesis is correct: the shim went dead before the 8.2.1 → 8.3.0 dependabot bump in #2132, not because of it.

One correction to the issue's framing: the shim was not merely inert. Under aiohttp 3.14 its `hasattr` guard fell through, so conftest import was still writing a fake `AsyncStreamReaderMixin` into the real `aiohttp.streams` namespace on every test run. Removing it also removes that namespace pollution.

## Verification

Entered a cassette with **no shim applied** and checked `MockStream.__bases__` in two environments:

| Environment | vcrpy | aiohttp | Result |
|---|---|---|---|
| local django image | 8.2.1 | 3.14.1 | cassette entry OK, `__bases__ == (asyncio.StreamReader,)` |
| clean venv | 8.3.0 | 3.14.1 | cassette entry OK, `__bases__ == (asyncio.StreamReader,)` |

The first row is the exact pre-bump pairing the issue asks about, which is what makes it decisive: the shim was already redundant at the old pin.

The three non-pytest `maybe_vcr_cassette()` call sites — `opencontractserver/tasks/data_extract_tasks.py:637` (celery worker) and `config/websocket/consumers/unified_agent_conversation.py:1163`/`:1431` (Daphne) — are exercised by `frontend-e2e-extract.yml` and `frontend-e2e-websocket.yml` in `OC_LLM_VCR_MODE=replay`. Both build via `local.yml`, and `compose/local/django/Dockerfile:59` installs `requirements/local.txt`, so they are protected by the version pin rather than by the deleted call.

## Changes

- Removed `ensure_aiohttp_vcr_compat()` from `opencontractserver/utils/vcr_replay.py` and its call in `maybe_vcr_cassette()`
- Removed the import and module-level call from `conftest.py`
- Replaced `EnsureAiohttpVcrCompatTests` with `VcrCassetteEntryTests` in `opencontractserver/tests/test_vcr_replay.py`
- Rewrote the `requirements/local.txt` comment, which still described vcrpy 8.1.1 as the pinned version and #996 as unreleased

`EnsureAiohttpVcrCompatTests` tested the shim itself, so it goes with the shim. `VcrCassetteEntryTests` keeps the part of the guard that survives: entering a cassette forces the lazy import of `vcr/stubs/aiohttp_stubs.py`, so it fails if a future vcrpy/aiohttp pairing reintroduces an import-time incompatibility. The review agent confirmed this by reproducing vcrpy 8.1.1's class line against aiohttp 3.14.1 — both new tests fail with the original `AttributeError`.

The `aiohttp>=3.13,<3.14` cap this was paired with (issue #1914) was already lifted on main; no requirements file pins aiohttp today.

## Testing

72 passing locally across the targeted VCR-consuming modules: `test_vcr_replay.py`, `test_structured_response_simple.py`, `test_structured_response_api.py`, `test_individual_extract_tasks.py`. The remaining VCR modules are slow integration suites and are left to CI — the mechanism is proven at conftest-import level, so they would re-confirm the same thing. pre-commit clean (black, isort, flake8, mypy, changelog fragment validation).

## Note for the release editor

`changelog.d/1920-aiohttp-cap.changed.md:15` cites `opencontractserver/tests/test_vcr_replay.py::EnsureAiohttpVcrCompatTests` as its regression test — the class this PR renames. That fragment is another PR's record and the one-file-per-PR convention says not to edit it here, so it is left alone; worth repointing at `VcrCassetteEntryTests` during collation. The three aiohttp/vcrpy fragments (#1914 cap added, #1920 cap lifted + shim added, #2140 shim removed) all land in the same `[Unreleased]` batch and net to zero, so they may be worth folding into one line at that point.