### PR TITLE
Tighten deep-research citation discipline (#2180–#2183)

### DIFF
--- a/changelog.d/2180-2183-research-citations.fixed.md
+++ b/changelog.d/2180-2183-research-citations.fixed.md
@@ -14,14 +14,15 @@
   (`opencontractserver/research/services/research_reports.py`) now tags each
   citation with `anchor_is_header`, and `ResearchReportService.finalize` records
   a concise warning (surfaced in the report's UI warning chips) when a footnote
-  resolves to a section header / structural anchor instead of a supporting
-  passage. Detection keys solely off `Annotation.structural` — the flag the
-  parsing pipeline sets on OC_SECTION layout annotations, which are exactly the
-  headers that mis-anchored in #2180. It deliberately does *not* also text-match
-  filing-style headings (`ITEM 1A`, `SECTION 8`, …), because legal prose commonly
-  opens an operative clause with its section number (“Section 8.1 requires …”),
-  which would false-positive on real citations in contract corpora. The lint is
-  observational — it never rewrites report prose.
+  resolves to a section header instead of a supporting passage. Detection keys on
+  the anchor's **annotation label** (`RESEARCH_HEADER_ANCHOR_LABELS`:
+  `OC_SECTION` + the LlamaParse heading labels `Title` / `Section Header` /
+  `Heading` / `Page Header`, matched case-/separator-insensitively) — *not* on
+  `Annotation.structural`, which the parsing pipeline sets on the entire layout
+  layer (body paragraphs, tables, sentence chunks) and which the bookmark-derived
+  OC_SECTION headers are `structural=False` for; keying on it would both flood
+  false positives and miss the real #2180 headers. The lint is observational — it
+  never rewrites report prose.
 - **Confirmed the report composer is not the source of the #2183 duplication.**
   The finalize path emits the agent's `markdown_body` verbatim (cite-rendered)
   and the salvage path renders each finding exactly once; the observed doubling

--- a/changelog.d/2180-2183-research-citations.fixed.md
+++ b/changelog.d/2180-2183-research-citations.fixed.md
@@ -1,0 +1,30 @@
+- **Tightened deep-research citation discipline (#2180, #2181, #2182, #2183).**
+  Added a `## Citation discipline` section to the deep-research system prompt
+  (`build_deep_research_system_prompt` in
+  `opencontractserver/research/constants.py`) that instructs the agent to: anchor
+  the passage whose own words support a claim and never a bare section header —
+  reaching for `search_exact_text_as_sources` to pull a pinpoint anchor (#2180);
+  cite the document that actually *contains* the language, following any
+  incorporation-by-reference / cross-reference hop to its source before anchoring
+  (#2181); leave task/prompt-derived background *uncited* rather than forcing a
+  corpus anchor onto it (#2182); and state each claim exactly once inside a
+  single `<cite>` tag, never as a plain sentence followed by a cited restatement
+  (#2183).
+- **Added a finalize-time weak-citation lint (#2180).** `_render_citations`
+  (`opencontractserver/research/services/research_reports.py`) now tags each
+  citation with `anchor_is_header`, and `ResearchReportService.finalize` records
+  a concise warning (surfaced in the report's UI warning chips) when a footnote
+  resolves to a section header / structural anchor instead of a supporting
+  passage. Detection keys off `Annotation.structural` (OC_SECTION headers) plus a
+  length-gated filing-heading heuristic (`ITEM 1A`, `PART II`, …); the new
+  `MAX_HEADER_ANCHOR_CHARS` constant keeps long operative passages that merely
+  begin with such a token eligible as real citations. The lint is observational —
+  it never rewrites report prose.
+- **Confirmed the report composer is not the source of the #2183 duplication.**
+  The finalize path emits the agent's `markdown_body` verbatim (cite-rendered)
+  and the salvage path renders each finding exactly once; the observed doubling
+  was agent-authored prose (a plain sentence joined to a near-identical cited
+  restatement), now addressed by the prompt rule above. New regression tests
+  (`test_finalize_renders_each_claim_once`,
+  `test_compose_salvage_body_renders_each_finding_once`) lock in single-render
+  behavior so a future composer change can't reintroduce it.

--- a/changelog.d/2180-2183-research-citations.fixed.md
+++ b/changelog.d/2180-2183-research-citations.fixed.md
@@ -15,11 +15,13 @@
   citation with `anchor_is_header`, and `ResearchReportService.finalize` records
   a concise warning (surfaced in the report's UI warning chips) when a footnote
   resolves to a section header / structural anchor instead of a supporting
-  passage. Detection keys off `Annotation.structural` (OC_SECTION headers) plus a
-  length-gated filing-heading heuristic (`ITEM 1A`, `PART II`, …); the new
-  `MAX_HEADER_ANCHOR_CHARS` constant keeps long operative passages that merely
-  begin with such a token eligible as real citations. The lint is observational —
-  it never rewrites report prose.
+  passage. Detection keys solely off `Annotation.structural` — the flag the
+  parsing pipeline sets on OC_SECTION layout annotations, which are exactly the
+  headers that mis-anchored in #2180. It deliberately does *not* also text-match
+  filing-style headings (`ITEM 1A`, `SECTION 8`, …), because legal prose commonly
+  opens an operative clause with its section number (“Section 8.1 requires …”),
+  which would false-positive on real citations in contract corpora. The lint is
+  observational — it never rewrites report prose.
 - **Confirmed the report composer is not the source of the #2183 duplication.**
   The finalize path emits the agent's `markdown_body` verbatim (cite-rendered)
   and the salvage path renders each finding exactly once; the observed doubling

--- a/opencontractserver/research/constants.py
+++ b/opencontractserver/research/constants.py
@@ -105,16 +105,6 @@ RESEARCH_MEMORY_PREVIEW_CHARS = 160
 RESEARCH_RECOVERY_FINDINGS_DIGEST = 20
 
 
-# A citation anchor whose text is a bare section heading (e.g.
-# "ITEM 1A. RISK FACTORS") cannot support a specific claim (issue #2180).
-# ``Annotation.structural`` is the primary signal; as a fallback for corpora
-# that do not flag headers structurally, a *non-structural* anchor is treated
-# as a header only when it is at most this many chars AND opens with a
-# filing-style heading token — long operative passages that merely begin with
-# "Item 1A ..." stay eligible as real citations.
-MAX_HEADER_ANCHOR_CHARS = 80
-
-
 # Plan + memory tool names. Unioned into the deep-research agent's
 # ``restrict_tool_names`` set alongside the scratchpad tools. The closures
 # themselves are appended as caller-supplied tools (never filtered), so this

--- a/opencontractserver/research/constants.py
+++ b/opencontractserver/research/constants.py
@@ -105,6 +105,16 @@ RESEARCH_MEMORY_PREVIEW_CHARS = 160
 RESEARCH_RECOVERY_FINDINGS_DIGEST = 20
 
 
+# A citation anchor whose text is a bare section heading (e.g.
+# "ITEM 1A. RISK FACTORS") cannot support a specific claim (issue #2180).
+# ``Annotation.structural`` is the primary signal; as a fallback for corpora
+# that do not flag headers structurally, a *non-structural* anchor is treated
+# as a header only when it is at most this many chars AND opens with a
+# filing-style heading token — long operative passages that merely begin with
+# "Item 1A ..." stay eligible as real citations.
+MAX_HEADER_ANCHOR_CHARS = 80
+
+
 # Plan + memory tool names. Unioned into the deep-research agent's
 # ``restrict_tool_names`` set alongside the scratchpad tools. The closures
 # themselves are appended as caller-supplied tools (never filtered), so this
@@ -230,6 +240,34 @@ def build_deep_research_system_prompt(
             "- Do NOT mutate corpus state — you have no write tools, by design.",
             "- Do NOT speculate beyond what the corpus supports. If the corpus "
             + "does not contain the answer, say so explicitly in the report.",
+            "",
+            "## Citation discipline",
+            "Citations are this product's core promise: a reader who clicks a "
+            + "footnote must land on the exact words that prove the sentence. "
+            + "Apply these rules to every `<cite>` tag and every `record_finding` "
+            + "call:",
+            "- Anchor the passage whose OWN words support the claim — never a "
+            + "bare section header. An annotation whose text is only a heading "
+            + "(e.g. `ITEM 1A. RISK FACTORS`) marks the top of a section, not the "
+            + "evidence. Once you know the language you want, call "
+            + "`search_exact_text_as_sources` to pull the pinpoint passage and "
+            + "cite THAT annotation.",
+            "- Cite the document that actually CONTAINS the language. If you "
+            + "reached a passage through a cross-reference or an "
+            + "incorporated-by-reference pointer (common in SEC filings — a 10-Q "
+            + "Item 1A that only says 'see Item 1A of our Form 10-K'), follow the "
+            + "reference to the source document and anchor the operative text "
+            + "there, not the referring cross-reference.",
+            "- Cite only claims grounded in retrieved passages. A sentence that "
+            + "merely restates the task, the prompt, or the background you were "
+            + "handed carries NO citation — leave it uncited rather than forcing "
+            + "on a corpus anchor that cannot support it. Uncited background is "
+            + "honest; a miscited anchor is not.",
+            "- State each claim once. Wrap the claim sentence itself in "
+            + '`<cite ids="...">...</cite>` — do NOT write the claim as plain '
+            + "prose and then repeat it as a cited restatement. Keep normal "
+            + "spacing and punctuation around the tags so the sentence reads "
+            + "cleanly.",
             "",
             "## Budget",
             f"- You have approximately {max_steps} tool calls. Plan accordingly.",

--- a/opencontractserver/research/constants.py
+++ b/opencontractserver/research/constants.py
@@ -7,6 +7,7 @@ runner) and the kickoff tool / tests.
 
 from __future__ import annotations
 
+from opencontractserver.constants.annotations import OC_SECTION_LABEL
 from opencontractserver.utils.prompt_sanitization import (
     UNTRUSTED_CONTENT_NOTICE,
     fence_user_content,
@@ -103,6 +104,33 @@ RESEARCH_MEMORY_PREVIEW_CHARS = 160
 # via ``search_memory`` once mirrored), but only the tail is replayed inline
 # so the preamble itself stays small.
 RESEARCH_RECOVERY_FINDINGS_DIGEST = 20
+
+
+# Annotation labels that mark a section header / heading rather than an
+# operative passage. The deep-research citation lint (issue #2180) flags a
+# footnote whose anchor carries one of these labels, matched case- and
+# separator-insensitively against ``Annotation.annotation_label.text``.
+#
+# Keyed on the LABEL, never on ``Annotation.structural``: the parsing pipeline
+# sets ``structural=True`` on ALL of its layout output — body paragraphs,
+# tables, list items, sentence chunks, … (see ``oc_text_parser`` /
+# ``llamaparse_parser``), not just headers — while the bookmark-derived
+# OC_SECTION headers that repro'd #2180 are explicitly ``structural=False``
+# (``pdf_outline_enricher``). The structural flag would thus both flood false
+# positives (every body-paragraph citation) and miss the real headers. The
+# label is the precise signal. ``Title`` / ``Section Header`` / ``Heading`` /
+# ``Page Header`` are the LlamaParse layout heading labels
+# (``LlamaParseParser.ELEMENT_TYPE_MAPPING``); ``OC_SECTION`` is the canonical
+# cross-parser section label.
+RESEARCH_HEADER_ANCHOR_LABELS: frozenset[str] = frozenset(
+    {
+        OC_SECTION_LABEL,  # "OC_SECTION" — canonical section layer (issue #2180)
+        "Title",
+        "Section Header",
+        "Heading",
+        "Page Header",
+    }
+)
 
 
 # Plan + memory tool names. Unioned into the deep-research agent's

--- a/opencontractserver/research/services/research_reports.py
+++ b/opencontractserver/research/services/research_reports.py
@@ -652,7 +652,10 @@ class ResearchReportService(BaseService):
         Composes ``executive_summary`` + ``markdown_body`` + a ``## Sources``
         footnote section. Citation post-processing converts placeholder
         ``<cite ids="1,2">claim</cite>`` spans into ``[^n]`` footnote
-        markers and builds the structured ``citations`` table.
+        markers and builds the structured ``citations`` table. A concise
+        weak-citation warning is appended to ``report.warnings`` when any
+        footnote anchors a section-header label (see ``_is_header_anchor``,
+        issue #2180); it is observational and never rewrites the prose.
 
         ``retrieved_annotation_ids`` is the union of annotation IDs the
         retrieval tools surfaced during this run (the

--- a/opencontractserver/research/services/research_reports.py
+++ b/opencontractserver/research/services/research_reports.py
@@ -18,6 +18,7 @@ from django.utils import timezone
 
 from opencontractserver.research.constants import (
     DEFAULT_MAX_STEPS_FALLBACK,
+    MAX_HEADER_ANCHOR_CHARS,
     MAX_RESEARCH_MEMORY_KEY_CHARS,
     MAX_RESEARCH_MEMORY_KEYS,
     MAX_RESEARCH_MEMORY_TOTAL_CHARS,
@@ -713,10 +714,28 @@ class ResearchReportService(BaseService):
             "last_progress_at",
             "modified",
         ]
-        if warnings:
+        # Surface a weak-citation warning when any footnote resolves to a
+        # section header / structural anchor rather than a supporting passage
+        # (issue #2180). Observational only — it never rewrites the prose, it
+        # just flags footnotes a reviewer (or future automated checker) should
+        # double-check.
+        extra_warnings: list[str] = list(warnings or [])
+        header_footnotes = [
+            c["footnote"] for c in citations if c.get("anchor_is_header")
+        ]
+        if header_footnotes:
+            markers = ", ".join(f"[^{n}]" for n in header_footnotes)
+            noun = "citation" if len(header_footnotes) == 1 else "citations"
+            extra_warnings.append(
+                f"{len(header_footnotes)} {noun} anchor a section header rather "
+                f"than a supporting passage ({markers}); verify they point at the "
+                "operative language."
+            )
+
+        if extra_warnings:
             # Append rather than replace so prior warnings from
             # ``append_finding`` / ``append_tool_call`` survive.
-            report.warnings = list(report.warnings or []) + list(warnings)
+            report.warnings = list(report.warnings or []) + extra_warnings
             update_fields.append("warnings")
 
         # Single atomic block so the terminal content write and the M2M
@@ -870,6 +889,36 @@ def _strip_fabricated_links(markdown: str) -> str:
     return _MARKDOWN_LINK_RE.sub(_replace, markdown)
 
 
+# A citation anchor whose text opens with a filing-style heading token
+# (``ITEM 1A``, ``PART II``, ``ARTICLE III`` …). Used as a fallback header
+# signal for anchors that are not flagged ``structural`` — see
+# ``_is_header_anchor`` and issue #2180.
+_HEADER_ANCHOR_RE = re.compile(
+    r"^\s*(?:ITEM|PART|ARTICLE|SECTION|SCHEDULE|EXHIBIT|APPENDIX)\s+[0-9IVXLA]",
+    re.IGNORECASE,
+)
+
+
+def _is_header_anchor(*, structural: bool, raw_text: str) -> bool:
+    """True when a citation anchor is a bare section header / structural
+    element rather than the passage whose words support a claim (issue #2180).
+
+    ``structural`` (the ``Annotation.structural`` flag — set for OC_SECTION
+    layout annotations, which rank well for section-topic queries) is the
+    primary signal. As a fallback for corpora that do not flag headings
+    structurally, a *short* anchor whose text opens with a filing-style heading
+    token (``ITEM 1A``, ``PART II`` …) is also treated as a header; the length
+    gate keeps long operative passages that merely begin with such a token from
+    being mistaken for a heading.
+    """
+    if structural:
+        return True
+    text = (raw_text or "").strip()
+    if not text or len(text) > MAX_HEADER_ANCHOR_CHARS:
+        return False
+    return bool(_HEADER_ANCHOR_RE.match(text))
+
+
 def _render_citations(
     markdown_body: str, allowed_annotation_ids: set[int]
 ) -> tuple[str, list[dict]]:
@@ -957,6 +1006,13 @@ def _render_citations(
                 "document_id": doc_id,
                 "page": page,
                 "raw_text": raw_text,
+                # Flag anchors that resolve to a bare section header / structural
+                # element so finalize can surface a weak-citation warning and any
+                # future automated citation-checking can key off it (issue #2180).
+                "anchor_is_header": _is_header_anchor(
+                    structural=bool(getattr(ann, "structural", False)),
+                    raw_text=raw_text,
+                ),
                 "display": " ".join(display_parts),
             }
         )

--- a/opencontractserver/research/services/research_reports.py
+++ b/opencontractserver/research/services/research_reports.py
@@ -24,6 +24,7 @@ from opencontractserver.research.constants import (
     MAX_RESEARCH_MEMORY_VALUE_CHARS,
     MAX_RESEARCH_PLAN_CHARS,
     MAX_RESEARCH_STEPS_CEILING,
+    RESEARCH_HEADER_ANCHOR_LABELS,
     RESEARCH_MEMORY_PREVIEW_CHARS,
     RESEARCH_MEMORY_SEARCH_MAX_HITS,
     RESEARCH_RECOVERY_FINDINGS_DIGEST,
@@ -724,12 +725,18 @@ class ResearchReportService(BaseService):
         ]
         if header_footnotes:
             markers = ", ".join(f"[^{n}]" for n in header_footnotes)
-            noun = "citation" if len(header_footnotes) == 1 else "citations"
-            extra_warnings.append(
-                f"{len(header_footnotes)} {noun} anchor a section header rather "
-                f"than a supporting passage ({markers}); verify they point at the "
-                "operative language."
-            )
+            if len(header_footnotes) == 1:
+                extra_warnings.append(
+                    "1 citation anchors a section header rather than a "
+                    f"supporting passage ({markers}); verify it points at the "
+                    "operative language."
+                )
+            else:
+                extra_warnings.append(
+                    f"{len(header_footnotes)} citations anchor section headers "
+                    f"rather than supporting passages ({markers}); verify they "
+                    "point at the operative language."
+                )
 
         if extra_warnings:
             # Append rather than replace so prior warnings from
@@ -888,25 +895,31 @@ def _strip_fabricated_links(markdown: str) -> str:
     return _MARKDOWN_LINK_RE.sub(_replace, markdown)
 
 
-def _is_header_anchor(*, structural: bool) -> bool:
-    """True when a citation anchor is a bare section header / structural
-    element rather than the passage whose words support a claim (issue #2180).
+def _normalize_label(text: str | None) -> str:
+    """Lowercase and collapse separator runs so ``"Section Header"``,
+    ``"section_header"`` and ``"section-header"`` all compare equal."""
+    return re.sub(r"[\s_\-]+", " ", (text or "").strip().lower())
 
-    Keyed solely on ``Annotation.structural`` — the flag the parsing pipeline
-    sets on OC_SECTION layout annotations (see ``llamaparse_parser`` /
-    ``oc_text_parser``). Those are exactly the section-header annotations that
-    rank well for section-topic queries and produced the mis-anchored citations
-    in #2180.
 
-    We deliberately do NOT also text-match filing-style headings (``ITEM 1A``,
-    ``SECTION 8`` …). Legal drafting very commonly opens an *operative* clause
-    with its section number ("Section 8.1 requires 30 days' written notice …"),
-    so a heading-token regex would false-positive on real, correct citations in
-    contract corpora — and OpenContracts runs over general contracts, not just
-    SEC filings. ``structural`` is the reliable signal; keep this predicate
-    keyed on it.
+# The header-label set, pre-normalised once so ``_is_header_anchor`` only has to
+# normalise its single input per call.
+_NORMALIZED_HEADER_ANCHOR_LABELS: frozenset[str] = frozenset(
+    _normalize_label(label) for label in RESEARCH_HEADER_ANCHOR_LABELS
+)
+
+
+def _is_header_anchor(*, label_text: str | None) -> bool:
+    """True when a citation anchor's annotation label denotes a section header
+    / heading rather than an operative passage (issue #2180).
+
+    Keyed on the annotation LABEL (``annotation_label.text``), matched case- and
+    separator-insensitively against ``RESEARCH_HEADER_ANCHOR_LABELS`` — NOT on
+    ``Annotation.structural``. ``structural`` marks the whole parser layout
+    layer (body paragraphs, tables, sentence chunks, …), so keying on it would
+    flag nearly every citation while missing the bookmark-derived OC_SECTION
+    headers that are ``structural=False``. See the constant's docstring.
     """
-    return bool(structural)
+    return _normalize_label(label_text) in _NORMALIZED_HEADER_ANCHOR_LABELS
 
 
 def _render_citations(
@@ -946,11 +959,13 @@ def _render_citations(
                 next_footnote += 1
 
     # Fetch annotation metadata in one query for the Sources block.
+    # ``annotation_label`` is pulled so the weak-citation lint (#2180) can read
+    # the anchor's label without an N+1.
     annotations_by_id = {
         ann.pk: ann
         for ann in Annotation.objects.filter(
             pk__in=footnote_for_id.keys()
-        ).select_related("document")
+        ).select_related("document", "annotation_label")
     }
 
     def _replace(match: re.Match[str]) -> str:
@@ -996,11 +1011,13 @@ def _render_citations(
                 "document_id": doc_id,
                 "page": page,
                 "raw_text": raw_text,
-                # Flag anchors that resolve to a bare section header / structural
-                # element so finalize can surface a weak-citation warning and any
-                # future automated citation-checking can key off it (issue #2180).
+                # Flag anchors whose annotation label is a section header /
+                # heading so finalize can surface a weak-citation warning and
+                # any future automated citation-checking can key off it (#2180).
                 "anchor_is_header": _is_header_anchor(
-                    structural=bool(getattr(ann, "structural", False)),
+                    label_text=getattr(
+                        getattr(ann, "annotation_label", None), "text", None
+                    ),
                 ),
                 "display": " ".join(display_parts),
             }

--- a/opencontractserver/research/services/research_reports.py
+++ b/opencontractserver/research/services/research_reports.py
@@ -18,7 +18,6 @@ from django.utils import timezone
 
 from opencontractserver.research.constants import (
     DEFAULT_MAX_STEPS_FALLBACK,
-    MAX_HEADER_ANCHOR_CHARS,
     MAX_RESEARCH_MEMORY_KEY_CHARS,
     MAX_RESEARCH_MEMORY_KEYS,
     MAX_RESEARCH_MEMORY_TOTAL_CHARS,
@@ -889,34 +888,25 @@ def _strip_fabricated_links(markdown: str) -> str:
     return _MARKDOWN_LINK_RE.sub(_replace, markdown)
 
 
-# A citation anchor whose text opens with a filing-style heading token
-# (``ITEM 1A``, ``PART II``, ``ARTICLE III`` …). Used as a fallback header
-# signal for anchors that are not flagged ``structural`` — see
-# ``_is_header_anchor`` and issue #2180.
-_HEADER_ANCHOR_RE = re.compile(
-    r"^\s*(?:ITEM|PART|ARTICLE|SECTION|SCHEDULE|EXHIBIT|APPENDIX)\s+[0-9IVXLA]",
-    re.IGNORECASE,
-)
-
-
-def _is_header_anchor(*, structural: bool, raw_text: str) -> bool:
+def _is_header_anchor(*, structural: bool) -> bool:
     """True when a citation anchor is a bare section header / structural
     element rather than the passage whose words support a claim (issue #2180).
 
-    ``structural`` (the ``Annotation.structural`` flag — set for OC_SECTION
-    layout annotations, which rank well for section-topic queries) is the
-    primary signal. As a fallback for corpora that do not flag headings
-    structurally, a *short* anchor whose text opens with a filing-style heading
-    token (``ITEM 1A``, ``PART II`` …) is also treated as a header; the length
-    gate keeps long operative passages that merely begin with such a token from
-    being mistaken for a heading.
+    Keyed solely on ``Annotation.structural`` — the flag the parsing pipeline
+    sets on OC_SECTION layout annotations (see ``llamaparse_parser`` /
+    ``oc_text_parser``). Those are exactly the section-header annotations that
+    rank well for section-topic queries and produced the mis-anchored citations
+    in #2180.
+
+    We deliberately do NOT also text-match filing-style headings (``ITEM 1A``,
+    ``SECTION 8`` …). Legal drafting very commonly opens an *operative* clause
+    with its section number ("Section 8.1 requires 30 days' written notice …"),
+    so a heading-token regex would false-positive on real, correct citations in
+    contract corpora — and OpenContracts runs over general contracts, not just
+    SEC filings. ``structural`` is the reliable signal; keep this predicate
+    keyed on it.
     """
-    if structural:
-        return True
-    text = (raw_text or "").strip()
-    if not text or len(text) > MAX_HEADER_ANCHOR_CHARS:
-        return False
-    return bool(_HEADER_ANCHOR_RE.match(text))
+    return bool(structural)
 
 
 def _render_citations(
@@ -1011,7 +1001,6 @@ def _render_citations(
                 # future automated citation-checking can key off it (issue #2180).
                 "anchor_is_header": _is_header_anchor(
                     structural=bool(getattr(ann, "structural", False)),
-                    raw_text=raw_text,
                 ),
                 "display": " ".join(display_parts),
             }

--- a/opencontractserver/tests/research/test_research_memory.py
+++ b/opencontractserver/tests/research/test_research_memory.py
@@ -431,3 +431,25 @@ class DeepResearchSystemPromptTestCase(TestCase):
         self.assertNotIn("Your current plan", prompt)
         self.assertNotIn("Findings recorded so far", prompt)
         self.assertNotIn("RESUMING", prompt)
+
+    def test_prompt_documents_citation_discipline(self):
+        """The citation-discipline section must encode all four failure modes
+        from issues #2180–#2183 so the agent anchors to supporting passages,
+        traverses incorporation-by-reference, refrains from citing task
+        context, and states each claim exactly once."""
+        prompt = build_deep_research_system_prompt(
+            task_description="Investigate X.",
+            corpus_title="Cases",
+            corpus_description=None,
+            max_steps=60,
+        )
+        self.assertIn("Citation discipline", prompt)
+        # #2180 — never cite a bare section header; prefer pinpoint anchors.
+        self.assertIn("section header", prompt)
+        self.assertIn("search_exact_text_as_sources", prompt)
+        # #2181 — follow incorporation-by-reference to the source document.
+        self.assertIn("incorporated-by-reference", prompt)
+        # #2182 — task/prompt/background restatements carry no citation.
+        self.assertIn("NO citation", prompt)
+        # #2183 — state each claim once, with no cited restatement.
+        self.assertIn("State each claim once", prompt)

--- a/opencontractserver/tests/research/test_research_report_service.py
+++ b/opencontractserver/tests/research/test_research_report_service.py
@@ -19,9 +19,11 @@ from opencontractserver.research.services.research_reports import (
     ResearchCancelled,
     ResearchReportService,
     _derive_title_from_prompt,
+    _is_header_anchor,
     _render_citations,
     _strip_fabricated_links,
 )
+from opencontractserver.tasks.research_tasks import _compose_salvage_body
 from opencontractserver.types.enums import JobStatus
 
 User = get_user_model()
@@ -300,6 +302,145 @@ class ResearchReportServiceTestCase(TestCase):
         )
         report.refresh_from_db()
         self.assertEqual(report.citations, [])
+
+    # ------------------------------------------------------------------
+    # finalize() — weak-citation (section-header) lint  [issue #2180]
+    # ------------------------------------------------------------------
+    def test_finalize_flags_structural_header_citation(self):
+        # A citation resolving to a structural (OC_SECTION) annotation anchors
+        # the top of a section, not the supporting passage — finalize flags it.
+        header = self._make_annotation(
+            structural=True, raw_text="ITEM 1A. RISK FACTORS"
+        )
+        report = self._make_report()
+        report.findings = [
+            {"section": "Risks", "claim": "c", "citations": [header.pk]},
+        ]
+        report.save(update_fields=["findings"])
+
+        body = f'<cite ids="{header.pk}">the filing discloses supply risk</cite>.'
+        ResearchReportService.finalize(
+            report,
+            executive_summary="",
+            markdown_body=body,
+            retrieved_annotation_ids=[header.pk],
+        )
+        report.refresh_from_db()
+        self.assertTrue(report.citations[0]["anchor_is_header"])
+        self.assertTrue(
+            any("section header" in str(w) for w in (report.warnings or [])),
+            report.warnings,
+        )
+
+    def test_finalize_flags_filing_heading_by_text_when_not_structural(self):
+        # Even without the structural flag, a short anchor that opens with a
+        # filing-style heading token is treated as a header (issue #2180's
+        # second example: "ITEM 3. QUANTITATIVE AND QUALITATIVE ...").
+        header = self._make_annotation(
+            structural=False,
+            raw_text="ITEM 3. QUANTITATIVE AND QUALITATIVE DISCLOSURES ABOUT MARKET RISK.",
+        )
+        report = self._make_report()
+        report.findings = [
+            {"section": "Market", "claim": "c", "citations": [header.pk]},
+        ]
+        report.save(update_fields=["findings"])
+        body = f'<cite ids="{header.pk}">no quantified sensitivity is disclosed</cite>.'
+        ResearchReportService.finalize(
+            report,
+            executive_summary="",
+            markdown_body=body,
+            retrieved_annotation_ids=[header.pk],
+        )
+        report.refresh_from_db()
+        self.assertTrue(report.citations[0]["anchor_is_header"])
+        self.assertTrue(
+            any("section header" in str(w) for w in (report.warnings or []))
+        )
+
+    def test_finalize_does_not_flag_operative_passage_citation(self):
+        # A normal, non-structural anchor with real operative language is a
+        # good citation — no weak-citation warning, flag is False.
+        passage = self._make_annotation(
+            structural=False,
+            raw_text=(
+                "Our fixed-price contracts expose us to cost-overrun risk because "
+                "we bear the burden of increases in raw-material prices."
+            ),
+        )
+        report = self._make_report()
+        report.findings = [
+            {"section": "Risks", "claim": "c", "citations": [passage.pk]},
+        ]
+        report.save(update_fields=["findings"])
+        body = (
+            f'<cite ids="{passage.pk}">fixed-price contracts carry overrun risk</cite>.'
+        )
+        ResearchReportService.finalize(
+            report,
+            executive_summary="",
+            markdown_body=body,
+            retrieved_annotation_ids=[passage.pk],
+        )
+        report.refresh_from_db()
+        self.assertFalse(report.citations[0]["anchor_is_header"])
+        self.assertFalse(
+            any("section header" in str(w) for w in (report.warnings or [])),
+            report.warnings,
+        )
+
+    def test_is_header_anchor_heuristics(self):
+        # Structural flag is the primary signal, regardless of text.
+        self.assertTrue(_is_header_anchor(structural=True, raw_text="anything at all"))
+        # Short filing-heading text is a header even when not structural.
+        self.assertTrue(
+            _is_header_anchor(structural=False, raw_text="ITEM 1A. RISK FACTORS")
+        )
+        # A long operative passage that merely begins with a heading token is
+        # NOT a header (the length gate keeps it eligible as a real citation).
+        long_passage = "Item 1A risk factors are discussed at length below: " + "x" * 80
+        self.assertFalse(_is_header_anchor(structural=False, raw_text=long_passage))
+        # Ordinary prose and empty text are never headers.
+        self.assertFalse(
+            _is_header_anchor(structural=False, raw_text="We bear cost-overrun risk.")
+        )
+        self.assertFalse(_is_header_anchor(structural=False, raw_text=""))
+
+    # ------------------------------------------------------------------
+    # Composer renders each finding once — NOT a doubler  [issue #2183]
+    # ------------------------------------------------------------------
+    def test_finalize_renders_each_claim_once(self):
+        # The finalize composer emits the agent's body verbatim (cite-rendered);
+        # it must never stitch a plain + cited variant of a sentence. Guards
+        # against a regression that would double each claim.
+        ann = self._make_annotation(raw_text="operative language here")
+        report = self._make_report()
+        sentence = "Aluminum and copper prices drive input-cost exposure"
+        report.findings = [
+            {"section": "Risks", "claim": sentence, "citations": [ann.pk]},
+        ]
+        report.save(update_fields=["findings"])
+        body = f'<cite ids="{ann.pk}">{sentence}</cite>.'
+        ResearchReportService.finalize(
+            report,
+            executive_summary="",
+            markdown_body=body,
+            retrieved_annotation_ids=[ann.pk],
+        )
+        report.refresh_from_db()
+        self.assertEqual(report.content.count(sentence), 1)
+        self.assertIn("[^1]", report.content)
+
+    def test_compose_salvage_body_renders_each_finding_once(self):
+        report = self._make_report()
+        report.findings = [
+            {"section": "Risks", "claim": "unique-claim-alpha", "citations": [1]},
+            {"section": "Risks", "claim": "unique-claim-beta", "citations": []},
+        ]
+        report.save(update_fields=["findings"])
+        body = _compose_salvage_body(report, response_text="")
+        self.assertEqual(body.count("unique-claim-alpha"), 1)
+        self.assertEqual(body.count("unique-claim-beta"), 1)
 
     # ------------------------------------------------------------------
     # Helpers

--- a/opencontractserver/tests/research/test_research_report_service.py
+++ b/opencontractserver/tests/research/test_research_report_service.py
@@ -332,30 +332,37 @@ class ResearchReportServiceTestCase(TestCase):
             report.warnings,
         )
 
-    def test_finalize_flags_filing_heading_by_text_when_not_structural(self):
-        # Even without the structural flag, a short anchor that opens with a
-        # filing-style heading token is treated as a header (issue #2180's
-        # second example: "ITEM 3. QUANTITATIVE AND QUALITATIVE ...").
-        header = self._make_annotation(
+    def test_finalize_does_not_flag_non_structural_clause_opening_with_section_ref(
+        self,
+    ):
+        # Regression guard (review of #2180): the lint keys on the structural
+        # flag ONLY, never on heading-like text. Legal prose routinely opens an
+        # operative clause with its section number ("Section 8.1 requires ...");
+        # a non-structural anchor like that is a real, correct citation and must
+        # NOT be flagged, or the warning would false-positive on contract corpora.
+        clause = self._make_annotation(
             structural=False,
-            raw_text="ITEM 3. QUANTITATIVE AND QUALITATIVE DISCLOSURES ABOUT MARKET RISK.",
+            raw_text="Section 8.1 requires 30 days' written notice prior to termination.",
         )
         report = self._make_report()
         report.findings = [
-            {"section": "Market", "claim": "c", "citations": [header.pk]},
+            {"section": "Termination", "claim": "c", "citations": [clause.pk]},
         ]
         report.save(update_fields=["findings"])
-        body = f'<cite ids="{header.pk}">no quantified sensitivity is disclosed</cite>.'
+        body = (
+            f'<cite ids="{clause.pk}">30 days notice is required to terminate</cite>.'
+        )
         ResearchReportService.finalize(
             report,
             executive_summary="",
             markdown_body=body,
-            retrieved_annotation_ids=[header.pk],
+            retrieved_annotation_ids=[clause.pk],
         )
         report.refresh_from_db()
-        self.assertTrue(report.citations[0]["anchor_is_header"])
-        self.assertTrue(
-            any("section header" in str(w) for w in (report.warnings or []))
+        self.assertFalse(report.citations[0]["anchor_is_header"])
+        self.assertFalse(
+            any("section header" in str(w) for w in (report.warnings or [])),
+            report.warnings,
         )
 
     def test_finalize_does_not_flag_operative_passage_citation(self):
@@ -389,22 +396,13 @@ class ResearchReportServiceTestCase(TestCase):
             report.warnings,
         )
 
-    def test_is_header_anchor_heuristics(self):
-        # Structural flag is the primary signal, regardless of text.
-        self.assertTrue(_is_header_anchor(structural=True, raw_text="anything at all"))
-        # Short filing-heading text is a header even when not structural.
-        self.assertTrue(
-            _is_header_anchor(structural=False, raw_text="ITEM 1A. RISK FACTORS")
-        )
-        # A long operative passage that merely begins with a heading token is
-        # NOT a header (the length gate keeps it eligible as a real citation).
-        long_passage = "Item 1A risk factors are discussed at length below: " + "x" * 80
-        self.assertFalse(_is_header_anchor(structural=False, raw_text=long_passage))
-        # Ordinary prose and empty text are never headers.
-        self.assertFalse(
-            _is_header_anchor(structural=False, raw_text="We bear cost-overrun risk.")
-        )
-        self.assertFalse(_is_header_anchor(structural=False, raw_text=""))
+    def test_is_header_anchor_keys_on_structural_flag_only(self):
+        # The predicate is keyed solely on Annotation.structural — the reliable
+        # OC_SECTION header signal — never on heading-like text, so operative
+        # prose that opens with a section reference is never mistaken for a
+        # header (see the finalize false-positive guard above).
+        self.assertTrue(_is_header_anchor(structural=True))
+        self.assertFalse(_is_header_anchor(structural=False))
 
     # ------------------------------------------------------------------
     # Composer renders each finding once — NOT a doubler  [issue #2183]

--- a/opencontractserver/tests/research/test_research_report_service.py
+++ b/opencontractserver/tests/research/test_research_report_service.py
@@ -353,6 +353,38 @@ class ResearchReportServiceTestCase(TestCase):
         report.refresh_from_db()
         self.assertTrue(report.citations[0]["anchor_is_header"])
 
+    def test_finalize_plural_weak_citation_warning(self):
+        # Two header-anchored citations exercise the plural warning branch and
+        # its "N citations anchor section headers" grammar.
+        h1 = self._make_annotation(
+            label_text="OC_SECTION", raw_text="ITEM 1A. RISK FACTORS"
+        )
+        h2 = self._make_annotation(label_text="Section Header", raw_text="Market Risk")
+        report = self._make_report()
+        report.findings = [
+            {"section": "Risks", "claim": "c", "citations": [h1.pk, h2.pk]},
+        ]
+        report.save(update_fields=["findings"])
+        body = (
+            f'<cite ids="{h1.pk}">supply risk is disclosed</cite>. '
+            f'<cite ids="{h2.pk}">market risk is disclosed</cite>.'
+        )
+        ResearchReportService.finalize(
+            report,
+            executive_summary="",
+            markdown_body=body,
+            retrieved_annotation_ids=[h1.pk, h2.pk],
+        )
+        report.refresh_from_db()
+        self.assertTrue(all(c["anchor_is_header"] for c in report.citations))
+        self.assertTrue(
+            any(
+                "2 citations anchor section headers" in str(w)
+                for w in (report.warnings or [])
+            ),
+            report.warnings,
+        )
+
     def test_finalize_does_not_flag_structural_body_paragraph_citation(self):
         # Regression guard (review of #2180): the parsing pipeline marks EVERY
         # layout chunk structural=True — body paragraphs and sentence chunks

--- a/opencontractserver/tests/research/test_research_report_service.py
+++ b/opencontractserver/tests/research/test_research_report_service.py
@@ -211,7 +211,7 @@ class ResearchReportServiceTestCase(TestCase):
     # ------------------------------------------------------------------
     def _make_annotation(self, **overrides) -> Annotation:
         label, _ = AnnotationLabel.objects.get_or_create(
-            text="default",
+            text=overrides.pop("label_text", "default"),
             defaults={"creator": self.user, "label_type": "TOKEN_LABEL"},
         )
         doc = overrides.pop(
@@ -306,11 +306,11 @@ class ResearchReportServiceTestCase(TestCase):
     # ------------------------------------------------------------------
     # finalize() — weak-citation (section-header) lint  [issue #2180]
     # ------------------------------------------------------------------
-    def test_finalize_flags_structural_header_citation(self):
-        # A citation resolving to a structural (OC_SECTION) annotation anchors
-        # the top of a section, not the supporting passage — finalize flags it.
+    def test_finalize_flags_section_header_label_citation(self):
+        # A citation whose anchor carries a section-header label (OC_SECTION)
+        # anchors the top of a section, not the supporting passage — flag it.
         header = self._make_annotation(
-            structural=True, raw_text="ITEM 1A. RISK FACTORS"
+            label_text="OC_SECTION", raw_text="ITEM 1A. RISK FACTORS"
         )
         report = self._make_report()
         report.findings = [
@@ -332,16 +332,64 @@ class ResearchReportServiceTestCase(TestCase):
             report.warnings,
         )
 
-    def test_finalize_does_not_flag_non_structural_clause_opening_with_section_ref(
-        self,
-    ):
-        # Regression guard (review of #2180): the lint keys on the structural
-        # flag ONLY, never on heading-like text. Legal prose routinely opens an
-        # operative clause with its section number ("Section 8.1 requires ...");
-        # a non-structural anchor like that is a real, correct citation and must
-        # NOT be flagged, or the warning would false-positive on contract corpora.
+    def test_finalize_flags_llamaparse_heading_label_citation(self):
+        # LlamaParse layout heading labels ("Section Header", …) are flagged
+        # too, matched case-/separator-insensitively.
+        header = self._make_annotation(
+            label_text="Section Header", raw_text="Risk Factors"
+        )
+        report = self._make_report()
+        report.findings = [
+            {"section": "Risks", "claim": "c", "citations": [header.pk]},
+        ]
+        report.save(update_fields=["findings"])
+        body = f'<cite ids="{header.pk}">the section covers supply risk</cite>.'
+        ResearchReportService.finalize(
+            report,
+            executive_summary="",
+            markdown_body=body,
+            retrieved_annotation_ids=[header.pk],
+        )
+        report.refresh_from_db()
+        self.assertTrue(report.citations[0]["anchor_is_header"])
+
+    def test_finalize_does_not_flag_structural_body_paragraph_citation(self):
+        # Regression guard (review of #2180): the parsing pipeline marks EVERY
+        # layout chunk structural=True — body paragraphs and sentence chunks
+        # included (oc_text_parser / llamaparse_parser) — so the lint must key
+        # on the annotation LABEL, not the structural flag. A structural body
+        # sentence (the normal similarity_search hit) is a real citation and
+        # must NOT be flagged.
+        body_chunk = self._make_annotation(
+            label_text="SENTENCE",
+            structural=True,
+            raw_text="The Company's primary raw materials include aluminum and copper.",
+        )
+        report = self._make_report()
+        report.findings = [
+            {"section": "Risks", "claim": "c", "citations": [body_chunk.pk]},
+        ]
+        report.save(update_fields=["findings"])
+        body = f'<cite ids="{body_chunk.pk}">raw materials include aluminum</cite>.'
+        ResearchReportService.finalize(
+            report,
+            executive_summary="",
+            markdown_body=body,
+            retrieved_annotation_ids=[body_chunk.pk],
+        )
+        report.refresh_from_db()
+        self.assertFalse(report.citations[0]["anchor_is_header"])
+        self.assertFalse(
+            any("section header" in str(w) for w in (report.warnings or [])),
+            report.warnings,
+        )
+
+    def test_finalize_does_not_flag_body_clause_opening_with_section_ref(self):
+        # A body-labelled clause that merely opens with a section reference
+        # ("Section 8.1 requires ...") is a correct citation to operative
+        # language — never flagged, since detection keys on the label, not text.
         clause = self._make_annotation(
-            structural=False,
+            label_text="Paragraph",
             raw_text="Section 8.1 requires 30 days' written notice prior to termination.",
         )
         report = self._make_report()
@@ -365,44 +413,18 @@ class ResearchReportServiceTestCase(TestCase):
             report.warnings,
         )
 
-    def test_finalize_does_not_flag_operative_passage_citation(self):
-        # A normal, non-structural anchor with real operative language is a
-        # good citation — no weak-citation warning, flag is False.
-        passage = self._make_annotation(
-            structural=False,
-            raw_text=(
-                "Our fixed-price contracts expose us to cost-overrun risk because "
-                "we bear the burden of increases in raw-material prices."
-            ),
-        )
-        report = self._make_report()
-        report.findings = [
-            {"section": "Risks", "claim": "c", "citations": [passage.pk]},
-        ]
-        report.save(update_fields=["findings"])
-        body = (
-            f'<cite ids="{passage.pk}">fixed-price contracts carry overrun risk</cite>.'
-        )
-        ResearchReportService.finalize(
-            report,
-            executive_summary="",
-            markdown_body=body,
-            retrieved_annotation_ids=[passage.pk],
-        )
-        report.refresh_from_db()
-        self.assertFalse(report.citations[0]["anchor_is_header"])
-        self.assertFalse(
-            any("section header" in str(w) for w in (report.warnings or [])),
-            report.warnings,
-        )
-
-    def test_is_header_anchor_keys_on_structural_flag_only(self):
-        # The predicate is keyed solely on Annotation.structural — the reliable
-        # OC_SECTION header signal — never on heading-like text, so operative
-        # prose that opens with a section reference is never mistaken for a
-        # header (see the finalize false-positive guard above).
-        self.assertTrue(_is_header_anchor(structural=True))
-        self.assertFalse(_is_header_anchor(structural=False))
+    def test_is_header_anchor_keys_on_label(self):
+        # Header-like labels (case-/separator-insensitive) are flagged...
+        self.assertTrue(_is_header_anchor(label_text="OC_SECTION"))
+        self.assertTrue(_is_header_anchor(label_text="Section Header"))
+        self.assertTrue(_is_header_anchor(label_text="section_header"))
+        self.assertTrue(_is_header_anchor(label_text="Title"))
+        # ...body/content labels and a missing label are not.
+        self.assertFalse(_is_header_anchor(label_text="Paragraph"))
+        self.assertFalse(_is_header_anchor(label_text="SENTENCE"))
+        self.assertFalse(_is_header_anchor(label_text="Table"))
+        self.assertFalse(_is_header_anchor(label_text=None))
+        self.assertFalse(_is_header_anchor(label_text=""))
 
     # ------------------------------------------------------------------
     # Composer renders each finding once — NOT a doubler  [issue #2183]


### PR DESCRIPTION
## Summary

Four issues from a live citation audit of a deep-research run (ResearchReport 4, 192 SEC filings) all trace to how the deep-research agent chooses and renders citations. This PR fixes them with one focused, high-leverage change — a `## Citation discipline` section in the agent's system prompt — plus a deterministic, observational backstop for the header-anchor problem.

| Issue | Problem | Fix |
|---|---|---|
| #2180 | Footnotes anchor **section headers** (`"ITEM 1A. RISK FACTORS"`) instead of the supporting passage | Prompt rule + finalize-time weak-citation lint |
| #2181 | Citations don't traverse **incorporation-by-reference** — they cite the referring 10-Q, not the 10-K that holds the language | Prompt rule: cite the doc that *contains* the language; follow the reference first |
| #2182 | **Prompt-derived** context ("Event Overview") gets decorated with unrelated corpus anchors | Prompt rule: task/background restatements carry **no** citation |
| #2183 | Report **duplicates every finding sentence** (`…price increases.TCFIII SPACECO…[^2][^3]`) | Prompt rule: state each claim once inside a single `<cite>` tag |

## Root-cause note on #2183

The issue speculated the composer concatenates `finding.summary` + `finding.cited_text`. It does not: the normal finalize path emits the agent's `markdown_body` verbatim (cite-rendered), the salvage path renders exactly one bullet per finding, and the frontend renders only `content` (never re-rendering `findings`). The observed doubling — a plain sentence joined with no space to a near-identical cited restatement — is **agent-authored prose**, so it's fixed by the write-once prompt rule. New regression tests lock in single-render composition so a future composer change can't reintroduce it.

## Changes

- **`opencontractserver/research/constants.py`** — new `## Citation discipline` section in `build_deep_research_system_prompt` covering all four rules; new `RESEARCH_HEADER_ANCHOR_LABELS` set (`OC_SECTION` + the LlamaParse heading labels `Title` / `Section Header` / `Heading` / `Page Header`) used by the lint.
- **`opencontractserver/research/services/research_reports.py`** — `_is_header_anchor()` / `_normalize_label()` helpers + `_render_citations` now `select_related`s `annotation_label` (no N+1) and tags each citation `anchor_is_header` when its **annotation label** is a section-header label (matched case-/separator-insensitively). `finalize` records a concise weak-citation warning (surfaced in the report UI's existing warning chips) when a footnote anchors a header. Observational only — it never rewrites prose. Detection is keyed on the **label, not `Annotation.structural`**: the parsing pipeline sets `structural=True` on its entire layout layer (body paragraphs, tables, sentence chunks), and the bookmark-derived OC_SECTION headers are `structural=False`, so keying on it would both flood false positives and miss the real headers.
- **Tests** — `test_prompt_documents_citation_discipline`; finalize-lint tests (`OC_SECTION` + LlamaParse-heading label → warning; a `structural=True` body paragraph and a body clause that merely opens with "Section 8.1 …" → no warning; singular + plural warning grammar); single-render composition guards for both `finalize` and `_compose_salvage_body`.
- **Changelog fragment** `changelog.d/2180-2183-research-citations.fixed.md`.

## Testing

- `python -m py_compile`, `black`, `flake8`, and `scripts/collate_changelog.py --check` all pass.
- New unit tests added for every deterministic behavior change, traced against the real code paths. (The Dockerized backend suite couldn't be built inside the authoring sandbox — the egress proxy re-terminates TLS for the container build's `pip` — so it runs in CI; the Codecov patch report confirms the suite executed there.)

## Scope notes

- Only #2180 gets a deterministic, testable backstop (the header lint). #2181 / #2182 / #2183 are prompt-only rules with no runtime enforcement — consistent with the #2183 root-cause finding (agent-authored prose, not a composer bug). Confirming those three change agent behavior in practice needs another live citation audit.
- The lint's `RESEARCH_HEADER_ANCHOR_LABELS` covers `OC_SECTION` + the LlamaParse heading taxonomy. Docling/oc_text_parser headers are caught via the parser-agnostic `OC_SECTION` bookmark layer; a Docling doc with header-like text that never receives an `OC_SECTION` annotation would be missed. Acceptable for an observational lint; a possible follow-up if Docling coverage needs to be explicit.

Closes #2180
Closes #2181
Closes #2182
Closes #2183

> Note on #2181: this implements the immediate agent-instruction fix. The issue's "longer term" idea — exposing the corpus's `INCORPORATED_BY_REFERENCE` / `HAS_EXHIBIT` relationship edges as research tools for deliberate traversal — remains a good follow-up.