### PR TITLE
Pin mcp below v2 to fix pip resolution and avoid a breaking-API bump

### DIFF
--- a/changelog.d/2207-pin-mcp-below-v2.fixed.md
+++ b/changelog.d/2207-pin-mcp-below-v2.fixed.md
@@ -1,0 +1,13 @@
+- `requirements/base.txt:85` — pinned `mcp` to `>=1.28.1,<2` (was unbounded).
+  Dependabot's `mcp>=2.0.0` bump (#2207) hit `pip`'s resolver as
+  `resolution-too-deep`: `pydantic-ai-slim[mcp]`'s `fastmcp-slim` dependency
+  caps `mcp<2.0` across its entire published range, so the unbounded pin was
+  resolving to 1.x only by transitive accident. `mcp` 2.0 is also a breaking
+  rewrite — `mcp.server.lowlevel.Server` drops decorator-based handler
+  registration (`@mcp_server.list_resources()` etc.) in favor of `on_*=`
+  constructor kwargs with a new `(ctx, params)` handler signature — which
+  `opencontractserver/mcp/server.py` does not yet speak (10 registration
+  sites across `create_mcp_server()` and `create_scoped_mcp_server()`), so
+  forcing the bump would fail at ASGI import time, not just in CI. PR #2207
+  is left open/unmerged; revisit the `mcp` 2.x migration as its own scoped
+  task once `fastmcp-slim` ships v2 support.

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -82,7 +82,14 @@ posthog==7.33.0  # https://github.com/posthog/posthog-python
 
 # Model Context Protocol
 # ------------------------------------------------------------------------------
-mcp>=1.28.1  # https://github.com/anthropics/python-sdk
+mcp>=1.28.1,<2  # https://github.com/modelcontextprotocol/python-sdk
+# ^ pydantic-ai-slim[mcp] -> fastmcp-slim caps mcp<2.0 across its whole
+# published range as of 2026-08; mcp 2.0 is a breaking rewrite (decorator-based
+# handler registration on mcp.server.lowlevel.Server removed in favor of
+# on_*= constructor kwargs) that opencontractserver/mcp/server.py does not yet
+# speak. Bump this pin only alongside a migration of that file, once
+# fastmcp-slim ships v2 support (or fastmcp-slim/mcp is dropped in favor of
+# calling the v2 API directly).
 
 # Not directly required, pinned by Snyk to avoid a vulnerability
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `requirements/base.txt` pins `mcp` to `>=1.28.1,<2` (was unbounded).
- Dependabot's #2207 (`mcp>=2.0.0`) hits pip's `resolution-too-deep`: `pydantic-ai-slim[mcp]` → `fastmcp-slim` caps `mcp<2.0` across its whole published range, so the unbounded pin was only ever resolving to 1.x by transitive accident.
- `mcp` 2.0 is also a breaking rewrite — `mcp.server.lowlevel.Server` drops decorator-based handler registration (`@mcp_server.list_resources()` etc.) for `on_*=` constructor kwargs with a new `(ctx, params)` signature. `opencontractserver/mcp/server.py` uses the old decorator API at 10 registration sites across `create_mcp_server()` / `create_scoped_mcp_server()`, both of which run at Django/ASGI import time — forcing the bump would break the MCP subsystem at process startup, not just in CI.
- PR #2207 is left open/unmerged. Revisit the `mcp` 2.x migration as its own scoped task once `fastmcp-slim` ships v2 support.

## Test plan
- [x] `pip install --dry-run` against the updated `requirements/local.txt` resolves cleanly (previously `ResolutionImpossible`/`resolution-too-deep`).
- [x] `pre-commit run --files requirements/base.txt` passes.
- [x] Changelog fragment added and validated (`scripts/collate_changelog.py --check`).