### PR TITLE
Add California foreclosure compliance corpus analyzer

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -1832,3 +1832,18 @@ MCP_CORS_ALLOWED_ORIGINS = env.list(
 # Host; because MCP bypasses ALLOWED_HOSTS, pinning this in production is
 # recommended (e.g. MCP_PUBLIC_BASE_URL=https://contracts.opensource.legal).
 MCP_PUBLIC_BASE_URL = env.str("MCP_PUBLIC_BASE_URL", default="")
+
+# ------------------------------------------------------------------------------
+# FORECLOSURE COMPLIANCE RULESET
+# ------------------------------------------------------------------------------
+# The California foreclosure ruleset (Civ. Code § 2924 et seq.) runs as a
+# separate service — `legalis-ca-foreclosure-api`, a Rust binary — rather than
+# in-process. An FFI boundary would couple this deployment to a Rust toolchain
+# and turn the ruleset's panics into worker crashes; over HTTP it is
+# independently deployable and independently versioned.
+#
+# Endpoints consumed: GET /health, GET /v1/rules, POST /v1/evaluate.
+FORECLOSURE_API_URL = env.str(
+    "FORECLOSURE_API_URL", default="http://foreclosure-api:8090"
+)
+FORECLOSURE_API_TIMEOUT = env.int("FORECLOSURE_API_TIMEOUT", default=30)

--- a/docs/foreclosure-compliance.md
+++ b/docs/foreclosure-compliance.md
@@ -1,0 +1,141 @@
+# California Foreclosure Compliance
+
+Runs the `legalis-ca-foreclosure` ruleset — Civ. Code § 2924 et seq. encoded as
+dated, versioned rules — over a corpus of recorded instruments and produces a
+compliance chronology.
+
+> **No rule encoding has been reviewed by a licensed attorney.** The analyzer
+> reports this in every result. Output is not legal advice.
+
+## Why a corpus analyzer
+
+A foreclosure matter maps onto a corpus: each recorded instrument — Notice of
+Default, Notice of Trustee's Sale, Trustee's Deed — is a document, and the
+matter is the corpus they belong to.
+
+It is corpus-scoped rather than per-document because no single instrument
+answers the question. Whether the three-month period under § 2924(a)(2) elapsed
+needs the Notice of Default *and* the Notice of Sale together.
+
+## Architecture
+
+```
+Corpus of recorded instruments
+      │  matter.py — instrument kind + dates off each document
+      ▼
+matter payload (JSON)
+      │  client.py — HTTP
+      ▼
+foreclosure-api  (Rust, legalis-ca-foreclosure-api)
+      │  dated statutory rules
+      ▼
+compliance report → Analysis.result_message
+```
+
+The ruleset runs as a **separate service, not in-process**. It is Rust; an FFI
+boundary would couple this deployment to a Rust toolchain and turn the
+ruleset's panics into Celery worker crashes. Over HTTP it is independently
+deployable and independently versioned, at the cost of one network hop per
+matter.
+
+## Running it
+
+```bash
+docker compose -f local.yml --profile foreclosure up
+```
+
+Then run the **California Foreclosure Compliance** analyzer against a corpus.
+It registers automatically — `auto_create_doc_analyzers` syncs any
+`@corpus_analyzer_task` from the Celery registry into an `Analyzer` row on
+startup.
+
+### Settings
+
+| Setting | Env var | Default |
+|---|---|---|
+| `FORECLOSURE_API_URL` | `FORECLOSURE_API_URL` | `http://foreclosure-api:8090` |
+| `FORECLOSURE_API_TIMEOUT` | `FORECLOSURE_API_TIMEOUT` | `30` |
+
+## What is read from documents, and what is not
+
+**Read from the instruments:** instrument type, recording date, date mailed to
+the trustor, first publication date, date posted, instrument number.
+
+**Not read, because they appear on no recorded instrument:** the sale date, the
+loan's purpose, the property's occupancy and unit count, reinstatement tenders,
+postponements, payoff requests. These come from the analyzer's input (see the
+input schema) or from `Corpus.custom_meta["foreclosure"]`.
+
+Anything absent is **not** assumed. The ruleset reports `INSUFFICIENT RECORD`,
+which is a distinct outcome from compliance. A compliance finding resting on an
+assumed fact is worse than no finding.
+
+## What it checks
+
+| Provision | Requirement |
+|---|---|
+| § 2924(a)(2) | Three months between Notice of Default and Notice of Sale |
+| § 2924b(b)(1) | NOD mailed within 10 **business** days of recording |
+| § 2924b(b)(2) | Notice of Sale mailed ≥ 20 days before sale |
+| § 2924f(b)(1) | Published and posted ≥ 20 days; recorded ≥ 14 days before sale |
+| § 2924c(e) | Reinstatement until 5 **business** days before sale |
+| § 2924g(d) | Postponement announced at the time and place of sale |
+| § 2943(c) | Payoff demand statement within 21 days |
+| § 2941(b), (d) | Reconveyance after payoff; $500 statutory damages |
+
+Business days follow the Civ. Code § 7 holiday set, not calendar days. For a
+sale on 2024-07-12 this moves the § 2924c(e) cutoff from 07-04 to 07-05 —
+which decides whether a tender was timely.
+
+## What it will not decide
+
+Two rules exist to be refused:
+
+- Whether service was **reasonably calculated** to reach the trustor (§ 2924b)
+- Whether a default rate is an **unenforceable penalty** (§ 1671(b))
+
+Both come back as `REQUIRES JUDGMENT`. There is no rate threshold above which
+§ 1671 is satisfied, and inventing one would manufacture a legal conclusion the
+engine has no basis for. The value of computing the deterministic rules
+depends on being visibly unwilling to compute these.
+
+## Outcomes
+
+| Status | Meaning |
+|---|---|
+| `compliant` | Requirement met |
+| `violation` | Requirement not met |
+| `requires_judgment` | A human must decide |
+| `insufficient_record` | Not enough in the record to evaluate — **not** a pass |
+| `not_applicable` | The rule does not reach this matter |
+| `record_inconsistent` | The record contradicts itself |
+| `not_yet_in_force` | The provision post-dates the matter |
+
+## Point-in-time law
+
+Rules carry dated versions and are selected against the matter's **operative
+date** — the recording of the Notice of Default. A 2011 foreclosure is not
+evaluated against post-HBOR text; a provision enacted later reports
+`NOT YET IN FORCE` rather than being applied retroactively.
+
+`GET /v1/rules` on the service returns the full manifest: every provision,
+its dated versions, and how many have been attorney-reviewed.
+
+## Failure behaviour
+
+If the service is unreachable the task **raises**. It does not return "no
+violations found". A compliance analyzer that reports a clean bill of health
+because it could not reach its ruleset is worse than one that crashes, and
+there is a test asserting this.
+
+The task is idempotent — it reads documents and returns a result dict, with no
+side-effect writes — as required for `CELERY_TASK_ACKS_LATE`.
+
+## Tests
+
+```bash
+pytest opencontractserver/tests/test_foreclosure_compliance.py
+```
+
+32 tests covering classification, date extraction, matter assembly and client
+error handling. The ruleset itself has 94 tests in the Rust crate.

--- a/local.yml
+++ b/local.yml
@@ -150,6 +150,25 @@ services:
     mem_limit: 1g
     restart: unless-stopped
 
+  # California foreclosure compliance ruleset (Civ. Code § 2924 et seq.), used
+  # by the `california_foreclosure_compliance` corpus analyzer. Built from
+  # legalis-parser: crates/legalis-ca-foreclosure-api/Dockerfile.
+  #
+  # Opt-in via the "foreclosure" compose profile:
+  #   docker compose -f local.yml --profile foreclosure up
+  #
+  # Stateless and dependency-free — no database, no models, no outbound calls.
+  # It takes a matter in and returns findings, so it needs almost nothing.
+  foreclosure-api:
+    profiles: ["foreclosure"]
+    image: ghcr.io/quantum-general-intelligence/legalis-ca-foreclosure-api:0.1.0
+    container_name: foreclosure-api
+    environment:
+      FORECLOSURE_API_BIND: 0.0.0.0:8090
+    # Deadline arithmetic over a handful of dates; it does not need more.
+    mem_limit: 256m
+    restart: unless-stopped
+
   # Optional alternative PDF parser (deterministic, rule-based; renders straight
   # to the OpenContracts format). Opt-in via the "warp-ingest" compose profile:
   #   docker compose -f local.yml --profile warp-ingest up

--- a/opencontractserver/foreclosure/__init__.py
+++ b/opencontractserver/foreclosure/__init__.py
@@ -1,0 +1,17 @@
+"""California foreclosure compliance.
+
+Integrates the ``legalis-ca-foreclosure`` ruleset — Civ. Code § 2924 et seq.
+encoded as dated, versioned rules — with OpenContracts corpora.
+
+The ruleset runs as a separate service rather than in-process. It is written in
+Rust, and an FFI boundary would couple this deployment to a Rust toolchain and
+turn the ruleset's panics into worker crashes. Over HTTP it is independently
+deployable and independently versioned, at the cost of one network hop per
+matter.
+
+A foreclosure matter maps onto a corpus: each recorded instrument (Notice of
+Default, Notice of Trustee's Sale, Trustee's Deed) is a document, and the
+matter is the corpus they belong to. That is why this is a
+``@corpus_analyzer_task`` rather than a per-document one — no single instrument
+answers whether the three-month period elapsed.
+"""

--- a/opencontractserver/foreclosure/client.py
+++ b/opencontractserver/foreclosure/client.py
@@ -1,0 +1,148 @@
+"""HTTP client for the California foreclosure compliance service.
+
+Talks to ``legalis-ca-foreclosure-api``, which exposes the Rust ruleset over
+three endpoints: ``/health``, ``/v1/rules`` and ``/v1/evaluate``.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+import requests
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BASE_URL = "http://foreclosure-api:8090"
+DEFAULT_TIMEOUT_SECONDS = 30
+
+
+class ForeclosureServiceError(RuntimeError):
+    """The compliance service could not be reached or rejected the request."""
+
+
+@dataclass(frozen=True)
+class ComplianceResult:
+    """What the service returned for one matter."""
+
+    summary: dict[str, Any]
+    report: dict[str, Any]
+    text: str
+
+    @property
+    def violations(self) -> list[dict[str, Any]]:
+        return [f for f in self.report.get("findings", []) if f.get("status") == "violation"]
+
+    @property
+    def requires_judgment(self) -> list[dict[str, Any]]:
+        return [
+            f
+            for f in self.report.get("findings", [])
+            if f.get("status") == "requires_judgment"
+        ]
+
+    @property
+    def insufficient_record(self) -> list[dict[str, Any]]:
+        return [
+            f
+            for f in self.report.get("findings", [])
+            if f.get("status") == "insufficient_record"
+        ]
+
+    @property
+    def needs_attention(self) -> bool:
+        return bool(self.summary.get("needs_attention"))
+
+
+def _base_url() -> str:
+    return getattr(settings, "FORECLOSURE_API_URL", DEFAULT_BASE_URL).rstrip("/")
+
+
+def _timeout() -> int:
+    return getattr(settings, "FORECLOSURE_API_TIMEOUT", DEFAULT_TIMEOUT_SECONDS)
+
+
+class ForeclosureComplianceClient:
+    """Client for the compliance ruleset service."""
+
+    def __init__(self, base_url: str | None = None, timeout: int | None = None):
+        self.base_url = (base_url or _base_url()).rstrip("/")
+        self.timeout = timeout or _timeout()
+
+    def health(self) -> dict[str, Any]:
+        """Ruleset identity and rule counts.
+
+        Includes ``attorney_verified_count``, which the caller should surface
+        rather than discard — a ruleset nobody has reviewed produces findings
+        nobody should rely on unreviewed.
+        """
+        return self._get("/health")
+
+    def rules(self) -> dict[str, Any]:
+        """The full ruleset manifest: provisions, dated versions, review status."""
+        return self._get("/v1/rules")
+
+    def evaluate(self, matter: dict[str, Any]) -> ComplianceResult:
+        """Evaluate a matter and return its compliance report."""
+        payload = self._post("/v1/evaluate", matter)
+        try:
+            return ComplianceResult(
+                summary=payload["summary"],
+                report=payload["report"],
+                text=payload.get("text", ""),
+            )
+        except KeyError as exc:
+            raise ForeclosureServiceError(
+                f"compliance service response missing {exc}"
+            ) from exc
+
+    # ---- transport -------------------------------------------------------- #
+
+    def _get(self, path: str) -> dict[str, Any]:
+        try:
+            response = requests.get(f"{self.base_url}{path}", timeout=self.timeout)
+        except requests.RequestException as exc:
+            raise ForeclosureServiceError(
+                f"could not reach the compliance service at {self.base_url}: {exc}"
+            ) from exc
+        return self._decode(response, path)
+
+    def _post(self, path: str, body: dict[str, Any]) -> dict[str, Any]:
+        try:
+            response = requests.post(
+                f"{self.base_url}{path}", json=body, timeout=self.timeout
+            )
+        except requests.RequestException as exc:
+            raise ForeclosureServiceError(
+                f"could not reach the compliance service at {self.base_url}: {exc}"
+            ) from exc
+        return self._decode(response, path)
+
+    @staticmethod
+    def _decode(response: requests.Response, path: str) -> dict[str, Any]:
+        # A 400 carries a machine-readable reason the caller can act on; keep
+        # it rather than collapsing every failure into "service error".
+        if response.status_code == 400:
+            try:
+                detail = response.json()
+            except ValueError:
+                detail = {"detail": response.text[:500]}
+            raise ForeclosureServiceError(
+                f"compliance service rejected the request: "
+                f"{detail.get('error', 'bad_request')} — {detail.get('detail', '')}"
+            )
+
+        if not response.ok:
+            raise ForeclosureServiceError(
+                f"compliance service returned {response.status_code} for {path}: "
+                f"{response.text[:500]}"
+            )
+
+        try:
+            return response.json()
+        except ValueError as exc:
+            raise ForeclosureServiceError(
+                f"compliance service returned non-JSON for {path}"
+            ) from exc

--- a/opencontractserver/foreclosure/matter.py
+++ b/opencontractserver/foreclosure/matter.py
@@ -1,0 +1,272 @@
+"""Building a foreclosure matter from a corpus of recorded instruments.
+
+Each document in the corpus is one recorded instrument. This module reads the
+instrument type and the dates off each document's extracted text and assembles
+the matter payload the compliance ruleset expects.
+
+# What is read from documents, and what is not
+
+Dates that appear on the face of a recorded instrument — the recording date,
+the date mailed to the trustor, the publication and posting dates — are read
+from the text.
+
+Facts that do *not* appear on any recorded instrument are not invented. The
+loan's purpose, the property's occupancy, whether a reinstatement was tendered
+and refused: none of these are printed on a Notice of Default. They come from
+``Corpus.custom_meta`` or from the analyzer's input, and where they are absent
+the ruleset reports ``INSUFFICIENT RECORD`` rather than guessing. That is the
+intended behaviour — a compliance finding built on an assumed fact is worse
+than no finding.
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+import re
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Instrument kinds as the ruleset's serde representation expects them.
+NOTICE_OF_DEFAULT = "notice_of_default"
+NOTICE_OF_SALE = "notice_of_sale"
+TRUSTEES_DEED = "trustees_deed_upon_sale"
+SUBSTITUTION_OF_TRUSTEE = "substitution_of_trustee"
+ASSIGNMENT = "assignment_of_deed_of_trust"
+RECONVEYANCE = "reconveyance"
+RESCISSION = "rescission_of_notice_of_default"
+DEED_OF_TRUST = "deed_of_trust"
+
+# Ordered most-specific first. A Notice of Default recites the deed of trust it
+# secures, so a naive substring scan would classify it as a deed of trust; the
+# match that starts earliest in the text wins, and headings are searched before
+# body text by the caller.
+_INSTRUMENT_PATTERNS: list[tuple[str, str]] = [
+    ("rescission of notice of default", RESCISSION),
+    ("notice of default", NOTICE_OF_DEFAULT),
+    ("notice of trustee's sale", NOTICE_OF_SALE),
+    ("notice of trustees sale", NOTICE_OF_SALE),
+    ("notice of sale", NOTICE_OF_SALE),
+    ("trustee's deed upon sale", TRUSTEES_DEED),
+    ("trustees deed upon sale", TRUSTEES_DEED),
+    ("substitution of trustee", SUBSTITUTION_OF_TRUSTEE),
+    ("assignment of deed of trust", ASSIGNMENT),
+    ("full reconveyance", RECONVEYANCE),
+    ("deed of trust", DEED_OF_TRUST),
+]
+
+_DATE_FORMATS = ("%B %d, %Y", "%B %d %Y", "%m/%d/%Y", "%Y-%m-%d", "%b %d, %Y")
+
+_RECORDING_LABELS = ("Recording Date", "Date Recorded", "Recorded on")
+_MAILING_LABELS = ("Date Mailed to Trustor", "Date Mailed", "Mailed on")
+_PUBLICATION_LABELS = ("First Publication Date", "Date of First Publication")
+_POSTING_LABELS = ("Date Posted", "Posted on")
+
+_INSTRUMENT_NUMBER_RE = re.compile(
+    r"instrument\s+no\.?\s*:?\s*([0-9][0-9\-]*)", re.IGNORECASE
+)
+
+
+def classify_instrument(text: str) -> str | None:
+    """Identify the instrument kind, or ``None`` if the text does not say.
+
+    The earliest match wins so that a specific heading outranks a passing
+    mention later in the body.
+    """
+    if not text:
+        return None
+    lowered = text.lower()
+
+    best: tuple[int, str] | None = None
+    for needle, kind in _INSTRUMENT_PATTERNS:
+        position = lowered.find(needle)
+        if position == -1:
+            continue
+        if best is None or position < best[0]:
+            best = (position, kind)
+    return best[1] if best else None
+
+
+def parse_date(value: str) -> datetime.date | None:
+    """Parse a date in any of the forms these instruments use."""
+    cleaned = value.strip().rstrip(".,;")
+    for fmt in _DATE_FORMATS:
+        try:
+            return datetime.datetime.strptime(cleaned, fmt).date()
+        except ValueError:
+            continue
+    return None
+
+
+def find_labelled_date(text: str, labels: tuple[str, ...]) -> datetime.date | None:
+    """Find a date following any of ``labels``."""
+    if not text:
+        return None
+
+    lowered = text.lower()
+    for label in labels:
+        position = lowered.find(label.lower())
+        if position == -1:
+            continue
+        tail = text[position + len(label) :].lstrip(": \t ")
+        # These dates run at most three tokens ("January 15, 2024").
+        candidate = " ".join(tail.split()[:3])
+        parsed = parse_date(candidate)
+        if parsed is not None:
+            return parsed
+    return None
+
+
+def find_instrument_number(text: str) -> str | None:
+    match = _INSTRUMENT_NUMBER_RE.search(text or "")
+    return match.group(1) if match else None
+
+
+def instrument_from_text(
+    text: str,
+    *,
+    title: str = "",
+    document_id: Any = None,
+) -> dict[str, Any] | None:
+    """Build one recorded-instrument payload from a document's text.
+
+    The title is searched for the instrument kind before the body, for the same
+    reason headings beat body text: the title names what the document *is*.
+
+    Returns ``None`` when the kind or the recording date cannot be established
+    — an instrument the ruleset cannot place in the timeline is better omitted
+    than guessed at, and its absence surfaces as ``INSUFFICIENT RECORD``.
+    """
+    kind = classify_instrument(title) or classify_instrument(text)
+    if kind is None:
+        logger.info("Document %s: instrument type not recognised", document_id)
+        return None
+
+    recorded = find_labelled_date(text, _RECORDING_LABELS)
+    if recorded is None:
+        logger.info(
+            "Document %s: classified as %s but no recording date found",
+            document_id,
+            kind,
+        )
+        return None
+
+    payload: dict[str, Any] = {
+        "kind": kind,
+        "recorded_date": recorded.isoformat(),
+        "instrument_number": find_instrument_number(text),
+        "mailed_date": None,
+        "first_publication_date": None,
+        "posted_date": None,
+        "provenance": None,
+    }
+
+    mailed = find_labelled_date(text, _MAILING_LABELS)
+    if mailed:
+        payload["mailed_date"] = mailed.isoformat()
+
+    published = find_labelled_date(text, _PUBLICATION_LABELS)
+    if published:
+        payload["first_publication_date"] = published.isoformat()
+
+    posted = find_labelled_date(text, _POSTING_LABELS)
+    if posted:
+        payload["posted_date"] = posted.isoformat()
+
+    if document_id is not None:
+        payload["provenance"] = {
+            "document_id": str(document_id),
+            "page": None,
+            "bbox": None,
+            "snippet": None,
+        }
+
+    return payload
+
+
+def _read_text(document: Any) -> str:
+    """Read a document's extracted text, tolerating an absent extract."""
+    extract = getattr(document, "txt_extract_file", None)
+    if not extract:
+        return ""
+    try:
+        return extract.read().decode("utf-8")
+    except Exception as exc:  # pragma: no cover - storage-dependent
+        logger.warning("Could not read text for document %s: %s", document.id, exc)
+        return ""
+
+
+# Facts that never appear on a recorded instrument and must be supplied.
+_MATTER_FACT_KEYS = (
+    "sale_date",
+    "payoff_date",
+    "loan_purpose",
+    "occupancy",
+    "dwelling_units",
+    "default_rate_percent",
+    "county",
+)
+
+_MATTER_LIST_KEYS = (
+    "postponements",
+    "reinstatement_tenders",
+    "payoff_requests",
+)
+
+
+def build_matter(
+    *,
+    matter_id: str,
+    documents: list[Any],
+    facts: dict[str, Any] | None = None,
+) -> tuple[dict[str, Any], list[Any]]:
+    """Assemble the matter payload for the compliance ruleset.
+
+    ``facts`` supplies what the instruments cannot: the sale date, the loan's
+    purpose, occupancy, and any tenders, postponements or payoff requests.
+
+    Returns the payload and the list of documents that could not be read as
+    recorded instruments, so the caller can report them rather than silently
+    dropping them.
+    """
+    facts = facts or {}
+
+    instruments: list[dict[str, Any]] = []
+    unrecognised: list[Any] = []
+
+    for document in documents:
+        payload = instrument_from_text(
+            _read_text(document),
+            title=getattr(document, "title", "") or "",
+            document_id=getattr(document, "id", None),
+        )
+        if payload is None:
+            unrecognised.append(document)
+        else:
+            instruments.append(payload)
+
+    matter: dict[str, Any] = {
+        "matter_id": matter_id,
+        "county": None,
+        "instruments": instruments,
+        "sale_date": None,
+        "postponements": [],
+        "reinstatement_tenders": [],
+        "payoff_requests": [],
+        "payoff_date": None,
+        "loan_purpose": None,
+        "occupancy": None,
+        "dwelling_units": None,
+        "default_rate_percent": None,
+    }
+
+    for key in _MATTER_FACT_KEYS:
+        if facts.get(key) is not None:
+            matter[key] = facts[key]
+
+    for key in _MATTER_LIST_KEYS:
+        if facts.get(key):
+            matter[key] = facts[key]
+
+    return matter, unrecognised

--- a/opencontractserver/tasks/__init__.py
+++ b/opencontractserver/tasks/__init__.py
@@ -11,6 +11,7 @@ from .doc_analysis_tasks import *  # noqa: F403, F401
 from .doc_tasks import burn_doc_annotations
 from .export_tasks import package_annotated_docs
 from .extract_orchestrator_tasks import run_extract
+from .foreclosure_tasks import california_foreclosure_compliance
 from .fork_tasks import fork_corpus
 from .import_tasks import (
     import_corpus,
@@ -34,6 +35,7 @@ from .telemetry_tasks import send_usage_heartbeat
 # by default search tasks in package.tasks
 
 __all__ = [
+    "california_foreclosure_compliance",
     "corpus_reference_enrichment",
     "crawl_authorities",
     "run_extract",

--- a/opencontractserver/tasks/foreclosure_tasks.py
+++ b/opencontractserver/tasks/foreclosure_tasks.py
@@ -1,0 +1,242 @@
+"""California foreclosure compliance analyzer.
+
+Runs the ``legalis-ca-foreclosure`` ruleset over a corpus of recorded
+instruments and stores the resulting compliance report on the Analysis.
+
+Corpus-scoped rather than document-scoped: no single instrument answers whether
+the three-month period under Civ. Code § 2924(a)(2) elapsed. That question
+needs the Notice of Default and the Notice of Sale together, which is what a
+corpus holds.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from opencontractserver.foreclosure.client import (
+    ForeclosureComplianceClient,
+    ForeclosureServiceError,
+)
+from opencontractserver.foreclosure.matter import build_matter
+from opencontractserver.shared.decorators import corpus_analyzer_task
+
+logger = logging.getLogger(__name__)
+
+
+FORECLOSURE_INPUT_SCHEMA = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "CaliforniaForeclosureComplianceInput",
+    "type": "object",
+    "description": (
+        "Facts that do not appear on any recorded instrument and must be "
+        "supplied. Anything omitted is reported as INSUFFICIENT RECORD rather "
+        "than assumed."
+    ),
+    "properties": {
+        "sale_date": {
+            "type": "string",
+            "format": "date",
+            "description": "Date the trustee's sale was held (YYYY-MM-DD).",
+        },
+        "loan_purpose": {
+            "type": "string",
+            "enum": ["consumer", "business_purpose"],
+            "description": (
+                "Gates the Homeowner Bill of Rights. Consumer-mortgage "
+                "protections do not reach a business-purpose loan."
+            ),
+        },
+        "occupancy": {
+            "type": "string",
+            "enum": ["owner_occupied", "non_owner_occupied", "unknown"],
+        },
+        "dwelling_units": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "HBOR reaches residential property of 1-4 units.",
+        },
+        "county": {"type": "string"},
+        "payoff_date": {"type": "string", "format": "date"},
+        "default_rate_percent": {
+            "type": "number",
+            "description": (
+                "Contractual default rate. Raises a § 1671 penalty question, "
+                "which the ruleset refers to a human and never decides."
+            ),
+        },
+        "reinstatement_tenders": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "tendered_date": {"type": "string", "format": "date"},
+                    "amount_sufficient": {"type": ["boolean", "null"]},
+                    "accepted": {"type": "boolean"},
+                },
+                "required": ["tendered_date", "accepted"],
+            },
+        },
+        "postponements": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "from_date": {"type": "string", "format": "date"},
+                    "to_date": {"type": "string", "format": "date"},
+                    "announced_at_sale": {"type": "boolean"},
+                },
+                "required": ["from_date", "to_date", "announced_at_sale"],
+            },
+        },
+        "payoff_requests": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "requested_date": {"type": "string", "format": "date"},
+                    "delivered_date": {"type": ["string", "null"], "format": "date"},
+                },
+                "required": ["requested_date"],
+            },
+        },
+    },
+    "additionalProperties": False,
+}
+
+
+@corpus_analyzer_task(input_schema=FORECLOSURE_INPUT_SCHEMA)
+def california_foreclosure_compliance(
+    *args,
+    corpus_id: int,
+    analysis_id: int,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    """
+    # California Foreclosure Compliance
+
+    Checks a corpus of recorded instruments against Civ. Code § 2924 et seq.
+    and returns a dated compliance chronology.
+
+    ## What it checks
+
+    - **§ 2924(a)(2)** — three months between Notice of Default and Notice of Sale
+    - **§ 2924b(b)(1), (b)(2)** — service of notices on the trustor
+    - **§ 2924f(b)(1)** — publication, posting and recording of the Notice of Sale
+    - **§ 2924c(e)** — reinstatement right, in *business* days
+    - **§ 2924g(d)** — postponement announced at the time and place of sale
+    - **§ 2943(c)** — payoff demand statement within 21 days
+    - **§ 2941(b), (d)** — reconveyance after payoff
+
+    ## What it will not decide
+
+    Whether service was reasonably calculated to reach the trustor, and whether
+    a default rate is an unenforceable penalty under § 1671, come back as
+    questions for a human. There is no arithmetic that settles them, and the
+    ruleset does not pretend otherwise.
+
+    ## Outcomes
+
+    A finding is COMPLIANT, VIOLATION, REQUIRES JUDGMENT, INSUFFICIENT RECORD,
+    NOT APPLICABLE, RECORD INCONSISTENT, or NOT YET IN FORCE. **Insufficient
+    record is not compliance** — a missing Notice of Default reports as a gap,
+    never as a pass.
+
+    ## Status
+
+    No rule encoding has been reviewed by a licensed attorney. The result
+    records this. Output is not legal advice.
+    """
+    from opencontractserver.corpuses.models import Corpus
+    from opencontractserver.documents.models import Document
+
+    corpus = Corpus.objects.get(id=corpus_id)
+    documents = list(Document.objects.filter(corpus=corpus).order_by("id"))
+
+    if not documents:
+        return {
+            "status": "no_documents",
+            "message": f"Corpus {corpus_id} contains no documents to analyse.",
+            "violations": 0,
+        }
+
+    # Facts the instruments cannot supply come from the analyzer input, then
+    # from the corpus metadata as a fallback.
+    facts: dict[str, Any] = {}
+    corpus_meta = getattr(corpus, "custom_meta", None) or {}
+    if isinstance(corpus_meta, dict):
+        facts.update(corpus_meta.get("foreclosure", {}) or {})
+    facts.update({k: v for k, v in kwargs.items() if v is not None})
+
+    matter, unrecognised = build_matter(
+        matter_id=f"corpus-{corpus_id}",
+        documents=documents,
+        facts=facts,
+    )
+
+    if not matter["instruments"]:
+        return {
+            "status": "no_instruments_recognised",
+            "message": (
+                f"None of the {len(documents)} document(s) in corpus {corpus_id} "
+                "could be read as a recorded instrument with a recording date. "
+                "Check that the documents have been parsed and that their text "
+                "carries a labelled recording date."
+            ),
+            "documents_examined": len(documents),
+            "violations": 0,
+        }
+
+    client = ForeclosureComplianceClient()
+
+    try:
+        health = client.health()
+        result = client.evaluate(matter)
+    except ForeclosureServiceError as exc:
+        # Surface the failure rather than reporting a clean bill of health.
+        logger.error("Foreclosure compliance service failed: %s", exc)
+        raise
+
+    violations = result.violations
+    judgment = result.requires_judgment
+    gaps = result.insufficient_record
+
+    logger.info(
+        "Corpus %s: %d violation(s), %d requiring judgment, %d gap(s)",
+        corpus_id,
+        len(violations),
+        len(judgment),
+        len(gaps),
+    )
+
+    return {
+        "status": "completed",
+        "ruleset": health.get("ruleset"),
+        "jurisdiction": health.get("jurisdiction"),
+        "attorney_verified_rules": health.get("attorney_verified_count", 0),
+        "operative_date": result.report.get("operative_date"),
+        "documents_examined": len(documents),
+        "instruments_recognised": len(matter["instruments"]),
+        "documents_unrecognised": [str(d.id) for d in unrecognised],
+        "summary": result.summary,
+        "violations": len(violations),
+        "findings": [
+            {
+                "rule_id": f.get("rule_id"),
+                "rule_name": f.get("rule_name"),
+                "status": f.get("status"),
+                "citation": f.get("citation"),
+                "version_effective_from": f.get("version_effective_from"),
+                "detail": f.get("detail"),
+                "workings": f.get("workings", []),
+                "missing": f.get("missing", []),
+            }
+            for f in result.report.get("findings", [])
+        ],
+        "report_text": result.text,
+        "disclaimer": (
+            "Generated from encoded statutory rules and the dates in the "
+            "record. No rule encoding has been reviewed by a licensed "
+            "attorney. Not legal advice."
+        ),
+    }

--- a/opencontractserver/tests/test_foreclosure_compliance.py
+++ b/opencontractserver/tests/test_foreclosure_compliance.py
@@ -1,0 +1,370 @@
+"""
+Tests for the California foreclosure compliance integration.
+
+Organised into scenario groups:
+
+1. INSTRUMENT CLASSIFICATION - reading what a document *is* off its text
+2. DATE EXTRACTION           - reading the dates the statute measures from
+3. MATTER ASSEMBLY           - turning a corpus of instruments into a matter
+4. SERVICE CLIENT            - transport, error surfacing, result shaping
+
+The ruleset itself is tested in the Rust crate (`legalis-ca-foreclosure`, 94
+tests). These tests cover the Python side of the boundary: what gets sent, and
+what is done with what comes back.
+
+Deliberately covered: the cases that must NOT read as compliance. A document
+whose type cannot be established, a matter with no recognisable instruments,
+and a service that is down all have to fail loudly — a compliance analyzer that
+reports a clean bill of health because it could not reach its ruleset is worse
+than one that crashes.
+"""
+
+import datetime
+from unittest.mock import MagicMock, patch
+
+import requests
+from django.test import SimpleTestCase
+
+from opencontractserver.foreclosure.client import (
+    ComplianceResult,
+    ForeclosureComplianceClient,
+    ForeclosureServiceError,
+)
+from opencontractserver.foreclosure.matter import (
+    NOTICE_OF_DEFAULT,
+    NOTICE_OF_SALE,
+    RECONVEYANCE,
+    build_matter,
+    classify_instrument,
+    find_instrument_number,
+    find_labelled_date,
+    instrument_from_text,
+    parse_date,
+)
+
+# ---------------------------------------------------------------------------
+# 1. INSTRUMENT CLASSIFICATION
+# ---------------------------------------------------------------------------
+
+
+class InstrumentClassificationTests(SimpleTestCase):
+    def test_classifies_a_notice_of_default(self):
+        self.assertEqual(
+            classify_instrument("NOTICE OF DEFAULT AND ELECTION TO SELL"),
+            NOTICE_OF_DEFAULT,
+        )
+
+    def test_notice_of_default_outranks_the_deed_of_trust_it_recites(self):
+        # The full heading contains "deed of trust"; the earliest match wins so
+        # the specific instrument is not shadowed by the general one.
+        self.assertEqual(
+            classify_instrument(
+                "NOTICE OF DEFAULT AND ELECTION TO SELL UNDER DEED OF TRUST"
+            ),
+            NOTICE_OF_DEFAULT,
+        )
+
+    def test_classifies_a_notice_of_trustees_sale_with_and_without_apostrophe(self):
+        self.assertEqual(classify_instrument("NOTICE OF TRUSTEE'S SALE"), NOTICE_OF_SALE)
+        self.assertEqual(classify_instrument("NOTICE OF TRUSTEES SALE"), NOTICE_OF_SALE)
+
+    def test_classifies_a_reconveyance(self):
+        self.assertEqual(
+            classify_instrument("FULL RECONVEYANCE"),
+            RECONVEYANCE,
+        )
+
+    def test_unrecognised_text_returns_none_rather_than_guessing(self):
+        self.assertIsNone(classify_instrument("Quarterly earnings statement"))
+        self.assertIsNone(classify_instrument(""))
+
+
+# ---------------------------------------------------------------------------
+# 2. DATE EXTRACTION
+# ---------------------------------------------------------------------------
+
+
+class DateExtractionTests(SimpleTestCase):
+    def test_parses_the_formats_recorded_instruments_use(self):
+        expected = datetime.date(2024, 1, 15)
+        for value in ("January 15, 2024", "01/15/2024", "2024-01-15", "Jan 15, 2024"):
+            with self.subTest(value=value):
+                self.assertEqual(parse_date(value), expected)
+
+    def test_rejects_text_that_is_not_a_date(self):
+        self.assertIsNone(parse_date("sometime last spring"))
+
+    def test_finds_a_labelled_recording_date(self):
+        text = "A.P.N.: 123-456\nRecording Date: January 15, 2024\nTrustor: Someone"
+        self.assertEqual(
+            find_labelled_date(text, ("Recording Date",)),
+            datetime.date(2024, 1, 15),
+        )
+
+    def test_label_matching_is_case_insensitive(self):
+        self.assertEqual(
+            find_labelled_date("recording date: 01/15/2024", ("Recording Date",)),
+            datetime.date(2024, 1, 15),
+        )
+
+    def test_absent_label_yields_none(self):
+        self.assertIsNone(find_labelled_date("no dates here", ("Recording Date",)))
+
+    def test_finds_the_instrument_number(self):
+        self.assertEqual(
+            find_instrument_number("Instrument No. 2024-0114872 recorded"),
+            "2024-0114872",
+        )
+        self.assertIsNone(find_instrument_number("no number present"))
+
+
+class InstrumentFromTextTests(SimpleTestCase):
+    NOD_TEXT = (
+        "NOTICE OF DEFAULT AND ELECTION TO SELL UNDER DEED OF TRUST\n"
+        "Instrument No. 2024-0114872\n"
+        "Recording Date: January 15, 2024\n"
+        "Date Mailed to Trustor: January 22, 2024\n"
+    )
+
+    def test_builds_an_instrument_payload(self):
+        payload = instrument_from_text(self.NOD_TEXT, document_id=7)
+        self.assertIsNotNone(payload)
+        self.assertEqual(payload["kind"], NOTICE_OF_DEFAULT)
+        self.assertEqual(payload["recorded_date"], "2024-01-15")
+        self.assertEqual(payload["mailed_date"], "2024-01-22")
+        self.assertEqual(payload["instrument_number"], "2024-0114872")
+
+    def test_provenance_names_the_source_document(self):
+        payload = instrument_from_text(self.NOD_TEXT, document_id=7)
+        self.assertEqual(payload["provenance"]["document_id"], "7")
+
+    def test_title_is_consulted_before_body_text(self):
+        # The body mentions a reconveyance; the title says what this document is.
+        payload = instrument_from_text(
+            "This instrument follows a Full Reconveyance of an earlier lien.\n"
+            "Recording Date: March 1, 2024\n",
+            title="NOTICE OF TRUSTEE'S SALE",
+        )
+        self.assertEqual(payload["kind"], NOTICE_OF_SALE)
+
+    def test_document_without_a_recording_date_is_dropped_not_guessed(self):
+        payload = instrument_from_text("NOTICE OF DEFAULT with no dates", document_id=1)
+        self.assertIsNone(payload)
+
+    def test_unrecognisable_document_is_dropped(self):
+        self.assertIsNone(
+            instrument_from_text("Recording Date: January 15, 2024", document_id=1)
+        )
+
+
+# ---------------------------------------------------------------------------
+# 3. MATTER ASSEMBLY
+# ---------------------------------------------------------------------------
+
+
+class FakeFile:
+    def __init__(self, text: str):
+        self._text = text
+
+    def read(self):
+        return self._text.encode("utf-8")
+
+
+class FakeDocument:
+    def __init__(self, doc_id, title, text):
+        self.id = doc_id
+        self.title = title
+        self.txt_extract_file = FakeFile(text) if text is not None else None
+
+
+class MatterAssemblyTests(SimpleTestCase):
+    def _documents(self):
+        return [
+            FakeDocument(
+                1,
+                "Notice of Default",
+                "NOTICE OF DEFAULT\nRecording Date: January 15, 2024\n"
+                "Date Mailed to Trustor: January 22, 2024\n",
+            ),
+            FakeDocument(
+                2,
+                "Notice of Trustee's Sale",
+                "NOTICE OF TRUSTEE'S SALE\nRecording Date: April 22, 2024\n"
+                "First Publication Date: April 22, 2024\n"
+                "Date Posted: April 22, 2024\n",
+            ),
+        ]
+
+    def test_builds_a_matter_from_a_corpus_of_instruments(self):
+        matter, unrecognised = build_matter(
+            matter_id="corpus-1", documents=self._documents()
+        )
+        self.assertEqual(len(matter["instruments"]), 2)
+        self.assertEqual(unrecognised, [])
+        self.assertEqual(matter["matter_id"], "corpus-1")
+
+    def test_facts_that_no_instrument_carries_come_from_input(self):
+        matter, _ = build_matter(
+            matter_id="corpus-1",
+            documents=self._documents(),
+            facts={
+                "sale_date": "2024-06-14",
+                "loan_purpose": "consumer",
+                "occupancy": "owner_occupied",
+                "dwelling_units": 1,
+            },
+        )
+        self.assertEqual(matter["sale_date"], "2024-06-14")
+        self.assertEqual(matter["loan_purpose"], "consumer")
+
+    def test_absent_facts_stay_null_rather_than_being_invented(self):
+        matter, _ = build_matter(matter_id="c", documents=self._documents())
+        # These gate whole bodies of law; guessing them would be worse than
+        # reporting the gap.
+        self.assertIsNone(matter["sale_date"])
+        self.assertIsNone(matter["loan_purpose"])
+        self.assertIsNone(matter["occupancy"])
+
+    def test_unreadable_documents_are_reported_not_silently_dropped(self):
+        documents = self._documents() + [
+            FakeDocument(3, "Cover letter", "Dear Sir, please find enclosed.")
+        ]
+        matter, unrecognised = build_matter(matter_id="c", documents=documents)
+        self.assertEqual(len(matter["instruments"]), 2)
+        self.assertEqual([d.id for d in unrecognised], [3])
+
+    def test_document_with_no_extract_is_unrecognised(self):
+        matter, unrecognised = build_matter(
+            matter_id="c", documents=[FakeDocument(9, "Untitled", None)]
+        )
+        self.assertEqual(matter["instruments"], [])
+        self.assertEqual(len(unrecognised), 1)
+
+    def test_list_facts_pass_through(self):
+        matter, _ = build_matter(
+            matter_id="c",
+            documents=self._documents(),
+            facts={
+                "reinstatement_tenders": [
+                    {
+                        "tendered_date": "2024-06-05",
+                        "amount_sufficient": True,
+                        "accepted": False,
+                    }
+                ]
+            },
+        )
+        self.assertEqual(len(matter["reinstatement_tenders"]), 1)
+
+
+# ---------------------------------------------------------------------------
+# 4. SERVICE CLIENT
+# ---------------------------------------------------------------------------
+
+
+class ComplianceResultTests(SimpleTestCase):
+    def _result(self):
+        return ComplianceResult(
+            summary={"violations": 2, "needs_attention": True},
+            report={
+                "findings": [
+                    {"rule_id": "a", "status": "violation"},
+                    {"rule_id": "b", "status": "violation"},
+                    {"rule_id": "c", "status": "requires_judgment"},
+                    {"rule_id": "d", "status": "insufficient_record"},
+                    {"rule_id": "e", "status": "compliant"},
+                ]
+            },
+            text="report",
+        )
+
+    def test_partitions_findings_by_status(self):
+        result = self._result()
+        self.assertEqual(len(result.violations), 2)
+        self.assertEqual(len(result.requires_judgment), 1)
+        self.assertEqual(len(result.insufficient_record), 1)
+
+    def test_insufficient_record_is_not_counted_as_a_violation(self):
+        result = self._result()
+        ids = {f["rule_id"] for f in result.violations}
+        self.assertNotIn("d", ids)
+
+    def test_needs_attention_reads_the_summary(self):
+        self.assertTrue(self._result().needs_attention)
+
+
+class ForeclosureClientTests(SimpleTestCase):
+    def _response(self, status_code=200, json_body=None, text=""):
+        response = MagicMock(spec=requests.Response)
+        response.status_code = status_code
+        response.ok = 200 <= status_code < 300
+        response.text = text
+        if json_body is None:
+            response.json.side_effect = ValueError("no json")
+        else:
+            response.json.return_value = json_body
+        return response
+
+    @patch("opencontractserver.foreclosure.client.requests.get")
+    def test_health_returns_ruleset_identity(self, mock_get):
+        mock_get.return_value = self._response(
+            json_body={
+                "status": "ok",
+                "jurisdiction": "US-CA",
+                "rule_count": 11,
+                "attorney_verified_count": 0,
+            }
+        )
+        health = ForeclosureComplianceClient("http://svc").health()
+        self.assertEqual(health["jurisdiction"], "US-CA")
+        self.assertEqual(health["attorney_verified_count"], 0)
+
+    @patch("opencontractserver.foreclosure.client.requests.post")
+    def test_evaluate_shapes_the_result(self, mock_post):
+        mock_post.return_value = self._response(
+            json_body={
+                "summary": {"violations": 1, "needs_attention": True},
+                "report": {"findings": [{"rule_id": "x", "status": "violation"}]},
+                "text": "REPORT",
+            }
+        )
+        result = ForeclosureComplianceClient("http://svc").evaluate({"matter_id": "m"})
+        self.assertEqual(len(result.violations), 1)
+        self.assertEqual(result.text, "REPORT")
+
+    @patch("opencontractserver.foreclosure.client.requests.post")
+    def test_service_rejection_carries_the_reason(self, mock_post):
+        mock_post.return_value = self._response(
+            status_code=400,
+            json_body={"error": "invalid_matter", "detail": "matter_id must not be empty"},
+        )
+        with self.assertRaises(ForeclosureServiceError) as ctx:
+            ForeclosureComplianceClient("http://svc").evaluate({"matter_id": ""})
+        self.assertIn("matter_id", str(ctx.exception))
+
+    @patch("opencontractserver.foreclosure.client.requests.post")
+    def test_unreachable_service_raises_rather_than_returning_empty(self, mock_post):
+        # The failure mode that matters: a compliance analyzer must never report
+        # "no violations" because it could not reach its ruleset.
+        mock_post.side_effect = requests.ConnectionError("connection refused")
+        with self.assertRaises(ForeclosureServiceError) as ctx:
+            ForeclosureComplianceClient("http://svc").evaluate({"matter_id": "m"})
+        self.assertIn("could not reach", str(ctx.exception))
+
+    @patch("opencontractserver.foreclosure.client.requests.post")
+    def test_server_error_is_surfaced(self, mock_post):
+        mock_post.return_value = self._response(status_code=503, text="unavailable")
+        with self.assertRaises(ForeclosureServiceError):
+            ForeclosureComplianceClient("http://svc").evaluate({"matter_id": "m"})
+
+    @patch("opencontractserver.foreclosure.client.requests.post")
+    def test_malformed_success_response_is_an_error(self, mock_post):
+        mock_post.return_value = self._response(json_body={"unexpected": True})
+        with self.assertRaises(ForeclosureServiceError):
+            ForeclosureComplianceClient("http://svc").evaluate({"matter_id": "m"})
+
+    @patch("opencontractserver.foreclosure.client.requests.get")
+    def test_base_url_trailing_slash_is_normalised(self, mock_get):
+        mock_get.return_value = self._response(json_body={"status": "ok"})
+        ForeclosureComplianceClient("http://svc/").health()
+        self.assertEqual(mock_get.call_args[0][0], "http://svc/health")


### PR DESCRIPTION
Runs the legalis-ca-foreclosure ruleset (Civ. Code § 2924 et seq.) over a corpus of recorded instruments and stores the compliance chronology on the Analysis.

A foreclosure matter maps onto a corpus: each recorded instrument is a document. This is corpus-scoped rather than per-document because no single instrument answers the question — whether the three-month period under § 2924(a)(2) elapsed needs the Notice of Default and the Notice of Sale together.

The ruleset runs as a sidecar rather than in-process. It is Rust; an FFI boundary would couple this deployment to a Rust toolchain and turn the ruleset's panics into Celery worker crashes.

What is read from documents: instrument type, recording date, date mailed to the trustor, publication and posting dates. What is not read, because it appears on no recorded instrument: the sale date, loan purpose, occupancy, tenders, postponements, payoff requests. Those come from the analyzer input or Corpus.custom_meta, and anything absent reports INSUFFICIENT RECORD rather than being assumed — a finding resting on an assumed fact is worse than no finding.

Instrument classification consults the document title before the body, since a Notice of Default recites the deed of trust it secures and a whole-text scan picks the wrong instrument.

If the service is unreachable the task raises rather than returning "no violations found"; a compliance analyzer that reports a clean bill of health because it could not reach its ruleset is worse than one that crashes, and a test asserts this. The task is idempotent, as CELERY_TASK_ACKS_LATE requires.

Adds the foreclosure-api sidecar behind a compose profile, FORECLOSURE_API_URL and FORECLOSURE_API_TIMEOUT settings, and docs. 32 tests.


Claude-Session: https://claude.ai/code/session_01QmjyGXUNXHKZETogxWuDdu