### PR TITLE
Document authority tagging and the modular authority-pack system

### DIFF
--- a/changelog.d/authority-tagging-docs.changed.md
+++ b/changelog.d/authority-tagging-docs.changed.md
@@ -1,0 +1,31 @@
+- **Documented the authority tagging system and authority packs against what
+  #2215 actually shipped**, and wired the pack screenshots the component tests
+  have been capturing into the docs that describe them.
+  - `docs/architecture/authority-console.md` — the **Authority Packs tab**
+    section was four paragraphs with no visuals despite nine
+    `admin--authority-packs-tab--*` / `admin--pack-preflight-modal--*`
+    screenshots being captured on every screenshot run and referenced by no
+    doc. It now shows the catalog, the derived status-badge vocabulary
+    (`Invalid` / `Available` / `Partially installed` / `Installed privately` /
+    `Partially public` / `Fully public`, per `PacksTab.tsx::packStatus`), the
+    empty catalog as the symptom of an unmounted pack directory, and the
+    preflight modal — including the `expectedFingerprint` round-trip that
+    rejects a pack edited between preflight and install, the publish opt-in's
+    charter gate, and the `load_authority_pack --check` headless equivalent.
+  - `docs/guides/authoring-authority-packs.md` —
+    documents the previously undocumented **`sources.yaml` source plan** and the
+    out-of-process collector (`scripts/authority_import/`) that turns it into
+    GUI-importable corpus ZIPs; adds the **in-pack import contract** (relative
+    imports resolve wherever a pack is mounted, an absolute in-tree dotted path
+    silently fails to register the module's providers once sideloaded — the
+    defect that stranded 15 providers); points at the schema-v2 fixture pack
+    `tests/fixtures/authority_packs/example_utility` as the complete worked
+    example alongside v1 `bolivia`; explains the `pack.yaml`-required root scan
+    and `E2E_RUN_AUTHORITY_IMPORTS`; and replaces two dead
+    `test_grid_dossier_*` test references (those modules moved out of the tree
+    with the packs) with the modules that exist.
+  - `docs/architecture/reference-web-enrichment.md` — states where the Tier-1
+    detection vocabulary comes from, closing the gap between the tagging engine
+    and the packs that extend it (`prefixes`/`aliases` plus a pack's optional
+    `shape_rules` / `abbreviations`), so standing up detection for a new body of
+    law reads as the data change it is.

--- a/changelog.d/authority-tagging-docs.changed.md
+++ b/changelog.d/authority-tagging-docs.changed.md
@@ -2,10 +2,13 @@
   #2215 actually shipped**, and wired the pack screenshots the component tests
   have been capturing into the docs that describe them.
   - `docs/architecture/authority-console.md` — the **Authority Packs tab**
-    section was four paragraphs with no visuals despite nine
+    section was four paragraphs with no visuals, while thirteen
     `admin--authority-packs-tab--*` / `admin--pack-preflight-modal--*`
-    screenshots being captured on every screenshot run and referenced by no
-    doc. It now shows the catalog, the derived status-badge vocabulary
+    screenshots sat in the auto directory referenced by no doc. It links the
+    five that teach something; the rest are loading spinners, error banners and
+    near-duplicates that `AuthorityPackPreflightCoverage.ct.tsx` captures for
+    coverage, which is not the same job as documentation. It now shows the
+    catalog, the derived status-badge vocabulary
     (`Invalid` / `Available` / `Partially installed` / `Installed privately` /
     `Partially public` / `Fully public`, per `PacksTab.tsx::packStatus`), the
     empty catalog as the symptom of an unmounted pack directory, and the

--- a/changelog.d/authority-tagging-docs.changed.md
+++ b/changelog.d/authority-tagging-docs.changed.md
@@ -22,8 +22,9 @@
     imports resolve wherever a pack is mounted, an absolute in-tree dotted path
     silently fails to register the module's providers once sideloaded — the
     defect that stranded 15 providers); points at the schema-v2 fixture pack
-    `tests/fixtures/authority_packs/example_utility` as the complete worked
-    example alongside v1 `bolivia`; explains the `pack.yaml`-required root scan
+    `opencontractserver/tests/fixtures/authority_packs/example_utility` as the
+    complete worked example alongside v1 `bolivia`; explains the
+    `pack.yaml`-required root scan
     and `E2E_RUN_AUTHORITY_IMPORTS`; and replaces two dead
     `test_grid_dossier_*` test references (those modules moved out of the tree
     with the packs) with the modules that exist.

--- a/changelog.d/authority-tagging-docs.changed.md
+++ b/changelog.d/authority-tagging-docs.changed.md
@@ -31,4 +31,10 @@
     detection vocabulary comes from, closing the gap between the tagging engine
     and the packs that extend it (`prefixes`/`aliases` plus a pack's optional
     `shape_rules` / `abbreviations`), so standing up detection for a new body of
-    law reads as the data change it is.
+    law reads as the data change it is. Also shows what tagging *produces*: the
+    doc rendered the References panel's transient **In progress** state but
+    never its settled one, and described the corpus governance-graph glimpse
+    without showing it — both screenshots existed and were referenced by no doc.
+    Linking them makes one point twice over, in list form and in graph form: an
+    **Awaiting source** row and a hollow ghost node are the same unresolved
+    citation, and are exactly what seeds the authority crawl.

--- a/docs/architecture/authority-console.md
+++ b/docs/architecture/authority-console.md
@@ -79,7 +79,7 @@ not stored:
 
 | Badge | Meaning |
 |---|---|
-| `Invalid` | The manifest failed server validation; the card shows the error and cannot be installed. |
+| `Invalid` | The manifest failed server validation. The card shows the error, and its button reads **Review pack** and is *disabled* ("Repair this server-deployed pack before installing it") — an invalid pack cannot even be opened, since `can_install` tracks `valid` exactly. |
 | `Available` | Valid, nothing installed yet. |
 | `Partially installed` | Some but not all of the pack's corpora exist. |
 | `Installed privately` | Every corpus installed, none public. |
@@ -93,7 +93,8 @@ that was never bind-mounted yields exactly this:
 
 #### Preflight
 
-**Review & install** runs a fresh, side-effect-free preflight
+**Review & install** (the button on any valid pack) runs a fresh,
+side-effect-free preflight
 (`AuthorityPackService.preflight`) and shows what an install *would* do before
 anything is written:
 

--- a/docs/architecture/authority-console.md
+++ b/docs/architecture/authority-console.md
@@ -62,23 +62,74 @@ corresponding tab so existing bookmarks keep working for one release.
 
 ### Authority Packs tab
 
+![Authority Console — Authority Packs catalog](../assets/images/screenshots/auto/admin--authority-packs-tab--status-badges.png)
+
 The trusted server catalog is discovered from the shipped pack directory and
-`AUTHORITY_PACK_ROOTS` / `AUTHORITY_PACK_PATHS`. The browser sends an opaque
-pack ID, never a filesystem
-path, URL, archive, or manifest. Opening a pack runs a fresh side-effect-free
-preflight and displays its fingerprint, corpus identities, current installation
-state, source-host lineage, and publication approval.
+`AUTHORITY_PACK_ROOTS` / `AUTHORITY_PACK_PATHS` (see
+[Installing a sideloaded pack](../guides/authoring-authority-packs.md#installing-a-sideloaded-pack)).
+The browser sends an opaque pack ID, **never** a filesystem path, URL, archive,
+or manifest — the catalog is the only way in, so the console cannot be used to
+upload pack code or point the server at an arbitrary directory.
+
+Each card carries the pack's display name over its manifest `name`, the
+declared jurisdiction / manifest schema version / charter approval state as
+chips, `Corpora` + `Installed n/m` + `Public n/m` counts, and its declared
+source-host count. The status badge (`PacksTab.tsx::packStatus`) is derived,
+not stored:
+
+| Badge | Meaning |
+|---|---|
+| `Invalid` | The manifest failed server validation; the card shows the error and cannot be installed. |
+| `Available` | Valid, nothing installed yet. |
+| `Partially installed` | Some but not all of the pack's corpora exist. |
+| `Installed privately` | Every corpus installed, none public. |
+| `Partially public` / `Fully public` | Some / all installed corpora are published. |
+
+An empty catalog is the normal symptom of an unmounted or mis-pointed pack
+directory — the pack root is resolved **inside** the container, so a host path
+that was never bind-mounted yields exactly this:
+
+![Authority Packs — empty catalog](../assets/images/screenshots/auto/admin--authority-packs-tab--empty-catalog.png)
+
+#### Preflight
+
+**Review & install** runs a fresh, side-effect-free preflight
+(`AuthorityPackService.preflight`) and shows what an install *would* do before
+anything is written:
+
+![Pack preflight modal](../assets/images/screenshots/auto/admin--pack-preflight-modal--summary-badges.png)
+
+The manifest fingerprint is round-tripped as `expectedFingerprint` on the
+install mutation, so a pack edited on disk between preflight and install is
+rejected rather than silently installing something else. Declared source hosts
+are listed because installing is the trust decision that widens the SSRF
+allowlist. The per-corpus table gives each corpus's slug, charter approval,
+installation state, and visibility.
 
 Installation is private by default and atomically reuses the same
-`AuthorityPackService` as the legacy operator command. Public installation is
-an explicit option and remains disabled while a declared charter is unapproved
-or `pending_legal_review`.
+`AuthorityPackService` as the operator command. **Publish** is a separate
+opt-in checkbox that stays disabled while a declared charter is unapproved or
+`pending_legal_review` (the *Publication unavailable* notice above). The modal
+refuses to close while an install is in flight, so a half-applied transaction is
+never left unattended. A server-side rejection is surfaced in place as
+*Installation failed* rather than as a toast that scrolls away.
+
+The same validation is reachable headlessly — `load_authority_pack --check`
+prints the fingerprint, source hosts, approval state, and per-corpus plan and
+writes nothing, because a headless deployment has no authority-admin browser
+session.
+
+After a successful install the card flips to its new state and the corpora are
+live:
+
+![Authority Packs catalog after installing](../assets/images/screenshots/auto/admin--pack-preflight-modal--install-and-publish.png)
 
 Once a corpus is installed, **Import corpus ZIP** opens the existing
 corpus-export modal with that corpus's server-issued ID. Direct and resumable
 chunked uploads therefore share the normal import service and permission gate;
-the console does not add a second ingestion system. This supports deployments
-whose acquisition/crawling happens outside OpenContracts.
+the console does not add a second ingestion system. This is the landing surface
+for deployments whose acquisition and crawling happen outside OpenContracts —
+see [Collecting content out of process](../guides/authoring-authority-packs.md#collecting-content-out-of-process-the-source-plan).
 
 ### Authorities (Registry tab)
 

--- a/docs/architecture/authority-console.md
+++ b/docs/architecture/authority-console.md
@@ -124,10 +124,11 @@ prints the fingerprint, source hosts, approval state, and per-corpus plan and
 writes nothing, because a headless deployment has no authority-admin browser
 session.
 
-After a successful install the card flips to its new state and the corpora are
-live:
+After a successful install the modal closes and the card flips to its new state
+— below, a pack installed privately, so both corpora exist but neither is
+published (`Installed 2/2`, `Public 0/2`):
 
-![Authority Packs catalog after installing](../assets/images/screenshots/auto/admin--pack-preflight-modal--install-and-publish.png)
+![Authority Packs catalog after a private install](../assets/images/screenshots/auto/admin--pack-preflight-modal--install-and-publish.png)
 
 Once a corpus is installed, **Import corpus ZIP** opens the existing
 corpus-export modal with that corpus's server-issued ID. Direct and resumable

--- a/docs/architecture/authority-console.md
+++ b/docs/architecture/authority-console.md
@@ -112,7 +112,11 @@ opt-in checkbox that stays disabled while a declared charter is unapproved or
 `pending_legal_review` (the *Publication unavailable* notice above). The modal
 refuses to close while an install is in flight, so a half-applied transaction is
 never left unattended. A server-side rejection is surfaced in place as
-*Installation failed* rather than as a toast that scrolls away.
+*Installation failed* rather than as a toast that scrolls away — a slug already
+owned by another creator is the common one, and it is refused here rather than
+producing a second corpus:
+
+![Pack preflight — install rejected by the server](../assets/images/screenshots/auto/admin--pack-preflight-modal--install-rejected.png)
 
 The same validation is reachable headlessly — `load_authority_pack --check`
 prints the fingerprint, source hosts, approval state, and per-corpus plan and

--- a/docs/architecture/reference-web-enrichment.md
+++ b/docs/architecture/reference-web-enrichment.md
@@ -50,6 +50,16 @@ span overlap**, and grammar/LLM candidates add only the non-overlapping tail. So
 citation the grammar already catches is never *also* stored as a (lower-trust) LLM
 row.
 
+**Where a jurisdiction's vocabulary comes from.** The registry tier reads
+`AuthorityNamespace` prefixes and aliases, which are curated through the
+[Authority Console](authority-console.md) Registry tab and loaded in bulk from
+the shipped `authority_mappings.yaml` baseline plus every installed **authority
+pack**. A pack also carries optional `shape_rules` (classify a numbered prefix
+family) and `abbreviations` (Bluebook-style forms the Tier-2a extractor matches),
+merged onto the shipped baseline at runtime — so standing up detection for a new
+body of law is a data change, not a code change. See
+[Authoring an Authority Pack](../guides/authoring-authority-packs.md).
+
 ### Customs / trade grammar family (CBP CROSS-style corpora)
 
 The grammar tier also ships two deterministic customs families

--- a/docs/architecture/reference-web-enrichment.md
+++ b/docs/architecture/reference-web-enrichment.md
@@ -14,6 +14,20 @@ to laws it does *not* contain (the "wanted authorities") seed a global
 from public-domain providers so the citations resolve from `EXTERNAL` to
 `RESOLVED`.
 
+What a reader ends up with is the document's **References panel** — every tag the
+engine produced, in both directions:
+
+![References panel — resolved and unresolved citations on a document](../assets/images/screenshots/auto/annotations--references-panel--with-data.png)
+
+Under `CITES`, each row is one `CorpusReference` — chipped by what it points at
+(`Law`, `Exhibit`), counted by mentions (`×2` where the same authority is cited
+twice), and badged with where it landed. **Linked** means the target is in reach
+and the row opens it; **Awaiting source** is the interesting one — an
+unresolved `LAW` reference, a statute this corpus cites but does not contain.
+Those rows *are* the wanted authorities that seed the crawl, which is what makes
+the panel read as a to-do list rather than a list of failures. `CITED BY` is the
+same web read backwards, from the `DocumentRelationship` projection.
+
 This document covers the detection engine, the in-flight persistence lifecycle,
 the cross-document concurrency model, the authority crawl, and how to operate all
 of it (trigger, monitor, explore). It assumes the reader is comfortable with the
@@ -267,10 +281,19 @@ stays on the Runs tab.
 
 ### Explore — the governance graph
 
-Every corpus landing page shows a static governance-graph *glimpse*; "Explore the
-full graph" opens the deep-linkable interactive **explorer** at `?view=graph`
-(`GovernanceGraphExplorer`, sharing `utils/governanceGraphLayout.ts` with the
-glimpse). Filings sit above, the law shelf below; pan/zoom, search, and
+Every corpus landing page shows a static governance-graph *glimpse* — the whole
+reference web of a corpus in one frame, filings above and the law shelf below:
+
+![Governance-graph glimpse on a corpus landing page](../assets/images/screenshots/auto/corpus--governance-graph--with-data.png)
+
+The hollow, dashed node is the same story the References panel tells in list
+form: a statute the corpus cites but has not ingested. Solid law nodes are
+resolved; the ghost is a wanted authority waiting on the crawl.
+
+"Explore the full graph" opens the deep-linkable interactive **explorer** at
+`?view=graph` (`GovernanceGraphExplorer`, sharing
+`utils/governanceGraphLayout.ts` with the glimpse). Filings sit above, the law
+shelf below; pan/zoom, search, and
 kind/authority filters (dim, don't reflow) let you navigate, and selecting a node
 opens a detail drawer.
 

--- a/docs/guides/authoring-authority-packs.md
+++ b/docs/guides/authoring-authority-packs.md
@@ -484,8 +484,9 @@ so the registry and SSRF allowlist pick up the pack's `providers/` module and
 `source_hosts` — discovery happens at registry build.
 
 An administrator can do the same thing without a shell. **Review & install** on
-a catalog card runs the identical validation and shows what the install would
-do before anything is written:
+a catalog card runs the identical validation and shows what the install would do
+before anything is written (a pack that failed validation instead shows a
+disabled **Review pack** button — repair it on disk first):
 
 ![Pack preflight modal](../assets/images/screenshots/auto/admin--pack-preflight-modal--summary-badges.png)
 

--- a/docs/guides/authoring-authority-packs.md
+++ b/docs/guides/authoring-authority-packs.md
@@ -34,16 +34,26 @@ allowlist entries, and corpus definitions all travel inside the directory.
   charters/<area>.yaml               # v2: corpus scope and legal-review ownership
   metadata/<schema>.yaml             # v2: typed AuthoritySourceRecord fields
   relationships.yaml                 # v2: canonical-key relationship declarations
+  sources.yaml                       # OPTIONAL: source plan for the out-of-process collector
   providers/<name>_provider.py       # OPTIONAL: citation-keyed scraper (discovered from here)
   discovery_providers/<name>.py      # OPTIONAL: listing-index crawler (discovered from here)
   fixtures/                          # OPTIONAL: test/golden data; never legal approval
 ```
 
-The reference pack lives at
-`opencontractserver/enrichment/data/authority_packs/bolivia/` — read it alongside
-this guide; it is the canonical worked example (taxonomy + curated content +
-Spanish persona; no scraper, because its sources are listing-page, not
-key-addressable).
+**Two worked examples, for two different purposes.** Read whichever matches
+what you are writing:
+
+| Example | Schema | Read it for |
+|---|---|---|
+| `opencontractserver/enrichment/data/authority_packs/bolivia/` | v1 | The shipped, installable pack — taxonomy + curated content + a Spanish persona. No scraper: its sources are listing-page, not key-addressable. |
+| `opencontractserver/tests/fixtures/authority_packs/example_utility/` | **v2** | A complete, deliberately fictional multi-corpus pack exercising every v2 slot — slugs, charters, typed metadata, relationships, prefix binding, and a `sources.yaml` source plan. |
+
+`example_utility` lives under `tests/fixtures/` rather than the in-tree pack
+root on purpose: `authority_pack_dirs()` enumerates *every* immediate
+subdirectory of that root, so a fixture placed there would ship as an
+installable pack on every deployment. Tests mount it explicitly via
+`override_settings(AUTHORITY_PACK_PATHS=[…])`, which is also the cheapest way to
+try a pack of your own without committing it.
 
 Each artifact binds to an existing extension seam, so the runtime needs **zero
 changes** to accept a new pack:
@@ -58,6 +68,7 @@ changes** to accept a new pack:
 | Corpus charter | `charters/<area>.yaml` | Load-time scope/review declaration (schema v2) | required in v2 |
 | Typed metadata schema | `metadata/<schema>.yaml` | Existing `Fieldset` / `Column` / `Datacell` metadata path | optional |
 | Authority relationships | `relationships.yaml` | Canonical-key `AuthorityRelationship` rows | optional |
+| Source plan | `sources.yaml` | The out-of-process collector (`scripts/authority_import/`) → corpus-export ZIPs | optional |
 | Corpus namespace binding | `pack.yaml` corpus `authority_prefixes:` | Existing pack-owned `AuthorityNamespace` rows → exact target corpus | optional |
 | Source hosts (for a scraper) | `pack.yaml` `source_hosts:` | the SSRF allowlist, merged at runtime | optional |
 | Provider credentials | the `PipelineSettings` encrypted-secrets vault (**not** a pack file) | `get_component_settings()`, keyed by provider class path | optional |
@@ -81,6 +92,7 @@ jurisdiction: us-example
 mappings: authority_mappings.example.yaml
 metadata_schema: metadata/authority_source_record.yaml  # pack-wide default
 relationships: relationships.yaml
+sources: sources.yaml                 # optional; read only by the out-of-process collector
 source_hosts:
   - example.gov                       # bare host; no scheme, port, or path
 corpora:
@@ -126,10 +138,10 @@ successfully, keeps each provider-authored edge in
 all — no error, no warning, no failing import. The only visible symptom is an
 authority graph that is quietly missing edges. (This stranded 154 of 396
 declared edges across one deployment's four packs before every prefix was
-bound;
-`test_grid_dossier_authority_pack_data.py::
-test_every_declared_prefix_is_bound_to_exactly_one_pack_corpus` now fails a
-pack that leaves one unbound.)
+bound.) Because binding is a property of a pack's own data, a pack repository
+should assert it in its own suite; the loader-side rules — a prefix bound by at
+most one corpus, no undeclared/manual/foreign/already-bound namespaces — are
+covered by `test_authority_pack_loader.py`.
 
 Leaving a prefix unbound is right only when its documents are never sideloaded
 into a corpus of this pack — for example a prefix declared purely so citations
@@ -213,6 +225,34 @@ This workflow requires no provider module or `source_hosts` declaration and
 does not make OpenContracts contact the publisher. Provenance collected by the
 external pipeline should travel in the exported document paths and metadata.
 
+### Collecting content out of process (the source plan)
+
+You do not have to build those ZIPs by hand. A pack may declare a **source
+plan** in `sources.yaml`, and the standalone builder
+`scripts/authority_import/build_authority_imports.py` runs it *outside* the
+application — reusing the pack's own registered discovery and source providers —
+and writes `<pack>/imports/<corpus-slug>.zip` plus an index and a scrape report:
+
+```bash
+python scripts/authority_import/build_authority_imports.py \
+  --rights-approved /srv/authorities/<repo>/packs/<pack>
+```
+
+Each plan entry names one candidate mode (`discovery_provider` + `index_urls`,
+an explicit `candidates` list, or `canonical_keys`) and an `ingestion_mode`:
+`full_content` runs the normal authority rights gate, while `link_only`
+discovers and locates but never fetches publisher bytes. `--rights-approved`
+records the external collector's per-build decision for `LICENSED` /
+`REVIEW_REQUIRED` records; without it those records fail closed. It does not
+publish the corpora, approve graph edges, or waive publisher restrictions.
+
+The web app never runs the scraper on this path — the operator uploads the
+generated ZIPs through **Authority Packs → Import corpus ZIP**. Full field
+reference, the rights and TLS rules, and the pre-import verification checklist
+live with the builder in
+[`scripts/authority_import/README.md`](https://github.com/Open-Source-Legal/OpenContracts/blob/main/scripts/authority_import/README.md);
+`example_utility/sources.yaml` is a working two-source plan.
+
 ## Shipping a scraper inside the pack
 
 A live-fetch provider is the one irreducibly-Python slot (every source's HTML/XML/
@@ -236,6 +276,41 @@ instead of in core's `pipeline/authority_source_providers/`:
    manifest. They cannot borrow a host declared by another installed pack, and
    both the initial URL and redirect-final host must belong to that manifest.
 4. Put any credentials in the secrets vault (above), never in the pack.
+
+### Importing a pack's own modules
+
+A pack with more than one provider usually wants a shared helper (publisher
+identity derivation, a parsing utility) at its pack root. **Reach it with a
+relative import, never an absolute dotted path:**
+
+```python
+# in <pack>/providers/example_provider.py
+from ..publisher_identity import derive_canonical_key   # ✅ works in-tree and sideloaded
+```
+
+In-pack component modules are imported *by file path* under a synthetic
+`_authority_pack.<pack>.…` namespace whose parent packages the registry creates
+(`opencontractserver/pipeline/registry.py::_ensure_synthetic_package`). Relative
+imports resolve against that namespace identically wherever the pack is mounted,
+which is what "a pack is copy-to-port" requires.
+
+An absolute in-tree path
+(`from opencontractserver.enrichment.data.authority_packs.<pack>.helper import …`)
+appears to work only while the pack sits in this repository and is *also*
+importable as a real Python package. The moment it is sideloaded that import
+raises and **every provider in the module silently fails to register** — the
+pack installs, the corpora appear, and nothing fetches. This is not
+hypothetical: it stranded 15 providers across two packs on their first sideload.
+Covered by `PackSiblingImportTests` in `test_authority_pack_providers.py`.
+
+Two related rules:
+
+- **Pack directory basenames should be unique** across the in-tree root and
+  every configured root/path. Colliding basenames are disambiguated with a path
+  digest and logged as a warning, but the readable namespace is worth keeping.
+- **Re-mounting a pack name from a different directory is safe.** The registry
+  drops the old directory's cached submodules, so a swapped pack cannot hand
+  back the previous pack's helper.
 
 ### The shared `AuthoritySourceRecord`
 
@@ -373,6 +448,23 @@ registered once. A path that is not a directory is logged and skipped rather
 than failing worker boot. Under Docker the directory has to be **mounted into
 the container** — the path is resolved inside it, not on the host.
 
+A root is *scanned*, so only subdirectories containing a `pack.yaml` count. That
+makes a root pointed one level too deep (at a pack rather than at the bundle)
+contribute nothing, instead of surfacing that pack's own `charters/` and
+`specs/` as broken packs. Explicit `AUTHORITY_PACK_PATHS` entries are
+deliberately not filtered that way: you named that directory, so a missing
+manifest must surface as an invalid pack you can repair rather than vanish.
+
+**Confirm the server can see it.** Configured packs appear in **Admin Settings →
+Authority Console → Authority Packs**:
+
+![Authority Packs catalog](../assets/images/screenshots/auto/admin--authority-packs-tab--status-badges.png)
+
+An empty catalog means no configured directory yielded a pack — most often a
+host path that was never bind-mounted into the container:
+
+![Authority Packs — empty catalog](../assets/images/screenshots/auto/admin--authority-packs-tab--empty-catalog.png)
+
 **Verify before installing.** A sideloaded pack is code and data you did not
 necessarily write. `--check` runs the same validation as the Authority Console
 preflight and writes nothing:
@@ -391,9 +483,24 @@ personas, metadata schemas, and relationships in one transaction. Then restart
 so the registry and SSRF allowlist pick up the pack's `providers/` module and
 `source_hosts` — discovery happens at registry build.
 
-An administrator can do the same thing without a shell: **Admin Settings →
-Authority Console → Authority Packs** lists every configured pack, shows its
-preflight, and installs it.
+An administrator can do the same thing without a shell. **Review & install** on
+a catalog card runs the identical validation and shows what the install would
+do before anything is written:
+
+![Pack preflight modal](../assets/images/screenshots/auto/admin--pack-preflight-modal--summary-badges.png)
+
+The fingerprint shown here is sent back with the install, so a pack edited on
+disk in between is rejected rather than quietly installing something else.
+Installation is private by default; **publish** is a separate opt-in that stays
+disabled while a declared charter is unapproved or `pending_legal_review`. See
+[Authority Console § Authority Packs tab](../architecture/authority-console.md#authority-packs-tab).
+
+**Acceptance runs.** A pack repository that keeps its own end-to-end acceptance
+spec (install the packs, import the prepared ZIPs, assert the resulting corpora)
+runs it against this frontend with `E2E_RUN_AUTHORITY_IMPORTS=true`, which
+raises Playwright's timeouts for a real-stack install of large corpora. No
+in-tree spec sets it — the packs, their exports, and the spec all live with the
+deployment.
 
 ## Add / remove / copy
 
@@ -531,7 +638,12 @@ vocabulary*, not per-authority config:
   prefixes / license / priority / credential status.
 - The seeded corpora are queryable, each answering in its pack persona.
 
-Tests for the mechanics live in `opencontractserver/tests/test_authority_pack.py`,
-`test_authority_pack_providers.py`, `test_authority_source_hosts.py`,
-`test_authority_sources.py`, `test_authority_ingestion_invariants.py`, and the
-`test_grid_dossier_*` modules.
+Tests for the mechanics live in `opencontractserver/tests/`:
+`test_authority_pack.py` (manifest + install service),
+`test_authority_pack_loader.py` (convergence, idempotency, curator-state
+preservation, atomic abort, prefix binding — against the `example_utility`
+fixture), `test_authority_pack_sideload.py` (the `AUTHORITY_PACK_ROOTS` /
+`AUTHORITY_PACK_PATHS` contract), `test_authority_pack_providers.py` (in-pack
+provider discovery and sibling imports), `test_authority_pack_taxonomy.py`
+(`shape_rules` / `abbreviations`), `test_authority_source_hosts.py`,
+`test_authority_sources.py`, and `test_authority_ingestion_invariants.py`.


### PR DESCRIPTION
The pack machinery landed in #2215 with its docs partly describing the tree as it was before the packs moved out, and with screenshots the component tests capture on every run referenced by no document at all. Docs only — no code changes.

## Screenshots were being captured and never used

`AuthorityPackPreflightCoverage.ct.tsx` calls `docScreenshot` 14 times. Thirteen of those images are on disk under `docs/assets/images/screenshots/auto/` (the fourteenth, `--install-post-commit-warning`, has never been generated — the screenshot workflow is on-demand and hasn't run since that test was added), and **every one of them was referenced by no markdown file**. The workflow has been regenerating pictures nobody could see.

This PR links the five that teach a reader something. The other eight stay unlinked deliberately: loading spinners, error banners, a near-duplicate of the summary modal, and `--import-unbridged`, whose disabled "not connected in this view" state belongs to the test harness rather than the product. CT tests capture states for *coverage*; docs use the ones that carry meaning, and padding a page with spinners would make it worse, not more complete.

## Authority Console — the Authority Packs tab

The tab that installs a pack was four paragraphs with no visuals. It now shows:

- the **catalog**, and the status vocabulary a card's badge is derived from (`PacksTab.tsx::packStatus` — derived, not stored);
- the **empty catalog**, which is the normal symptom of a pack directory never bind-mounted into the container, since the path resolves inside it;
- the **preflight modal**: the `expectedFingerprint` round-trip that rejects a pack edited on disk between preflight and install, the publish opt-in's charter gate, the refusal to close mid-install, and `load_authority_pack --check` as the headless equivalent for a deployment with no admin browser session;
- a **rejected install** — the slug-collision refusal the authoring guide already described in prose.

## Pack authoring guide

Three real gaps, not just polish:

- **`sources.yaml` and the out-of-process collector** were documented only in `scripts/authority_import/README.md`, which no doc linked to. That's the whole path for a deployment whose crawling happens elsewhere; it's now in the anatomy and slot table, pointing at the builder README rather than duplicating it.
- **The in-pack import contract.** Relative imports resolve wherever a pack is mounted; an absolute in-tree dotted path silently fails to register the whole module's providers once sideloaded — the defect that stranded 15 providers. This is the one rule an author *cannot* discover from a pack that still lives in the tree, so it now sits next to the provider instructions.
- **Two worked examples**, because neither alone shows the format: v1 `bolivia` (shipped, installable) and the schema-v2 fixture `tests/fixtures/authority_packs/example_utility` — plus why the fixture lives under `tests/fixtures/` and not the pack root.

Also: the `pack.yaml`-required root scan (why a root pointed one level too deep contributes nothing, and why explicit `AUTHORITY_PACK_PATHS` entries are deliberately not filtered that way), `E2E_RUN_AUTHORITY_IMPORTS`, and two references to `test_grid_dossier_*` modules that left the tree with the packs — replaced with the modules that exist.

## Reference-web enrichment

The detection-tier table never said where Tier-1's vocabulary comes from, which is the link between the tagging engine and the packs that extend it: `prefixes`/`aliases` plus a pack's optional `shape_rules` / `abbreviations` merge onto the shipped baseline at runtime, so standing up detection for a new body of law is a data change. Now stated, with pointers both ways.

## Verification

- Every image and relative markdown link in the touched files resolves on disk.
- `scripts/collate_changelog.py --check` passes (301 fragments).
- Applicable pre-commit hooks for markdown (`trailing-whitespace`, `end-of-file-fixer`) verified by hand; `pre-commit` is not installed in this container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eos5eGFoKZLqcpFGjM1gXE