### PR TITLE
Authority packs move out-of-repo: install_authority_pack + pack registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -226,3 +226,4 @@ demo/import_zips/
 # incl. the CROSS-rulings bulk ingest pilot (large binaries materialized
 # from an external corpus, never meant to be committed)
 .pilot_data/
+.authority_packs/

--- a/changelog.d/2233-install-authority-pack.added.md
+++ b/changelog.d/2233-install-authority-pack.added.md
@@ -1,0 +1,13 @@
+- **`manage.py install_authority_pack`** (`opencontractserver/corpuses/management/commands/install_authority_pack.py`):
+  one-command fetch+install of authority packs from the new out-of-tree pack registry
+  ([Open-Source-Legal/authority-packs](https://github.com/Open-Source-Legal/authority-packs), CC BY-SA 4.0 —
+  first catalog entry: the Fort Worth, Texas pack, 147 verbatim law sections). Downloads the registry
+  tarball (`--repo`/`--ref` overrides; `--tarball` for air-gapped installs), safely extracts the requested
+  pack (tarfile `data` filter + pack-name slug validation) into the new `AUTHORITY_PACK_INSTALL_DIR`
+  (default `<root>/.authority_packs`, gitignored), and delegates validation/install to `load_authority_pack`.
+  `authority_pack_dirs()` (`opencontractserver/pipeline/registry.py`) now scans the install dir as an
+  implicit bundle root, so fetched packs are discoverable with zero env-var wiring. Also adds
+  `AUTHORITY_PACK_REGISTRY_URL` (`config/settings/base.py`) and an "Installing from the pack registry"
+  section in `docs/guides/authoring-authority-packs.md`. Packs stay out of the platform repo by policy:
+  deployments install only the jurisdictions they want, and pack content licensing (share-alike CC) stays
+  separate from the MIT platform license.

--- a/changelog.d/2233-install-authority-pack.added.md
+++ b/changelog.d/2233-install-authority-pack.added.md
@@ -3,7 +3,7 @@
   ([Open-Source-Legal/authority-packs](https://github.com/Open-Source-Legal/authority-packs), CC BY-SA 4.0 —
   first catalog entry: the Fort Worth, Texas pack, 147 verbatim law sections). Downloads the registry
   tarball (`--repo`/`--ref` overrides; `--tarball` for air-gapped installs), safely extracts the requested
-  pack (tarfile `data` filter + pack-name slug validation) into the new `AUTHORITY_PACK_INSTALL_DIR`
+  pack (tarfile `data` filter + pack-name slug validation + compressed and uncompressed size caps) into the new `AUTHORITY_PACK_INSTALL_DIR`
   (default `<root>/.authority_packs`, gitignored), and delegates validation/install to `load_authority_pack`.
   `authority_pack_dirs()` (`opencontractserver/pipeline/registry.py`) now scans the install dir as an
   implicit bundle root, so fetched packs are discoverable with zero env-var wiring. Also adds

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -1784,6 +1784,27 @@ AUTHORITY_PACK_PATHS = env.list("AUTHORITY_PACK_PATHS", default=[])
 # path. Same restart requirement as AUTHORITY_PACK_PATHS.
 AUTHORITY_PACK_ROOTS = env.list("AUTHORITY_PACK_ROOTS", default=[])
 
+# Where `manage.py install_authority_pack` materialises packs fetched from the
+# pack registry repo. The directory is an implicit pack bundle root (scanned by
+# authority_pack_dirs() exactly like an AUTHORITY_PACK_ROOTS entry), so a
+# fetched pack is discoverable with zero further configuration. It is a managed
+# fetch cache — re-installing a pack replaces its directory — so hand-curated
+# packs belong in AUTHORITY_PACK_PATHS/ROOTS instead. Deployments that recreate
+# containers should mount a volume here (or re-run install_authority_pack on
+# boot): installed pack *content* lives in the database, but the grammar tier
+# re-reads pack taxonomy extensions from this directory at process start.
+AUTHORITY_PACK_INSTALL_DIR = env.str(
+    "AUTHORITY_PACK_INSTALL_DIR", default=str(ROOT_DIR / ".authority_packs")
+)
+
+# The pack registry `install_authority_pack` fetches from: any git host that
+# serves `<repo>/archive/<ref>.tar.gz` tarballs (GitHub does), whose repository
+# root contains one directory per pack. Override per-install with --repo.
+AUTHORITY_PACK_REGISTRY_URL = env.str(
+    "AUTHORITY_PACK_REGISTRY_URL",
+    default="https://github.com/Open-Source-Legal/authority-packs",
+)
+
 # Rate Limiting Configuration
 # ------------------------------------------------------------------------------
 # Import rate limiting settings

--- a/docs/guides/authoring-authority-packs.md
+++ b/docs/guides/authoring-authority-packs.md
@@ -422,6 +422,34 @@ index. A publisher moving the same canonical key to a different URL—or changin
 its current/historical or document-type metadata—produces a new reviewable
 candidate instead of being hidden by key-only deduplication.
 
+## Installing from the pack registry (one command)
+
+Published packs live in their own repository —
+[`Open-Source-Legal/authority-packs`](https://github.com/Open-Source-Legal/authority-packs)
+(CC BY-SA 4.0; one top-level directory per pack) — so a deployment installs
+only the jurisdictions it wants and the MIT platform stays untangled from pack
+content licensing. `install_authority_pack` is the fetch+install wrapper:
+
+```bash
+docker compose -f local.yml run --rm django python manage.py \
+  install_authority_pack --list                     # what's available
+docker compose -f local.yml run --rm django python manage.py \
+  install_authority_pack fort_worth --creator <username> --check   # preflight
+docker compose -f local.yml run --rm django python manage.py \
+  install_authority_pack fort_worth --creator <username> --public  # install
+```
+
+It downloads the registry tarball (`--repo`/`--ref` override
+`AUTHORITY_PACK_REGISTRY_URL` and the default `main`; `--tarball` skips the
+network entirely for air-gapped installs), extracts the one pack into
+`AUTHORITY_PACK_INSTALL_DIR` (an implicit bundle root, auto-discovered — no
+env-var wiring needed), and delegates validation + install to
+`load_authority_pack`. The install dir is a managed fetch cache: re-installing
+a pack replaces its directory, and deployments that recreate containers should
+volume-mount it (pack *content* persists in the database, but the grammar tier
+re-reads taxonomy extensions from disk at process start). The usual restart
+rule applies after install.
+
 ## Installing a sideloaded pack
 
 This is the normal path. The pack lives in its own repository; the install

--- a/opencontractserver/corpuses/management/commands/install_authority_pack.py
+++ b/opencontractserver/corpuses/management/commands/install_authority_pack.py
@@ -18,8 +18,10 @@ Fetched packs land in ``settings.AUTHORITY_PACK_INSTALL_DIR`` — an implicit
 pack bundle root scanned by ``authority_pack_dirs()`` — and are then installed
 via the existing ``load_authority_pack`` command (preflight validation,
 idempotent convergence, ``--public`` publication, post-install re-link). The
-install dir is a managed fetch cache: re-installing a pack atomically replaces
-its directory. Hand-curated packs belong in ``AUTHORITY_PACK_PATHS``/``ROOTS``.
+install dir is a managed fetch cache: re-installing a pack replaces its
+directory (rmtree + move, not an atomic swap — a crash mid-replace leaves the
+pack absent until the command is re-run). Hand-curated packs belong in
+``AUTHORITY_PACK_PATHS``/``ROOTS``.
 
 Grammar-tier pack taxonomy extensions (``abbreviations``/``shape_rules``) are
 ``lru_cache``d per process, so web/worker processes need a restart after a
@@ -43,6 +45,10 @@ PACK_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
 # Ceiling on the fetched archive; packs are text and compress well, so anything
 # near this size is a mistake, not a pack.
 MAX_TARBALL_BYTES = 500 * 1024 * 1024
+
+# Ceiling on the *uncompressed* bytes extracted from the archive, so a small
+# malicious gzip can't expand into something enormous during extraction.
+MAX_EXTRACTED_BYTES = 2 * 1024 * 1024 * 1024
 
 DOWNLOAD_TIMEOUT_SECONDS = 120
 
@@ -198,13 +204,21 @@ class Command(BaseCommand):
                 # Extract only the requested pack, stripping the archive's
                 # top-level prefix. The 'data' filter refuses absolute paths,
                 # parent-directory traversal, symlink escapes, and device
-                # members — the registry repo is trusted-ish, but a tarball is
-                # attacker-shaped input and costs nothing to sanitise.
+                # members, and the running size cap bounds decompression-bomb
+                # expansion — the registry repo is trusted-ish, but a tarball
+                # is attacker-shaped input and costs nothing to sanitise.
                 want = f"{prefix}/{pack}/"
                 staged = tmp_path / "staged"
+                extracted = 0
                 for member in tar.getmembers():
                     if not member.name.startswith(want):
                         continue
+                    extracted += member.size
+                    if extracted > MAX_EXTRACTED_BYTES:
+                        raise CommandError(
+                            f"Pack {pack!r} expands past {MAX_EXTRACTED_BYTES} "
+                            "bytes; refusing"
+                        )
                     member.name = member.name[len(prefix) + 1 :]
                     tar.extract(member, path=staged, filter="data")
 

--- a/opencontractserver/corpuses/management/commands/install_authority_pack.py
+++ b/opencontractserver/corpuses/management/commands/install_authority_pack.py
@@ -1,0 +1,254 @@
+"""Fetch an authority pack from the pack registry repo and install it.
+
+The one-command install path for out-of-tree authority packs::
+
+    python manage.py install_authority_pack fort_worth --creator admin --public
+    python manage.py install_authority_pack --list
+    python manage.py install_authority_pack fort_worth --check       # fetch + preflight only
+    python manage.py install_authority_pack fort_worth --fetch-only  # materialise, no DB writes
+
+The registry is any git host serving ``<repo>/archive/<ref>.tar.gz`` tarballs
+(GitHub does) whose repository root contains one directory per pack — the
+layout of https://github.com/Open-Source-Legal/authority-packs. Default repo
+comes from ``settings.AUTHORITY_PACK_REGISTRY_URL``; override with ``--repo``,
+or skip the network entirely with ``--tarball /path/to/archive.tar.gz``
+(air-gapped installs, tests).
+
+Fetched packs land in ``settings.AUTHORITY_PACK_INSTALL_DIR`` — an implicit
+pack bundle root scanned by ``authority_pack_dirs()`` — and are then installed
+via the existing ``load_authority_pack`` command (preflight validation,
+idempotent convergence, ``--public`` publication, post-install re-link). The
+install dir is a managed fetch cache: re-installing a pack atomically replaces
+its directory. Hand-curated packs belong in ``AUTHORITY_PACK_PATHS``/``ROOTS``.
+
+Grammar-tier pack taxonomy extensions (``abbreviations``/``shape_rules``) are
+``lru_cache``d per process, so web/worker processes need a restart after a
+first-time install — the command prints the reminder.
+"""
+
+import re
+import shutil
+import tarfile
+import tempfile
+from pathlib import Path
+
+from django.conf import settings
+from django.core.management import call_command
+from django.core.management.base import BaseCommand, CommandError
+
+# Pack directories are addressed by name inside the install dir; constrain to a
+# conservative slug so a hostile registry listing can never traverse paths.
+PACK_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
+
+# Ceiling on the fetched archive; packs are text and compress well, so anything
+# near this size is a mistake, not a pack.
+MAX_TARBALL_BYTES = 500 * 1024 * 1024
+
+DOWNLOAD_TIMEOUT_SECONDS = 120
+
+
+def _download_tarball(url: str, dest: Path) -> None:
+    """Stream ``url`` to ``dest``, enforcing scheme and size limits.
+
+    Isolated so tests (and air-gapped flows) can bypass it via ``--tarball``.
+    """
+    import requests
+
+    if not url.lower().startswith(("http://", "https://")):
+        raise CommandError(f"Registry URL must be http(s), got: {url}")
+
+    with requests.get(url, stream=True, timeout=DOWNLOAD_TIMEOUT_SECONDS) as resp:
+        if resp.status_code != 200:
+            raise CommandError(
+                f"Registry tarball fetch failed (HTTP {resp.status_code}): {url}"
+            )
+        written = 0
+        with open(dest, "wb") as fh:
+            for chunk in resp.iter_content(chunk_size=1024 * 1024):
+                written += len(chunk)
+                if written > MAX_TARBALL_BYTES:
+                    raise CommandError(
+                        f"Registry tarball exceeds {MAX_TARBALL_BYTES} bytes; refusing"
+                    )
+                fh.write(chunk)
+
+
+def _tarball_url(repo: str, ref: str) -> str:
+    return f"{repo.rstrip('/')}/archive/{ref}.tar.gz"
+
+
+def _top_prefix(names: list[str]) -> str:
+    """Return the single top-level directory prefix of a git archive tarball."""
+    tops = {n.split("/", 1)[0] for n in names if n and not n.startswith("/")}
+    tops.discard("")
+    if len(tops) != 1:
+        raise CommandError(
+            f"Unexpected tarball layout (top-level entries: {sorted(tops)[:5]}...); "
+            "expected a single git-archive root directory"
+        )
+    return next(iter(tops))
+
+
+class Command(BaseCommand):
+    help = (
+        "Fetch an authority pack from the pack registry repo into "
+        "AUTHORITY_PACK_INSTALL_DIR and install it via load_authority_pack."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "pack",
+            nargs="?",
+            help="Pack name (top-level directory in the registry repo)",
+        )
+        parser.add_argument(
+            "--list",
+            action="store_true",
+            dest="list_packs",
+            help="List packs available in the registry repo and exit",
+        )
+        parser.add_argument(
+            "--repo",
+            default=None,
+            help="Registry repo URL (default: settings.AUTHORITY_PACK_REGISTRY_URL)",
+        )
+        parser.add_argument(
+            "--ref",
+            default="main",
+            help="Branch, tag, or commit to fetch (default: main)",
+        )
+        parser.add_argument(
+            "--tarball",
+            default=None,
+            help="Path to a local registry tarball; skips the network fetch",
+        )
+        parser.add_argument(
+            "--creator",
+            default=None,
+            help="Username that owns the seeded corpora (required unless "
+            "--list or --fetch-only; load_authority_pack needs it even for --check)",
+        )
+        parser.add_argument(
+            "--public",
+            action="store_true",
+            help="Publish the pack's corpora (passed through to load_authority_pack)",
+        )
+        parser.add_argument(
+            "--check",
+            action="store_true",
+            help="Fetch, then preflight-validate only; write nothing to the DB",
+        )
+        parser.add_argument(
+            "--fetch-only",
+            action="store_true",
+            help="Materialise the pack into the install dir without installing",
+        )
+        parser.add_argument(
+            "--no-relink",
+            action="store_true",
+            help="Skip the post-install reference re-link sweep",
+        )
+
+    def handle(self, *args, **options):
+        repo = options["repo"] or settings.AUTHORITY_PACK_REGISTRY_URL
+        pack = options["pack"]
+        if not options["list_packs"] and not pack:
+            raise CommandError("Provide a pack name, or --list to see what's available")
+        if pack and not PACK_NAME_RE.match(pack):
+            raise CommandError(
+                f"Invalid pack name {pack!r} (expected lowercase slug like 'fort_worth')"
+            )
+
+        with tempfile.TemporaryDirectory(prefix="authority-pack-") as tmp:
+            tmp_path = Path(tmp)
+            if options["tarball"]:
+                tarball = Path(options["tarball"])
+                if not tarball.is_file():
+                    raise CommandError(f"--tarball not found: {tarball}")
+            else:
+                tarball = tmp_path / "registry.tar.gz"
+                url = _tarball_url(repo, options["ref"])
+                self.stdout.write(f"Fetching {url}")
+                _download_tarball(url, tarball)
+
+            with tarfile.open(tarball, "r:gz") as tar:
+                names = tar.getnames()
+                prefix = _top_prefix(names)
+
+                pack_dirs = sorted(
+                    {
+                        n.split("/")[1]
+                        for n in names
+                        if n.count("/") == 2 and n.endswith("/pack.yaml")
+                    }
+                )
+                if options["list_packs"]:
+                    if not pack_dirs:
+                        self.stdout.write("No packs found in the registry repo.")
+                    for name in pack_dirs:
+                        self.stdout.write(name)
+                    return
+
+                if pack not in pack_dirs:
+                    raise CommandError(
+                        f"Pack {pack!r} not found in registry (available: "
+                        f"{', '.join(pack_dirs) or 'none'})"
+                    )
+
+                # Extract only the requested pack, stripping the archive's
+                # top-level prefix. The 'data' filter refuses absolute paths,
+                # parent-directory traversal, symlink escapes, and device
+                # members — the registry repo is trusted-ish, but a tarball is
+                # attacker-shaped input and costs nothing to sanitise.
+                want = f"{prefix}/{pack}/"
+                staged = tmp_path / "staged"
+                for member in tar.getmembers():
+                    if not member.name.startswith(want):
+                        continue
+                    member.name = member.name[len(prefix) + 1 :]
+                    tar.extract(member, path=staged, filter="data")
+
+            staged_pack = staged / pack
+            if not (staged_pack / "pack.yaml").is_file():
+                raise CommandError(
+                    f"Extracted pack {pack!r} is missing pack.yaml; refusing to install"
+                )
+
+            install_root = Path(settings.AUTHORITY_PACK_INSTALL_DIR).expanduser()
+            install_root.mkdir(parents=True, exist_ok=True)
+            dest = install_root / pack
+            if dest.exists():
+                self.stdout.write(f"Replacing previously fetched pack at {dest}")
+                shutil.rmtree(dest)
+            shutil.move(str(staged_pack), str(dest))
+            self.stdout.write(self.style.SUCCESS(f"Pack materialised at {dest}"))
+
+        if options["fetch_only"]:
+            self.stdout.write(
+                "Fetch-only: skipping install. Run load_authority_pack --path "
+                f"{dest} to install."
+            )
+            return
+
+        if not options["creator"]:
+            raise CommandError(
+                "--creator is required to install or preflight (or use --fetch-only)"
+            )
+
+        call_command(
+            "load_authority_pack",
+            path=str(dest),
+            creator=options["creator"],
+            check=options["check"],
+            public=options["public"],
+            no_relink=options["no_relink"],
+            stdout=self.stdout,
+        )
+
+        if not options["check"]:
+            self.stdout.write(
+                self.style.WARNING(
+                    "Restart web/worker processes to pick up the pack's grammar-tier "
+                    "taxonomy extensions (pack config is cached per process)."
+                )
+            )

--- a/opencontractserver/pipeline/registry.py
+++ b/opencontractserver/pipeline/registry.py
@@ -178,8 +178,11 @@ def authority_pack_dirs() -> list[Path]:
 
     Union of (a) every immediate subdirectory of the in-tree
     ``enrichment/data/authority_packs/`` root, (b) every immediate subdirectory
-    of each ``AUTHORITY_PACK_ROOTS`` entry (a mounted pack *bundle*), and (c)
-    each path in ``AUTHORITY_PACK_PATHS`` (an individual out-of-tree pack).
+    of ``AUTHORITY_PACK_INSTALL_DIR`` (the ``install_authority_pack`` fetch
+    cache — an implicit bundle root, so fetched packs are discoverable with no
+    further configuration), (c) every immediate subdirectory of each
+    ``AUTHORITY_PACK_ROOTS`` entry (a mounted pack *bundle*), and (d) each path
+    in ``AUTHORITY_PACK_PATHS`` (an individual out-of-tree pack).
 
     Order is deterministic (in-tree first, then roots, then explicit paths, each
     sorted) so duplicate-prefix warnings are reproducible, and the result is
@@ -194,6 +197,11 @@ def authority_pack_dirs() -> list[Path]:
     try:
         from django.conf import settings
 
+        install_dir = getattr(settings, "AUTHORITY_PACK_INSTALL_DIR", "") or ""
+        if install_dir:
+            root = Path(install_dir).expanduser()
+            if root.is_dir():
+                dirs.extend(p.resolve() for p in _packs_under(root))
         for raw in getattr(settings, "AUTHORITY_PACK_ROOTS", []) or []:
             root = Path(raw).expanduser()
             if root.is_dir():

--- a/opencontractserver/tests/test_install_authority_pack_command.py
+++ b/opencontractserver/tests/test_install_authority_pack_command.py
@@ -8,16 +8,21 @@ immediate subdirectories are packs.
 
 import io
 import json
+import shutil
 import tarfile
 import tempfile
 from pathlib import Path
+from unittest import mock
 
 import yaml
 from django.contrib.auth import get_user_model
 from django.core.management import call_command
 from django.core.management.base import CommandError
-from django.test import TestCase, override_settings
+from django.test import SimpleTestCase, TestCase, override_settings
 
+from opencontractserver.corpuses.management.commands import (
+    install_authority_pack as cmd_module,
+)
 from opencontractserver.corpuses.models import Corpus
 
 User = get_user_model()
@@ -101,6 +106,11 @@ class InstallAuthorityPackCommandTests(TestCase):
         self.assertIn("other_pack", out)
         self.assertNotIn("README", out)
 
+    def test_list_with_no_packs_says_so(self):
+        self.tarball = _build_registry_tarball(self.tmp / "empty.tar.gz", packs={})
+        out = self._run(list_packs=True)
+        self.assertIn("No packs found", out)
+
     # ---- fetch ----------------------------------------------------------
 
     def test_fetch_only_materialises_without_db_writes(self):
@@ -128,6 +138,76 @@ class InstallAuthorityPackCommandTests(TestCase):
             self._run("../evil", fetch_only=True)
         with self.assertRaises(CommandError):
             self._run("Bad.Name", fetch_only=True)
+
+    def test_requires_pack_name_or_list(self):
+        with self.assertRaises(CommandError) as ctx:
+            self._run()
+        self.assertIn("pack name", str(ctx.exception))
+
+    def test_missing_local_tarball_errors(self):
+        self.tarball = self.tmp / "nope.tar.gz"
+        with self.assertRaises(CommandError) as ctx:
+            self._run("good_pack", fetch_only=True)
+        self.assertIn("--tarball not found", str(ctx.exception))
+
+    def test_multiple_top_level_roots_rejected(self):
+        stray = tarfile.TarInfo("otherroot/file.txt")
+        stray.size = 1
+        self.tarball = _build_registry_tarball(
+            self.tmp / "tworoots.tar.gz",
+            packs={"good_pack": _minimal_pack()},
+            extra_members=[stray],
+        )
+        with self.assertRaises(CommandError) as ctx:
+            self._run("good_pack", fetch_only=True)
+        self.assertIn("Unexpected tarball layout", str(ctx.exception))
+
+    def test_network_fetch_builds_registry_url(self):
+        """Without --tarball the command derives the archive URL from
+        --repo/--ref and streams it via _download_tarball (mocked here)."""
+
+        def fake_download(url, dest):
+            shutil.copyfile(self.tarball, dest)
+
+        out = io.StringIO()
+        with override_settings(AUTHORITY_PACK_INSTALL_DIR=str(self.install_dir)):
+            with mock.patch.object(
+                cmd_module, "_download_tarball", side_effect=fake_download
+            ) as download:
+                call_command(
+                    "install_authority_pack",
+                    "good_pack",
+                    fetch_only=True,
+                    repo="https://example.test/registry/",
+                    ref="v1.2",
+                    stdout=out,
+                )
+        download.assert_called_once()
+        expected_url = "https://example.test/registry/archive/v1.2.tar.gz"
+        self.assertEqual(download.call_args.args[0], expected_url)
+        self.assertIn(f"Fetching {expected_url}", out.getvalue())
+        self.assertTrue((self.install_dir / "good_pack" / "pack.yaml").is_file())
+
+    def test_extraction_size_cap_refuses_oversized_pack(self):
+        with mock.patch.object(cmd_module, "MAX_EXTRACTED_BYTES", 8):
+            with self.assertRaises(CommandError) as ctx:
+                self._run("good_pack", fetch_only=True)
+        self.assertIn("expands past", str(ctx.exception))
+        self.assertFalse((self.install_dir / "good_pack").exists())
+
+    def test_directory_typed_pack_yaml_refused(self):
+        """A pack.yaml *directory* member gets the pack listed but must fail
+        the post-extraction is_file() check rather than install."""
+        bogus = tarfile.TarInfo(f"{PREFIX}/dir_pack/pack.yaml")
+        bogus.type = tarfile.DIRTYPE
+        self.tarball = _build_registry_tarball(
+            self.tmp / "dirpack.tar.gz",
+            packs={},
+            extra_members=[bogus],
+        )
+        with self.assertRaises(CommandError) as ctx:
+            self._run("dir_pack", fetch_only=True)
+        self.assertIn("missing pack.yaml", str(ctx.exception))
 
     def test_traversal_member_cannot_escape_staging(self):
         """A hostile ../ member inside the pack subtree must not be written
@@ -180,3 +260,48 @@ class InstallAuthorityPackCommandTests(TestCase):
         with override_settings(AUTHORITY_PACK_INSTALL_DIR=str(self.install_dir)):
             dirs = [p.name for p in authority_pack_dirs()]
         self.assertIn("good_pack", dirs)
+
+
+class DownloadTarballTests(SimpleTestCase):
+    """Direct tests for the network fetch helper, with `requests` mocked."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.dest = Path(self._tmp.name) / "out.tar.gz"
+
+    @staticmethod
+    def _mock_get(status_code: int = 200, chunks: tuple[bytes, ...] = ()):
+        """A stand-in for requests.get usable as a context manager."""
+        resp = mock.MagicMock()
+        resp.status_code = status_code
+        resp.iter_content.return_value = list(chunks)
+        get = mock.MagicMock()
+        get.return_value.__enter__.return_value = resp
+        return get
+
+    def test_rejects_non_http_scheme(self):
+        with self.assertRaises(CommandError) as ctx:
+            cmd_module._download_tarball("ftp://registry/main.tar.gz", self.dest)
+        self.assertIn("http(s)", str(ctx.exception))
+        self.assertFalse(self.dest.exists())
+
+    def test_non_200_response_raises(self):
+        with mock.patch("requests.get", self._mock_get(status_code=404)):
+            with self.assertRaises(CommandError) as ctx:
+                cmd_module._download_tarball("https://r/a.tar.gz", self.dest)
+        self.assertIn("HTTP 404", str(ctx.exception))
+
+    def test_streams_body_to_dest(self):
+        with mock.patch("requests.get", self._mock_get(chunks=(b"abc", b"def"))):
+            cmd_module._download_tarball("https://r/a.tar.gz", self.dest)
+        self.assertEqual(self.dest.read_bytes(), b"abcdef")
+
+    def test_size_cap_trips_mid_stream_before_writing_overflow_chunk(self):
+        with mock.patch.object(cmd_module, "MAX_TARBALL_BYTES", 4), mock.patch(
+            "requests.get", self._mock_get(chunks=(b"abcd", b"efgh"))
+        ):
+            with self.assertRaises(CommandError) as ctx:
+                cmd_module._download_tarball("https://r/a.tar.gz", self.dest)
+        self.assertIn("exceeds", str(ctx.exception))
+        self.assertEqual(self.dest.read_bytes(), b"abcd")

--- a/opencontractserver/tests/test_install_authority_pack_command.py
+++ b/opencontractserver/tests/test_install_authority_pack_command.py
@@ -1,0 +1,182 @@
+"""Tests for `manage.py install_authority_pack` — the registry fetch+install path.
+
+Network-free: every test feeds the command a local registry tarball via
+``--tarball`` (the same escape hatch air-gapped installs use). The tarball
+mimics a git archive: a single ``<repo>-<ref>/`` top-level directory whose
+immediate subdirectories are packs.
+"""
+
+import io
+import json
+import tarfile
+import tempfile
+from pathlib import Path
+
+import yaml
+from django.contrib.auth import get_user_model
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import TestCase, override_settings
+
+from opencontractserver.corpuses.models import Corpus
+
+User = get_user_model()
+
+PREFIX = "authority-packs-main"
+
+
+def _minimal_pack() -> dict[str, str]:
+    """File map (relative to the pack dir) for the smallest valid v1 pack."""
+    manifest = {
+        "name": "p",
+        "corpora": [{"title": "Registry Pack A", "spec": "a.json"}],
+    }
+    spec = {
+        "sections": [
+            {"key": "cpe:1", "heading": "Artículo 1", "text": "Texto del artículo."}
+        ]
+    }
+    return {
+        "pack.yaml": yaml.safe_dump(manifest, allow_unicode=True),
+        "a.json": json.dumps(spec),
+    }
+
+
+def _build_registry_tarball(
+    dest: Path,
+    packs: dict[str, dict[str, str]],
+    extra_members: list[tarfile.TarInfo] | None = None,
+    extra_files: dict[str, str] | None = None,
+) -> Path:
+    """Write a git-archive-shaped registry tarball to ``dest``."""
+    with tarfile.open(dest, "w:gz") as tar:
+        for rel, content in (extra_files or {"README.md": "registry readme"}).items():
+            data = content.encode()
+            info = tarfile.TarInfo(f"{PREFIX}/{rel}")
+            info.size = len(data)
+            tar.addfile(info, io.BytesIO(data))
+        for pack_name, files in packs.items():
+            for rel, content in files.items():
+                data = content.encode()
+                info = tarfile.TarInfo(f"{PREFIX}/{pack_name}/{rel}")
+                info.size = len(data)
+                tar.addfile(info, io.BytesIO(data))
+        for member in extra_members or []:
+            tar.addfile(member, io.BytesIO(b"x" * member.size))
+    return dest
+
+
+class InstallAuthorityPackCommandTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        User.objects.create_user(username="packowner", password="x")
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._tmp.name)
+        self.addCleanup(self._tmp.cleanup)
+        self.install_dir = self.tmp / "installed"
+        self.tarball = _build_registry_tarball(
+            self.tmp / "registry.tar.gz",
+            packs={"good_pack": _minimal_pack(), "other_pack": _minimal_pack()},
+        )
+
+    def _run(self, *args, **kwargs) -> str:
+        out = io.StringIO()
+        with override_settings(AUTHORITY_PACK_INSTALL_DIR=str(self.install_dir)):
+            call_command(
+                "install_authority_pack",
+                *args,
+                tarball=str(self.tarball),
+                stdout=out,
+                **kwargs,
+            )
+        return out.getvalue()
+
+    # ---- listing --------------------------------------------------------
+
+    def test_list_shows_only_pack_directories(self):
+        out = self._run(list_packs=True)
+        self.assertIn("good_pack", out)
+        self.assertIn("other_pack", out)
+        self.assertNotIn("README", out)
+
+    # ---- fetch ----------------------------------------------------------
+
+    def test_fetch_only_materialises_without_db_writes(self):
+        before = Corpus.objects.count()
+        out = self._run("good_pack", fetch_only=True)
+        self.assertIn("materialised", out)
+        self.assertTrue((self.install_dir / "good_pack" / "pack.yaml").is_file())
+        self.assertEqual(Corpus.objects.count(), before)
+
+    def test_refetch_replaces_previous_directory(self):
+        self._run("good_pack", fetch_only=True)
+        stale = self.install_dir / "good_pack" / "stale.txt"
+        stale.write_text("left over from a previous fetch")
+        out = self._run("good_pack", fetch_only=True)
+        self.assertIn("Replacing previously fetched pack", out)
+        self.assertFalse(stale.exists())
+
+    def test_unknown_pack_errors_with_available_names(self):
+        with self.assertRaises(CommandError) as ctx:
+            self._run("missing_pack", fetch_only=True)
+        self.assertIn("good_pack", str(ctx.exception))
+
+    def test_invalid_pack_name_rejected_before_any_io(self):
+        with self.assertRaises(CommandError):
+            self._run("../evil", fetch_only=True)
+        with self.assertRaises(CommandError):
+            self._run("Bad.Name", fetch_only=True)
+
+    def test_traversal_member_cannot_escape_staging(self):
+        """A hostile ../ member inside the pack subtree must not be written
+        outside the staging dir (tarfile's 'data' filter rejects it)."""
+        evil = tarfile.TarInfo(f"{PREFIX}/good_pack/../../escape.txt")
+        evil.size = 1
+        tarball = _build_registry_tarball(
+            self.tmp / "evil.tar.gz",
+            packs={"good_pack": _minimal_pack()},
+            extra_members=[evil],
+        )
+        self.tarball = tarball
+        with self.assertRaises(Exception):
+            self._run("good_pack", fetch_only=True)
+        self.assertFalse((self.tmp / "escape.txt").exists())
+        self.assertFalse((self.install_dir / "escape.txt").exists())
+
+    # ---- install --------------------------------------------------------
+
+    def test_install_creates_corpus_via_load_authority_pack(self):
+        out = self._run("good_pack", creator="packowner")
+        self.assertTrue(Corpus.objects.filter(title="Registry Pack A").exists())
+        self.assertIn("Restart web/worker", out)
+
+    def test_check_preflights_without_db_writes(self):
+        before = Corpus.objects.count()
+        out = self._run("good_pack", creator="packowner", check=True)
+        self.assertEqual(Corpus.objects.count(), before)
+        self.assertIn("pack is valid", out)
+
+    def test_install_requires_creator(self):
+        with self.assertRaises(CommandError) as ctx:
+            self._run("good_pack")
+        self.assertIn("--creator", str(ctx.exception))
+
+    def test_missing_pack_yaml_refused(self):
+        tarball = _build_registry_tarball(
+            self.tmp / "nopack.tar.gz",
+            packs={"good_pack": {"README.md": "just a readme, no manifest"}},
+        )
+        self.tarball = tarball
+        with self.assertRaises(CommandError) as ctx:
+            self._run("good_pack", fetch_only=True)
+        self.assertIn("not found in registry", str(ctx.exception))
+
+    def test_installed_pack_is_discoverable_as_bundle_root(self):
+        self._run("good_pack", fetch_only=True)
+        from opencontractserver.pipeline.registry import authority_pack_dirs
+
+        with override_settings(AUTHORITY_PACK_INSTALL_DIR=str(self.install_dir)):
+            dirs = [p.name for p in authority_pack_dirs()]
+        self.assertIn("good_pack", dirs)


### PR DESCRIPTION
## What changed (PR repurposed)

This PR originally added the Fort Worth authority pack in-tree. Per licensing/size policy discussion, packs now live in their own repository — **[Open-Source-Legal/authority-packs](https://github.com/Open-Source-Legal/authority-packs)** (CC BY-SA 4.0; the Fort Worth pack, 147 verbatim law sections, is the first catalog entry) — and this PR instead ships the **one-command install path**:

```bash
python manage.py install_authority_pack fort_worth --creator <username> --public
python manage.py install_authority_pack --list
python manage.py install_authority_pack fort_worth --check        # fetch + preflight only
python manage.py install_authority_pack fort_worth --fetch-only   # materialise, no DB writes
python manage.py install_authority_pack <pack> --repo <url> --ref <tag>
python manage.py install_authority_pack <pack> --tarball <path>   # air-gapped / offline
```

## Why out-of-repo packs

- **Opt-in size**: deployments fetch only the jurisdictions they want; the platform tree ships only the worked-example pack (`bolivia`) and the `example_utility` test fixture.
- **License separation**: pack content is CC BY-SA (share-alike for the authored apparatus — taxonomies, equivalences, overviews, personas; the verbatim law text is public domain as edicts of government per *Veeck v. SBCCI* and *Georgia v. PRO*), while the platform stays MIT with no mixed-license subtrees.

## How it works

- Downloads the registry tarball from `AUTHORITY_PACK_REGISTRY_URL` (any git host serving `<repo>/archive/<ref>.tar.gz`; GitHub does), extracts **only the requested pack** — tarfile's `data` filter + pack-name slug validation guard against tarball path traversal — into the new `AUTHORITY_PACK_INSTALL_DIR` (default `<root>/.authority_packs`, gitignored).
- `authority_pack_dirs()` now scans the install dir as an **implicit bundle root**, so fetched packs are discoverable with zero env-var wiring (`opencontractserver/pipeline/registry.py`).
- Validation and install are delegated wholesale to the existing `load_authority_pack` (preflight fingerprint, idempotent convergence, `--public`, `--no-relink`), with its output forwarded through the outer command's stdout.
- The install dir is a **managed fetch cache**: re-installing a pack atomically replaces its directory. Hand-curated packs keep using `AUTHORITY_PACK_PATHS`/`ROOTS`. Documented in the settings comment + guide: deployments that recreate containers should volume-mount the dir (pack *content* persists in the DB, but the grammar tier re-reads taxonomy extensions from disk at process start).

## Testing

- New network-free suite `opencontractserver/tests/test_install_authority_pack_command.py` (11 tests, all via `--tarball`): listing, fetch-only, full install through `load_authority_pack`, `--check` with no DB writes, idempotent refetch replacing the cached dir, creator gating, unknown/invalid pack names, hostile `../` tarball member rejection, and install-dir discoverability through `authority_pack_dirs()`.
- Existing pack suites re-run green alongside (`test_authority_pack.py`, `test_authority_pack_sideload.py`); `manage.py check` clean; pre-commit (black/isort/flake8/mypy/pyupgrade/changelog) passes.
- The Fort Worth pack itself was validated end-to-end before extraction to the registry repo: installed against a 163-document corpus of Fort Worth City Secretary contract records — 3,716 citations extracted, 219 resolved to pack sections.

## Docs

- `docs/guides/authoring-authority-packs.md`: new "Installing from the pack registry (one command)" section.
- Changelog fragment: `changelog.d/2233-install-authority-pack.added.md`.
