### PR TITLE
Add contributor CLA + PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## Summary
+
+<!-- What does this PR do, and why? -->
+
+## Changes
+
+<!-- Bullet list of the concrete changes. Reference specific files/functions where useful. -->
+
+## Test plan
+
+<!-- How did you verify this? Include the commands you ran and their result. -->
+
+## Checklist
+
+- [ ] Tests pass locally for any code this PR touches
+- [ ] `pre-commit run --all-files` passes (black, isort, flake8, prettier)
+- [ ] TypeScript compiles cleanly (`yarn build` or `yarn lint`), if frontend code changed
+- [ ] A changelog fragment was added under `changelog.d/` (see `changelog.d/README.md`) for user-facing changes, bug fixes, new dependencies, or migrations
+- [ ] Any new dependency was checked against what's already in the stack — a new SDK/library needs a reason it isn't already covered (e.g. by an existing `pydantic-ai-slim` extra)
+
+## Contributor License Agreement
+
+By submitting this pull request, you agree to license your contribution
+under the project's [Contributor License Agreement](../CLA.md). First-time
+contributors: a bot will comment on this PR asking you to confirm by
+replying with a short sign phrase — no separate signup required.

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,43 @@
+name: "CLA Assistant"
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+# Explicit permissions, in case the repo's default GITHUB_TOKEN permissions are read-only.
+permissions:
+  actions: write
+  contents: write # signatures are committed to the `cla-signatures` branch below
+  pull-requests: write
+  statuses: write
+
+jobs:
+  CLAAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: >
+          (github.event.comment.body == 'recheck' ||
+           github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') ||
+          github.event_name == 'pull_request_target'
+        # Pinned by commit SHA (tag v2.6.1), not a moving tag/branch ref — this
+        # project is archived/read-only upstream, so treat the action itself as
+        # a frozen dependency. https://github.com/contributor-assistant/github-action
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-signatures: "signatures/version1/cla.json"
+          path-to-document: "https://github.com/Open-Source-Legal/OpenContracts/blob/main/CLA.md"
+          # `main` is a protected branch (required PR reviews), and this action
+          # signs contributors by committing directly to `branch` — protected
+          # branches reject that push. Signatures live on a dedicated,
+          # unprotected `cla-signatures` branch instead. One-time setup: create
+          # an empty `cla-signatures` branch on the remote before this workflow
+          # can commit a signature for the first time.
+          branch: "cla-signatures"
+          # Automated dependency-bump PRs (Dependabot) aren't a human agreeing
+          # to anything — exempt them rather than block routine bumps.
+          allowlist: dependabot[bot]

--- a/CLA.md
+++ b/CLA.md
@@ -1,97 +1,134 @@
 # OpenContracts Individual Contributor License Agreement
 
-Thank you for your interest in contributing to OpenContracts (the
-"Project"), maintained by John Scrudato IV (the "Maintainer"), the
-copyright holder of OpenContracts
-(https://github.com/Open-Source-Legal/OpenContracts).
+Thank you for your interest in OpenContracts (the "Project"), maintained
+by John Scrudato IV (the "Maintainer"). To clarify the intellectual
+property license granted with Contributions from any person or entity,
+the Project must have a record of a signed Contributor License Agreement
+("CLA") from each Contributor, indicating agreement with the license
+terms below. This Agreement is for your protection as a Contributor as
+well as the protection of the Maintainer and the Project's users. It
+does not change your rights to use your own Contributions for any other
+purpose.
 
-This Contributor License Agreement ("Agreement") clarifies the
-intellectual property license granted with any Contribution you make to
-the Project. It protects you as a Contributor and the Project's users. It
-does **not** transfer ownership of your Contributions — you keep the
-copyright, and you remain free to use your own Contributions for any
-other purpose.
+You accept and agree to the following terms and conditions for Your
+Contributions (present and future) that You submit to the Project.
+Except for the license granted herein to the Maintainer and recipients
+of software distributed by the Project, You reserve all right, title,
+and interest in and to Your Contributions — this Agreement does not
+transfer ownership or assign copyright.
 
-By signing this Agreement — via the process described below — you accept
-and agree to the following terms for any past and future Contribution
-submitted to the Project.
+<sub>Adapted from the [Apache Software Foundation Individual Contributor
+License Agreement v2.2](https://www.apache.org/licenses/icla.pdf), a
+long-standing, publicly-published CLA that the ASF makes available for
+reuse. Substantive terms track that text; the differences are the
+grantee (an individual maintainer rather than a nonprofit foundation),
+one added relicensing clarification in Section 2, and the signing
+mechanism in "How to sign" below, which replaces ASF's mail-a-signed-PDF
+process with an in-PR bot flow.</sub>
 
 ## 1. Definitions
 
-"You" (or "Your") means the individual signing this Agreement.
+"You" (or "Your") shall mean the copyright owner or legal entity
+authorized by the copyright owner that is making this Agreement with the
+Maintainer. For legal entities, the entity making a Contribution and all
+other entities that control, are controlled by, or are under common
+control with that entity are considered to be a single Contributor. For
+the purposes of this definition, "control" means (i) the power, direct
+or indirect, to cause the direction or management of such entity,
+whether by contract or otherwise, (ii) ownership of fifty percent (50%)
+or more of the outstanding shares, or (iii) beneficial ownership of such
+entity.
 
-"Contribution" means any original work of authorship, including any
-modification or addition to existing work, that is intentionally
+"Contribution" shall mean any original work of authorship, including any
+modifications or additions to an existing work, that is intentionally
 submitted by You to the Project for inclusion in, or documentation of,
-any product owned or managed by the Maintainer (the "Work"). "Submitted"
-means any form of electronic, verbal, or written communication sent to
-the Maintainer or a designated representative, including communication
+any of the products owned or managed by the Maintainer (the "Work"). For
+the purposes of this definition, "submitted" means any form of
+electronic, verbal, or written communication sent to the Maintainer or a
+designated representative, including but not limited to communication
 on issue trackers and source code control systems managed by, or on
-behalf of, the Maintainer — including pull requests on
-https://github.com/Open-Source-Legal/OpenContracts.
+behalf of, the Maintainer for the purpose of discussing and improving
+the Work — including pull requests on
+https://github.com/Open-Source-Legal/OpenContracts — but excluding
+communication that is conspicuously marked or otherwise designated in
+writing by You as "Not a Contribution."
 
 ## 2. Grant of Copyright License
 
-Subject to the terms of this Agreement, You hereby grant to the
-Maintainer and to recipients of software distributed by the Project a
-perpetual, worldwide, non-exclusive, royalty-free, irrevocable copyright
-license to reproduce, prepare derivative works of, publicly display,
-publicly perform, sublicense, and distribute Your Contributions and such
-derivative works, under the Project's current license (MIT) or any
-future license the Maintainer chooses for the Project — including more
-permissive or more restrictive licenses — provided such relicensing does
-not retroactively restrict Your own rights to Your Contributions.
+Subject to the terms and conditions of this Agreement, You hereby grant
+to the Maintainer and to recipients of software distributed by the
+Project a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable copyright license to reproduce, prepare derivative works of,
+publicly display, publicly perform, sublicense, and distribute Your
+Contributions and such derivative works, under the Project's current
+license (MIT) or any future license the Maintainer chooses for the
+Project — including more permissive or more restrictive licenses —
+provided such relicensing does not retroactively restrict Your own
+rights to Your Contributions.
 
 ## 3. Grant of Patent License
 
-Subject to the terms of this Agreement, You hereby grant to the
-Maintainer and to recipients of software distributed by the Project a
-perpetual, worldwide, non-exclusive, royalty-free, irrevocable (except
-as stated in this section) patent license to make, have made, use, offer
-to sell, sell, import, and otherwise transfer the Work, where such
-license applies only to those patent claims licensable by You that are
-necessarily infringed by Your Contribution(s) alone or by combination of
-Your Contribution(s) with the Work to which such Contribution(s) was
-submitted. If any entity institutes patent litigation against You or any
-other entity alleging that Your Contribution, or the Work to which You
-have contributed, constitutes direct or contributory patent
+Subject to the terms and conditions of this Agreement, You hereby grant
+to the Maintainer and to recipients of software distributed by the
+Project a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable (except as stated in this section) patent license to make,
+have made, use, offer to sell, sell, import, and otherwise transfer the
+Work, where such license applies only to those patent claims licensable
+by You that are necessarily infringed by Your Contribution(s) alone or
+by combination of Your Contribution(s) with the Work to which such
+Contribution(s) was submitted. If any entity institutes patent
+litigation against You or any other entity (including a cross-claim or
+counterclaim in a lawsuit) alleging that Your Contribution, or the Work
+to which You have contributed, constitutes direct or contributory patent
 infringement, then any patent licenses granted to that entity under this
-Agreement for that Contribution or Work terminate as of the date such
-litigation is filed.
+Agreement for that Contribution or Work shall terminate as of the date
+such litigation is filed.
 
-## 4. You Retain Ownership
+## 4. Right to Grant
 
-You retain all right, title, and interest in and to Your Contributions.
-This Agreement only grants the licenses described above — it does not
-assign copyright to the Maintainer.
+You represent that You are legally entitled to grant the above license.
+If Your employer(s) has rights to intellectual property that You create
+that includes Your Contributions, You represent that You have received
+permission to make Contributions on behalf of that employer, that Your
+employer has waived such rights for Your Contributions to the Project,
+or that Your employer has executed a separate Corporate CLA with the
+Maintainer.
 
-## 5. Representations
+## 5. Original Creation
 
-You represent that:
+You represent that each of Your Contributions is Your original creation
+(see Section 7 for submissions on behalf of others). You represent that
+Your Contribution submissions include complete details of any
+third-party license or other restriction (including, but not limited
+to, related patents and trademarks) of which You are personally aware
+and which are associated with any part of Your Contributions.
 
-- You are legally entitled to grant the licenses above. If Your employer
-  has rights to intellectual property You create that includes Your
-  Contributions, You represent that You have received permission to
-  contribute on behalf of that employer, that Your employer has waived
-  such rights for Your Contributions, or that Your employer has executed
-  a separate Corporate CLA with the Maintainer.
-- Each of Your Contributions is Your original creation, or You have
-  sufficient rights to submit it under the terms of this Agreement.
-- Your Contribution submissions include complete details of any
-  third-party license or other restriction of which You are personally
-  aware and which is associated with any part of Your Contributions.
+## 6. No Obligation to Support; No Warranty
 
-## 6. No Warranty
+You are not expected to provide support for Your Contributions, except
+to the extent You desire to provide support. You may provide support for
+free, for a fee, or not at all. Unless required by applicable law or
+agreed to in writing, You provide Your Contributions on an "AS IS"
+BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied, including, without limitation, any warranties or conditions of
+TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR
+PURPOSE.
 
-Unless required by applicable law or agreed to in writing, You provide
-Your Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
-OF ANY KIND, either express or implied.
+## 7. Submitting Third-Party Work
 
-## 7. Notification of Changes
+Should You wish to submit work that is not Your original creation, You
+may submit it to the Project separately from any Contribution,
+identifying the complete details of its source and of any license or
+other restriction (including, but not limited to, related patents,
+trademarks, and license agreements) of which You are personally aware,
+and conspicuously marking the work as "Submitted on behalf of a
+third-party: [named here]."
+
+## 8. Notification of Changes
 
 You agree to notify the Maintainer of any facts or circumstances of
-which You become aware that would make the representations in Section 5
-inaccurate in any respect.
+which You become aware that would make the representations in this
+Agreement inaccurate in any respect.
 
 ## How to sign
 

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,103 @@
+# OpenContracts Individual Contributor License Agreement
+
+Thank you for your interest in contributing to OpenContracts (the
+"Project"), maintained by the Open-Source-Legal organization
+(https://github.com/Open-Source-Legal/OpenContracts) (the "Maintainers").
+
+This Contributor License Agreement ("Agreement") clarifies the
+intellectual property license granted with any Contribution you make to
+the Project. It protects you as a Contributor and the Project's users. It
+does **not** transfer ownership of your Contributions — you keep the
+copyright, and you remain free to use your own Contributions for any
+other purpose.
+
+By signing this Agreement — via the process described below — you accept
+and agree to the following terms for any past and future Contribution
+submitted to the Project.
+
+## 1. Definitions
+
+"You" (or "Your") means the individual signing this Agreement.
+
+"Contribution" means any original work of authorship, including any
+modification or addition to existing work, that is intentionally
+submitted by You to the Project for inclusion in, or documentation of,
+any product owned or managed by the Maintainers (the "Work"). "Submitted"
+means any form of electronic, verbal, or written communication sent to
+the Maintainers or their representatives, including communication on
+issue trackers and source code control systems managed by, or on behalf
+of, the Maintainers — including pull requests on
+https://github.com/Open-Source-Legal/OpenContracts.
+
+## 2. Grant of Copyright License
+
+Subject to the terms of this Agreement, You hereby grant to the
+Maintainers and to recipients of software distributed by the Project a
+perpetual, worldwide, non-exclusive, royalty-free, irrevocable copyright
+license to reproduce, prepare derivative works of, publicly display,
+publicly perform, sublicense, and distribute Your Contributions and such
+derivative works, under the Project's current license (MIT) or any
+future license the Maintainers choose for the Project — including more
+permissive or more restrictive licenses — provided such relicensing does
+not retroactively restrict Your own rights to Your Contributions.
+
+## 3. Grant of Patent License
+
+Subject to the terms of this Agreement, You hereby grant to the
+Maintainers and to recipients of software distributed by the Project a
+perpetual, worldwide, non-exclusive, royalty-free, irrevocable (except
+as stated in this section) patent license to make, have made, use, offer
+to sell, sell, import, and otherwise transfer the Work, where such
+license applies only to those patent claims licensable by You that are
+necessarily infringed by Your Contribution(s) alone or by combination of
+Your Contribution(s) with the Work to which such Contribution(s) was
+submitted. If any entity institutes patent litigation against You or any
+other entity alleging that Your Contribution, or the Work to which You
+have contributed, constitutes direct or contributory patent
+infringement, then any patent licenses granted to that entity under this
+Agreement for that Contribution or Work terminate as of the date such
+litigation is filed.
+
+## 4. You Retain Ownership
+
+You retain all right, title, and interest in and to Your Contributions.
+This Agreement only grants the licenses described above — it does not
+assign copyright to the Maintainers.
+
+## 5. Representations
+
+You represent that:
+
+- You are legally entitled to grant the licenses above. If Your employer
+  has rights to intellectual property You create that includes Your
+  Contributions, You represent that You have received permission to
+  contribute on behalf of that employer, that Your employer has waived
+  such rights for Your Contributions, or that Your employer has executed
+  a separate Corporate CLA with the Maintainers.
+- Each of Your Contributions is Your original creation, or You have
+  sufficient rights to submit it under the terms of this Agreement.
+- Your Contribution submissions include complete details of any
+  third-party license or other restriction of which You are personally
+  aware and which is associated with any part of Your Contributions.
+
+## 6. No Warranty
+
+Unless required by applicable law or agreed to in writing, You provide
+Your Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+OF ANY KIND, either express or implied.
+
+## 7. Notification of Changes
+
+You agree to notify the Maintainers of any facts or circumstances of
+which You become aware that would make the representations in Section 5
+inaccurate in any respect.
+
+## How to sign
+
+Signing happens automatically the first time you open a pull request
+against this repository: the CLA Assistant bot comments asking you to
+reply with the sign phrase it provides. Your signature (GitHub username,
+timestamp, and this document's version) is recorded in
+[`signatures/version1/cla.json`](signatures/version1/cla.json). You only
+need to sign once — the bot recognizes returning contributors
+automatically on later pull requests.

--- a/CLA.md
+++ b/CLA.md
@@ -1,8 +1,9 @@
 # OpenContracts Individual Contributor License Agreement
 
 Thank you for your interest in contributing to OpenContracts (the
-"Project"), maintained by the Open-Source-Legal organization
-(https://github.com/Open-Source-Legal/OpenContracts) (the "Maintainers").
+"Project"), maintained by John Scrudato IV (the "Maintainer"), the
+copyright holder of OpenContracts
+(https://github.com/Open-Source-Legal/OpenContracts).
 
 This Contributor License Agreement ("Agreement") clarifies the
 intellectual property license granted with any Contribution you make to
@@ -22,29 +23,29 @@ submitted to the Project.
 "Contribution" means any original work of authorship, including any
 modification or addition to existing work, that is intentionally
 submitted by You to the Project for inclusion in, or documentation of,
-any product owned or managed by the Maintainers (the "Work"). "Submitted"
+any product owned or managed by the Maintainer (the "Work"). "Submitted"
 means any form of electronic, verbal, or written communication sent to
-the Maintainers or their representatives, including communication on
-issue trackers and source code control systems managed by, or on behalf
-of, the Maintainers — including pull requests on
+the Maintainer or a designated representative, including communication
+on issue trackers and source code control systems managed by, or on
+behalf of, the Maintainer — including pull requests on
 https://github.com/Open-Source-Legal/OpenContracts.
 
 ## 2. Grant of Copyright License
 
 Subject to the terms of this Agreement, You hereby grant to the
-Maintainers and to recipients of software distributed by the Project a
+Maintainer and to recipients of software distributed by the Project a
 perpetual, worldwide, non-exclusive, royalty-free, irrevocable copyright
 license to reproduce, prepare derivative works of, publicly display,
 publicly perform, sublicense, and distribute Your Contributions and such
 derivative works, under the Project's current license (MIT) or any
-future license the Maintainers choose for the Project — including more
+future license the Maintainer chooses for the Project — including more
 permissive or more restrictive licenses — provided such relicensing does
 not retroactively restrict Your own rights to Your Contributions.
 
 ## 3. Grant of Patent License
 
 Subject to the terms of this Agreement, You hereby grant to the
-Maintainers and to recipients of software distributed by the Project a
+Maintainer and to recipients of software distributed by the Project a
 perpetual, worldwide, non-exclusive, royalty-free, irrevocable (except
 as stated in this section) patent license to make, have made, use, offer
 to sell, sell, import, and otherwise transfer the Work, where such
@@ -62,7 +63,7 @@ litigation is filed.
 
 You retain all right, title, and interest in and to Your Contributions.
 This Agreement only grants the licenses described above — it does not
-assign copyright to the Maintainers.
+assign copyright to the Maintainer.
 
 ## 5. Representations
 
@@ -73,7 +74,7 @@ You represent that:
   Contributions, You represent that You have received permission to
   contribute on behalf of that employer, that Your employer has waived
   such rights for Your Contributions, or that Your employer has executed
-  a separate Corporate CLA with the Maintainers.
+  a separate Corporate CLA with the Maintainer.
 - Each of Your Contributions is Your original creation, or You have
   sufficient rights to submit it under the terms of this Agreement.
 - Your Contribution submissions include complete details of any
@@ -88,7 +89,7 @@ OF ANY KIND, either express or implied.
 
 ## 7. Notification of Changes
 
-You agree to notify the Maintainers of any facts or circumstances of
+You agree to notify the Maintainer of any facts or circumstances of
 which You become aware that would make the representations in Section 5
 inaccurate in any respect.
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 John Scrudato
+Copyright (c) 2026 John Scrudato IV
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary

- Adds `CLA.md`: an Individual Contributor License Agreement (license-grant style — contributors keep copyright, grant the project a perpetual/worldwide/royalty-free copyright + patent license). Drafted from common OSS-CLA practice; **has not been reviewed by counsel**.
- Adds `.github/workflows/cla.yml`: wires up `contributor-assistant/github-action` (pinned by commit SHA, not a movable tag — upstream repo is archived/read-only) so first-time contributors sign by replying to a PR comment. `dependabot[bot]` is allowlisted so routine dependency bumps aren't blocked.
- Adds `.github/PULL_REQUEST_TEMPLATE.md`: summary/changes/test-plan sections, a checklist drawn from the repo's actual baseline commit rules (pre-commit, TS compile, changelog fragment, dependency justification), and the CLA notice.

## Why

Getting ready to invite more external contributors; want a real CLA-sign flow and a PR template that surfaces our norms (tests, pre-commit, changelog fragments) to people who haven't read CLAUDE.md, before that starts.

## Setup notes

- `main` is a protected branch (required PR reviews) and the CLA bot signs contributors by pushing a commit directly to whatever `branch:` it's given — protected branches reject that. Signatures are stored on a separate `cla-signatures` branch instead; that branch has been created (empty) on the remote already, so the workflow should work as soon as this merges.
- `CLA.md`'s entity language ("the Open-Source-Legal organization") is a placeholder pending confirmation of the correct legal entity.

## Test plan

- [x] `pre-commit run --files CLA.md .github/workflows/cla.yml .github/PULL_REQUEST_TEMPLATE.md` — passes
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/cla.yml'))"` — valid YAML
- [ ] End-to-end: open a throwaway PR after merge and confirm the bot comments + records a signature on `cla-signatures`