### PR TITLE
docs: fix broken documentation link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ To add a deployment-specific variant, drop a `<key>.json` file in `frontend/src/
 
 ## Documentation
 
-Browse the full documentation at [jsv4.github.io/OpenContracts](https://jsv4.github.io/OpenContracts/) or in the repo:
+Browse the full documentation at [open-source-legal.github.io/OpenContracts](https://open-source-legal.github.io/OpenContracts/) or in the repo:
 
 | Guide                                                                       | Description                          |
 | --------------------------------------------------------------------------- | ------------------------------------ |


### PR DESCRIPTION
The documentation link in the README still points at `https://jsv4.github.io/OpenContracts/`, which 404s now that the repo lives under the `Open-Source-Legal` org. This updates it to `https://open-source-legal.github.io/OpenContracts/`, which returns 200 and matches `site_url` in `mkdocs.yml`.

One-line change, docs only.

### Also worth a maintainer's attention (not fixable in a PR)

The repo's **About** sidebar link is set to `https://open-source-legal.github.io/opencontracts/` (lowercase `opencontracts`), which also 404s — GitHub Pages paths are case-sensitive. The working URL is:

```
https://open-source-legal.github.io/OpenContracts/
```

That's a repo setting rather than a file, so it needs a maintainer to change it in Settings (or `gh repo edit --homepage https://open-source-legal.github.io/OpenContracts/`).
