### PR TITLE
docs: fix six broken links across docs and frontend README

### DIFF
--- a/docs/architecture/agent_corpus_actions_design.md
+++ b/docs/architecture/agent_corpus_actions_design.md
@@ -430,5 +430,5 @@ Tests covering agent task execution:
 
 - [Corpus Actions Intro](../corpus_actions/intro_to_corpus_actions.md)
 - [Document Versioning](./document_versioning.md)
-- [Agent Framework](../llms/README.md)
+- [Agent Framework](llms/README.md)
 - [Permissioning Guide](../permissioning/consolidated_permissioning_guide.md)

--- a/docs/architecture/websocket/frontend.md
+++ b/docs/architecture/websocket/frontend.md
@@ -837,7 +837,7 @@ getThreadUpdatesWebSocket(conversationId, authToken?)
 ## Related Files
 
 - [`frontend/src/components/widgets/chat/ChatMessage.tsx`](../../../frontend/src/components/widgets/chat/ChatMessage.tsx): Message rendering component
-- [`frontend/src/components/annotator/context/ChatSourceAtom.ts`](../../../frontend/src/components/annotator/context/ChatSourceAtom.ts): Source state management
+- [`frontend/src/components/annotator/context/ChatSourceAtom.tsx`](../../../frontend/src/components/annotator/context/ChatSourceAtom.tsx): Source state management
 - [`frontend/src/components/chat/get_websockets.ts`](../../../frontend/src/components/chat/get_websockets.ts): WebSocket URL utilities
 - [`frontend/src/graphql/queries.ts`](../../../frontend/src/graphql/queries.ts): GraphQL conversation queries
 - [`frontend/src/hooks/useNetworkStatus.ts`](../../../frontend/src/hooks/useNetworkStatus.ts): Network/visibility status for reconnection

--- a/docs/configuration/frontend-configuration.md
+++ b/docs/configuration/frontend-configuration.md
@@ -19,7 +19,7 @@ The frontend uses different environment variable prefixes depending on the deplo
 
 **How it works**: In production, the container entrypoint script writes a runtime-loaded file at `frontend/public/env-config.js` that populates `window._env_` with the `REACT_APP_*` variables converted from `OPEN_CONTRACTS_REACT_APP_*`. For example, `OPEN_CONTRACTS_REACT_APP_USE_AUTH0` becomes `window._env_.REACT_APP_USE_AUTH0` in the frontend code. The browser fetches `env-config.js` on every page load, so configuration changes do **not** require a frontend rebuild — only a container restart (or `env-config.js` regeneration) is needed.
 
-See [`frontend/public/env-config.js`](https://github.com/Open-Source-Legal/OpenContracts/blob/main/frontend/public/env-config.js) for the file structure and the [Frontend Telemetry doc](../telemetry/Frontend.md) for how the same mechanism is used to inject PostHog keys.
+See [`frontend/env.sh`](https://github.com/Open-Source-Legal/OpenContracts/blob/main/frontend/env.sh), the entrypoint script that generates it, for the file structure and the [Frontend Telemetry doc](../telemetry/Frontend.md) for how the same mechanism is used to inject PostHog keys.
 
 ## Available Configuration Options
 

--- a/docs/frontend/auth_flow.md
+++ b/docs/frontend/auth_flow.md
@@ -296,7 +296,7 @@ See `frontend/src/components/auth/AuthGate.test.tsx` for test examples.
 
 ## Related Documentation
 
-- [Authentication Pattern](../frontend/src/docs/AUTHENTICATION_PATTERN.md) - Detailed AuthGate pattern documentation
+- [Authentication Pattern](../../frontend/src/docs/AUTHENTICATION_PATTERN.md) - Detailed AuthGate pattern documentation
 - [Routing System](./routing_system.md) - How routing works with auth
 - [Apollo Cache](../architecture/apollo_cache.md) - Cache management details
 

--- a/docs/walkthrough/step-8-data-extract.md
+++ b/docs/walkthrough/step-8-data-extract.md
@@ -5,7 +5,7 @@ points, represented as columns in a grid, that will be asked of every document i
 You can define complex extract schemas, including python primitives, Pydantic models (no nesting - yet) and lists.
 
 Under the hood, the extraction system uses an agent-based pipeline powered by PydanticAI that intelligently retrieves
-and processes document content. For technical details, see the [LLM Framework documentation](../../architecture/llms/README.md).
+and processes document content. For technical details, see the [LLM Framework documentation](../architecture/llms/README.md).
 
 ## Building a Datagrid
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -17,7 +17,7 @@ You will also see any lint errors in the console.
 ### `npm test`
 
 Launches the test runner in the interactive watch mode.\
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
+See the section about [running tests](https://create-react-app.dev/docs/running-tests) for more information.
 
 ### `npm run build`
 
@@ -27,7 +27,7 @@ It correctly bundles React in production mode and optimizes the build for the be
 The build is minified and the filenames include the hashes.\
 Your app is ready to be deployed!
 
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
+See the section about [deployment](https://create-react-app.dev/docs/deployment) for more information.
 
 ### `npm run eject`
 


### PR DESCRIPTION
Six broken links, each verified against the tree or with a live HTTP request. Docs only — no code changes.

| File | Problem | Fix |
|---|---|---|
| `docs/walkthrough/step-8-data-extract.md` | `../../architecture/llms/README.md` — one `../` too many | `../architecture/llms/README.md` |
| `docs/architecture/agent_corpus_actions_design.md` | `../llms/README.md` resolved to `docs/llms/`, but `llms/` is inside `docs/architecture/` | `llms/README.md` |
| `docs/frontend/auth_flow.md` | `../frontend/src/docs/AUTHENTICATION_PATTERN.md` — one `../` too few | `../../frontend/src/docs/…` |
| `docs/architecture/websocket/frontend.md` | `ChatSourceAtom.ts` — the file is `.tsx` | `ChatSourceAtom.tsx` |
| `frontend/README.md` (×2) | Create React App docs moved off `facebook.github.io/create-react-app` (both links 404) | `create-react-app.dev/docs/…` |
| `docs/configuration/frontend-configuration.md` | Links to `blob/main/frontend/public/env-config.js`, but that file is gitignored and generated at container start — the link can never resolve | Points at `frontend/env.sh`, the script that generates it |

### Deliberately left alone

Two clusters of broken links need a maintainer's call, so I didn't guess:

1. **`config/graphql/{graphene_types,mutations,queries}.py`** — referenced from `agent_corpus_actions_design.md`, `commenting_system/*.md`, `social-media-previews.md`, and `dual_tree_implementation_plan.md`. Those monolithic modules were split into per-domain files (`agent_types.py`, `agent_mutations.py`, `corpus_queries.py`, …), so each reference needs repointing to the right one — an editorial decision, not a mechanical one.
2. **`docs/architecture/apollo_cache.md`** — linked from `auth_flow.md:301`, but no such file exists anywhere in the repo. Either it was never written or it moved under a different name.

Happy to follow up on either if you tell me where they should point.
