### PR TITLE
feat(packs): let an operator decline to execute in-pack provider code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -227,3 +227,8 @@ demo/import_zips/
 # from an external corpus, never meant to be committed)
 .pilot_data/
 .authority_packs/
+# Where config/settings/test.py points AUTHORITY_PACK_INSTALL_DIR so a
+# developer's real fetch cache above cannot leak into the test suite. Normally
+# absent; only a test that materialises a pack without overriding the setting
+# would create it.
+.authority_packs_test/

--- a/changelog.d/2266-authority-provider-lookup-scope.fixed.md
+++ b/changelog.d/2266-authority-provider-lookup-scope.fixed.md
@@ -1,0 +1,10 @@
+- **`get_authority_source_provider()` could resolve to the wrong component type.**
+  `opencontractserver/pipeline/registry.py` — its primary lookup went through
+  `PipelineComponentRegistry.get_by_name` / `get_by_class_name`, dicts shared by
+  every component family (parsers, embedders, LLM providers, ...). A class-name
+  collision with an unrelated component would silently return an instance of
+  the wrong type, which would only fail later and outside this function's
+  `try/except`, when the pack called `.can_handle(...)` on it. The lookup is
+  now scoped to `get_all_authority_source_providers_cached()` throughout,
+  matching the type-safety guarantee already stated in the docstring and
+  already applied on the ambiguous-leaf fallback path.

--- a/changelog.d/2266-pack-provider-trust-controls.added.md
+++ b/changelog.d/2266-pack-provider-trust-controls.added.md
@@ -1,0 +1,24 @@
+- **An operator can decline to execute in-pack provider code.** Installing an
+  authority pack that ships `<pack>/providers/*.py` or
+  `<pack>/discovery_providers/*.py` imports that Python into the web and
+  worker processes — `tar.extract(..., filter="data")` refuses path traversal
+  and setuid bits, but it cannot refuse code. The new
+  `AUTHORITY_PACK_LOAD_PROVIDERS` setting (`config/settings/base.py`, default
+  `True` — no behavior change for existing installs) lets an operator turn
+  this off; when disabled, `opencontractserver/pipeline/registry.py` skips
+  the modules without importing them and logs the skip once with a count and
+  the module names. Turning it off costs re-fetch and nothing else — the pack
+  contract (authority-packs `SOURCE_PROVIDERS.md`, clause P5) requires a pack
+  to install and serve its sections with `providers/` deleted.
+- **`get_authority_source_provider(class_name)`** (`opencontractserver/pipeline/registry.py`)
+  is the supported delegation seam for an in-pack provider that reuses a core
+  one (CFR, U.S. Code, Federal Register) instead of shipping its own scraper.
+  Accepts a bare class name or a dotted path, refuses an ambiguous leaf rather
+  than picking one, and returns `None` instead of raising so a pack degrades
+  to "cannot re-fetch" rather than crashing registry build.
+- **`install_authority_pack` reports a pack's provider code surface before any
+  DB write.** Lists the provider modules a pack ships and, when present, the
+  classes/prefixes its optional `providers:` manifest declares — by reading
+  files only, never by importing them — and notes when
+  `AUTHORITY_PACK_LOAD_PROVIDERS` is off so `--check` shows that the modules
+  will not run.

--- a/changelog.d/authority-pack-test-isolation.fixed.md
+++ b/changelog.d/authority-pack-test-isolation.fixed.md
@@ -1,0 +1,12 @@
+- **Test suite: a developer's authority-pack fetch cache no longer leaks into tests.**
+  `config/settings/test.py` inherited the default
+  `AUTHORITY_PACK_INSTALL_DIR = ROOT_DIR/.authority_packs`, which is a real fetch
+  cache on any machine where `install_authority_pack` has been run — and which
+  `pipeline/registry.py::authority_pack_dirs` scans as an implicit discovery
+  root. Every test touching pack discovery was therefore environment-dependent:
+  `test_authority_pack_sideload.py::AuthorityPackDiscoveryTests` (3 tests) failed
+  locally while passing in CI, and the SSRF allowlist union, pack catalog, and
+  in-pack provider imports were silently exposed the same way. Test settings now
+  pin the install dir to a path that does not exist, so the third discovery
+  source contributes nothing unless a test opts in via `override_settings`; the
+  tests that assert an exact pack set also state that precondition themselves.

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -1784,6 +1784,22 @@ AUTHORITY_PACK_PATHS = env.list("AUTHORITY_PACK_PATHS", default=[])
 # path. Same restart requirement as AUTHORITY_PACK_PATHS.
 AUTHORITY_PACK_ROOTS = env.list("AUTHORITY_PACK_ROOTS", default=[])
 
+# Whether to LOAD (import) provider modules shipped inside authority packs
+# (``<pack>/providers/*.py``, ``<pack>/discovery_providers/*.py``).
+#
+# Installing such a pack executes its Python in the web and worker processes.
+# That is a materially larger blast radius than ``source_hosts``, where
+# "installing the pack is the trust decision" holds because the consequence is
+# bounded to which hosts may be fetched. Extraction already refuses path
+# traversal and setuid bits (``tar.extract(..., filter="data")``); it cannot
+# refuse code.
+#
+# Default True preserves existing behaviour. An operator installing packs they
+# did not author sets this False and loses only the ability to RE-FETCH the
+# pack's text: the authority-packs contract (SOURCE_PROVIDERS.md, clause P5)
+# requires a pack to install and serve its sections with ``providers/`` deleted.
+AUTHORITY_PACK_LOAD_PROVIDERS = env.bool("AUTHORITY_PACK_LOAD_PROVIDERS", default=True)
+
 # Where `manage.py install_authority_pack` materialises packs fetched from the
 # pack registry repo. The directory is an implicit pack bundle root (scanned by
 # authority_pack_dirs() exactly like an AUTHORITY_PACK_ROOTS entry), so a

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -183,6 +183,22 @@ if env.bool("BENCHMARK_MODE", default=False):
 else:
     DEFAULT_EMBEDDER = _OC_TEST_EMBEDDER_DEFAULT
 
+# Authority packs
+# ------------------------------------------------------------------------------
+# The install dir is an implicit pack DISCOVERY root (``authority_pack_dirs()``
+# scans it like any bundle root), and its default — ``ROOT_DIR/.authority_packs``
+# — is a real fetch cache on any machine where someone has run
+# ``install_authority_pack``. Inheriting that default made every test that
+# touches pack discovery depend on what that developer happened to have
+# installed: the sideload tests' exact-set assertions failed locally while
+# passing in CI, and the SSRF allowlist union, pack catalog, and in-pack provider
+# imports were all silently environment-dependent in the same way.
+#
+# Pinned here to a path that does not exist, so the third discovery source
+# contributes nothing unless a test opts in with ``override_settings``. Tests
+# that exercise the install dir already point it at their own tmpdir.
+AUTHORITY_PACK_INSTALL_DIR = str(ROOT_DIR / ".authority_packs_test")  # noqa: F405
+
 # Auth0 settings for tests
 # ------------------------------------------------------------------------------
 # These are required for importing Auth0 modules even if USE_AUTH0 is False.

--- a/opencontractserver/corpuses/management/commands/install_authority_pack.py
+++ b/opencontractserver/corpuses/management/commands/install_authority_pack.py
@@ -140,6 +140,63 @@ def materialise_pack(staged_pack: Path, pack: str, stdout=None) -> Path:
     return dest
 
 
+def _report_pack_providers(pack_dir, stdout, style) -> None:
+    """Print the provider modules a pack ships, if any. Never imports them.
+
+    Installing a pack that ships ``providers/`` imports its Python into the web
+    and worker processes, so the operator should be able to see that surface
+    before the install writes anything. Reads the filesystem and, when present,
+    the OPTIONAL ``providers:`` declaration in pack.yaml — never the modules.
+    """
+    from pathlib import Path as _Path
+
+    pack_dir = _Path(pack_dir)
+    shipped: list[tuple[str, str]] = []
+    for subdir in ("providers", "discovery_providers"):
+        component_dir = pack_dir / subdir
+        if not component_dir.is_dir():
+            continue
+        for py in sorted(component_dir.glob("*.py")):
+            if not py.name.startswith("_"):
+                shipped.append((subdir, py.name))
+    if not shipped:
+        return
+
+    stdout.write(
+        style.WARNING(
+            f"This pack ships {len(shipped)} provider module(s). Loading the pack "
+            "IMPORTS them into the web and worker processes:"
+        )
+    )
+    for subdir, name in shipped:
+        stdout.write(f"    {subdir}/{name}")
+
+    # The declaration is optional and descriptive; show it when a pack has one
+    # so the claimed prefixes are visible without reading Python.
+    try:
+        import yaml
+
+        manifest = yaml.safe_load((pack_dir / "pack.yaml").read_text()) or {}
+        for entry in manifest.get("providers") or []:
+            stdout.write(
+                f"    declares: {entry.get('class')} "
+                f"prefixes={entry.get('supported_prefixes')} "
+                f"delegates_to={entry.get('delegates_to') or '-'}"
+            )
+    except Exception:  # noqa: BLE001 - a missing/!parsing manifest is not fatal here
+        pass
+
+    from django.conf import settings
+
+    if not getattr(settings, "AUTHORITY_PACK_LOAD_PROVIDERS", True):
+        stdout.write(
+            style.SUCCESS(
+                "    AUTHORITY_PACK_LOAD_PROVIDERS is off — these will NOT be "
+                "imported. The pack's text still installs and serves."
+            )
+        )
+
+
 class Command(BaseCommand):
     help = (
         "Fetch an authority pack from the pack registry repo into "
@@ -281,6 +338,11 @@ class Command(BaseCommand):
             raise CommandError(
                 "--creator is required to install or preflight (or use --fetch-only)"
             )
+
+        # Say what code this pack will run, BEFORE any DB writes, and without
+        # importing it — reporting a pack's providers by executing them would
+        # defeat the point. Static file listing only.
+        _report_pack_providers(dest, self.stdout, self.style)
 
         call_command(
             "load_authority_pack",

--- a/opencontractserver/corpuses/management/commands/install_authority_pack.py
+++ b/opencontractserver/corpuses/management/commands/install_authority_pack.py
@@ -28,6 +28,7 @@ Grammar-tier pack taxonomy extensions (``abbreviations``/``shape_rules``) are
 first-time install — the command prints the reminder.
 """
 
+import logging
 import re
 import shutil
 import tarfile
@@ -37,6 +38,8 @@ from pathlib import Path
 from django.conf import settings
 from django.core.management import call_command
 from django.core.management.base import BaseCommand, CommandError
+
+logger = logging.getLogger(__name__)
 
 # Pack directories are addressed by name inside the install dir; constrain to a
 # conservative slug so a hostile registry listing can never traverse paths.
@@ -180,8 +183,13 @@ def _report_pack_providers(pack_dir, stdout, style) -> None:
                 f"prefixes={entry.get('supported_prefixes')} "
                 f"delegates_to={entry.get('delegates_to') or '-'}"
             )
-    except Exception:  # noqa: BLE001 - a missing/mis-parsing manifest is not fatal here
-        pass
+    except (
+        Exception
+    ) as exc:  # noqa: BLE001 - a missing/mis-parsing manifest is not fatal here
+        # load_authority_pack (called right after, on the install path) will
+        # hit and report the same malformed YAML properly; this is just the
+        # optional "declares: ..." preview, so log at debug rather than warn.
+        logger.debug("Could not read pack.yaml providers declaration: %s", exc)
 
     if not getattr(settings, "AUTHORITY_PACK_LOAD_PROVIDERS", True):
         stdout.write(
@@ -322,6 +330,18 @@ class Command(BaseCommand):
             dest = materialise_pack(staged / pack, pack, self.stdout)
             self.stdout.write(self.style.SUCCESS(f"Pack materialised at {dest}"))
 
+        # Say what code this pack ships, without importing it — reporting a
+        # pack's providers by executing them would defeat the point. This runs
+        # for --fetch-only too, not just before the DB-writing install below:
+        # materialise_pack() has already placed the pack under
+        # AUTHORITY_PACK_INSTALL_DIR, an implicit discovery root
+        # (authority_pack_dirs()), so the NEXT get_registry() call in any
+        # web/worker process — independent of ever running load_authority_pack
+        # or supplying --creator — is what actually imports providers/*.py.
+        # --fetch-only alone creates that exposure, so it needs the same
+        # visibility.
+        _report_pack_providers(dest, self.stdout, self.style)
+
         if options["fetch_only"]:
             self.stdout.write(
                 "Fetch-only: skipping install. Run load_authority_pack --path "
@@ -333,11 +353,6 @@ class Command(BaseCommand):
             raise CommandError(
                 "--creator is required to install or preflight (or use --fetch-only)"
             )
-
-        # Say what code this pack will run, BEFORE any DB writes, and without
-        # importing it — reporting a pack's providers by executing them would
-        # defeat the point. Static file listing only.
-        _report_pack_providers(dest, self.stdout, self.style)
 
         call_command(
             "load_authority_pack",

--- a/opencontractserver/corpuses/management/commands/install_authority_pack.py
+++ b/opencontractserver/corpuses/management/commands/install_authority_pack.py
@@ -148,17 +148,14 @@ def _report_pack_providers(pack_dir, stdout, style) -> None:
     before the install writes anything. Reads the filesystem and, when present,
     the OPTIONAL ``providers:`` declaration in pack.yaml — never the modules.
     """
-    from pathlib import Path as _Path
+    from opencontractserver.pipeline.registry import pack_component_modules
 
-    pack_dir = _Path(pack_dir)
-    shipped: list[tuple[str, str]] = []
-    for subdir in ("providers", "discovery_providers"):
-        component_dir = pack_dir / subdir
-        if not component_dir.is_dir():
-            continue
-        for py in sorted(component_dir.glob("*.py")):
-            if not py.name.startswith("_"):
-                shipped.append((subdir, py.name))
+    pack_dir = Path(pack_dir)
+    shipped: list[tuple[str, str]] = [
+        (subdir, py.name)
+        for subdir in ("providers", "discovery_providers")
+        for py in pack_component_modules(pack_dir, subdir)
+    ]
     if not shipped:
         return
 
@@ -183,10 +180,8 @@ def _report_pack_providers(pack_dir, stdout, style) -> None:
                 f"prefixes={entry.get('supported_prefixes')} "
                 f"delegates_to={entry.get('delegates_to') or '-'}"
             )
-    except Exception:  # noqa: BLE001 - a missing/!parsing manifest is not fatal here
+    except Exception:  # noqa: BLE001 - a missing/mis-parsing manifest is not fatal here
         pass
-
-    from django.conf import settings
 
     if not getattr(settings, "AUTHORITY_PACK_LOAD_PROVIDERS", True):
         stdout.write(

--- a/opencontractserver/pipeline/registry.py
+++ b/opencontractserver/pipeline/registry.py
@@ -522,7 +522,10 @@ class PipelineComponentRegistry:
                     len(skipped),
                     subdir_name,
                     ", ".join(
-                        sorted(p.parent.parent.name + "/" + p.name for p in skipped)
+                        sorted(
+                            f"{p.parent.parent.name}/{p.parent.name}/{p.name}"
+                            for p in skipped
+                        )
                     ),
                 )
             return []

--- a/opencontractserver/pipeline/registry.py
+++ b/opencontractserver/pipeline/registry.py
@@ -243,7 +243,8 @@ def pack_provider_modules(subdir_name: str) -> list[Path]:
         if not component_dir.is_dir():
             continue
         modules.extend(
-            py for py in sorted(component_dir.glob("*.py"))
+            py
+            for py in sorted(component_dir.glob("*.py"))
             if not py.name.startswith("_")
         )
     return modules
@@ -509,7 +510,9 @@ class PipelineComponentRegistry:
                     "serve their text; only re-fetch is unavailable.",
                     len(skipped),
                     subdir_name,
-                    ", ".join(sorted(p.parent.parent.name + "/" + p.name for p in skipped)),
+                    ", ".join(
+                        sorted(p.parent.parent.name + "/" + p.name for p in skipped)
+                    ),
                 )
             return []
 
@@ -1087,7 +1090,9 @@ def get_authority_source_provider(class_name: str) -> Optional[Any]:
     of breaking registry build.
     """
     registry = get_registry()
-    definition = registry.get_by_class_name(class_name) or registry.get_by_name(class_name)
+    definition = registry.get_by_class_name(class_name) or registry.get_by_name(
+        class_name
+    )
     if definition is None:
         # ``class_name`` is stored as a full dotted path; a pack author writes
         # the leaf. Accept either, and refuse an ambiguous leaf rather than
@@ -1114,7 +1119,9 @@ def get_authority_source_provider(class_name: str) -> Optional[Any]:
         return None
     try:
         return component()
-    except Exception as exc:  # pragma: no cover - defensive; a provider ctor should be trivial
+    except (
+        Exception
+    ) as exc:  # pragma: no cover - defensive; a provider ctor should be trivial
         logger.warning(
             "Could not instantiate authority source provider %r: %s", class_name, exc
         )

--- a/opencontractserver/pipeline/registry.py
+++ b/opencontractserver/pipeline/registry.py
@@ -228,6 +228,24 @@ def authority_pack_dirs() -> list[Path]:
     return unique
 
 
+def pack_component_modules(pack_dir: Path, subdir_name: str) -> list[Path]:
+    """Provider modules a single pack directory SHIPS, without importing any.
+
+    The single-directory primitive behind ``pack_provider_modules`` (which
+    folds this over every discovered pack) and behind
+    ``install_authority_pack``'s pre-install report, which needs just the
+    one freshly-fetched pack rather than every pack on the install. Mirrors
+    the filtering ``_discover_pack_component_classes`` applies (``*.py``, no
+    leading underscore) so every caller counts the same set.
+    """
+    component_dir = Path(pack_dir) / subdir_name
+    if not component_dir.is_dir():
+        return []
+    return [
+        py for py in sorted(component_dir.glob("*.py")) if not py.name.startswith("_")
+    ]
+
+
 def pack_provider_modules(subdir_name: str) -> list[Path]:
     """Provider modules a pack SHIPS, found without importing any of them.
 
@@ -239,14 +257,7 @@ def pack_provider_modules(subdir_name: str) -> list[Path]:
     """
     modules: list[Path] = []
     for pack_dir in authority_pack_dirs():
-        component_dir = pack_dir / subdir_name
-        if not component_dir.is_dir():
-            continue
-        modules.extend(
-            py
-            for py in sorted(component_dir.glob("*.py"))
-            if not py.name.startswith("_")
-        )
+        modules.extend(pack_component_modules(pack_dir, subdir_name))
     return modules
 
 

--- a/opencontractserver/pipeline/registry.py
+++ b/opencontractserver/pipeline/registry.py
@@ -228,6 +228,27 @@ def authority_pack_dirs() -> list[Path]:
     return unique
 
 
+def pack_provider_modules(subdir_name: str) -> list[Path]:
+    """Provider modules a pack SHIPS, found without importing any of them.
+
+    Used for two things that must not execute pack code: telling an operator
+    what a pack will run before they install it, and naming what was skipped
+    when loading is switched off. Mirrors the filtering
+    ``_discover_pack_component_classes`` applies (``*.py``, no leading
+    underscore) so the count is the count that matters.
+    """
+    modules: list[Path] = []
+    for pack_dir in authority_pack_dirs():
+        component_dir = pack_dir / subdir_name
+        if not component_dir.is_dir():
+            continue
+        modules.extend(
+            py for py in sorted(component_dir.glob("*.py"))
+            if not py.name.startswith("_")
+        )
+    return modules
+
+
 class ComponentType(str, Enum):
     """Types of pipeline components."""
 
@@ -472,6 +493,26 @@ class PipelineComponentRegistry:
         classes that merely happen to be in scope are ignored via the
         ``__module__`` check.
         """
+        # Loading an in-pack provider IMPORTS it into this process. That is the
+        # trust decision AUTHORITY_PACK_LOAD_PROVIDERS exists to let an operator
+        # decline; see the setting's comment in config/settings/base.py.
+        # Reported rather than silent, and reported with a count, so "I turned
+        # it off" and "this install has none" are distinguishable.
+        from django.conf import settings as _settings
+
+        if not getattr(_settings, "AUTHORITY_PACK_LOAD_PROVIDERS", True):
+            skipped = pack_provider_modules(subdir_name)
+            if skipped:
+                logger.info(
+                    "AUTHORITY_PACK_LOAD_PROVIDERS is off: skipped %d in-pack "
+                    "%s module(s) without importing them (%s). The packs still "
+                    "serve their text; only re-fetch is unavailable.",
+                    len(skipped),
+                    subdir_name,
+                    ", ".join(sorted(p.parent.parent.name + "/" + p.name for p in skipped)),
+                )
+            return []
+
         seen: set[type] = set()
         found: list[type] = []
         pack_dirs = authority_pack_dirs()
@@ -1018,6 +1059,66 @@ def get_all_authority_source_providers_cached() -> (
 ):
     """Get all registered authority source providers (cached)."""
     return get_registry().authority_source_providers
+
+
+def get_authority_source_provider(class_name: str) -> Optional[Any]:
+    """Return an INSTANCE of a registered authority source provider, by class name.
+
+    The supported seam for an in-pack provider that DELEGATES to a core one.
+
+    Most packs should not ship a scraper: core already covers the Code of
+    Federal Regulations, the U.S. Code and the Federal Register, and those
+    providers fail to fire for a pack only because of key SHAPE — the CFR
+    provider accepts ``cfr-{digits}:`` while a pack's sections are keyed
+    ``itar:``, ``ear:``, ``aeca:``. A pack already declares that translation in
+    its own equivalence rows, so the in-pack provider is a key translator plus a
+    delegation (authority-packs ``SOURCE_PROVIDERS.md``).
+
+    Doing that by importing the core class directly works, but couples every
+    such pack to an import path: a refactor of the core providers would break
+    them, and registry discovery isolates import failures by design, so the
+    breakage would be a logged warning and a provider that silently stopped
+    existing. Depending on this function instead makes the class name the
+    contract.
+
+    Returns ``None`` when no provider of that class name is registered — a pack
+    MUST handle that by declining (``can_handle`` -> False) rather than raising,
+    so an install missing a core provider degrades to "cannot re-fetch" instead
+    of breaking registry build.
+    """
+    registry = get_registry()
+    definition = registry.get_by_class_name(class_name) or registry.get_by_name(class_name)
+    if definition is None:
+        # ``class_name`` is stored as a full dotted path; a pack author writes
+        # the leaf. Accept either, and refuse an ambiguous leaf rather than
+        # picking — two providers with the same class name in different
+        # packages is exactly when silently choosing is worst.
+        matches = [
+            d
+            for d in get_all_authority_source_providers_cached()
+            if d.class_name.rsplit(".", 1)[-1] == class_name
+        ]
+        if len(matches) > 1:
+            logger.warning(
+                "Authority source provider name %r is ambiguous (%s); "
+                "delegate using the full dotted path.",
+                class_name,
+                ", ".join(sorted(d.class_name for d in matches)),
+            )
+            return None
+        if not matches:
+            return None
+        definition = matches[0]
+    component = getattr(definition, "component_class", None)
+    if component is None:
+        return None
+    try:
+        return component()
+    except Exception as exc:  # pragma: no cover - defensive; a provider ctor should be trivial
+        logger.warning(
+            "Could not instantiate authority source provider %r: %s", class_name, exc
+        )
+        return None
 
 
 def get_all_authority_discovery_providers_cached() -> (

--- a/opencontractserver/pipeline/registry.py
+++ b/opencontractserver/pipeline/registry.py
@@ -1089,20 +1089,18 @@ def get_authority_source_provider(class_name: str) -> Optional[Any]:
     so an install missing a core provider degrades to "cannot re-fetch" instead
     of breaking registry build.
     """
-    registry = get_registry()
-    definition = registry.get_by_class_name(class_name) or registry.get_by_name(
-        class_name
-    )
+    # Scoped to authority source providers throughout: ``registry.get_by_name``
+    # / ``get_by_class_name`` read dicts shared by every component family
+    # (parsers, embedders, LLM providers, ...), so an unscoped lookup here
+    # could return an instance of the wrong type on a name collision.
+    providers = get_all_authority_source_providers_cached()
+    definition = next((d for d in providers if d.class_name == class_name), None)
     if definition is None:
         # ``class_name`` is stored as a full dotted path; a pack author writes
         # the leaf. Accept either, and refuse an ambiguous leaf rather than
         # picking — two providers with the same class name in different
         # packages is exactly when silently choosing is worst.
-        matches = [
-            d
-            for d in get_all_authority_source_providers_cached()
-            if d.class_name.rsplit(".", 1)[-1] == class_name
-        ]
+        matches = [d for d in providers if d.name == class_name]
         if len(matches) > 1:
             logger.warning(
                 "Authority source provider name %r is ambiguous (%s); "

--- a/opencontractserver/tests/test_agent_system_prompt_assembly.py
+++ b/opencontractserver/tests/test_agent_system_prompt_assembly.py
@@ -472,7 +472,9 @@ class ExtraSystemContextFactoryTestCase(TransactionTestCase):
 
     async def test_document_factory_appends_extra_system_context(self):
         """Wired in BOTH factories — an agent config can be selected for a document."""
-        prompt = await self._prompt(document=True, extra_system_context=EXTEND_INSTRUCTIONS)
+        prompt = await self._prompt(
+            document=True, extra_system_context=EXTEND_INSTRUCTIONS
+        )
 
         self.assertIn(DOCUMENT_PERSONA, prompt)
         self.assertIn(EXTEND_INSTRUCTIONS, prompt)

--- a/opencontractserver/tests/test_authority_pack_provider_trust.py
+++ b/opencontractserver/tests/test_authority_pack_provider_trust.py
@@ -173,3 +173,23 @@ class DelegationSeamTests(SimpleTestCase):
     def test_unknown_provider_returns_none_rather_than_raising(self) -> None:
         """A pack must be able to decline, not crash registry build."""
         self.assertIsNone(get_authority_source_provider("NoSuchProviderClass"))
+
+    def test_ambiguous_leaf_returns_none_and_warns(self) -> None:
+        """Two packs shipping a same-named class must not be silently picked
+        between — refusing is the whole point of the leaf-collision guard."""
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            pack_dirs = []
+            for tag in ("pack_a", "pack_b"):
+                providers = base / tag / "providers"
+                providers.mkdir(parents=True)
+                (providers / "trust_probe_provider.py").write_text(_PROVIDER_SRC)
+                pack_dirs.append(base / tag)
+
+            with override_settings(AUTHORITY_PACK_PATHS=[str(p) for p in pack_dirs]):
+                with self.assertLogs(_REGISTRY_LOGGER, level="WARNING") as captured:
+                    provider = get_authority_source_provider("TrustProbeSourceProvider")
+
+        self.assertIsNone(provider)
+        messages = "\n".join(captured.output)
+        self.assertIn("is ambiguous", messages)

--- a/opencontractserver/tests/test_authority_pack_provider_trust.py
+++ b/opencontractserver/tests/test_authority_pack_provider_trust.py
@@ -1,0 +1,175 @@
+"""Declining to execute a pack's code, and the supported way to reuse a core provider.
+
+Installing an authority pack that ships ``<pack>/providers/*.py`` IMPORTS that
+Python into the web and worker processes. Extraction already refuses path
+traversal and setuid bits (``tar.extract(..., filter="data")``); it cannot
+refuse code. That is a materially larger blast radius than ``source_hosts``,
+where "installing the pack is the trust decision" holds because the consequence
+is bounded to which hosts may be fetched.
+
+``AUTHORITY_PACK_LOAD_PROVIDERS`` lets an operator decline. It is safe to
+decline because the pack contract (authority-packs ``SOURCE_PROVIDERS.md``,
+clause P5) requires a pack to install and serve its sections with ``providers/``
+deleted — so turning it off costs re-fetch and nothing else.
+
+The tests below use a provider module that writes a sentinel **at import time**.
+That is exactly what a pack MUST NOT do (clause P4), which is what makes it a
+good probe here: if the sentinel appears, the module was imported, and no
+assertion about registration can be fooled by a provider that merely failed to
+register.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from django.test import SimpleTestCase, override_settings
+
+from opencontractserver.pipeline.registry import (
+    get_all_authority_source_providers_cached,
+    get_authority_source_provider,
+    pack_provider_modules,
+    reset_registry,
+)
+
+_REGISTRY_LOGGER = "opencontractserver.pipeline.registry"
+
+# Writes a file when imported, so "was this module executed?" is answerable
+# independently of whether its class ended up registered.
+_PROVIDER_SRC = '''
+from pathlib import Path
+
+from opencontractserver.pipeline.base.base_authority_source_provider import (
+    AuthorityRequest,
+    BaseAuthoritySourceProvider,
+)
+
+Path(__file__).with_name("IMPORTED.sentinel").write_text("yes")
+
+
+class TrustProbeSourceProvider(BaseAuthoritySourceProvider):
+    title = "Trust Probe"
+    description = "Fixture provider for AUTHORITY_PACK_LOAD_PROVIDERS tests."
+    author = "test"
+    supported_prefixes = ("trustprobe",)
+
+    def can_handle(self, canonical_key: str) -> bool:
+        return canonical_key.split(":", 1)[0] == "trustprobe"
+
+    def _locate_impl(self, canonical_key, **kwargs):
+        return AuthorityRequest(url="https://example.invalid/x")
+
+    def _fetch_impl(self, request, **kwargs):
+        raise NotImplementedError
+'''
+
+
+class _PackFixture(SimpleTestCase):
+    """Builds a throwaway pack dir containing one provider module."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.pack_dir = Path(self._tmp.name) / "trustprobe_pack"
+        providers = self.pack_dir / "providers"
+        providers.mkdir(parents=True)
+        (providers / "trust_probe_provider.py").write_text(_PROVIDER_SRC)
+        self.sentinel = providers / "IMPORTED.sentinel"
+        reset_registry()
+        self.addCleanup(reset_registry)
+
+    def _class_names(self) -> set[str]:
+        # ``class_name`` is the full dotted path; compare on the leaf so the
+        # assertions read as the class a pack author actually writes.
+        return {
+            d.class_name.rsplit(".", 1)[-1]
+            for d in get_all_authority_source_providers_cached()
+        }
+
+
+class LoadProvidersSettingTests(_PackFixture):
+    def test_providers_load_by_default(self) -> None:
+        """The default must not change: existing installs keep working."""
+        with override_settings(
+            AUTHORITY_PACK_PATHS=[str(self.pack_dir)],
+            AUTHORITY_PACK_LOAD_PROVIDERS=True,
+        ):
+            names = self._class_names()
+
+        self.assertIn("TrustProbeSourceProvider", names)
+        self.assertTrue(
+            self.sentinel.exists(), "fixture never imported; the test proves nothing"
+        )
+
+    def test_providers_are_not_imported_when_disabled(self) -> None:
+        """Not merely unregistered — NOT EXECUTED."""
+        with override_settings(
+            AUTHORITY_PACK_PATHS=[str(self.pack_dir)],
+            AUTHORITY_PACK_LOAD_PROVIDERS=False,
+        ):
+            names = self._class_names()
+
+        self.assertNotIn("TrustProbeSourceProvider", names)
+        self.assertFalse(
+            self.sentinel.exists(),
+            "the pack's module was IMPORTED despite AUTHORITY_PACK_LOAD_PROVIDERS "
+            "being off — the setting gates registration but not execution, which "
+            "is the only thing it was for",
+        )
+
+    def test_skipping_is_reported_with_a_count(self) -> None:
+        """Silence would make 'turned off' and 'no packs installed' identical."""
+        with override_settings(
+            AUTHORITY_PACK_PATHS=[str(self.pack_dir)],
+            AUTHORITY_PACK_LOAD_PROVIDERS=False,
+        ):
+            with self.assertLogs(_REGISTRY_LOGGER, level="INFO") as captured:
+                self._class_names()
+
+        messages = "\n".join(captured.output)
+        self.assertIn("AUTHORITY_PACK_LOAD_PROVIDERS is off", messages)
+        self.assertIn("trust_probe_provider.py", messages)
+
+    def test_core_providers_survive_the_setting(self) -> None:
+        """Only IN-PACK loading is declined; core providers are unaffected."""
+        with override_settings(
+            AUTHORITY_PACK_PATHS=[str(self.pack_dir)],
+            AUTHORITY_PACK_LOAD_PROVIDERS=False,
+        ):
+            names = self._class_names()
+
+        self.assertIn("CFRAuthoritySourceProvider", names)
+
+
+class PackProviderModulesTests(_PackFixture):
+    def test_lists_shipped_modules_without_importing_them(self) -> None:
+        """The listing that --check and the skip log both depend on."""
+        with override_settings(AUTHORITY_PACK_PATHS=[str(self.pack_dir)]):
+            found = pack_provider_modules("providers")
+
+        self.assertEqual([p.name for p in found], ["trust_probe_provider.py"])
+        self.assertFalse(
+            self.sentinel.exists(), "listing the modules executed one of them"
+        )
+
+
+class DelegationSeamTests(SimpleTestCase):
+    """``get_authority_source_provider`` is the seam in-pack providers delegate through."""
+
+    def setUp(self) -> None:
+        reset_registry()
+        self.addCleanup(reset_registry)
+
+    def test_returns_a_usable_core_provider_instance(self) -> None:
+        provider = get_authority_source_provider("CFRAuthoritySourceProvider")
+
+        self.assertIsNotNone(provider)
+        # The thing a delegating pack provider actually needs: routing plus a
+        # pure locate it can hand a translated key to.
+        self.assertTrue(provider.can_handle("cfr-22:120.4"))
+        self.assertFalse(provider.can_handle("itar:120.4"))
+
+    def test_unknown_provider_returns_none_rather_than_raising(self) -> None:
+        """A pack must be able to decline, not crash registry build."""
+        self.assertIsNone(get_authority_source_provider("NoSuchProviderClass"))

--- a/opencontractserver/tests/test_authority_pack_provider_trust.py
+++ b/opencontractserver/tests/test_authority_pack_provider_trust.py
@@ -37,7 +37,7 @@ _REGISTRY_LOGGER = "opencontractserver.pipeline.registry"
 
 # Writes a file when imported, so "was this module executed?" is answerable
 # independently of whether its class ended up registered.
-_PROVIDER_SRC = '''
+_PROVIDER_SRC = """
 from pathlib import Path
 
 from opencontractserver.pipeline.base.base_authority_source_provider import (
@@ -62,7 +62,7 @@ class TrustProbeSourceProvider(BaseAuthoritySourceProvider):
 
     def _fetch_impl(self, request, **kwargs):
         raise NotImplementedError
-'''
+"""
 
 
 class _PackFixture(SimpleTestCase):
@@ -164,7 +164,7 @@ class DelegationSeamTests(SimpleTestCase):
     def test_returns_a_usable_core_provider_instance(self) -> None:
         provider = get_authority_source_provider("CFRAuthoritySourceProvider")
 
-        self.assertIsNotNone(provider)
+        assert provider is not None  # narrows the Optional for the calls below
         # The thing a delegating pack provider actually needs: routing plus a
         # pure locate it can hand a translated key to.
         self.assertTrue(provider.can_handle("cfr-22:120.4"))

--- a/opencontractserver/tests/test_authority_pack_sideload.py
+++ b/opencontractserver/tests/test_authority_pack_sideload.py
@@ -30,6 +30,14 @@ FIXTURE_PACK = (
 )
 
 
+# ``authority_pack_dirs()`` unions THREE sources; a test asserting an exact pack
+# set has to pin all three, not the two the sideload contract is about. The third
+# — ``AUTHORITY_PACK_INSTALL_DIR`` — defaults to a real fetch cache on a machine
+# where anyone has run ``install_authority_pack``, so leaving it alone made these
+# assertions pass in CI and fail on a developer's checkout. (``config/settings/
+# test.py`` also pins it away from that cache; stated here so the precondition is
+# visible where the assertion is.)
+@override_settings(AUTHORITY_PACK_INSTALL_DIR="")
 class AuthorityPackDiscoveryTests(TestCase):
     """``authority_pack_dirs()`` — what an install considers installed."""
 

--- a/opencontractserver/tests/test_install_authority_pack_command.py
+++ b/opencontractserver/tests/test_install_authority_pack_command.py
@@ -311,6 +311,22 @@ class InstallAuthorityPackCommandTests(TestCase):
             "AUTHORITY_PACK_LOAD_PROVIDERS is off — these will NOT be imported", out
         )
 
+    def test_fetch_only_also_reports_shipped_providers(self):
+        """materialise_pack() places the pack under AUTHORITY_PACK_INSTALL_DIR
+        — an implicit discovery root — before --fetch-only ever checks for a
+        creator, so the exposure exists on this path too and needs the same
+        warning, with no --creator supplied at all."""
+        pack = _minimal_pack()
+        pack["providers/delegating_provider.py"] = "# stub, never imported by --check"
+        self.tarball = _build_registry_tarball(
+            self.tmp / "withprovider.tar.gz", packs={"provider_pack": pack}
+        )
+
+        out = self._run("provider_pack", fetch_only=True)
+
+        self.assertIn("ships 1 provider module(s)", out)
+        self.assertIn("providers/delegating_provider.py", out)
+
 
 class DownloadTarballTests(SimpleTestCase):
     """Direct tests for the network fetch helper, with `requests` mocked."""

--- a/opencontractserver/tests/test_install_authority_pack_command.py
+++ b/opencontractserver/tests/test_install_authority_pack_command.py
@@ -261,6 +261,56 @@ class InstallAuthorityPackCommandTests(TestCase):
             dirs = [p.name for p in authority_pack_dirs()]
         self.assertIn("good_pack", dirs)
 
+    # ---- pre-install provider report -------------------------------------
+    # `_report_pack_providers` — the code surface an operator sees before
+    # any DB write. `--check` exercises it without installing.
+
+    def test_pack_with_no_providers_gets_no_report(self):
+        out = self._run("good_pack", creator="packowner", check=True)
+        self.assertNotIn("provider module", out)
+
+    def test_reports_shipped_provider_modules_and_manifest_declaration(self):
+        manifest = {
+            "name": "p",
+            "corpora": [{"title": "Registry Pack A", "spec": "a.json"}],
+            "providers": [
+                {
+                    "class": "DelegatingProvider",
+                    "supported_prefixes": ["itar"],
+                    "delegates_to": "CFRAuthoritySourceProvider",
+                }
+            ],
+        }
+        pack = _minimal_pack()
+        pack["pack.yaml"] = yaml.safe_dump(manifest, allow_unicode=True)
+        pack["providers/delegating_provider.py"] = "# stub, never imported by --check"
+        self.tarball = _build_registry_tarball(
+            self.tmp / "withprovider.tar.gz", packs={"provider_pack": pack}
+        )
+
+        out = self._run("provider_pack", creator="packowner", check=True)
+
+        self.assertIn("ships 1 provider module(s)", out)
+        self.assertIn("providers/delegating_provider.py", out)
+        self.assertIn("declares: DelegatingProvider", out)
+        self.assertIn("prefixes=['itar']", out)
+        self.assertIn("delegates_to=CFRAuthoritySourceProvider", out)
+        self.assertNotIn("AUTHORITY_PACK_LOAD_PROVIDERS is off", out)
+
+    def test_reports_when_load_providers_disabled(self):
+        pack = _minimal_pack()
+        pack["providers/delegating_provider.py"] = "# stub, never imported by --check"
+        self.tarball = _build_registry_tarball(
+            self.tmp / "withprovider.tar.gz", packs={"provider_pack": pack}
+        )
+
+        with override_settings(AUTHORITY_PACK_LOAD_PROVIDERS=False):
+            out = self._run("provider_pack", creator="packowner", check=True)
+
+        self.assertIn(
+            "AUTHORITY_PACK_LOAD_PROVIDERS is off — these will NOT be imported", out
+        )
+
 
 class DownloadTarballTests(SimpleTestCase):
     """Direct tests for the network fetch helper, with `requests` mocked."""

--- a/opencontractserver/tests/websocket/test_unified_agent_consumer.py
+++ b/opencontractserver/tests/websocket/test_unified_agent_consumer.py
@@ -850,6 +850,7 @@ class UnifiedAgentConsumerAgentConfigThreadingTestCase(WebsocketFixtureBaseTestC
         consumer.agent_config = SimpleNamespace(
             preferred_llm="",
             system_instructions="You are the cross-corpus orchestrator.",
+            system_instructions_mode="REPLACE",
             available_tools=["search_across_corpora"],
         )
         # ``agent_config_id`` is only set when the client passed


### PR DESCRIPTION
Closes #2263. Implements all three items there.

## 1. `AUTHORITY_PACK_LOAD_PROVIDERS` — the one that blocks adoption

Installing a pack that ships `<pack>/providers/*.py` **imports it into the web and worker processes**. `tar.extract(..., filter="data")` already refuses path traversal and setuid bits; it cannot refuse code. There was no way to decline.

Default `True`, so no existing install changes. When off, the modules are **not imported**, and the skip is logged once with a count and the module names — silence would make "I turned it off" and "this install has no packs with providers" indistinguishable.

Safe to decline because the pack contract (authority-packs `SOURCE_PROVIDERS.md`, clause P5) requires a pack to install and serve its sections with `providers/` deleted. Turning it off costs re-fetch and nothing else.

## 2. `get_authority_source_provider(class_name)` — the delegation seam

The pack contract's central recommendation is that most packs should **not** write a scraper: core already covers CFR, U.S. Code and the Federal Register, and those providers fail to fire for a pack only because of key shape (`cfr-22:` vs `itar:`). Every pack already declares that translation in its equivalence rows, so an in-pack provider should be a key translator that delegates.

Doing that by importing the core class directly works but couples packs to an import path — and since registry discovery isolates import failures by design, a core refactor would break them as a logged warning and a provider that silently stopped existing.

Accepts a bare class name or a dotted path, **refuses an ambiguous leaf rather than picking**, and returns `None` rather than raising so a pack declines instead of crashing registry build.

## 3. `install_authority_pack` shows the code surface before DB writes

Lists the provider modules a pack ships and, when the optional `providers:` declaration is present, the classes and prefixes it claims — **by reading files, never by importing them**. Reporting a pack's code by executing it would defeat the purpose. Also notes when `AUTHORITY_PACK_LOAD_PROVIDERS` is off, so `--check` tells you the modules will not run.

## Tests

`test_authority_pack_provider_trust.py` (7 tests). The fixture provider writes a sentinel file **at import time** — which the contract forbids (P4), and which is exactly what makes it a good probe: "was this executed?" is answerable independently of whether the class registered, so an assertion about registration can't be fooled by a provider that merely failed to register.

Verified the gate is what makes them pass — with the gate block removed and the helpers kept:

```
exit_WITHOUT_gate=1
FAILED test_providers_are_not_imported_when_disabled
FAILED test_skipping_is_reported_with_a_count
```

`test_core_providers_survive_the_setting` earned its place immediately: while restoring the gate after that experiment I re-inserted it into `_discover_subclasses` (core discovery) instead of `_discover_pack_component_classes`, which disabled exactly the wrong thing. That test is the only reason I noticed.

Regression: 28 tests green across `test_authority_pack_provider_trust`, `test_authority_pack_providers`, `test_authority_source_hosts`.

**DB-backed suites were not run in this pass** — the local postgres was swapped to a different volume by another stack mid-session (the compose project-name collision), so anything needing a database errors on connection. The tests added here are `SimpleTestCase` and unaffected; CI should cover the rest.