### PR TITLE
ci: add backend-ci-gate, a Backend CI check that can actually be required

### DIFF
--- a/.github/scripts/backend_ci_gate.sh
+++ b/.github/scripts/backend_ci_gate.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+#
+# Backend CI's aggregate gate — the one check branch protection requires.
+#
+# WHY THIS EXISTS, since "just require the pytest job" is the obvious answer
+# and it does not work. Both of the direct alternatives fail, in opposite
+# directions:
+#
+#   1. Requiring `pytest` lets a red linter through. GitHub reports a job that
+#      its own `if:` skipped as SUCCESS to branch protection ("if a job within
+#      a workflow is skipped due to a conditional, it will report its status
+#      as Success"). Backend CI's `pytest` is gated on
+#      `needs.linter.result == 'success'`, so a red linter SKIPS pytest — and
+#      a required `pytest` check reads green for it. Measured, not theorised:
+#      when this was written, PRs #2260, #2264 and #2265 were all sitting at
+#      `linter=failure / pytest=skipped` and would have been mergeable.
+#
+#   2. Requiring `pytest` while the workflow carries a workflow-level path
+#      filter deadlocks every PR the filter excludes. A workflow skipped by
+#      path filtering never reports at all, and the required check hangs
+#      Pending forever — an unmergeable docs-only PR.
+#
+# So the requirable check has to be a job that ALWAYS runs and that inspects
+# the other jobs' results itself, distinguishing "skipped because this PR
+# genuinely touches no backend code" from "skipped because something upstream
+# broke". That distinction is this script.
+#
+# Usage:
+#   backend_ci_gate.sh <event> <backend> <linter> <pytest>
+#   backend_ci_gate.sh --self-test
+#
+#   event    github.event_name          e.g. pull_request | push
+#   backend  needs.changes.outputs.backend  'true' | 'false' | '' (job skipped
+#            on push, or errored — it is `continue-on-error`, and Backend CI
+#            deliberately fails open there)
+#   linter   needs.linter.result        success | failure | cancelled | skipped
+#   pytest   needs.pytest.result        success | failure | cancelled | skipped
+#
+# Exits 0 to allow the merge, 1 to block it.
+
+set -euo pipefail
+
+# Decide whether the observed job results are acceptable. Echoes a one-line
+# explanation either way; returns 0 (allow) or 1 (block).
+evaluate() {
+    local event="$1" backend="$2" linter="$3" pytest="$4"
+
+    # The only legitimate reason for the backend jobs not to have run: this is
+    # a PR and the path filter found no backend files in it. Note this is
+    # deliberately keyed on the literal 'false'. An empty value means the
+    # `changes` job was skipped (push events) or errored, and Backend CI's
+    # own `if:` conditions fail OPEN there and run the jobs anyway — so an
+    # empty value must fall through to the strict branch below, not here.
+    if [ "$event" = "pull_request" ] && [ "$backend" = "false" ]; then
+        # Defensive: under the current workflow both jobs are skipped in this
+        # case. If either somehow ran and failed, that is still a failure —
+        # do not let the path filter launder it.
+        if [ "$linter" = "failure" ] || [ "$linter" = "cancelled" ] ||
+            [ "$pytest" = "failure" ] || [ "$pytest" = "cancelled" ]; then
+            echo "BLOCK: no backend files changed, but linter=$linter pytest=$pytest"
+            return 1
+        fi
+        echo "ALLOW: no backend files changed (linter=$linter pytest=$pytest)"
+        return 0
+    fi
+
+    # Everything else — any push, and any PR that touches backend paths or
+    # whose path filter could not be trusted — must have actually run both
+    # jobs to completion. `skipped` is a failure here; that is the whole
+    # point of the gate.
+    if [ "$linter" != "success" ]; then
+        echo "BLOCK: linter=$linter (expected success)"
+        return 1
+    fi
+    if [ "$pytest" != "success" ]; then
+        echo "BLOCK: pytest=$pytest (expected success)"
+        return 1
+    fi
+
+    echo "ALLOW: linter=success pytest=success"
+    return 0
+}
+
+# Prove the gate can fail. Every row is a state Backend CI can actually
+# produce; the rows marked BLOCK are the ones a naive `required: pytest`
+# would have waved through.
+self_test() {
+    local failures=0 rc=0 out=""
+
+    # want  event         backend  linter     pytest    # what it is
+    local cases=(
+        "ALLOW pull_request false     skipped   skipped"   # docs/frontend-only PR
+        "ALLOW pull_request true      success   success"   # ordinary green PR
+        "BLOCK pull_request true      failure   skipped"   # <- the #2262 hole
+        "BLOCK pull_request true      success   skipped"   # pytest skipped silently
+        "BLOCK pull_request true      success   failure"   # tests genuinely failed
+        "BLOCK pull_request true      cancelled skipped"   # run cancelled
+        "ALLOW pull_request ''        success   success"   # changes errored, fail-open, jobs ran
+        "BLOCK pull_request ''        failure   skipped"   # changes errored AND linter red
+        "ALLOW push         ''        success   success"   # ordinary green push to main
+        "BLOCK push         ''        failure   skipped"   # <- the #2262 merge commit
+        "BLOCK push         ''        success   skipped"   # pytest skipped on a push
+        "BLOCK pull_request false     failure   skipped"   # defensive: ran anyway, failed
+        "BLOCK pull_request false     skipped   failure"   # defensive: ran anyway, failed
+    )
+
+    for row in "${cases[@]}"; do
+        # shellcheck disable=SC2086
+        set -- $row
+        local want="$1" event="$2" backend="$3" linter="$4" pytest="$5"
+        [ "$backend" = "''" ] && backend=""
+
+        rc=0
+        out="$(evaluate "$event" "$backend" "$linter" "$pytest")" || rc=$?
+
+        local got="ALLOW"
+        [ "$rc" -ne 0 ] && got="BLOCK"
+
+        if [ "$got" != "$want" ]; then
+            echo "FAIL  want=$want got=$got  [$event backend='$backend' linter=$linter pytest=$pytest] -> $out"
+            failures=$((failures + 1))
+        else
+            echo "ok    $want  [$event backend='$backend' linter=$linter pytest=$pytest]"
+        fi
+    done
+
+    if [ "$failures" -ne 0 ]; then
+        echo "self-test: $failures case(s) failed"
+        return 1
+    fi
+    echo "self-test: ${#cases[@]}/${#cases[@]} cases passed"
+    return 0
+}
+
+main() {
+    if [ "${1:-}" = "--self-test" ]; then
+        self_test
+        return $?
+    fi
+
+    if [ "$#" -ne 4 ]; then
+        echo "usage: $0 <event> <backend> <linter> <pytest>" >&2
+        echo "       $0 --self-test" >&2
+        return 2
+    fi
+
+    evaluate "$1" "$2" "$3" "$4"
+}
+
+main "$@"

--- a/.github/scripts/require_backend_ci_gate.sh
+++ b/.github/scripts/require_backend_ci_gate.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+#
+# Make `backend-ci-gate` a REQUIRED status check on a protected branch.
+#
+# This is the governance half of the `gate` job in backend.yml. Merging that
+# job changes nothing by itself — a check only gates a merge once branch
+# protection names it.
+#
+# Why this is a script and not a one-line `gh api` in a README:
+#
+#   * `PUT /repos/{o}/{r}/branches/{b}/protection` REPLACES THE ENTIRE
+#     protection object. Sending just `required_status_checks` silently drops
+#     `required_pull_request_reviews`, `allow_force_pushes: false`,
+#     `allow_deletions: false` and everything else currently set. So the
+#     current object has to be read back and re-sent with the new key merged
+#     in — which is what this does.
+#   * The narrower `PATCH .../protection/required_status_checks` sub-resource
+#     is not usable to CREATE the object: it 404s with "Required status checks
+#     not enabled" when none exists yet.
+#   * A required context is matched BYTE-FOR-BYTE against the check-run name.
+#     Requiring a name that is never reported blocks every PR forever, with no
+#     error anywhere. The preflight below refuses to do that.
+#
+# Usage:
+#   require_backend_ci_gate.sh              # dry run: print the PUT body, change nothing
+#   require_backend_ci_gate.sh --apply      # actually apply it
+#
+# Env: REPO, BRANCH, CONTEXT override the defaults below.
+
+set -euo pipefail
+
+REPO="${REPO:-Open-Source-Legal/OpenContracts}"
+BRANCH="${BRANCH:-main}"
+CONTEXT="${CONTEXT:-backend-ci-gate}"
+
+APPLY=0
+if [ "${1:-}" = "--apply" ]; then
+    APPLY=1
+elif [ -n "${1:-}" ]; then
+    echo "usage: $0 [--apply]" >&2
+    exit 2
+fi
+
+# --- Preflight: has this context ever actually been reported? ---------------
+# Requiring a name no workflow produces is the single worst outcome here: every
+# PR hangs Pending, permanently, and nothing logs a reason. Look for the name
+# on recent commits of the branch before trusting it.
+echo "Preflight: looking for a check run named '$CONTEXT' on recent $BRANCH commits..."
+found=0
+for sha in $(gh api "repos/$REPO/commits?sha=$BRANCH&per_page=15" -q '.[].sha'); do
+    if gh api "repos/$REPO/commits/$sha/check-runs" -q '.check_runs[].name' 2>/dev/null |
+        grep -Fxq "$CONTEXT"; then
+        echo "  found on ${sha:0:9}"
+        found=1
+        break
+    fi
+done
+
+if [ "$found" -ne 1 ]; then
+    echo >&2
+    echo "REFUSING: no check run named '$CONTEXT' found on the last 15 commits of $BRANCH." >&2
+    echo "The gate job must be merged to $BRANCH and have run at least once first," >&2
+    echo "otherwise requiring this context blocks every pull request indefinitely." >&2
+    exit 1
+fi
+
+# --- Build the replacement object from the CURRENT one ----------------------
+current="$(gh api "repos/$REPO/branches/$BRANCH/protection")"
+
+body="$(CONTEXT="$CONTEXT" python3 -c '
+import json, os, sys
+
+cur = json.load(sys.stdin)
+
+
+def enabled(key):
+    return bool(cur.get(key, {}).get("enabled", False))
+
+
+# The four nullable-but-required keys of the PUT body, plus every optional
+# flag currently set, so nothing is lost in the round trip.
+out = {
+    "required_status_checks": {
+        # strict=false: do NOT force every PR to be rebased onto the tip of
+        # the branch before merging. strict=true serialises all merges and
+        # is a much larger behavioural change than adding a gate.
+        "strict": False,
+        "checks": [{"context": os.environ["CONTEXT"]}],
+    },
+    "enforce_admins": enabled("enforce_admins"),
+    "required_pull_request_reviews": None,
+    "restrictions": None,
+    "required_linear_history": enabled("required_linear_history"),
+    "allow_force_pushes": enabled("allow_force_pushes"),
+    "allow_deletions": enabled("allow_deletions"),
+    "block_creations": enabled("block_creations"),
+    "required_conversation_resolution": enabled("required_conversation_resolution"),
+    "lock_branch": enabled("lock_branch"),
+    "allow_fork_syncing": enabled("allow_fork_syncing"),
+}
+
+rpr = cur.get("required_pull_request_reviews")
+if rpr is not None:
+    out["required_pull_request_reviews"] = {
+        "dismiss_stale_reviews": rpr.get("dismiss_stale_reviews", False),
+        "require_code_owner_reviews": rpr.get("require_code_owner_reviews", False),
+        "require_last_push_approval": rpr.get("require_last_push_approval", False),
+        "required_approving_review_count": rpr.get("required_approving_review_count", 0),
+    }
+
+restrictions = cur.get("restrictions")
+if restrictions is not None:
+    out["restrictions"] = {
+        "users": [u["login"] for u in restrictions.get("users", [])],
+        "teams": [t["slug"] for t in restrictions.get("teams", [])],
+        "apps": [a["slug"] for a in restrictions.get("apps", [])],
+    }
+
+json.dump(out, sys.stdout, indent=2)
+' <<<"$current")"
+
+echo
+echo "--- PUT repos/$REPO/branches/$BRANCH/protection ---"
+echo "$body"
+echo
+
+if [ "$APPLY" -ne 1 ]; then
+    echo "Dry run — nothing changed. Re-run with --apply to write this."
+    exit 0
+fi
+
+gh api -X PUT "repos/$REPO/branches/$BRANCH/protection" --input - <<<"$body" >/dev/null
+echo "Applied. Verifying..."
+gh api "repos/$REPO/branches/$BRANCH/protection/required_status_checks"

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -11,9 +11,16 @@ defaults:
   working-directory: ./
 
 on:
+  # NOTE: no `paths-ignore` on pull_request, deliberately. The `gate` job at
+  # the bottom of this file is the one meant to be REQUIRED by `main`'s branch
+  # protection, and a workflow skipped by path filtering never reports its
+  # checks at all — the required check would hang Pending and the PR would be
+  # permanently unmergeable. So the workflow always starts on a PR; the `changes` path
+  # filter below still keeps the expensive jobs from running, and a
+  # docs-only PR costs two ubuntu-latest jobs of a few seconds each.
+  # `push` keeps its filter: branch protection does not gate pushes.
   pull_request:
     branches: [ "master", "main", "v*" ]
-    paths-ignore: [ "docs/**" ]
 
   push:
     branches: [ "master", "main", "v*" ]
@@ -279,3 +286,40 @@ jobs:
 
       - name: Tear down the Stack
         run:  docker compose -f test.yml down
+
+  gate:
+    # The job to require on `main` — this one, not `pytest`. See
+    # .github/scripts/backend_ci_gate.sh for why requiring `pytest` directly
+    # leaves a red linter mergeable (a job skipped by its own `if:` reports
+    # SUCCESS to branch protection, and a red linter skips pytest).
+    #
+    # NOT YET REQUIRED as of this commit: `main` has no `required_status_checks`
+    # object at all, so merging this job gates nothing by itself. Turn it on
+    # with .github/scripts/require_backend_ci_gate.sh --apply, and check with
+    # `gh api repos/{owner}/{repo}/branches/main/protection` whether that has
+    # happened rather than assuming this comment is current.
+    #
+    # `if: always()` is what makes this requirable: it reports on every PR,
+    # including ones where every job above it was skipped.
+    name: backend-ci-gate
+    needs: [changes, linter, pytest]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout Code Repository
+        uses: actions/checkout@v7
+
+      - name: Self-test the gate logic
+        # Runs first, and on every invocation: a gate whose own decision
+        # table has silently inverted is worse than no gate. Costs ~0.1s.
+        run: bash .github/scripts/backend_ci_gate.sh --self-test
+
+      - name: Evaluate Backend CI results
+        run: |
+          bash .github/scripts/backend_ci_gate.sh \
+            "${{ github.event_name }}" \
+            "${{ needs.changes.outputs.backend }}" \
+            "${{ needs.linter.result }}" \
+            "${{ needs.pytest.result }}"

--- a/changelog.d/backend-ci-required-gate.added.md
+++ b/changelog.d/backend-ci-required-gate.added.md
@@ -1,0 +1,17 @@
+- **Added `backend-ci-gate`, a Backend CI check that branch protection can
+  actually require.** `main` has no `required_status_checks` object at all, so
+  nothing gates a merge on CI having run — PR #2262 merged with Backend CI
+  never having run on its head at all, and the push that merged it then failed
+  its linter, skipping `pytest` entirely. Requiring the `pytest` job is not the
+  fix: GitHub reports a job skipped by its own `if:` as **Success** to branch
+  protection, so a red linter (which skips `pytest`) still reads green —
+  PRs #2260, #2264 and #2265 sit in exactly that state. And requiring any job
+  in this workflow while its `pull_request` trigger carried
+  `paths-ignore: [docs/**]` would have left docs-only PRs permanently Pending,
+  since a workflow skipped by path filtering never reports at all. The new
+  `gate` job always runs and inspects the other jobs' results itself,
+  distinguishing "skipped because this PR touches no backend code" from
+  "skipped because something upstream broke". Its decision table lives in
+  `.github/scripts/backend_ci_gate.sh` and is self-tested (`--self-test`) on
+  every run; `.github/scripts/require_backend_ci_gate.sh` applies the branch
+  protection without clobbering the rest of the object.


### PR DESCRIPTION
## Why

`main` has **no `required_status_checks` at all**:

```
$ gh api repos/Open-Source-Legal/OpenContracts/branches/main/protection
{ "required_pull_request_reviews": {...}, "enforce_admins": {...}, ... }   # no required_status_checks key
```

Nothing gates a merge on CI having run, let alone passed. PR #2262 merged with Backend CI having **never run on its head commit**:

```
$ gh api repos/.../commits/fc21249c1/check-runs      # #2262's head
CLAAssistant  success ...  claude-review  success  ...   # no changes / linter / pytest at all
```

With nothing required, "no check reported" is not a blocker. The push that then merged it (`03e37b659`) failed at the linter, which skipped `pytest` — 0 seconds. `main` sat that way for ~30 hours, repaired only by accident when PR #2266's `pre-commit run --all-files` happened to reformat the same file.

## Why "just require the `pytest` job" isn't the fix

Requiring *something* would have blocked #2262 (a check that never reports stays Pending). But requiring `pytest` specifically leaves a second hole open and opens a third:

1. **A job skipped by its own `if:` reports SUCCESS to branch protection.** ([GitHub docs](https://docs.github.com/en/pull-requests/reference/status-checks): "If a job within a workflow is skipped due to a conditional, it will report its status as Success.") `pytest` is gated `if: needs.linter.result == 'success'`, so a **red linter skips it and the required check still reads green.** Not hypothetical — three open PRs are in that state right now:

   | PR | head | `linter` | `pytest` |
   |---|---|---|---|
   | #2260 | `0469df80d` | **failure** | skipped |
   | #2264 | `d27a4d632` | **failure** | skipped |
   | #2265 | `5bd1cda74` | **failure** | skipped |

   Under a required-`pytest` policy all three are mergeable today with a red linter.

2. **A workflow skipped by path filtering never reports at all**, so the required check hangs *Pending* and blocks forever. With `paths-ignore: [docs/**]` on the `pull_request` trigger, requiring any job in this workflow would make docs-only PRs permanently unmergeable.

## What this adds

A `gate` job (check name **`backend-ci-gate`**) that always runs and inspects the other jobs' results itself, distinguishing *"skipped because this PR touches no backend code"* from *"skipped because something upstream broke"*.

- Decision table: `.github/scripts/backend_ci_gate.sh`, run with `--self-test` (13 cases, ~0.1s) **before** each evaluation — a gate whose own logic has silently inverted is worse than no gate.
- `paths-ignore` dropped from the `pull_request` trigger only. The `changes` filter still keeps the expensive jobs off, so a docs-only PR now costs two `ubuntu-latest` jobs of a few seconds. `push` keeps its filter.
- `.github/scripts/require_backend_ci_gate.sh` applies the protection change. It exists because the obvious `gh api` call is a footgun: `PUT .../branches/main/protection` **replaces the entire object** (silently dropping the review rules and the force-push/deletion bans unless re-sent), and the narrower `PATCH .../protection/required_status_checks` 404s with *"Required status checks not enabled"* when none exists yet. It also **refuses to require a context name that has never been reported** on the branch — requiring a typo'd name blocks every PR with no error anywhere.

## Verification

Replayed the gate over the **last 60 real Backend CI runs**:

| event | linter | pytest | gate | run conclusion | n |
|---|---|---|---|---|---|
| pull_request | failure | skipped | **BLOCK** | failure | 8 |
| pull_request | failure | cancelled | **BLOCK** | cancelled | 1 |
| pull_request | success | failure | **BLOCK** | failure/cancelled | 3 |
| pull_request | skipped | skipped | ALLOW | success | 3 |
| pull_request | success | success | ALLOW | success/cancelled | 25 |
| push | failure | skipped | **BLOCK** | failure | 2 |
| push | success | success | ALLOW | success | 13 |

No genuinely green run is blocked. Mutation-checked too: neutering the two result comparisons makes the self-test fail 7/13 rather than pass silently. `require_backend_ci_gate.sh` dry-run verified to reproduce the current protection object byte-for-byte plus the new key, and to refuse `backend-ci-gate` today (not yet on `main`).

## Follow-up — merging this changes nothing on its own

Three things, in this order:

1. **Merge this.**
2. **Confirm the skip path on the wire.** This PR's own diff touches `backend.yml`, so it only exercises `backend=true`. Open a one-line docs-only PR and confirm `backend-ci-gate` reports **success** with `linter`/`pytest` skipped, and read the check name off `gh api .../check-runs` rather than trusting this description.
3. **Then** `bash .github/scripts/require_backend_ci_gate.sh --apply`. The 8 currently-open PRs will each need a merge from `main` before the check appears on their heads.

Two governance decisions this PR deliberately does **not** make:

- **`enforce_admins` is `false`.** Admins keep "merge without waiting for requirements to be met", so the gate is advisory for exactly the merge path #2262 took. Requiring the gate without flipping this is still a real improvement, but it is not airtight.
- **Six other workflows use workflow-level `paths:` filters**, so their checks are *not* safely requirable as-is — each would hang Pending forever on any PR its filter excludes. Swept rather than spot-checked: `frontend.yml`, `frontend-e2e.yml`, `frontend-e2e-extract.yml`, `frontend-e2e-websocket.yml`, `production-stack.yml` and `redis-integration.yml`. Each needs the same gate treatment before it can join the required list. (`backend.yml` keeps `paths-ignore` on `push` only, which is safe — branch protection does not gate pushes.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
