### PR TITLE
ci: correct the gate comment — backend-ci-gate is now required on main

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -293,11 +293,12 @@ jobs:
     # leaves a red linter mergeable (a job skipped by its own `if:` reports
     # SUCCESS to branch protection, and a red linter skips pytest).
     #
-    # NOT YET REQUIRED as of this commit: `main` has no `required_status_checks`
-    # object at all, so merging this job gates nothing by itself. Turn it on
-    # with .github/scripts/require_backend_ci_gate.sh --apply, and check with
-    # `gh api repos/{owner}/{repo}/branches/main/protection` whether that has
-    # happened rather than assuming this comment is current.
+    # Required on `main` as of 2026-08-20 (PR #2267). Note `enforce_admins` is
+    # false, so an admin can still bypass it. Re-apply or move it with
+    # .github/scripts/require_backend_ci_gate.sh --apply, and confirm the
+    # current state with
+    # `gh api repos/{owner}/{repo}/branches/main/protection`
+    # rather than assuming this comment is still accurate.
     #
     # `if: always()` is what makes this requirable: it reports on every PR,
     # including ones where every job above it was skipped.


### PR DESCRIPTION
#2267 landed the `gate` job carrying this comment:

> NOT YET REQUIRED as of this commit: `main` has no `required_status_checks` object at all...

True when written, false about 15 minutes later once `require_backend_ci_gate.sh --apply` ran:

```
$ gh api repos/Open-Source-Legal/OpenContracts/branches/main/protection/required_status_checks
{"strict":false,"contexts":["backend-ci-gate"],"checks":[{"context":"backend-ci-gate","app_id":15368}]}
```

Leaving it would be the same defect this repo keeps turning up — a comment asserting a gate's state in the present tense when it isn't so. Updated to state what is actually true, keep the `enforce_admins: false` caveat next to it, and keep `gh api .../branches/main/protection` as the authority over the comment.

## Incidentally, this PR is the end-to-end proof

It is the first PR to merge *under* the required check. If `backend-ci-gate` reports and gates it normally, the whole mechanism is confirmed on the wire rather than by inference.

For the record, applying the protection immediately flipped every open PR to `BLOCKED` — including #2260, #2264 and #2265, which were at `linter=failure / pytest=skipped` and therefore **mergeable with a red linter** until an hour ago. They need a merge from `main` to pick up the check, and then a green linter to pass it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)