### PR TITLE
DO NOT MERGE — probe: prove backend-ci-gate actually blocks a red linter

### DIFF
--- a/gate_failure_probe.py
+++ b/gate_failure_probe.py
@@ -1,0 +1,8 @@
+# TEMPORARY verification probe -- see the PR description. This file is
+# deliberately misformatted so `black` fails in the linter job, which skips
+# pytest, which is the exact state a required `pytest` check would report
+# GREEN for. It exists to prove `backend-ci-gate` reports FAILURE and that
+# GitHub actually blocks the merge. Delete with the branch.
+x=1
+def  f( a,b ):
+    return {  'a':a,"b":b }


### PR DESCRIPTION
**Throwaway. Will be closed as soon as it has reported. Do not merge.**

The `backend-ci-gate` chain has three links and only the first was measured:

| link | before this probe |
|---|---|
| the script decides BLOCK correctly | proven by self-test, mutation test, and a 60-run replay |
| a BLOCK verdict surfaces as `backend-ci-gate: failure` | **never observed** — every CI run of the gate so far exited 0 |
| a failed required check blocks the merge | inferred from GitHub's documented behaviour |

Every `BLOCKED` observed so far was *check absent → Pending*, which is a different mechanism.

This PR adds one deliberately misformatted `.py` file, so:

- `changes` → `backend=true` (root `*.py` is in the filter)
- `linter` → **failure** (black)
- `pytest` → **skipped** — no 16-minute run needed
- `backend-ci-gate` → should be **failure**, and this PR should be **BLOCKED**

If it is instead green or mergeable, the gate does not work and #2267 needs revisiting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)