### PR TITLE
fix: require_backend_ci_gate.sh replaced the required-checks list instead of adding to it

### DIFF
--- a/.github/scripts/branch_protection_body.py
+++ b/.github/scripts/branch_protection_body.py
@@ -1,0 +1,251 @@
+"""Build the PUT body that adds a required status check to a protected branch.
+
+``PUT /repos/{owner}/{repo}/branches/{branch}/protection`` replaces the ENTIRE
+protection object, so the only safe way to add one required check is to read
+the current object back and re-send it with the new context merged in. This
+module is that merge, kept separate from ``require_backend_ci_gate.sh`` so it
+can be self-tested without touching a live repository.
+
+Two things it must not do, both of which are silent when wrong:
+
+* **Replace the checks list.** Adding ``frontend-ci-gate`` must not remove
+  ``backend-ci-gate``. The first version of this code assigned
+  ``"checks": [{"context": CONTEXT}]`` outright, which meant the documented
+  way to require a second workflow would have quietly unrequired the first.
+* **Reset unrelated settings.** ``strict``, the review rules, the
+  force-push/deletion bans and any push restrictions all have to survive the
+  round trip untouched.
+
+Usage:
+    CONTEXT=backend-ci-gate python3 branch_protection_body.py < current.json
+    python3 branch_protection_body.py --self-test
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+
+def _enabled(current: dict, key: str) -> bool:
+    """Read one of the ``{"enabled": bool}`` sub-objects the GET returns."""
+    value = current.get(key)
+    if isinstance(value, dict):
+        return bool(value.get("enabled", False))
+    return bool(value)
+
+
+def _merge_checks(rsc: dict, context: str) -> list[dict]:
+    """Union ``context`` into the branch's existing required checks.
+
+    Accepts either the modern ``checks`` list or the legacy ``contexts`` list
+    of bare strings, and preserves ``app_id`` where GitHub reported one (that
+    field pins a check to the app allowed to report it; dropping it would
+    widen the requirement to any app).
+    """
+    existing = rsc.get("checks")
+    if existing is None:
+        existing = [{"context": name} for name in rsc.get("contexts", [])]
+
+    checks: list[dict] = []
+    seen: set[str] = set()
+    for entry in existing:
+        name = entry.get("context")
+        if not name or name in seen:
+            continue
+        seen.add(name)
+        merged = {"context": name}
+        if entry.get("app_id") is not None:
+            merged["app_id"] = entry["app_id"]
+        checks.append(merged)
+
+    if context not in seen:
+        checks.append({"context": context})
+
+    return checks
+
+
+def build_body(current: dict, context: str) -> dict:
+    """Return the full PUT body: everything currently set, plus ``context``."""
+    rsc = current.get("required_status_checks") or {}
+
+    body: dict = {
+        "required_status_checks": {
+            # Preserved, not hardcoded. `strict` forces every PR to be rebased
+            # onto the tip before merging, which serialises all merges — if a
+            # maintainer has turned it on, re-running this must not undo it.
+            "strict": bool(rsc.get("strict", False)),
+            "checks": _merge_checks(rsc, context),
+        },
+        "enforce_admins": _enabled(current, "enforce_admins"),
+        "required_pull_request_reviews": None,
+        "restrictions": None,
+        "required_linear_history": _enabled(current, "required_linear_history"),
+        "allow_force_pushes": _enabled(current, "allow_force_pushes"),
+        "allow_deletions": _enabled(current, "allow_deletions"),
+        "block_creations": _enabled(current, "block_creations"),
+        "required_conversation_resolution": _enabled(
+            current, "required_conversation_resolution"
+        ),
+        "lock_branch": _enabled(current, "lock_branch"),
+        "allow_fork_syncing": _enabled(current, "allow_fork_syncing"),
+    }
+
+    reviews = current.get("required_pull_request_reviews")
+    if reviews is not None:
+        body["required_pull_request_reviews"] = {
+            "dismiss_stale_reviews": reviews.get("dismiss_stale_reviews", False),
+            "require_code_owner_reviews": reviews.get(
+                "require_code_owner_reviews", False
+            ),
+            "require_last_push_approval": reviews.get(
+                "require_last_push_approval", False
+            ),
+            "required_approving_review_count": reviews.get(
+                "required_approving_review_count", 0
+            ),
+        }
+
+    restrictions = current.get("restrictions")
+    if restrictions is not None:
+        # The GET returns full objects; the PUT wants bare logins/slugs.
+        body["restrictions"] = {
+            "users": [u["login"] for u in restrictions.get("users", [])],
+            "teams": [t["slug"] for t in restrictions.get("teams", [])],
+            "apps": [a["slug"] for a in restrictions.get("apps", [])],
+        }
+
+    return body
+
+
+def _self_test() -> int:
+    """Prove the merge adds without removing, and preserves what it found."""
+    failures = 0
+
+    def check(name: str, condition: bool) -> None:
+        nonlocal failures
+        if condition:
+            print(f"ok    {name}")
+        else:
+            print(f"FAIL  {name}")
+            failures += 1
+
+    # 1. Fresh branch: no required_status_checks object at all.
+    fresh = build_body({}, "backend-ci-gate")
+    check(
+        "fresh branch gets exactly the new context",
+        fresh["required_status_checks"]["checks"] == [{"context": "backend-ci-gate"}],
+    )
+    check(
+        "fresh branch defaults strict=false",
+        fresh["required_status_checks"]["strict"] is False,
+    )
+
+    # 2. THE regression this module exists for: adding a second context must
+    #    not drop the first.
+    existing = {
+        "required_status_checks": {
+            "strict": False,
+            "checks": [{"context": "backend-ci-gate", "app_id": 15368}],
+        }
+    }
+    added = build_body(existing, "frontend-ci-gate")
+    contexts = [c["context"] for c in added["required_status_checks"]["checks"]]
+    check(
+        "adding a second context keeps the first",
+        contexts == ["backend-ci-gate", "frontend-ci-gate"],
+    )
+    check(
+        "app_id of the pre-existing check is preserved",
+        added["required_status_checks"]["checks"][0].get("app_id") == 15368,
+    )
+
+    # 3. Re-running with a context already present is a no-op, not a duplicate.
+    again = build_body(existing, "backend-ci-gate")
+    check(
+        "re-adding an existing context does not duplicate it",
+        again["required_status_checks"]["checks"]
+        == [{"context": "backend-ci-gate", "app_id": 15368}],
+    )
+
+    # 4. strict=true set by a maintainer must survive a re-run.
+    strict_on = build_body(
+        {"required_status_checks": {"strict": True, "checks": []}}, "backend-ci-gate"
+    )
+    check(
+        "strict=true is preserved",
+        strict_on["required_status_checks"]["strict"] is True,
+    )
+
+    # 5. Legacy `contexts` list (no `checks`) is migrated, not dropped.
+    legacy = build_body(
+        {"required_status_checks": {"strict": False, "contexts": ["old-check"]}},
+        "backend-ci-gate",
+    )
+    legacy_contexts = [c["context"] for c in legacy["required_status_checks"]["checks"]]
+    check(
+        "legacy contexts list is migrated and unioned",
+        legacy_contexts == ["old-check", "backend-ci-gate"],
+    )
+
+    # 6. Everything else round-trips.
+    rich = {
+        "required_pull_request_reviews": {
+            "dismiss_stale_reviews": True,
+            "require_code_owner_reviews": True,
+            "require_last_push_approval": True,
+            "required_approving_review_count": 2,
+        },
+        "enforce_admins": {"enabled": True},
+        "required_linear_history": {"enabled": True},
+        "allow_force_pushes": {"enabled": False},
+        "allow_deletions": {"enabled": False},
+        "block_creations": {"enabled": True},
+        "required_conversation_resolution": {"enabled": True},
+        "lock_branch": {"enabled": False},
+        "allow_fork_syncing": {"enabled": True},
+        "restrictions": {
+            "users": [{"login": "JSv4"}],
+            "teams": [{"slug": "core"}],
+            "apps": [{"slug": "dependabot"}],
+        },
+    }
+    out = build_body(rich, "backend-ci-gate")
+    check("enforce_admins preserved", out["enforce_admins"] is True)
+    check(
+        "review settings preserved",
+        out["required_pull_request_reviews"]["required_approving_review_count"] == 2
+        and out["required_pull_request_reviews"]["dismiss_stale_reviews"] is True,
+    )
+    check(
+        "restrictions flattened to logins/slugs",
+        out["restrictions"]
+        == {"users": ["JSv4"], "teams": ["core"], "apps": ["dependabot"]},
+    )
+    check("required_linear_history preserved", out["required_linear_history"] is True)
+    check("block_creations preserved", out["block_creations"] is True)
+    check("allow_fork_syncing preserved", out["allow_fork_syncing"] is True)
+
+    if failures:
+        print(f"self-test: {failures} case(s) failed")
+        return 1
+    print("self-test: all cases passed")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    if "--self-test" in argv:
+        return _self_test()
+
+    context = os.environ.get("CONTEXT")
+    if not context:
+        print("CONTEXT env var is required", file=sys.stderr)
+        return 2
+
+    json.dump(build_body(json.load(sys.stdin), context), sys.stdout, indent=2)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/.github/scripts/require_backend_ci_gate.sh
+++ b/.github/scripts/require_backend_ci_gate.sh
@@ -1,10 +1,17 @@
 #!/usr/bin/env bash
 #
-# Make `backend-ci-gate` a REQUIRED status check on a protected branch.
+# ADD a REQUIRED status check to a protected branch — `backend-ci-gate` by
+# default, any context via CONTEXT=.
 #
 # This is the governance half of the `gate` job in backend.yml. Merging that
 # job changes nothing by itself — a check only gates a merge once branch
 # protection names it.
+#
+# It ADDS: the new context is unioned into whatever the branch already
+# requires, so running this a second time with a different CONTEXT (which is
+# exactly what docs/development/test-suite.md tells you to do when another
+# workflow grows its own gate) does not unrequire the first one. `strict` and
+# every other protection setting are read back and re-sent unchanged.
 #
 # Why this is a script and not a one-line `gh api` in a README:
 #
@@ -13,7 +20,7 @@
 #     `required_pull_request_reviews`, `allow_force_pushes: false`,
 #     `allow_deletions: false` and everything else currently set. So the
 #     current object has to be read back and re-sent with the new key merged
-#     in — which is what this does.
+#     in — which is what branch_protection_body.py does.
 #   * The narrower `PATCH .../protection/required_status_checks` sub-resource
 #     is not usable to CREATE the object: it 404s with "Required status checks
 #     not enabled" when none exists yet.
@@ -24,10 +31,13 @@
 # Usage:
 #   require_backend_ci_gate.sh              # dry run: print the PUT body, change nothing
 #   require_backend_ci_gate.sh --apply      # actually apply it
+#   require_backend_ci_gate.sh --self-test  # exercise the merge logic, touch nothing
 #
 # Env: REPO, BRANCH, CONTEXT override the defaults below.
 
 set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 REPO="${REPO:-Open-Source-Legal/OpenContracts}"
 BRANCH="${BRANCH:-main}"
@@ -36,8 +46,10 @@ CONTEXT="${CONTEXT:-backend-ci-gate}"
 APPLY=0
 if [ "${1:-}" = "--apply" ]; then
     APPLY=1
+elif [ "${1:-}" = "--self-test" ]; then
+    exec python3 "$HERE/branch_protection_body.py" --self-test
 elif [ -n "${1:-}" ]; then
-    echo "usage: $0 [--apply]" >&2
+    echo "usage: $0 [--apply|--self-test]" >&2
     exit 2
 fi
 
@@ -67,57 +79,7 @@ fi
 # --- Build the replacement object from the CURRENT one ----------------------
 current="$(gh api "repos/$REPO/branches/$BRANCH/protection")"
 
-body="$(CONTEXT="$CONTEXT" python3 -c '
-import json, os, sys
-
-cur = json.load(sys.stdin)
-
-
-def enabled(key):
-    return bool(cur.get(key, {}).get("enabled", False))
-
-
-# The four nullable-but-required keys of the PUT body, plus every optional
-# flag currently set, so nothing is lost in the round trip.
-out = {
-    "required_status_checks": {
-        # strict=false: do NOT force every PR to be rebased onto the tip of
-        # the branch before merging. strict=true serialises all merges and
-        # is a much larger behavioural change than adding a gate.
-        "strict": False,
-        "checks": [{"context": os.environ["CONTEXT"]}],
-    },
-    "enforce_admins": enabled("enforce_admins"),
-    "required_pull_request_reviews": None,
-    "restrictions": None,
-    "required_linear_history": enabled("required_linear_history"),
-    "allow_force_pushes": enabled("allow_force_pushes"),
-    "allow_deletions": enabled("allow_deletions"),
-    "block_creations": enabled("block_creations"),
-    "required_conversation_resolution": enabled("required_conversation_resolution"),
-    "lock_branch": enabled("lock_branch"),
-    "allow_fork_syncing": enabled("allow_fork_syncing"),
-}
-
-rpr = cur.get("required_pull_request_reviews")
-if rpr is not None:
-    out["required_pull_request_reviews"] = {
-        "dismiss_stale_reviews": rpr.get("dismiss_stale_reviews", False),
-        "require_code_owner_reviews": rpr.get("require_code_owner_reviews", False),
-        "require_last_push_approval": rpr.get("require_last_push_approval", False),
-        "required_approving_review_count": rpr.get("required_approving_review_count", 0),
-    }
-
-restrictions = cur.get("restrictions")
-if restrictions is not None:
-    out["restrictions"] = {
-        "users": [u["login"] for u in restrictions.get("users", [])],
-        "teams": [t["slug"] for t in restrictions.get("teams", [])],
-        "apps": [a["slug"] for a in restrictions.get("apps", [])],
-    }
-
-json.dump(out, sys.stdout, indent=2)
-' <<<"$current")"
+body="$(CONTEXT="$CONTEXT" python3 "$HERE/branch_protection_body.py" <<<"$current")"
 
 echo
 echo "--- PUT repos/$REPO/branches/$BRANCH/protection ---"

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -68,6 +68,10 @@ jobs:
               - 'mypy.ini'
               - 'pyproject.toml'
               - '.github/workflows/backend.yml'
+              # The gate's own scripts. A change to the thing that decides
+              # whether a merge is allowed should be validated by the full
+              # suite, not waved through as "not backend code".
+              - '.github/scripts/**'
 
   linter:
     needs: changes

--- a/changelog.d/branch-protection-union.fixed.md
+++ b/changelog.d/branch-protection-union.fixed.md
@@ -1,0 +1,13 @@
+- **`require_backend_ci_gate.sh` replaced the required-checks list instead of
+  adding to it.** Adding a second required context — which
+  `docs/development/test-suite.md` explicitly tells you to do once another
+  workflow grows its own gate — would have silently *unrequired*
+  `backend-ci-gate`, with no error and a verification print that looked
+  correct. It also hardcoded `strict: false` (reverting a maintainer who had
+  turned it on) and dropped the `app_id` GitHub pins each check to, widening
+  the requirement to any app. The merge now unions contexts, preserves
+  `strict` and `app_id`, migrates a legacy `contexts` list, and is idempotent.
+  It moved to `.github/scripts/branch_protection_body.py` with a 13-case
+  `--self-test`, reachable as `require_backend_ci_gate.sh --self-test`.
+  `.github/scripts/**` is now in Backend CI's path filter, so a change to the
+  code that decides whether a merge is allowed runs the full suite.

--- a/docs/development/test-suite.md
+++ b/docs/development/test-suite.md
@@ -442,7 +442,16 @@ logic has silently inverted is worse than no gate.
   replaces the *entire* protection object, so a partial body silently drops
   the review rules and the force-push/deletion bans; and the narrower
   `PATCH .../protection/required_status_checks` returns 404 when no such
-  object exists yet.
+  object exists yet. The script **adds** — it unions the new context into
+  whatever the branch already requires and preserves `strict`, so
+
+  ```bash
+  CONTEXT=frontend-ci-gate .github/scripts/require_backend_ci_gate.sh --apply
+  ```
+
+  leaves `backend-ci-gate` required as well. Run it with no argument for a dry
+  run that prints the exact PUT body and changes nothing, or `--self-test` to
+  exercise the merge logic against synthetic protection objects.
 - **Other workflows are not safely requirable as-is.** `frontend.yml`,
   `frontend-e2e.yml`, `frontend-e2e-extract.yml`, `frontend-e2e-websocket.yml`,
   `production-stack.yml` and `redis-integration.yml` all use workflow-level


### PR DESCRIPTION
## The defect

#2267 shipped this merge:

```python
"checks": [{"context": os.environ["CONTEXT"]}],
```

That **replaces** the list. So the action #2267's own `docs/development/test-suite.md` tells the next person to take —

```bash
CONTEXT=frontend-ci-gate .github/scripts/require_backend_ci_gate.sh --apply
```

— would have silently **unrequired `backend-ci-gate`**, leaving `main` gated on the frontend check alone. No error, and the script's closing verification print would have looked entirely correct.

Two smaller instances of the same clobber, both equally silent:

| | shipped behaviour | consequence |
|---|---|---|
| `strict` | hardcoded `false` | reverts a maintainer who turned it on |
| `app_id` | dropped from existing checks | widens the requirement from *this app* to *any app* |

This is constraint 20's second form landing in the very PR that added a guard for its first form: the protection **object** was guarded against partial writes, and the checks **list** — which reaches the same primitive — was not.

## The fix

The merge moves to `.github/scripts/branch_protection_body.py` so it can be tested without a live repository, and gains a **13-case `--self-test`** (reachable as `require_backend_ci_gate.sh --self-test`) covering union, idempotency, `app_id`/`strict` preservation, legacy `contexts`-list migration, and round-tripping of the review rules and push restrictions.

Verified three ways:

- **Mutation check.** Reinstating the old assignment fails 4 of the 13 cases (`adding a second context keeps the first`, `app_id … preserved`, `re-adding … does not duplicate`, `legacy contexts … unioned`) rather than passing silently.
- **Against the live protection object.** Dry run is now idempotent and preserves the `app_id: 15368` GitHub assigned — which the shipped version would have dropped on the very next run.
- **`pre-commit run` clean**, including `black`, which wanted to reformat the new module. (Locally caught; that exact hook failing on a new file is what skipped `pytest` on #2262 in the first place.)

## Also

`.github/scripts/**` is added to Backend CI's `changes` path filter. A change to the code that decides whether a merge is allowed should run the full suite rather than be classified as "not backend code" — as this very PR would otherwise have been.

🤖 Generated with [Claude Code](https://claude.com/claude-code)