### PR TITLE
fix: anthropic 1.0.0 broke messages.create — drop temperature, pin <1 (unblocks main)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -131,6 +131,15 @@ repos:
           # provider SDKs disappears from PyPI (see the mistralai 404 on
           # 2026-05-12). Keep this extras list in lockstep with base.txt.
           - pydantic-ai-slim[openai,anthropic,google,mcp]>=1.56.0,<2
+          # NOT from base.txt: anthropic is a direct requirement of
+          # requirements/analyzers/claude_highlighter.txt, which both
+          # Dockerfiles glob into the image. Mirrored here so mypy checks the
+          # same major the image ships -- without it this hook resolves
+          # anthropic transitively and independently, which is how 1.0.0
+          # turned main red with no commit touching the code. The ceiling is
+          # <1, not <2 (1.0.0 satisfies <2). Keep in lock-step with that file;
+          # migration off the 0.x line is tracked in #2273.
+          - anthropic>=0.45.2,<1
           - spacy
           - tokenizers>=0.21,<0.23
           - posthog==7.12.0

--- a/changelog.d/anthropic-1x-drop-temperature.fixed.md
+++ b/changelog.d/anthropic-1x-drop-temperature.fixed.md
@@ -1,0 +1,28 @@
+- **`anthropic` 1.0.0 removed the sampling parameters, breaking both direct
+  `messages.create()` calls.** `temperature` is gone from the SDK's runtime
+  signature and from all three `create()` overloads, and there is no `**kwargs`
+  passthrough — so `temperature=0` now raises
+  `TypeError: Messages.create() got an unexpected keyword argument
+  'temperature'` **before the request is built**. That is a hard crash, not an
+  API-level 400. It reached `main` with no commit touching the code:
+  `requirements/analyzers/claude_highlighter.txt` declares `anthropic>=0.45.2`
+  with **no upper bound**, both Dockerfiles glob every
+  `requirements/*/*.txt` into the image, and there is no lock file — so a
+  major release published upstream is picked up by the next resolve, in CI
+  and in the production image alike. Both call sites in
+  `doc_analysis_tasks.py` (chunked text extraction and the Claude PII scanner)
+  drop the parameter. The API removed `temperature` on Opus 4.7+ and rejects
+  it on Sonnet 5, so this is the forward-correct fix rather than a
+  client-only shim; determinism, where it matters, comes from the prompt, and
+  `temperature=0` never guaranteed identical outputs in any case. The
+  `temperature=0` guard in the pydantic-ai layer (issue #1381) is a different
+  code path and is unaffected.
+- **Pinned `anthropic` to `>=0.45.2,<1` as a stopgap, in both the analyzer
+  requirements and the mypy hook's `additional_dependencies`.** Note the
+  ceiling is `<1`, not `<2` — `1.0.0` satisfies `<2`, so that bound would be a
+  no-op (verified: `>=0.45.2` and `>=0.45.2,<2` both resolve to `1.0.0`;
+  `>=0.45.2,<1` resolves to `0.125.0`). Mirroring the pin into the pre-commit
+  hook matters because that hook resolves its own dependency set — without it
+  CI type-checks against a different major than the image ships, which is how
+  this broke `main` with no commit touching the code. Migration onto the 1.x
+  line is tracked in #2273.

--- a/opencontractserver/tasks/doc_analysis_tasks.py
+++ b/opencontractserver/tasks/doc_analysis_tasks.py
@@ -406,12 +406,23 @@ def agentic_highlighter_claude(
             ]
 
             logger.info(f"Sending request to Claude for chunk {chunk_index + 1}")
+            # No ``temperature``: the anthropic SDK removed the sampling
+            # parameters in 1.0.0, and passing one now raises TypeError before
+            # the request is even built (there is no **kwargs passthrough).
+            # The parameter is gone from the API itself on Opus 4.7+ / Sonnet 5
+            # too, so this is not a client-only shim. Determinism, where it
+            # matters, comes from the prompt — temperature never guaranteed
+            # identical outputs regardless.
             response = client.messages.create(
                 model=anthropic_model,
-                temperature=0.0,
                 max_tokens=1024,
                 system=system_directive,
                 messages=[
+                    # Kept: with ``temperature`` present mypy failed at overload
+                    # resolution and never type-checked this, so the ignore read
+                    # as unused. Dropping the kwarg lets the overload match and
+                    # surfaces the real ``list[object]`` vs content-block
+                    # mismatch underneath.
                     {"role": "user", "content": request_payload},  # type: ignore[typeddict-item]
                 ],
             )
@@ -605,10 +616,11 @@ def pii_highlighter_claude(
 
     try:
         # Create the messages request
+        # ``temperature`` removed — see the note on the other messages.create
+        # call in this module; the SDK raises TypeError on it as of 1.0.0.
         response = client.messages.create(
             model=anthropic_model,
             max_tokens=8192,
-            temperature=0,
             messages=[
                 {
                     "role": "user",

--- a/requirements/analyzers/claude_highlighter.txt
+++ b/requirements/analyzers/claude_highlighter.txt
@@ -1,1 +1,17 @@
-anthropic>=0.45.2
+# Ceiling is <1, NOT <2: anthropic 1.0.0 satisfies `<2`, so that bound would be
+# a no-op here. Resolved versions, verified:
+#     anthropic>=0.45.2        -> 1.0.0
+#     anthropic>=0.45.2,<2     -> 1.0.0     (no-op)
+#     anthropic>=0.45.2,<1     -> 0.125.0
+#
+# 1.0.0 removed the sampling parameters (`temperature`/`top_p`/`top_k`) from
+# `messages.create()` with no **kwargs passthrough, so passing one raises
+# TypeError before the request is built. It arrived unannounced because this
+# file had no upper bound and both Dockerfiles glob requirements/*/*.txt into
+# the image, with no lock file to hold a resolved set.
+#
+# This pin is a STOPGAP that freezes the 0.x line; the migration is tracked in
+# issue #2273. Keep this ceiling in lock-step with the `anthropic` entry in
+# .pre-commit-config.yaml's mypy additional_dependencies, or CI will
+# type-check against a different major than the image ships.
+anthropic>=0.45.2,<1


### PR DESCRIPTION
**`main` is currently red and this unblocks it.** No commit caused it — [run 32435111357](https://github.com/Open-Source-Legal/OpenContracts/actions/runs/32435111357) (the #2269 merge commit) failed mypy while the previous merge was green, with nothing in between touching this code.

## What happened

`anthropic` published **1.0.0** (previous release `0.125.0`) and the next dependency resolve took it. Two independent resolution paths picked it up:

1. **`requirements/analyzers/claude_highlighter.txt`** declared `anthropic>=0.45.2` — a *direct* requirement with no upper bound. Both Dockerfiles glob every analyzer requirements file into the image:
   ```
   find ./requirements -mindepth 2 -type f -name "*.txt" | sed 's/^/-r /'
   ```
   so it reaches the local **and production** django images. There is no lock file, so every build re-resolves.
2. **The mypy hook's `additional_dependencies`** resolves its own dependency set, and pre-commit rebuilds hook envs from scratch on every run. That is why CI went red *first* — it re-resolves constantly, while the image only re-resolves when rebuilt.

## This is a hard crash, not a type error

Verified against the installed SDK rather than inferred from the mypy message:

```
anthropic 1.0.0
temperature in create():  False
overloads: 3  ->  temperature: False, False, False
has **kwargs: False

>>> client.messages.create(model="claude-opus-5", max_tokens=16, temperature=0.0, messages=[...])
TypeError: Messages.create() got an unexpected keyword argument 'temperature'
```

No `**kwargs` passthrough, so it raises *before the request is built* — both code paths would break outright on the next image rebuild, not return an API 400.

## Two changes

**1. Drop `temperature` from both `messages.create()` call sites** (`doc_analysis_tasks.py` — chunked text extraction and the Claude PII scanner; the only two direct SDK calls in the codebase). The parameter is removed from the API on Opus 4.7+ and rejected on Sonnet 5, so this is forward-correct rather than a client-only shim. Determinism, where these calls want it, has to come from the prompt — `temperature=0` never guaranteed identical outputs anyway.

**2. Pin `anthropic>=0.45.2,<1`** in the analyzer requirements *and* mirror it into the mypy hook.

> ⚠️ **The ceiling is `<1`, not `<2`.** I initially suggested `<2` to match the house style — that is a **no-op here**, because `1.0.0` satisfies it. Verified:
> ```
> anthropic>=0.45.2        -> 1.0.0
> anthropic>=0.45.2,<2     -> 1.0.0     # no-op
> anthropic>=0.45.2,<1     -> 0.125.0   # holds the line
> ```

Mirroring the pin into the hook is load-bearing: without it CI type-checks against a different major than the image ships, which is the skew that produced this incident.

## Verification

The code is correct on **both** majors — checked by rebuilding the pre-commit env from scratch each way (`pre-commit clean`), since the cached env had stale deps and passed regardless:

| hook env | mypy |
|---|---|
| anthropic **1.0.0** | Passed |
| anthropic **0.125.0** (pinned) | Passed |

Full `pre-commit run --all-files` green against a freshly-resolved env.

## One subtlety worth review attention

CI reported `:415: error: Unused "type: ignore" comment`, but the ignore is **kept**. With `temperature` present, mypy failed at overload resolution and never type-checked the payload — so the ignore only *looked* dead. Removing the kwarg lets the overload match and surfaces the real `list[object]` vs content-block mismatch underneath. I removed it first, and the fresh-env rebuild caught the mistake.

## Correction to my own review comment

I said `anthropic` was "the only unbounded direct dependency." **That was wrong** — a sweep of `requirements/**/*.txt` found **47** with no upper bound, of which ~11 are libraries whose API we call directly (`spacy` and `django-guardian` are fully bare). Details and triage in #2273.

## Follow-ups, tracked in #2273

- Migrating onto the 1.x line properly — this pin is a stopgap that freezes 0.x, not a fix.
- Reading the full 1.0.0 release notes: we found the `temperature` removal only because it happened to break a type check.
- Whether to bound the other unbounded deps by hand or adopt a constraints/lock file.
- Separately: `CLAUDE_ANALYZER_DEFAULT_MODEL = "claude-3-5-sonnet-latest"` (`constants/llm.py:65`) names a model retired 2025-10-28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)