### PR TITLE
fix: use identity checks for type comparisons; remove mutable default argument

### DIFF
--- a/opencontractserver/llms/tools/tool_factory.py
+++ b/opencontractserver/llms/tools/tool_factory.py
@@ -175,15 +175,15 @@ class CoreTool:
 
             # Try to infer type from annotation
             if param.annotation != inspect.Parameter.empty:
-                if param.annotation == int:
+                if param.annotation is int:
                     param_info["type"] = "integer"
-                elif param.annotation == float:
+                elif param.annotation is float:
                     param_info["type"] = "number"
-                elif param.annotation == bool:
+                elif param.annotation is bool:
                     param_info["type"] = "boolean"
-                elif param.annotation == list:
+                elif param.annotation is list:
                     param_info["type"] = "array"
-                elif param.annotation == dict:
+                elif param.annotation is dict:
                     param_info["type"] = "object"
 
             properties[param_name] = param_info

--- a/opencontractserver/pipeline/utils.py
+++ b/opencontractserver/pipeline/utils.py
@@ -444,7 +444,7 @@ def run_post_processors(
     processor_paths: list[str],
     zip_bytes: bytes,
     export_data: OpenContractsExportDataJsonPythonType,
-    input_kwargs: dict[str, Any] = {},
+    input_kwargs: dict[str, Any] | None = None,
 ) -> tuple[bytes, OpenContractsExportDataJsonPythonType]:
     """
     Load and run post-processors in sequence.
@@ -459,6 +459,7 @@ def run_post_processors(
             - Modified zip bytes
             - Modified export data dictionary
     """
+    input_kwargs = input_kwargs or {}
     current_zip_bytes = zip_bytes
     current_export_data = export_data
 


### PR DESCRIPTION
## Summary

1. **`opencontractserver/llms/tools/tool_factory.py`** — the annotation→JSON-schema dispatch chain compares type objects with `==` five times (`param.annotation == int`, `float`, `bool`, `list`, `dict`) — ruff E721. Identity (`is`) is the intended semantics for type objects and avoids surprises with metaclass-defined `__eq__`.

2. **`opencontractserver/pipeline/utils.py`** — `run_post_processors(..., input_kwargs: dict[str, Any] = {})` shares one dict across every call (ruff B006). Changed to the `None` sentinel with `input_kwargs = input_kwargs or {}` after the docstring; identical behavior for all callers.

## Testing
`python -m py_compile` passes on both files; `ruff check --select B006,E721` on them goes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)