### PR TITLE
fix(frontend): restore local sessions after refresh

### DIFF
--- a/changelog.d/local-session-restoration.fixed.md
+++ b/changelog.d/local-session-restoration.fixed.md
@@ -1,0 +1,6 @@
+- **Restored local username/password sessions across browser refreshes.** Local
+  JWT sessions now persist for up to 24 hours, repopulate authenticated
+  navigation and document/corpus controls while backend user details load, and
+  are cleared on logout, expiry, or genuine authentication failures. Ordinary
+  `403 Forbidden` permission responses no longer discard an otherwise valid
+  session.

--- a/frontend/src/components/auth/AuthGate.tsx
+++ b/frontend/src/components/auth/AuthGate.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useRef } from "react";
-import { useAuth0, LogoutOptions } from "@auth0/auth0-react";
+import { useAuth0, LogoutOptions, User } from "@auth0/auth0-react";
 import { useReactiveVar } from "@apollo/client";
 import {
   authToken,
@@ -11,6 +11,10 @@ import { toast } from "react-toastify";
 import { ModernLoadingDisplay } from "../widgets/ModernLoadingDisplay";
 import { useCacheManager } from "../../hooks/useCacheManager";
 import { getRuntimeEnv } from "../../utils/env";
+import {
+  loadLocalAuthSession,
+  loadLocalAuthSessionUser,
+} from "../../utils/localAuthSession";
 
 // LocalStorage key to track if user has ever successfully authenticated.
 // Used to distinguish first-time visitors from returning users with expired sessions.
@@ -171,10 +175,13 @@ export const AuthGate: React.FC<AuthGateProps> = ({
     let cancelled = false;
 
     if (!useAuth0Flag) {
-      // Non-Auth0 mode: immediately mark as initialized
-      if (authStatusVar() === "LOADING") {
-        authStatusVar("ANONYMOUS");
-      }
+      // Restore a local username/password session before children mount so
+      // their first GraphQL requests include the bearer token.
+      const storedToken = loadLocalAuthSession();
+      const storedUser = loadLocalAuthSessionUser();
+      authToken(storedToken || "");
+      userObj(storedToken && storedUser ? (storedUser as User) : null);
+      authStatusVar(storedToken ? "AUTHENTICATED" : "ANONYMOUS");
       authInitCompleteVar(true);
       setAuthInitialized(true);
       return () => {

--- a/frontend/src/components/corpuses/CorpusListView.tsx
+++ b/frontend/src/components/corpuses/CorpusListView.tsx
@@ -451,9 +451,10 @@ export const CorpusListView: React.FC<CorpusListViewProps> = ({
   const navigate = useNavigate();
   const currentUser = useReactiveVar(userObj);
   const backendUser = useReactiveVar(backendUserObj);
-  // Use userObj for auth check - consistent with NavMenu which gates protected items on user object
-  // Note: authToken can be out of sync with userObj in some edge cases
-  const isAuthenticated = Boolean(currentUser);
+  // Local sessions restore the token first and populate backendUser via GET_ME.
+  // Either identity proves the UI is authenticated; requiring only userObj
+  // incorrectly hides New Corpus after a page refresh.
+  const isAuthenticated = Boolean(currentUser || backendUser);
   // Ownership keys off the backend user id (the public GraphQL UserType)
   // so we don't depend on the redacted email field.
   const currentUserId = backendUser?.id;

--- a/frontend/src/components/layout/useNavMenu.ts
+++ b/frontend/src/components/layout/useNavMenu.ts
@@ -11,6 +11,7 @@ import {
 import { header_menu_items } from "../../assets/configurations/menus";
 import { useEnv } from "../hooks/UseEnv";
 import { useCacheManager } from "../../hooks/useCacheManager";
+import { clearLocalAuthSession } from "../../utils/localAuthSession";
 
 /**
  * Shared navigation menu logic for both desktop and mobile nav components.
@@ -27,11 +28,18 @@ export const useNavMenu = () => {
   } = useAuth0();
   const cache_user = useReactiveVar(userObj);
   const backendUser = useReactiveVar(backendUserObj);
+  const authStatus = useReactiveVar(authStatusVar);
   const { pathname } = useLocation();
   const navigate = useNavigate();
   const { resetOnAuthChange } = useCacheManager();
 
-  const user = REACT_APP_USE_AUTH0 ? auth0_user : cache_user;
+  // Local login initially supplies ``cache_user`` directly. After a page
+  // refresh only the persisted JWT is restored; GET_ME then repopulates
+  // ``backendUser``. Use that canonical backend identity so the navigation
+  // does not incorrectly render "Login" for a restored session.
+  const user = REACT_APP_USE_AUTH0
+    ? auth0_user
+    : backendUser || cache_user;
   // ``useAuth0()`` must be called unconditionally (hooks rules), but without a
   // mounted Auth0Provider it returns the default context whose ``isLoading`` is
   // permanently true. Consumers gate the whole auth surface on this flag
@@ -39,7 +47,9 @@ export const useNavMenu = () => {
   // passing it through unguarded hid the entire user menu AND the login button
   // in every ``REACT_APP_USE_AUTH0=false`` deployment. Same guard App.tsx
   // applies for the same reason.
-  const isLoading = REACT_APP_USE_AUTH0 ? auth0Loading : false;
+  const isLoading = REACT_APP_USE_AUTH0
+    ? auth0Loading
+    : authStatus === "AUTHENTICATED" && !user;
   const show_export_modal = useReactiveVar(showExportModal);
 
   // Filter menu items based on authentication
@@ -83,6 +93,7 @@ export const useNavMenu = () => {
     // refetch. If this ordering is reversed, the hook would re-issue all
     // active queries with the still-valid token before it's cleared.
     // See: useRefetchOnAuthChange.ts lines 31-36.
+    clearLocalAuthSession();
     authToken("");
     userObj(null);
     authStatusVar("ANONYMOUS");
@@ -92,7 +103,9 @@ export const useNavMenu = () => {
       (error) =>
         console.warn("[useNavMenu] Cache reset failed on logout:", {
           error: error instanceof Error ? error.message : error,
-          userId: user?.sub || cache_user?.id,
+          userId: REACT_APP_USE_AUTH0
+            ? auth0_user?.sub
+            : backendUser?.id || cache_user?.id,
           timestamp: new Date().toISOString(),
         })
     );

--- a/frontend/src/graphql/errorLink.test.ts
+++ b/frontend/src/graphql/errorLink.test.ts
@@ -5,11 +5,12 @@
  * terminating mock link that emits synthetic errors through the real
  * `errorLink`. This exercises every catch/return branch:
  *
- *  - GraphQL 401 / 403 / UNAUTHENTICATED → clears auth state + warn toast
+ *  - GraphQL 401 / UNAUTHENTICATED → clears auth state + warn toast
+ *  - GraphQL 403 → preserves the valid authenticated session
  *  - Expired-JWT message variants → warn toast + window.location.reload
  *  - Message-based unauthorized / not-authenticated detection
  *  - Non-auth GraphQL errors → logged but auth state untouched
- *  - Network 401/403 → clears auth state + warn toast
+ *  - Network 401 → clears auth state; 403 preserves it
  *  - Generic network error → error toast, auth state untouched
  */
 
@@ -146,16 +147,16 @@ describe("errorLink", () => {
       expect(reloadSpy).not.toHaveBeenCalled();
     });
 
-    it("clears auth state on 403", async () => {
+    it("preserves auth state on 403 permission denial", async () => {
       const err = new GraphQLError("Forbidden", {
         extensions: { status: 403 },
       });
 
       await runOperation(graphQLErrorLink([err]));
 
-      expect(authToken()).toBe("");
-      expect(authStatusVar()).toBe("ANONYMOUS");
-      expect(toast.warning).toHaveBeenCalledOnce();
+      expect(authToken()).toBe("test-token");
+      expect(authStatusVar()).toBe("AUTHENTICATED");
+      expect(toast.warning).not.toHaveBeenCalled();
     });
 
     it("clears auth state on UNAUTHENTICATED extension code", async () => {
@@ -244,15 +245,15 @@ describe("errorLink", () => {
       );
     });
 
-    it("clears auth state on 403 network error", async () => {
+    it("preserves auth state on 403 network permission denial", async () => {
       const netErr = Object.assign(new Error("Forbidden"), {
         statusCode: 403,
       });
 
       await runOperation(networkErrorLink(netErr));
 
-      expect(authToken()).toBe("");
-      expect(authStatusVar()).toBe("ANONYMOUS");
+      expect(authToken()).toBe("test-token");
+      expect(authStatusVar()).toBe("AUTHENTICATED");
     });
 
     it("shows network error toast for non-auth network failures", async () => {

--- a/frontend/src/graphql/errorLink.ts
+++ b/frontend/src/graphql/errorLink.ts
@@ -2,11 +2,12 @@ import { onError } from "@apollo/client/link/error";
 import { toast } from "react-toastify";
 import { authToken, authStatusVar, userObj } from "./cache";
 import { notifyTransientNetworkError } from "../utils/networkNotifications";
+import { clearLocalAuthSession } from "../utils/localAuthSession";
 
 /**
  * Apollo error link that handles authentication errors and network errors.
  *
- * For 401/403 errors:
+ * For authentication errors (401/UNAUTHENTICATED/expired JWT):
  * - Switches to ANONYMOUS mode (allows browsing public content)
  * - Shows a toast notification with option to log back in
  * - Clears auth token and user object
@@ -31,10 +32,12 @@ export const errorLink = onError(
           err.message?.toLowerCase().includes("token expired") ||
           err.message?.toLowerCase().includes("jwt expired");
 
-        // Handle authentication errors (401/403) or expired tokens
+        // A 403 means the caller is authenticated but lacks permission for
+        // this operation. Do not destroy a valid persisted session because
+        // one optional query was forbidden.
+        // Handle only genuine authentication failures or expired tokens.
         if (
           statusCode === 401 ||
-          statusCode === 403 ||
           statusCode === "UNAUTHENTICATED" ||
           err.message?.toLowerCase().includes("unauthorized") ||
           err.message?.toLowerCase().includes("not authenticated") ||
@@ -51,6 +54,7 @@ export const errorLink = onError(
             );
 
             // Clear auth state
+            clearLocalAuthSession();
             authToken("");
             userObj(null);
             authStatusVar("ANONYMOUS");
@@ -72,6 +76,7 @@ export const errorLink = onError(
 
           // Switch to anonymous mode - allows user to browse public content
           // without forcing an immediate re-login
+          clearLocalAuthSession();
           authToken("");
           userObj(null);
           authStatusVar("ANONYMOUS");
@@ -101,11 +106,13 @@ export const errorLink = onError(
     if (networkError) {
       const netErr = networkError as any;
 
-      // Handle network-level authentication errors
-      if (netErr.statusCode === 401 || netErr.statusCode === 403) {
+      // A network-level 403 is authorization failure, not proof that the
+      // token is invalid. Only a 401 clears the persisted login.
+      if (netErr.statusCode === 401) {
         console.error("[Apollo Error Link] Network auth error:", networkError);
 
         // Switch to anonymous mode - allows user to browse public content
+        clearLocalAuthSession();
         authToken("");
         userObj(null);
         authStatusVar("ANONYMOUS");

--- a/frontend/src/utils/localAuthSession.test.ts
+++ b/frontend/src/utils/localAuthSession.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearLocalAuthSession,
+  loadLocalAuthSession,
+  loadLocalAuthSessionUser,
+  LOCAL_AUTH_SESSION_TTL_MS,
+  saveLocalAuthSession,
+} from "./localAuthSession";
+
+describe("localAuthSession", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("restores a token for up to 24 hours", () => {
+    vi.setSystemTime(new Date("2026-08-30T08:00:00Z"));
+    saveLocalAuthSession("jwt-token");
+
+    vi.setSystemTime(
+      new Date(Date.now() + LOCAL_AUTH_SESSION_TTL_MS - 1)
+    );
+    expect(loadLocalAuthSession()).toBe("jwt-token");
+  });
+
+  it("restores the local user's display identity", () => {
+    const user = { id: "1", username: "admin", isSuperuser: true };
+    saveLocalAuthSession("jwt-token", user);
+
+    expect(loadLocalAuthSessionUser()).toEqual(user);
+  });
+
+  it("removes an expired token", () => {
+    vi.setSystemTime(new Date("2026-08-30T08:00:00Z"));
+    saveLocalAuthSession("jwt-token");
+
+    vi.setSystemTime(new Date(Date.now() + LOCAL_AUTH_SESSION_TTL_MS));
+    expect(loadLocalAuthSession()).toBeNull();
+  });
+
+  it("clears a saved session on logout", () => {
+    saveLocalAuthSession("jwt-token");
+    clearLocalAuthSession();
+    expect(loadLocalAuthSession()).toBeNull();
+  });
+});

--- a/frontend/src/utils/localAuthSession.ts
+++ b/frontend/src/utils/localAuthSession.ts
@@ -1,0 +1,89 @@
+const LOCAL_AUTH_SESSION_KEY = "oc_local_auth_session";
+export const LOCAL_AUTH_SESSION_TTL_MS = 24 * 60 * 60 * 1000;
+
+type StoredLocalAuthSession = {
+  token: string;
+  expiresAt: number;
+  user?: unknown;
+};
+
+const getStorage = (): Storage | null => {
+  try {
+    return typeof window !== "undefined" ? window.localStorage : null;
+  } catch {
+    return null;
+  }
+};
+
+export const saveLocalAuthSession = (token: string, user?: unknown): void => {
+  const storage = getStorage();
+  if (!storage || !token) return;
+
+  const session: StoredLocalAuthSession = {
+    token,
+    expiresAt: Date.now() + LOCAL_AUTH_SESSION_TTL_MS,
+    user,
+  };
+  try {
+    storage.setItem(LOCAL_AUTH_SESSION_KEY, JSON.stringify(session));
+  } catch {
+    // Authentication still works for the current page when storage is blocked.
+  }
+};
+
+export const loadLocalAuthSessionUser = (): unknown | null => {
+  const storage = getStorage();
+  if (!storage) return null;
+
+  try {
+    const raw = storage.getItem(LOCAL_AUTH_SESSION_KEY);
+    if (!raw) return null;
+    const session = JSON.parse(raw) as Partial<StoredLocalAuthSession>;
+    if (
+      typeof session.token !== "string" ||
+      typeof session.expiresAt !== "number" ||
+      session.expiresAt <= Date.now() ||
+      !session.user ||
+      typeof session.user !== "object"
+    ) {
+      return null;
+    }
+    return session.user;
+  } catch {
+    return null;
+  }
+};
+
+export const loadLocalAuthSession = (): string | null => {
+  const storage = getStorage();
+  if (!storage) return null;
+
+  try {
+    const raw = storage.getItem(LOCAL_AUTH_SESSION_KEY);
+    if (!raw) return null;
+
+    const session = JSON.parse(raw) as Partial<StoredLocalAuthSession>;
+    if (
+      typeof session.token !== "string" ||
+      !session.token ||
+      typeof session.expiresAt !== "number" ||
+      session.expiresAt <= Date.now()
+    ) {
+      storage.removeItem(LOCAL_AUTH_SESSION_KEY);
+      return null;
+    }
+
+    return session.token;
+  } catch {
+    storage.removeItem(LOCAL_AUTH_SESSION_KEY);
+    return null;
+  }
+};
+
+export const clearLocalAuthSession = (): void => {
+  try {
+    getStorage()?.removeItem(LOCAL_AUTH_SESSION_KEY);
+  } catch {
+    // Storage may be disabled by browser policy.
+  }
+};

--- a/frontend/src/views/Corpuses.tsx
+++ b/frontend/src/views/Corpuses.tsx
@@ -992,7 +992,7 @@ export const Corpuses = () => {
   };
 
   let corpus_actions: DropdownActionProps[] = [];
-  if (currentUser) {
+  if (currentUser || backendUser) {
     corpus_actions = [
       ...corpus_actions,
       {
@@ -1020,7 +1020,7 @@ export const Corpuses = () => {
   }
 
   let contract_actions: DropdownActionProps[] = [];
-  if (selected_document_ids.length > 0 && currentUser) {
+  if (selected_document_ids.length > 0 && (currentUser || backendUser)) {
     contract_actions.push({
       icon: "remove circle",
       title: "Remove Contract(s)",

--- a/frontend/src/views/Documents.tsx
+++ b/frontend/src/views/Documents.tsx
@@ -164,6 +164,7 @@ const DocumentIcon = () => (
 export const Documents = () => {
   const current_user = useReactiveVar(userObj);
   const backend_user = useReactiveVar(backendUserObj);
+  const is_authenticated = Boolean(current_user || backend_user);
   const show_bulk_upload_modal = useReactiveVar(showBulkUploadModal);
   const show_upload_new_documents_modal = useReactiveVar(
     showUploadNewDocumentsModal
@@ -684,7 +685,7 @@ export const Documents = () => {
                 </ViewToggleButton>
               </ViewToggle>
 
-              {current_user &&
+              {is_authenticated &&
                 (selected_document_ids.length > 0 ? (
                   <ActionButtons>
                     <Button
@@ -817,7 +818,7 @@ export const Documents = () => {
                 action={
                   activeStatusFilter === STATUS_FILTERS.ALL &&
                   !hasAdvancedFilters &&
-                  current_user ? (
+                  is_authenticated ? (
                     <Button
                       variant="primary"
                       leftIcon={<Plus size={16} />}
@@ -864,7 +865,7 @@ export const Documents = () => {
                   key: "add-to-corpus",
                   icon: <FolderOpen size={16} />,
                   label: "Add to Corpus",
-                  visible: Boolean(current_user),
+                  visible: is_authenticated,
                   onClick: () => {
                     selectedDocumentIds([contextMenu.document.id]);
                     showAddDocsToCorpusModal(true);
@@ -875,7 +876,7 @@ export const Documents = () => {
                   key: "edit",
                   icon: <Edit size={16} />,
                   label: "Edit Details",
-                  visible: Boolean(current_user),
+                  visible: is_authenticated,
                   onClick: () => {
                     editingDocument(contextMenu.document);
                     handleCloseContextMenu();
@@ -887,7 +888,7 @@ export const Documents = () => {
                   label: selected_document_ids.includes(contextMenu.document.id)
                     ? "Deselect"
                     : "Select",
-                  visible: Boolean(current_user),
+                  visible: is_authenticated,
                   onClick: () => {
                     handleSelect(contextMenu.document.id);
                     handleCloseContextMenu();
@@ -898,7 +899,7 @@ export const Documents = () => {
                   icon: <Trash2 size={16} />,
                   label: "Delete",
                   variant: "danger" as const,
-                  visible: Boolean(current_user),
+                  visible: is_authenticated,
                   onClick: () => {
                     selectedDocumentIds([contextMenu.document.id]);
                     showDeleteDocumentsModal(true);

--- a/frontend/src/views/Login.tsx
+++ b/frontend/src/views/Login.tsx
@@ -13,6 +13,7 @@ import { User, Lock } from "lucide-react";
 import { CiteMark } from "../components/brand/CiteMark";
 import { CiteWordmark } from "../components/brand/CiteWordmark";
 import { useCacheManager } from "../hooks/useCacheManager";
+import { saveLocalAuthSession } from "../utils/localAuthSession";
 import { OS_LEGAL_COLORS } from "../assets/configurations/osLegalStyles";
 
 const PageWrapper = styled.div`
@@ -131,6 +132,7 @@ export const Login = () => {
           console.warn("[Login] Cache reset failed on login:", cacheError);
         }
 
+        saveLocalAuthSession(data.tokenAuth.token, data.tokenAuth.user);
         authToken(data.tokenAuth.token);
         userObj(data.tokenAuth.user);
         authStatusVar("AUTHENTICATED");


### PR DESCRIPTION
## Summary

Fixes #2289.

Local username/password sessions now survive a full browser refresh for up to
24 hours, and authenticated navigation plus document/corpus controls remain
available while canonical backend-user details load.

This also corrects authentication error classification: `401`,
`UNAUTHENTICATED`, expired JWTs, and explicit logout clear persisted state;
ordinary `403 Forbidden` permission responses preserve the valid session.

## Root cause

Local authentication state lived only in Apollo reactive variables. Refreshing
the page reset the JWT and user identity before child components mounted and
issued GraphQL queries. Several UI gates also treated `userObj` as the sole
proof of authentication, even after `backendUserObj` had been populated.

Separately, the Apollo error link treated every `403` as an invalid token,
conflating authorization failure with authentication failure.

## Changes

- Add a small local-session utility with a fixed 24-hour TTL and defensive
  handling for unavailable, malformed, or expired browser storage.
- Restore the token and display identity in `AuthGate` before authenticated
  children mount.
- Save on successful local login and clear on logout or genuine authentication
  failure.
- Use the restored/backend identity when rendering navigation and authenticated
  document/corpus actions.
- Preserve session state on GraphQL and network-level `403` responses.
- Add focused tests covering restoration, identity, expiry, logout, and
  `401`/`403` behavior.

Auth0 behavior is unchanged. The client TTL does not extend the JWT's own
server-enforced lifetime.

## Verification

- `docker compose -f local.yml --profile fullstack build frontend`
- `yarn test:unit --run src/utils/localAuthSession.test.ts src/graphql/errorLink.test.ts`
  - 2 test files passed
  - 14 tests passed
- `python3 scripts/collate_changelog.py --check`
- `git diff --check`

Manual local-Docker verification:

- Login survives a hard refresh.
- Navigation restores the authenticated user rather than showing **Login**.
- **Upload**, **Add to Corpus**, and corpus-management actions remain visible.
- Logout clears the persisted session.
- A permission-denied `403` does not sign the user out.

## Related

- #744 — stale/expired-token signaling (Auth0-oriented)
- #2104 — similar local-deployment user-detail and upload-control symptoms
