### PR TITLE
fix(frontend): stabilize label-set workflows

### DIFF
--- a/changelog.d/2295-labelset-workflows.fixed.md
+++ b/changelog.d/2295-labelset-workflows.fixed.md
@@ -1,0 +1,5 @@
+- **Made label-set creation and selection reliable in the frontend.** Label
+  colors now use the backend's accepted hex format, failed create mutations no
+  longer produce false success feedback, populated label lists keep the add
+  action beside search, and corpus creation immediately reflects the selected
+  label set.

--- a/frontend/src/components/corpuses/CorpusModal.tsx
+++ b/frontend/src/components/corpuses/CorpusModal.tsx
@@ -580,9 +580,13 @@ export const CorpusModal: React.FC<CorpusModalProps> = ({
     []
   );
 
-  const handleLabelSetChange = useCallback((values: any) => {
-    setLabelSetId(values.labelSet || null);
-  }, []);
+  const handleLabelSetChange = useCallback(
+    (values: { labelSet: string | null; labelSetObj?: LabelSetType }) => {
+      setLabelSetId(values.labelSet || null);
+      setLabelSetObj(values.labelSetObj);
+    },
+    []
+  );
 
   const handleEmbedderChange = useCallback((values: any) => {
     setPreferredEmbedder(values.preferredEmbedder || null);

--- a/frontend/src/components/labelsets/LabelSetDetailPage.tsx
+++ b/frontend/src/components/labelsets/LabelSetDetailPage.tsx
@@ -30,6 +30,7 @@ import { getPermissions } from "../../utils/transform";
 import { getCreatorDisplay } from "../../utils/userDisplay";
 import { PermissionTypes } from "../types";
 import { OS_LEGAL_COLORS } from "../../assets/configurations/osLegalStyles";
+import { isValidHexColor, normalizeHexColor } from "../../utils/colorUtils";
 
 // Import extracted components from detail folder
 import {
@@ -89,6 +90,7 @@ import {
   OverviewActions,
   ActionButton,
   LabelsSection,
+  SearchToolbar,
   SearchContainer,
   SearchInput,
   SearchIconWrapper,
@@ -147,39 +149,15 @@ interface LabelSetDetailPageProps {
 // ═══════════════════════════════════════════════════════════════════════════════
 
 /**
- * Validates if a string is a valid hex color (3 or 6 character format)
- * Accepts with or without leading #
- */
-const isValidHexColor = (color: string): boolean => {
-  return /^#?([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/.test(color);
-};
-
-/**
- * Expands a 3-character hex color to 6-character format
- * e.g., "abc" becomes "aabbcc"
- */
-const expandHexColor = (color: string): string => {
-  if (color.length === 3) {
-    return color
-      .split("")
-      .map((c) => c + c)
-      .join("");
-  }
-  return color;
-};
-
-/**
- * Sanitizes a color value, returning the fallback if invalid
- * Strips leading #, validates format, and expands 3-char to 6-char
+ * Sanitizes a color value for the GraphQL API. The backend requires the
+ * leading ``#`` for every accepted hex shape.
  */
 const sanitizeColor = (
   color: string | null | undefined,
   fallback: string = DEFAULT_LABEL_COLOR
 ): string => {
-  if (!color) return fallback;
-  const cleaned = color.replace("#", "");
-  if (!isValidHexColor(cleaned)) return fallback;
-  return expandHexColor(cleaned);
+  const candidate = color || fallback;
+  return normalizeHexColor(isValidHexColor(candidate) ? candidate : fallback);
 };
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -312,7 +290,7 @@ export const LabelSetDetailPage: React.FC<LabelSetDetailPageProps> = ({
     setEditForm({
       text: label.text || "",
       description: label.description || "",
-      color: label.color || DEFAULT_LABEL_COLOR,
+      color: (label.color || DEFAULT_LABEL_COLOR).replace(/^#/, ""),
     });
   };
 
@@ -401,9 +379,17 @@ export const LabelSetDetailPage: React.FC<LabelSetDetailPageProps> = ({
         labelsetId: opened_labelset?.id ? opened_labelset.id : "",
       },
     })
-      .then(() => {
+      .then(async (result) => {
+        const payload = result.data?.createAnnotationLabelForLabelset;
+        if (!payload?.ok) {
+          toast.error(payload?.message || "Failed to create label");
+          return;
+        }
+
+        // Await the server result so the empty-state/counters cannot render
+        // stale data after the success notification.
+        await refetch();
         toast.success("Label created successfully");
-        refetch();
         handleCancelEdit();
       })
       .catch((err) => {
@@ -607,7 +593,7 @@ export const LabelSetDetailPage: React.FC<LabelSetDetailPageProps> = ({
               <LabelEditLabel>Color</LabelEditLabel>
               <ColorInput
                 type="color"
-                value={`#${editForm.color}`}
+                value={normalizeHexColor(editForm.color)}
                 onChange={(e) =>
                   setEditForm({
                     ...editForm,
@@ -615,7 +601,7 @@ export const LabelSetDetailPage: React.FC<LabelSetDetailPageProps> = ({
                   })
                 }
               />
-              <LabelColor $color={`#${editForm.color}`} />
+              <LabelColor $color={normalizeHexColor(editForm.color)} />
             </LabelEditRow>
             <LabelEditActions>
               <LabelActionButton
@@ -702,7 +688,7 @@ export const LabelSetDetailPage: React.FC<LabelSetDetailPageProps> = ({
               <LabelEditLabel>Color</LabelEditLabel>
               <ColorInput
                 type="color"
-                value={`#${editForm.color}`}
+                value={normalizeHexColor(editForm.color)}
                 onChange={(e) =>
                   setEditForm({
                     ...editForm,
@@ -710,7 +696,7 @@ export const LabelSetDetailPage: React.FC<LabelSetDetailPageProps> = ({
                   })
                 }
               />
-              <LabelColor $color={`#${editForm.color}`} />
+              <LabelColor $color={normalizeHexColor(editForm.color)} />
             </LabelEditRow>
             <LabelEditActions>
               <LabelActionButton
@@ -761,7 +747,7 @@ export const LabelSetDetailPage: React.FC<LabelSetDetailPageProps> = ({
                   <LabelEditLabel>Color</LabelEditLabel>
                   <ColorInput
                     type="color"
-                    value={`#${editForm.color}`}
+                    value={normalizeHexColor(editForm.color)}
                     onChange={(e) =>
                       setEditForm({
                         ...editForm,
@@ -769,7 +755,7 @@ export const LabelSetDetailPage: React.FC<LabelSetDetailPageProps> = ({
                       })
                     }
                   />
-                  <LabelColor $color={`#${editForm.color}`} />
+                  <LabelColor $color={normalizeHexColor(editForm.color)} />
                 </LabelEditRow>
                 <LabelEditActions>
                   <LabelActionButton
@@ -793,7 +779,9 @@ export const LabelSetDetailPage: React.FC<LabelSetDetailPageProps> = ({
                 <LabelGrip>
                   <GripIcon />
                 </LabelGrip>
-                <LabelColor $color={`#${label.color || DEFAULT_LABEL_COLOR}`} />
+                <LabelColor
+                  $color={normalizeHexColor(label.color || DEFAULT_LABEL_COLOR)}
+                />
                 <LabelContent>
                   <LabelName>{label.text}</LabelName>
                   <LabelDescription>{label.description}</LabelDescription>
@@ -821,16 +809,34 @@ export const LabelSetDetailPage: React.FC<LabelSetDetailPageProps> = ({
             )
           )}
         </LabelsList>
-
-        {/* Add button - hidden when already creating */}
-        {canUpdate && !isCreating && (
-          <AddLabelButton onClick={() => handleStartCreate(labelType)}>
-            <PlusIcon /> Add Label
-          </AddLabelButton>
-        )}
       </>
     );
   };
+
+  const renderLabelToolbar = (
+    placeholder: string,
+    labelType: LabelType,
+    hasExistingLabels: boolean
+  ) => (
+    <SearchToolbar>
+      <SearchContainer>
+        <SearchIconWrapper>
+          <SearchIcon />
+        </SearchIconWrapper>
+        <SearchInput
+          type="text"
+          placeholder={placeholder}
+          value={searchTerm}
+          onChange={(e) => setSearchTerm(e.target.value)}
+        />
+      </SearchContainer>
+      {canUpdate && hasExistingLabels && creatingLabelType !== labelType && (
+        <AddLabelButton onClick={() => handleStartCreate(labelType)}>
+          <PlusIcon /> Add Label
+        </AddLabelButton>
+      )}
+    </SearchToolbar>
+  );
 
   // Render content based on active tab
   const renderContent = () => {
@@ -893,17 +899,11 @@ export const LabelSetDetailPage: React.FC<LabelSetDetailPageProps> = ({
       case "text_labels":
         return (
           <LabelsSection>
-            <SearchContainer>
-              <SearchIconWrapper>
-                <SearchIcon />
-              </SearchIconWrapper>
-              <SearchInput
-                type="text"
-                placeholder="Search text labels..."
-                value={searchTerm}
-                onChange={(e) => setSearchTerm(e.target.value)}
-              />
-            </SearchContainer>
+            {renderLabelToolbar(
+              "Search text labels...",
+              LabelType.TokenLabel,
+              text_labels.length > 0
+            )}
             {renderLabelsList(
               text_label_results,
               LabelType.TokenLabel,
@@ -915,17 +915,11 @@ export const LabelSetDetailPage: React.FC<LabelSetDetailPageProps> = ({
       case "doc_labels":
         return (
           <LabelsSection>
-            <SearchContainer>
-              <SearchIconWrapper>
-                <SearchIcon />
-              </SearchIconWrapper>
-              <SearchInput
-                type="text"
-                placeholder="Search doc labels..."
-                value={searchTerm}
-                onChange={(e) => setSearchTerm(e.target.value)}
-              />
-            </SearchContainer>
+            {renderLabelToolbar(
+              "Search doc labels...",
+              LabelType.DocTypeLabel,
+              doc_type_labels.length > 0
+            )}
             {renderLabelsList(
               doc_label_results,
               LabelType.DocTypeLabel,
@@ -937,17 +931,11 @@ export const LabelSetDetailPage: React.FC<LabelSetDetailPageProps> = ({
       case "relationship_labels":
         return (
           <LabelsSection>
-            <SearchContainer>
-              <SearchIconWrapper>
-                <SearchIcon />
-              </SearchIconWrapper>
-              <SearchInput
-                type="text"
-                placeholder="Search relationship labels..."
-                value={searchTerm}
-                onChange={(e) => setSearchTerm(e.target.value)}
-              />
-            </SearchContainer>
+            {renderLabelToolbar(
+              "Search relationship labels...",
+              LabelType.RelationshipLabel,
+              relationship_labels.length > 0
+            )}
             {renderLabelsList(
               relationship_label_results,
               LabelType.RelationshipLabel,
@@ -959,17 +947,11 @@ export const LabelSetDetailPage: React.FC<LabelSetDetailPageProps> = ({
       case "span_labels":
         return (
           <LabelsSection>
-            <SearchContainer>
-              <SearchIconWrapper>
-                <SearchIcon />
-              </SearchIconWrapper>
-              <SearchInput
-                type="text"
-                placeholder="Search labels..."
-                value={searchTerm}
-                onChange={(e) => setSearchTerm(e.target.value)}
-              />
-            </SearchContainer>
+            {renderLabelToolbar(
+              "Search span labels...",
+              LabelType.SpanLabel,
+              span_labels.length > 0
+            )}
             {renderLabelsList(
               span_label_results,
               LabelType.SpanLabel,

--- a/frontend/src/components/labelsets/detail/LabelSetDetailStyles.ts
+++ b/frontend/src/components/labelsets/detail/LabelSetDetailStyles.ts
@@ -518,9 +518,18 @@ export const LabelsSection = styled.div`
   gap: 20px;
 `;
 
+export const SearchToolbar = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  max-width: 600px;
+`;
+
 export const SearchContainer = styled.div`
   position: relative;
-  max-width: 400px;
+  flex: 1;
+  min-width: 0;
 `;
 
 export const SearchInput = styled.input`
@@ -760,6 +769,7 @@ export const AddLabelButton = styled.button`
   cursor: pointer;
   transition: all 0.15s ease;
   align-self: flex-start;
+  white-space: nowrap;
 
   &:hover {
     background: ${OS_LEGAL_COLORS.surfaceHover};

--- a/frontend/src/components/widgets/CRUD/LabelSetSelector.tsx
+++ b/frontend/src/components/widgets/CRUD/LabelSetSelector.tsx
@@ -29,7 +29,10 @@ interface LabelSetSelectorProps {
   read_only?: boolean;
   labelSet?: LabelSetType;
   style?: Record<string, any>;
-  onChange?: (values: any) => void;
+  onChange?: (values: {
+    labelSet: string | null;
+    labelSetObj?: LabelSetType;
+  }) => void;
   /** Open dropdown upward (useful when near bottom of container) */
   upward?: boolean;
 }
@@ -60,17 +63,24 @@ export const LabelSetSelector = ({
     refetch();
   }, [search_term, refetch]);
 
+  const items = data?.labelsets?.edges ?? [];
+
   const handleChange = (value: string | null) => {
     // If user has not actually changed the labelSet, do nothing:
     if (value === labelSet?.id) return;
 
     // If user explicitly clears, value === null => labelSet null
     // Otherwise labelSet is new value (the new labelSet.id).
-    onChange?.({ labelSet: value ?? null });
+    const selectedLabelSet = value
+      ? items.find((edge) => edge.node.id === value)?.node
+      : undefined;
+    onChange?.({
+      labelSet: value ?? null,
+      labelSetObj: selectedLabelSet,
+    });
   };
 
-  let items = data?.labelsets?.edges ? data.labelsets.edges : [];
-  let options = items.map((labelsetEdge) => {
+  const options = items.map((labelsetEdge) => {
     const node = labelsetEdge.node;
     return {
       value: node.id,

--- a/frontend/src/graphql/mutations.ts
+++ b/frontend/src/graphql/mutations.ts
@@ -1199,8 +1199,10 @@ export interface CreateAnnotationLabelForLabelsetInputs {
 }
 
 export interface CreateAnnotationLabelForLabelsetOutputs {
-  ok?: boolean;
-  message?: string;
+  createAnnotationLabelForLabelset?: {
+    ok?: boolean;
+    message?: string;
+  } | null;
 }
 
 export const CREATE_ANNOTATION_LABEL_FOR_LABELSET = gql`

--- a/frontend/tests/LabelSetDetailPage.coverage.ct.tsx
+++ b/frontend/tests/LabelSetDetailPage.coverage.ct.tsx
@@ -460,7 +460,7 @@ test.describe("LabelSetDetailPage – coverage", () => {
           readOnly: false,
           text: "Brand New Span",
           description: "",
-          color: "0F766E",
+          color: "#0F766E",
           myPermissions: ["READ", "UPDATE", "DELETE"],
           isPublic: false,
           analyzer: null,
@@ -477,7 +477,7 @@ test.describe("LabelSetDetailPage – coverage", () => {
           createLabelMock(LABELSET_ID, {
             text: "Brand New Span",
             description: "",
-            color: "0F766E",
+            color: "#0F766E",
             labelType: "SPAN_LABEL",
           }),
           ...labelsetQueryMocks(labelsetAfterCreate, 2),
@@ -504,6 +504,42 @@ test.describe("LabelSetDetailPage – coverage", () => {
         await expect(
           component.getByText("Brand New Span", { exact: true })
         ).toBeVisible({ timeout: 10000 });
+      }
+    );
+
+    test(
+      "keeps the create form open when the mutation reports failure",
+      { timeout: 25000 },
+      async ({ mount }) => {
+        const mocks: MockedResponse[] = [
+          ...labelsetQueryMocks(fullLabelset, 1),
+          createLabelMock(
+            LABELSET_ID,
+            {
+              text: "Rejected Label",
+              description: "",
+              color: "#0F766E",
+              labelType: "SPAN_LABEL",
+            },
+            false
+          ),
+        ];
+
+        const component = await mountPage(mount, mocks);
+        await expect(component.getByText("Coverage Label Set")).toBeVisible({
+          timeout: 10000,
+        });
+
+        await component.getByRole("button", { name: /Span Labels/i }).click();
+        await component.getByRole("button", { name: /Add Label/i }).click();
+        await component
+          .getByPlaceholder("Enter label name")
+          .fill("Rejected Label");
+        await component.getByTitle("Create").click();
+
+        await expect(
+          component.getByPlaceholder("Enter label name")
+        ).toHaveValue("Rejected Label");
       }
     );
   });

--- a/frontend/tests/LabelSetSelector.ct.tsx
+++ b/frontend/tests/LabelSetSelector.ct.tsx
@@ -74,6 +74,26 @@ test.describe("LabelSetSelector", () => {
     await component.unmount();
   });
 
+  test("returns the selected label set object to controlled consumers", async ({
+    mount,
+    page,
+  }) => {
+    const component = await mount(<LabelSetSelectorTestWrapper />);
+
+    await page.locator(".oc-dropdown__trigger").click();
+    await page
+      .locator(".oc-dropdown__option")
+      .filter({ hasText: "Financial Labels" })
+      .click();
+
+    await expect(component.getByTestId("selected-labelset")).toHaveText("ls-2");
+    await expect(page.locator(".oc-dropdown__value")).toContainText(
+      "Financial Labels"
+    );
+
+    await component.unmount();
+  });
+
   test("read-only mode disables dropdown", async ({ mount, page }) => {
     const component = await mount(
       <LabelSetSelectorTestWrapper read_only={true} />

--- a/frontend/tests/LabelSetSelectorTestWrapper.tsx
+++ b/frontend/tests/LabelSetSelectorTestWrapper.tsx
@@ -65,12 +65,10 @@ export const LabelSetSelectorTestWrapper: React.FC<WrapperProps> = ({
   const handleChange = (values: any) => {
     if (values.labelSet === null) {
       setSelectedLabelSet(undefined);
-    } else {
-      // Find the label set from the mock data to simulate a real selection
-      const found = labelsetNodes.find((ls) => ls.id === values.labelSet);
-      if (found) {
-        setSelectedLabelSet(found as unknown as LabelSetType);
-      }
+    } else if (values.labelSetObj) {
+      // Mirror CorpusModal: consumers need the selected object immediately so
+      // the controlled dropdown reflects the user's choice.
+      setSelectedLabelSet(values.labelSetObj);
     }
   };
 


### PR DESCRIPTION
## Summary

Fixes the misleading state and validation failures encountered while creating labels and assigning a label set during corpus creation.

Fixes #2295.

## Changes

- Normalize label colors to a backend-compatible `#RRGGBB` value while keeping native color inputs stable for stored values with or without `#`.
- Model and inspect the nested `createAnnotationLabelForLabelset` mutation payload, report backend failures accurately, and await refreshed label-set data before closing the create form.
- Keep **Add Label** beside search for populated text, document, relationship, and span label lists.
- Return the selected `LabelSetType` from `LabelSetSelector` so controlled consumers such as `CorpusModal` immediately display the user's selection.
- Add component-test coverage for rejected create mutations and controlled label-set selection.
- Add a `changelog.d` fragment.

## Test plan

- `NODE_OPTIONS=--max-old-space-size=4096 yarn build` via the frontend Docker builder — passed (TypeScript and Vite production build).
- Prettier check for all changed frontend and test files — passed.
- `python3 scripts/collate_changelog.py --check` — passed.
- Added focused Playwright component tests; the browser component suite was not executed locally.

## Checklist

- [ ] Tests pass locally for any code this PR touches (focused coverage added; browser component suite not run locally)
- [ ] `pre-commit run --all-files` passes (not run locally)
- [x] TypeScript compiles cleanly (`yarn build` or `yarn lint`), if frontend code changed
- [x] A changelog fragment was added under `changelog.d/` for the user-facing fixes
- [x] No new dependency was introduced

## Contributor License Agreement

By submitting this pull request, I agree to license this contribution under the project's [Contributor License Agreement](../CLA.md).
