### PR TITLE
Skip claude-review on fork PRs instead of failing

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,28 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Skip PRs whose head is a fork — this job cannot run there, so report
+    # "skipped" rather than a red X the contributor has no way to clear.
+    #
+    # GitHub clamps `pull_request` runs from forks: the `id-token: write`
+    # declared below is silently dropped and the secret store is withheld
+    # (`Secret source: None`). The action then fails with "Could not fetch an
+    # OIDC token. Did you remember to add `id-token: write` to your workflow
+    # permissions?", which accuses this file even though the permission is
+    # right there — see run 33611167884 on PR #2296. Approving the run does not
+    # help: that run was maintainer-approved and still got no secrets. And with
+    # GITHUB_TOKEN read-only on fork PRs, the `gh pr comment` below would fail
+    # even if authentication succeeded.
+    #
+    # Dependabot is unaffected: its branches live in this repository, so
+    # head.repo.full_name matches and the OIDC exchange works (run 33788653880).
+    #
+    # Do NOT switch this to pull_request_target to "fix" it. That runs in
+    # base-repo context with the OAuth secret and a write-capable token, while
+    # reviewing a PR means checking out untrusted head code. To review a fork
+    # PR, comment `@claude` on it instead: .github/workflows/claude.yml runs on
+    # issue_comment in base context and gates on the commenter's write access.
+    if: github.event.pull_request.head.repo.full_name == github.repository
 
     runs-on: ubuntu-latest
     permissions:

--- a/changelog.d/claude-review-fork-skip.fixed.md
+++ b/changelog.d/claude-review-fork-skip.fixed.md
@@ -1,0 +1,21 @@
+- **`claude-review` reported a red X on every fork PR that no contributor
+  could clear.** `.github/workflows/claude-code-review.yml` triggers on
+  `pull_request`, but GitHub clamps runs whose head is a fork: the declared
+  `id-token: write` is silently dropped and the secret store is withheld
+  (`Secret source: None`, `claude_code_oauth_token: ""`). The action failed
+  with *"Could not fetch an OIDC token. Did you remember to add `id-token:
+  write` to your workflow permissions?"* — an error that accuses the workflow
+  file even though the permission is declared on line 43, sending anyone who
+  debugs from the message alone to edit code that is already correct
+  (run 33611167884, PR #2296). Re-running with "Approve and run" does not
+  restore secrets, and `GITHUB_TOKEN` is read-only on fork PRs, so the
+  `gh pr comment` the job is asked to make could not have posted either — three
+  independent blockers, any one of them fatal. The job now carries
+  `if: github.event.pull_request.head.repo.full_name == github.repository`
+  and reports **skipped** on forks, which is what actually happened. Dependabot
+  is unaffected: its branches live in this repository, so the guard passes and
+  the OIDC exchange works as before (run 33788653880). The comment above the
+  guard records why `pull_request_target` is not the fix — it would put the
+  OAuth secret and a write-capable token in a job checking out untrusted head
+  code — and points at the `@claude` mention path in
+  `.github/workflows/claude.yml` for reviewing a fork PR on demand.


### PR DESCRIPTION
## Problem

`claude-review` fails on every fork-based PR, and the error message points at the wrong thing.

Observed on #2296 ([run 33611167884](https://github.com/Open-Source-Legal/OpenContracts/actions/runs/33611167884)):

```
##[error] Could not fetch an OIDC token.
          Did you remember to add `id-token: write` to your workflow permissions?
```

`.github/workflows/claude-code-review.yml` **does** declare `id-token: write`. GitHub dropped it, because the head repo is a fork. The effective grant on that run:

```
##[group]GITHUB_TOKEN Permissions
Contents: read   Issues: read   Metadata: read   PullRequests: read
Secret source: None
```

No `IdToken`, everything read-only, no secrets. Anyone debugging from the error text alone will go edit a file that is already correct.

## Three independent blockers, any one fatal

| # | Blocker | Evidence in run log |
|---|---------|---------------------|
| 1 | `id-token: write` downgraded → no OIDC | `ACTIONS_ID_TOKEN_REQUEST_URL` missing; 3 retries, all fail |
| 2 | Secret store withheld | `Secret source: None`, `"claude_code_oauth_token": ""` |
| 3 | `GITHUB_TOKEN` read-only | the prompt's `gh pr comment` could not post regardless |

Two things people assume will fix it, which don't:

- **"Approve and run."** That run is `run_attempt: 2, triggering_actor: JSv4` — already maintainer-approved — and still shows `Secret source: None`. Approval lets an untrusted workflow *start*; it does not hand it credentials.
- **A stale secret.** The dependabot run one day earlier ([33788653880](https://github.com/Open-Source-Legal/OpenContracts/actions/runs/33788653880)) shows the happy path end to end: `OIDC token successfully obtained` → `Exchanging OIDC token for app token...` → `App token successfully obtained` → `Using GITHUB_TOKEN from OIDC`. The secret is fine.

Across the last 40 runs of this workflow, every non-fork branch succeeds and the only two non-successes are the only two fork PRs (#2296 `failure`, and `fix/local-session-restoration` still sitting at `action_required`).

## Change

One line on the job, plus a comment recording why:

```yaml
if: github.event.pull_request.head.repo.full_name == github.repository
```

The job now reports **skipped** on fork PRs — which is accurate, it genuinely cannot run — instead of a red X the contributor has no way to clear and no fault in. Dependabot is unaffected: its branches live in this repository, so the guard passes and the OIDC exchange works exactly as before.

The commented-out "Optional: Filter by PR author" scaffolding it replaces is removed rather than left alongside.

## Why not `pull_request_target`

That's the obvious fix and it's a trap, so the comment in the workflow says so explicitly. `pull_request_target` runs in base-repo context with full secrets, OIDC and a write-capable token — and reviewing a PR means checking out the untrusted head. On a `frontend/` PR a single `yarn install` is postinstall RCE against the org's `CLAUDE_CODE_OAUTH_TOKEN`.

Even without code execution, the diff is attacker-controlled input the model reads. The action's own docs say it (`allowed_non_write_users`): *"Processing untrusted content exposes the workflow to prompt injection... best-effort scrub... reduces but does not eliminate."* The narrow `claude_args` allowlist (`gh` subcommands only) is what holds the line today; `pull_request_target` would pair injected text with a write-capable token.

To review a fork PR on demand, comment `@claude` on it — `.github/workflows/claude.yml` fires on `issue_comment`, which runs in base context with secrets intact, and the action gates on the *commenter's* write permission, so maintainers can invoke it and contributors can't.

## Scope

Only `claude-code-review.yml`. `CODECOV_TOKEN` is the other non-default secret in `.github/workflows/`, used by `backend.yml`, `frontend.yml`, `codecov-notify.yml` and the three `frontend-e2e-*.yml` files; those are untouched here and worth a separate look if fork PRs turn out to trip them too.

## Verification

- `pre-commit run --files .github/workflows/claude-code-review.yml changelog.d/claude-review-fork-skip.fixed.md` → all hooks pass (`check yaml`, `validate changelog fragments`).
- `yaml.safe_load` on the workflow parses; the guard lands on `jobs.claude-review.if` and `permissions` is unchanged.
- The guard's positive case is exercised by this PR itself: `claude-review` ran ([34009576994](https://github.com/Open-Source-Legal/OpenContracts/actions/runs/34009576994)) with `Secret source: Actions`, `OIDC token successfully obtained`, `Exchanging OIDC token for app token` — i.e. the `if:` evaluated true and the job reached the authenticated path. The negative case can only be exercised by an actual fork PR; #2296 will exercise it on its next sync after this merges.

### One thing this run surfaced that is *not* fixed here

That job reports **pass** without having reviewed anything:

```
##[warning] Skipping action due to workflow validation: Workflow validation failed.
            The workflow file must exist and have identical content to the version
            on the repository...
Action skipped due to workflow validation error.
Exiting due to workflow validation skip
outcome=success; conclusion=success
```

`claude-code-action` refuses to run when the PR modifies the workflow that invokes it — sensible, since a PR could otherwise rewrite the review prompt — but it exits **success**, not skipped. So **every PR touching `.github/workflows/` gets a green `claude-review` with no review behind it**, and nothing in the check name says so. Pre-existing upstream behavior, orthogonal to this change, and worth its own issue rather than scope creep here.
