### PR TITLE
fix(docker): exclude local state and .envs/ from the build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,7 +6,13 @@ venv/
 .venv/
 env/
 .env
-.envs/.local/
+# The WHOLE .envs/ tree, not just .local/. `.envs/.production/.django` is real
+# credential material on a developer's disk (untracked, ~60 assignments) plus a
+# CREDENTIALS.md — excluding only .local/ baked those into the production image.
+# Nothing inside the image reads .envs/: compose consumes it host-side via
+# `env_file:`, and the k8s pods get config from the Secret Manager CSI mount at
+# /var/secrets/django/.env.
+.envs/
 .vscode/
 .idea/
 
@@ -15,16 +21,21 @@ env/
 .gitignore
 .github/
 
-# Python build artefacts and caches
-__pycache__/
-*.py[cod]
-*.egg-info/
-.pytest_cache/
-.mypy_cache/
-.ruff_cache/
+# Python build artefacts and caches.
+# NOTE: .dockerignore patterns are matched against the full path relative to
+# the context root and do NOT recurse implicitly the way .gitignore does — a
+# bare `__pycache__/` excludes only the one at the root. The `**/` prefix is
+# what catches the ~70 nested cache dirs under opencontractserver/ and config/.
+**/__pycache__/
+**/*.py[cod]
+**/*.egg-info/
+**/.pytest_cache/
+**/.mypy_cache/
+**/.ruff_cache/
 .tox/
 .coverage
 .coverage.*
+coverage.xml
 htmlcov/
 
 # Frontend has its own image
@@ -56,6 +67,18 @@ static/
 site/
 .ipython/
 
+# Local scratch corpora, fetch caches, and pilot data. These are all gitignored
+# developer state, but .dockerignore is independent of .gitignore — without
+# these entries `COPY .` uploads them to the daemon and bakes them into the
+# production image (~13GB as of 2026-09, dominated by .pilot_data/).
+# `.authority_packs*` deliberately covers the live cache, the _test/ variant,
+# and any ad-hoc `.pre-native-backup`-style copies left on disk.
+.pilot_data/
+.authority_packs*
+.eval_extract/
+demo/
+imports/
+
 # Top-level docs (CHANGELOG.md is intentionally retained)
 README.md
 CLAUDE.md
@@ -64,3 +87,7 @@ CLAUDE.md
 .pre-commit-config.yaml
 .cursor/
 .claude/
+.claire/
+.playwright-mcp/
+node_modules/
+screenshots/


### PR DESCRIPTION
## What

`.dockerignore` had drifted well behind `.gitignore`. The Django image builds with `.` as its context and ends in `COPY . ${APP_HOME}`, so everything not excluded is uploaded to the daemon **and baked into the production image**. Found while cutting a release.

**Build context: ~13.3 GB → 34.7 MB.**

## Three separate problems

**1. Local scratch corpora and fetch caches were never excluded.**

| Path | Size |
|---|---|
| `.pilot_data/` | 13 GB |
| `.eval_extract/` | 164 MB |
| `demo/` | 103 MB |
| `.authority_packs*` | 72 MB |

All gitignored — but `.dockerignore` doesn't inherit from `.gitignore`, so that bought nothing.

**2. `.envs/` was only excluded at `.envs/.local/`.** That left `.envs/.production/.django` (real credential material on a developer's disk, ~60 assignments) and `.envs/.production/CREDENTIALS.md` shipping inside the image.

Nothing in the image reads `.envs/` — compose consumes it host-side via `env_file:`, and the k8s pods take config from the Secret Manager CSI mount at `/var/secrets/django/.env`. Now excluding the whole tree.

**3. The cache patterns only ever matched the repo root.** `.dockerignore` patterns match the full path relative to the context root and do **not** recurse the way `.gitignore` does, so a bare `__pycache__/` never touched the ~70 nested cache dirs under `opencontractserver/` and `config/`. Switched to `**/` form, with a comment so it doesn't regress.

Also excludes `node_modules/`, `.playwright-mcp/`, `.claire/`, `screenshots/`, `coverage.xml`.

## Verification

Built a probe image against the real build context rather than reasoning about the patterns:

- `manage.py` present
- all **1590** `.py` files present
- `config/`, `compose/`, `requirements/`, `scripts/`, `changelog.d/`, `conftest.py` all present
- `.envs/` absent
- context 34.7 MB

Also confirmed `compose/production/django/Dockerfile` references none of the newly-excluded paths — its only `COPY`s are `./requirements`, `./compose/production/django/*`, and `.`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XDryg5VKqXJsRHgyqPJFLw