### PR TITLE
Support shared PDF, DOCX and TXT parsers in remote workers

### DIFF
--- a/changelog.d/2316-remote-parsers.added.md
+++ b/changelog.d/2316-remote-parsers.added.md
@@ -1,0 +1,1 @@
+- Remote ingest supports Docling or Warp PDF parsing, Docxodus DOCX parsing, and TXT chunking through shared database-independent adapters, with validated local settings, canonical MIME routing, accurate parser provenance, and preserved span annotations and structural links.

--- a/config/settings/remote_worker.py
+++ b/config/settings/remote_worker.py
@@ -1,36 +1,17 @@
-"""
-Django settings for the remote-ingest worker (``scripts/remote_ingest``).
+"""Import the application parsers without a database or Redis service.
 
-The remote worker runs the OpenContracts parsing pipeline (DoclingParser) on a
-beefy off-cluster host and streams finished documents to a target instance via
-the worker-upload REST API. It NEVER touches the target's database — it only
-needs Django importable so the real parser code (and its model imports) loads.
-
-To keep the remote host dependency-free (no Postgres, no Redis), this module
-points ``DATABASE_URL`` at a throwaway SQLite file. No migrations are run, so the
-tables do not exist — but the only DB access on the parse path is
-``PipelineComponentBase._load_settings`` querying ``PipelineSettings``, which
-catches the resulting error and falls back to dataclass defaults + the
-``DOCLING_*`` / ``EMBEDDINGS_*`` environment variables. The parse itself
-(``DoclingParser.parse_pdf_bytes``) is entirely database-free.
-
-If a deployment prefers a real database (e.g. to pin parser settings via the
-``PipelineSettings`` table), point ``DATABASE_URL`` at any reachable Postgres —
-this module's only job is to provide safe defaults so Django boots without one.
+Parser settings are explicit worker-local snapshots, loaded from component
+schemas by scripts.remote_ingest.parsers. Target PipelineSettings are never read.
+The dummy backend also prevents an inherited DATABASE_URL from enabling queries.
 """
 
 import os
 
-# These MUST be set before importing base.py: base reads ``DATABASE_URL`` via
-# ``env.db(...)`` (no default) at import time. A throwaway SQLite path keeps the
-# remote host free of any database service.
+# base.py requires a DATABASE_URL during import; replace its backend below.
 os.environ.setdefault("DATABASE_URL", "sqlite:////tmp/oc_remote_worker.sqlite3")
 os.environ.setdefault("DJANGO_SECRET_KEY", "remote-worker-not-a-secret-no-web-surface")
 
 from .base import *  # noqa: E402,F401,F403
 
-# The worker exposes no web/admin surface, runs no Celery, serves no requests.
 DEBUG = False
-
-# Belt-and-suspenders: never run ATOMIC_REQUESTS against the placeholder DB.
-DATABASES["default"]["ATOMIC_REQUESTS"] = False  # noqa: F405
+DATABASES = {"default": {"ENGINE": "django.db.backends.dummy"}}

--- a/docs/upload_methods/remote_ingest_worker.md
+++ b/docs/upload_methods/remote_ingest_worker.md
@@ -1,7 +1,7 @@
 # Remote Ingest Worker
 
 The remote ingest worker runs the **full OpenContracts ingestion pipeline**
-(Docling parse + embeddings) on a beefy off-cluster host and streams the
+(PDF/DOCX/TXT parsing + embeddings) on a beefy off-cluster host and streams the
 finished documents -- PAWLs token layer, text layer, structural annotations,
 relationships, embeddings, and any metadata you calculate -- into a corpus via
 the [Worker Uploads](worker_uploads.md) REST API.
@@ -37,10 +37,8 @@ ingest worker when you want to throw your own hardware at ingestion.
 
 ## Faithful by Construction
 
-The worker runs the **same Docling microservice image** and the **same
-`DoclingParser` code** the server runs, and embeds against the **same
-vector-embedder image**. So the result is indistinguishable from an in-cluster
-ingestion:
+The worker uses the same parser adapters as the server. Equivalent local
+settings, service versions and source metadata preserve the parsing result:
 
 - **PAWLs token layer** -- identical tokenization (no drift); the worker-upload
   path trusts these tokens verbatim.
@@ -51,17 +49,17 @@ ingestion:
   relationships exactly as in-cluster ingestion does.
 - **Embeddings** -- same model, same inputs (full text for the document,
   `rawText` per annotation).
-- **Thumbnail** -- regenerated server-side from the uploaded PDF.
+- **Thumbnail** -- regenerated server-side from the uploaded source document (asynchronously).
 
 ## How It Works
 
-A small **docker-compose bundle** runs on the remote host: the Docling parser
-microservice, the vector embedder microservice, and a worker driver. The driver
+A small **docker-compose bundle** runs on the remote host: the selected parser
+services, an optional vector embedder, and a worker driver. The driver
 is a resumable, per-document CLI:
 
-1. `plan` scans the PDF tree into a SQLite ledger.
-2. `run` parses each PDF (real `DoclingParser`), runs your enrichers, computes
-   embeddings, and `POST`s a `multipart/form-data` payload (PDF + metadata JSON)
+1. `plan` scans selected extensions into a SQLite ledger.
+2. `run` detects MIME, selects the configured parser, runs your enrichers, computes
+   embeddings, and `POST`s a `multipart/form-data` payload (source + metadata JSON)
    to `/api/worker-uploads/documents/` with `Authorization: WorkerKey <token>`.
 3. `verify` polls the target for each upload's terminal status.
 
@@ -70,6 +68,82 @@ workers, and paces itself against the target's worker-upload backlog. The ledger
 makes the whole run crash-resumable -- re-running `run` skips finished documents.
 The worker needs **no database access** to the target: it only makes outbound
 HTTPS calls to the worker-upload endpoint.
+
+## Parser selection and local settings
+
+Without a configuration file, the worker selects **Docling for PDF only**.
+To enable PDF, DOCX and TXT, use the bundled
+[`parser-config.example.json`](../../scripts/remote_ingest/parser-config.example.json):
+
+```bash
+export OC_PARSER_CONFIG=/app/scripts/remote_ingest/parser-config.example.json
+# Start the services selected in that file, plus the optional embedder:
+docker compose -f remote_worker.yml up -d docling-parser docxodus-parser vector-embedder
+docker compose -f remote_worker.yml run --rm worker plan --extensions .pdf,.docx,.txt
+docker compose -f remote_worker.yml run --rm worker run
+```
+
+`--parser-config /path/to/config.json` overrides `OC_PARSER_CONFIG`. Paths must
+be visible inside the worker container. The file contains a `parsers` object
+mapping canonical MIME types to component names/class paths, and an optional
+`settings` object keyed by **full selected class path**. The example uses
+paragraph chunking; remove that override to use TXT's normal sentence default.
+A custom mapping replaces the default mapping, so a TXT-only worker needs no
+PDF parser configuration or service.
+
+| Input MIME | Supported component (under `opencontractserver.pipeline.parsers`) | Dependency |
+|---|---|---|
+| `application/pdf` | `docling_parser_rest.DoclingParser` | Docling service; `DOCLING_PARSER_SERVICE_URL` required |
+| `application/pdf` | `warp_ingest_parser.WarpIngestParser` | Warp-Ingest service; `WARP_INGEST_API_KEY` required |
+| `application/vnd.openxmlformats-officedocument.wordprocessingml.document` | `docxodus_parser.DocxodusServiceParser` | Docxodus service matching the frontend library version |
+| `text/plain` (also `application/txt`) | `oc_text_parser.TxtParser` | No service; sentence chunking needs spaCy and its configured model |
+
+To use Warp, replace the PDF mapping with
+`opencontractserver.pipeline.parsers.warp_ingest_parser.WarpIngestParser` and
+start `warp-ingest` instead of `docling-parser`. The bundle wires the same
+`WARP_INGEST_API_KEY` to both service and worker. Docxodus/Warp are optional
+Compose services; `worker` starts no parser services automatically. For
+`--no-embeddings`, the vector embedder can also be omitted.
+
+Settings precedence is **schema defaults < declared environment variables <
+JSON settings**. All selected parsers are resolved through the application
+component lookup, checked against `supported_file_types`, and configured before
+processing documents. Unknown fields, invalid types, missing required values
+(including secrets), invalid chunk recipes, and conflicting Warp OCR flags fail
+startup. Field diagnostics omit values. Use environment variables for credentials;
+never commit them in configuration files. To pass additional schema environment
+variables through Compose, use `docker compose run -e NAME=value ...` or a local
+Compose override; JSON also supports settings without an `env_var`, such as TXT
+`chunkers` and Docling `use_cloud_run_iam_auth`.
+
+These are **local settings**, independent of the target instance's admin/GUI
+`PipelineSettings`. Equivalent source metadata, effective settings and service
+versions use the same server/remote parsing and normalization methods. The
+worker never fetches target settings. The extension list only filters discovery:
+bytes are checked by the application's upload MIME detector, so renaming a PDF
+to `.txt` still selects PDF. Unsupported/undetectable content or an unmapped MIME
+fails before upload; the source MIME supplies both multipart and metadata types.
+
+PDF retains PAWLS/token annotations and rebuilds `content` using the normal
+PAWLS translation layer. Token page references index the PAWLS array; legacy
+Docling page metadata can be one-based and is preserved. DOCX retains parser
+content and character offsets. TXT
+uses UTF-8 text with universal newline handling, matching text-mode storage
+reads. Missing DOCX/TXT annotation types default to `SPAN_LABEL` on both worker
+and target. Docxodus container `rawText` remains its heading (possibly empty); the shared
+normalizer puts the exact covered section text in `annotation_json.text`.
+Spans must match that field (or `rawText` for TXT), token references must resolve, and
+annotation IDs, parents and relationship endpoints are checked before upload.
+TXT emits stable `txt-N` IDs; other parser IDs are preserved.
+
+`parser_name` is the selected component's title. `parser_version="1.0"` preserves
+the normal structural-set provenance convention: it is **not a discovered
+service/model version**. `LocalParsers.identity(mime)` exposes a defensive copy
+of the class path and effective settings for future preparation fingerprints.
+That in-memory snapshot includes secrets: do not log or persist it. Callers may
+supply different title/description envelopes; PDF `content` is reconstructed
+exactly as normal persistence does. Preparation caching, settings synchronization,
+file conversion, and embedding/completion validation are separate work.
 
 ## Setup
 

--- a/opencontractserver/pipeline/base/base_component.py
+++ b/opencontractserver/pipeline/base/base_component.py
@@ -71,7 +71,9 @@ class PipelineComponentBase(ABC):
         {}
     )  # If you want user to provide inputs, define a jsonschema here
 
-    def __init__(self, **kwargs):
+    def __init__(
+        self, *, component_settings: Optional[dict[str, Any]] = None, **kwargs
+    ):
         """
         Initialize the PipelineComponentBase.
 
@@ -79,6 +81,8 @@ class PipelineComponentBase(ABC):
         component has a Settings dataclass defined.
 
         Args:
+            component_settings: Explicit local settings snapshot. When supplied
+                (including an empty dict), never load settings from the database.
             **kwargs: Passed to superclass constructors in MRO.
         """
         super().__init__()  # Ensures MRO is handled correctly
@@ -87,9 +91,12 @@ class PipelineComponentBase(ABC):
         # Full DB settings (including decrypted secrets) are loaded at most once
         # per component instance. ``None`` distinguishes "not loaded" from a
         # successfully loaded empty mapping.
-        self._component_settings_cache: Optional[dict[str, Any]] = None
+        self._local_component_settings = deepcopy(component_settings)
+        self._component_settings_cache = deepcopy(component_settings)
         # Load settings (will be None if no Settings dataclass)
-        self._settings: Optional[Any] = self._load_settings()
+        self._settings: Optional[Any] = self._load_settings(
+            strict=component_settings is not None
+        )
 
     @property
     def settings(self) -> Optional[Any]:
@@ -172,7 +179,7 @@ class PipelineComponentBase(ABC):
         Returns:
             The reloaded Settings dataclass instance.
         """
-        self._component_settings_cache = None
+        self._component_settings_cache = deepcopy(self._local_component_settings)
         self._settings = self._load_settings(strict=strict)
         return self._settings
 

--- a/opencontractserver/pipeline/base/parser.py
+++ b/opencontractserver/pipeline/base/parser.py
@@ -201,21 +201,20 @@ class BaseParser(PipelineComponentBase, ABC):
 
         # Handle PAWLS content if any
         pawls_file_content = open_contracts_data.get("pawls_file_content")
+        document.page_count = open_contracts_data.get("page_count", 1)
         if pawls_file_content:
             compact_data = compact_pawls_pages(pawls_file_content)
             pawls_string = json.dumps(compact_data)
             pawls_file = ContentFile(pawls_string.encode("utf-8"))
             document.pawls_parse_file.save(f"doc_{doc_id}.pawls", pawls_file)
 
-            # Create text layer from PAWLS tokens (use original v1 data)
-            span_translation_layer = build_translation_layer(pawls_file_content)
-            # Optionally overwrite txt_extract_file with text from PAWLS
-            txt_file = ContentFile(span_translation_layer.doc_text.encode("utf-8"))
-            document.txt_extract_file.save(f"doc_{doc_id}.txt", txt_file)
-            document.page_count = len(pawls_file_content)
-        else:
-            # Handle cases without PAWLS content
-            document.page_count = open_contracts_data.get("page_count", 1)
+            # DOCX can also include display PAWLS, but character spans anchor
+            # to parser content. Reconstruct only the PDF text layer.
+            if document.file_type in (FileTypeEnum.PDF, FileTypeEnum.PDF.mimetype):
+                span_translation_layer = build_translation_layer(pawls_file_content)
+                txt_file = ContentFile(span_translation_layer.doc_text.encode("utf-8"))
+                document.txt_extract_file.save(f"doc_{doc_id}.txt", txt_file)
+                document.page_count = len(pawls_file_content)
 
         document.save()
 

--- a/opencontractserver/pipeline/parsers/docling_parser_rest.py
+++ b/opencontractserver/pipeline/parsers/docling_parser_rest.py
@@ -266,9 +266,9 @@ class DoclingParser(BaseChunkedParser):
             },
         )
 
-    def __init__(self):
+    def __init__(self, **kwargs):
         """Initialize the Docling REST parser with settings from PipelineSettings."""
-        super().__init__()  # Loads settings via PipelineComponentBase
+        super().__init__(**kwargs)  # Loads settings via PipelineComponentBase
 
         # Access settings via the settings property (populated from PipelineSettings DB)
         # Use dataclass defaults if settings not yet loaded from database

--- a/opencontractserver/pipeline/parsers/docxodus_parser.py
+++ b/opencontractserver/pipeline/parsers/docxodus_parser.py
@@ -83,9 +83,9 @@ class DocxodusServiceParser(BaseParser):
             },
         )
 
-    def __init__(self):
+    def __init__(self, **kwargs):
         """Initialize the Docxodus REST parser with settings from PipelineSettings."""
-        super().__init__()
+        super().__init__(**kwargs)
         s = self.settings if self.settings is not None else self.Settings()
         self.service_url = s.service_url
         self.request_timeout = s.request_timeout
@@ -126,6 +126,14 @@ class DocxodusServiceParser(BaseParser):
         with default_storage.open(document.pdf_file.name, "rb") as f:
             docx_bytes = f.read()
 
+        return self.parse_docx_bytes(
+            docx_bytes, title=document.title or "", doc_id=doc_id
+        )
+
+    def parse_docx_bytes(
+        self, docx_bytes: bytes, *, title: str = "", doc_id: int = 0
+    ) -> OpenContractDocExport:
+        """Parse raw DOCX bytes using the same service normalization as ingestion."""
         # Reject files exceeding the configured size limit
         file_size_mb = len(docx_bytes) / (1024 * 1024)
         if file_size_mb > self.max_file_size_mb:
@@ -140,7 +148,7 @@ class DocxodusServiceParser(BaseParser):
         docx_base64 = base64.b64encode(docx_bytes).decode("utf-8")
 
         payload: dict[str, Any] = {
-            "filename": document.title or f"doc_{doc_id}.docx",
+            "filename": title or f"doc_{doc_id}.docx",
             "docx_base64": docx_base64,
         }
 
@@ -257,6 +265,26 @@ class DocxodusServiceParser(BaseParser):
                 DocxodusServiceParser._normalize_annotation(ann)
                 for ann in normalized["labelled_text"]
             ]
+            # Container rawText is a heading (or empty for an untitled section),
+            # while its span covers its children too. Keep that service text,
+            # but expose the exact covered text in the documented span field.
+            parent_ids = {
+                ann.get("parent_id")
+                for ann in normalized["labelled_text"]
+                if ann.get("parent_id") is not None
+            }
+            content = normalized["content"]
+            for ann in normalized["labelled_text"]:
+                span = ann.get("annotation_json")
+                if ann.get("id") in parent_ids and isinstance(span, dict):
+                    start, end = span.get("start"), span.get("end")
+                    if (
+                        isinstance(content, str)
+                        and type(start) is int
+                        and type(end) is int
+                        and 0 <= start <= end <= len(content)
+                    ):
+                        ann["annotation_json"] = {**span, "text": content[start:end]}
 
         # Normalize relationship fields
         if "relationships" in normalized:

--- a/opencontractserver/pipeline/parsers/oc_text_parser.py
+++ b/opencontractserver/pipeline/parsers/oc_text_parser.py
@@ -87,9 +87,9 @@ class TxtParser(BaseParser):
             },
         )
 
-    def __init__(self) -> None:
+    def __init__(self, **kwargs) -> None:
         """Initialise the parser. Chunker instantiation is deferred to parse time."""
-        super().__init__()
+        super().__init__(**kwargs)
 
     def _resolve_chunkers(
         self, override: Optional[list[ChunkerSpec]] = None
@@ -148,6 +148,24 @@ class TxtParser(BaseParser):
         with default_storage.open(txt_path, mode="r") as txt_file:
             text_content = txt_file.read()
 
+        return self.parse_text(
+            text_content,
+            title=document.title or "",
+            description=document.description or "",
+            doc_id=doc_id,
+            **all_kwargs,
+        )
+
+    def parse_text(
+        self,
+        text_content: str,
+        *,
+        title: str = "",
+        description: str = "",
+        doc_id: int = 0,
+        **all_kwargs,
+    ) -> OpenContractDocExport:
+        """Parse decoded text without storage or database access; preserve offsets."""
         chunker_override = all_kwargs.get("chunkers")
         if chunker_override is not None and not isinstance(chunker_override, list):
             raise TypeError(
@@ -163,9 +181,9 @@ class TxtParser(BaseParser):
         # Base envelope shared across strategies. Labels and annotations
         # are filled in as we iterate the chunkers.
         open_contracts_data: OpenContractDocExport = {
-            "title": document.title or "",
+            "title": title or "",
             "content": text_content,
-            "description": document.description or "",
+            "description": description or "",
             "pawls_file_content": [],  # No PAWLS data for plain text
             "page_count": 1,  # Single page
             "doc_labels": [],
@@ -182,7 +200,9 @@ class TxtParser(BaseParser):
                 if label_name not in text_labels:
                     text_labels[label_name] = _make_label(label_name)
 
-                labelled_text.append(_annotation_for_chunk(chunk, label_name))
+                annotation = _annotation_for_chunk(chunk, label_name)
+                annotation["id"] = f"txt-{len(labelled_text)}"
+                labelled_text.append(annotation)
                 chunks_produced += 1
 
             logger.debug(

--- a/opencontractserver/pipeline/parsers/warp_ingest_parser.py
+++ b/opencontractserver/pipeline/parsers/warp_ingest_parser.py
@@ -184,9 +184,9 @@ class WarpIngestParser(BaseParser):
             },
         )
 
-    def __init__(self):
+    def __init__(self, **kwargs):
         """Initialize the Warp-Ingest REST parser with settings from PipelineSettings."""
-        super().__init__()  # Loads settings via PipelineComponentBase
+        super().__init__(**kwargs)  # Loads settings via PipelineComponentBase
         s = self.settings if self.settings is not None else self.Settings()
 
         self.service_url = s.service_url
@@ -236,21 +236,6 @@ class WarpIngestParser(BaseParser):
                 is_transient=False,
             )
 
-        # Resolve per-call overrides on top of the component settings.
-        apply_ocr = all_kwargs.get("apply_ocr", self.apply_ocr)
-        disable_ocr = all_kwargs.get("disable_ocr", self.disable_ocr)
-        semantic_units = all_kwargs.get("semantic_units", self.semantic_units)
-        include_images = all_kwargs.get("include_images", self.include_images)
-
-        # Warp-Ingest returns 422 when both are set; fail fast with a clear,
-        # non-transient message instead of round-tripping to the service.
-        if apply_ocr and disable_ocr:
-            raise DocumentParsingError(
-                f"WarpIngestParser misconfigured for document {doc_id}: "
-                "apply_ocr and disable_ocr are mutually exclusive.",
-                is_transient=False,
-            )
-
         # Guard peak worker memory: the whole PDF is buffered in memory and
         # POSTed in one request (no chunking), so reject oversized files using
         # the storage size metadata *before* reading the bytes in — an
@@ -267,9 +252,39 @@ class WarpIngestParser(BaseParser):
         with default_storage.open(document.pdf_file.name, "rb") as f:
             pdf_bytes = f.read()
 
+        return self.parse_pdf_bytes(
+            pdf_bytes, title=document.title or "", doc_id=doc_id, **all_kwargs
+        )
+
+    def parse_pdf_bytes(
+        self, pdf_bytes: bytes, *, title: str = "", doc_id: int = 0, **all_kwargs
+    ) -> OpenContractDocExport:
+        """Parse raw PDF bytes without reading a Document or storage fields."""
+        # Resolve per-call overrides on top of the component settings.
+        apply_ocr = all_kwargs.get("apply_ocr", self.apply_ocr)
+        disable_ocr = all_kwargs.get("disable_ocr", self.disable_ocr)
+        semantic_units = all_kwargs.get("semantic_units", self.semantic_units)
+        include_images = all_kwargs.get("include_images", self.include_images)
+
+        # Warp-Ingest returns 422 when both are set; fail fast with a clear,
+        # non-transient message instead of round-tripping to the service.
+        if apply_ocr and disable_ocr:
+            raise DocumentParsingError(
+                f"WarpIngestParser misconfigured for document {doc_id}: "
+                "apply_ocr and disable_ocr are mutually exclusive.",
+                is_transient=False,
+            )
+
+        if len(pdf_bytes) > self.max_file_size_mb * 1024 * 1024:
+            raise DocumentParsingError(
+                f"PDF exceeds the {self.max_file_size_mb} MB Warp-Ingest limit. "
+                "Adjust WARP_INGEST_MAX_FILE_SIZE_MB to raise it.",
+                is_transient=False,
+            )
+
         # A ``.pdf`` filename + explicit content type satisfy Warp-Ingest's
         # media-type check (it returns 415 for non-PDF uploads).
-        filename = self._safe_pdf_filename(document.title, doc_id)
+        filename = self._safe_pdf_filename(title, doc_id)
 
         params = {
             "render_format": WARP_INGEST_RENDER_FORMAT,

--- a/opencontractserver/tests/test_doc_parser_docxodus.py
+++ b/opencontractserver/tests/test_doc_parser_docxodus.py
@@ -1,6 +1,7 @@
 import io
 import json
 import zipfile
+from typing import cast
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
@@ -12,6 +13,7 @@ from requests.exceptions import ConnectionError, Timeout
 from opencontractserver.documents.models import Document
 from opencontractserver.pipeline.base.exceptions import DocumentParsingError
 from opencontractserver.pipeline.parsers.docxodus_parser import DocxodusServiceParser
+from opencontractserver.types.dicts import OpenContractDocExport
 
 User = get_user_model()
 
@@ -113,6 +115,23 @@ class TestDocxodusServiceParser(TestCase):
             ],
             "relationships": [],
         }
+
+    def test_save_preserves_content_when_docx_includes_display_pawls(self):
+        from opencontractserver.tests.test_doc_parser_warp_ingest import _sample_export
+
+        export = DocxodusServiceParser._normalize_response(self.sample_response)
+        export["content"] = "Hello World\n"
+        export["pawls_file_content"] = _sample_export()["pawls_file_content"]
+        parser = DocxodusServiceParser()
+        with patch(
+            "opencontractserver.tasks.embeddings_task.calculate_embeddings_for_annotation_batch.delay"
+        ):
+            parser.save_parsed_data(
+                self.user.pk, self.doc.pk, cast(OpenContractDocExport, export)
+            )
+        self.doc.refresh_from_db()
+        with self.doc.txt_extract_file.open("r") as content:
+            self.assertEqual(content.read(), "Hello World\n")
 
     @patch("opencontractserver.pipeline.parsers.docxodus_parser.requests.post")
     def test_parse_document_success(self, mock_post):

--- a/opencontractserver/tests/test_remote_ingest_parsers.py
+++ b/opencontractserver/tests/test_remote_ingest_parsers.py
@@ -1,0 +1,628 @@
+"""Remote parsing parity and wire contracts; all these tests forbid database access."""
+
+import json
+import os
+from copy import deepcopy
+from dataclasses import dataclass, field
+from io import BytesIO, StringIO
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import Mock, patch
+
+from django.test import SimpleTestCase
+from plasmapdf.models.PdfDataLayer import build_translation_layer
+from pypdf import PdfWriter
+
+from opencontractserver.pipeline.base.base_component import PipelineComponentBase
+from opencontractserver.pipeline.base.file_types import FileTypeEnum
+from opencontractserver.pipeline.base.settings_schema import (
+    PipelineSetting,
+    SettingType,
+)
+from opencontractserver.pipeline.utils import get_component_by_name
+from opencontractserver.tests.test_doc_parser_docxodus import make_minimal_docx
+from opencontractserver.tests.test_doc_parser_warp_ingest import _sample_export
+from scripts.remote_ingest import oc_remote_ingest as cli
+from scripts.remote_ingest.parsers import (
+    DOCLING,
+    DOCXODUS,
+    TXT,
+    WARP,
+    LocalParsers,
+    canonical_mime,
+    local_settings,
+    normalize_and_validate_export,
+)
+
+PDF = FileTypeEnum.PDF.mimetype
+DOCX = FileTypeEnum.DOCX.mimetype
+TEXT = FileTypeEnum.TXT.mimetype
+
+
+def worker_config(**overrides) -> cli.Config:
+    values: dict[str, Any] = dict(
+        target_url="https://target",
+        worker_token="secret",
+        corpus_id=None,
+        root_dir="/tmp",
+        ledger_path="/tmp/ledger",
+        extensions=(".pdf",),
+        max_workers=1,
+        max_attempts=1,
+        queue_high=0,
+        queue_low=0,
+        embeddings=False,
+        target_folder_from_tree=True,
+        verify_tls=True,
+        limit=0,
+        enrichers=[],
+    )
+    values.update(overrides)
+    return cli.Config(**values)
+
+
+def span_export():
+    return {
+        "content": "Heading\nBody paragraph.",
+        "page_count": 1,
+        "pawls_file_content": [],
+        "file_type": DOCX,
+        "labelled_text": [
+            {
+                "id": "heading",
+                "annotationLabel": "Heading",
+                "rawText": "Heading",
+                "annotation_json": {"start": 0, "end": 7},
+                "structural": True,
+            },
+            {
+                "id": "body",
+                "parent_id": "heading",
+                "annotationLabel": "Paragraph",
+                "rawText": "Body paragraph.",
+                "annotation_json": {"start": 8, "end": 23},
+                "structural": True,
+            },
+        ],
+        "relationships": [
+            {
+                "relationshipLabel": "contains",
+                "source_annotation_ids": ["heading"],
+                "target_annotation_ids": ["body"],
+            }
+        ],
+    }
+
+
+def pdf_bytes():
+    writer = PdfWriter()
+    writer.add_blank_page(width=612, height=792)
+    stream = BytesIO()
+    writer.write(stream)
+    return stream.getvalue()
+
+
+class RemoteParserTests(SimpleTestCase):
+    def setUp(self):
+        self.tmp = TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.config_path = Path(self.tmp.name) / "parsers.json"
+        self.env = patch.dict(os.environ, {}, clear=True)
+        self.env.start()
+        self.addCleanup(self.env.stop)
+        self.db_settings = patch(
+            "opencontractserver.documents.models.PipelineSettings.get_instance"
+        )
+        self.get_settings = self.db_settings.start()
+        self.addCleanup(self.db_settings.stop)
+
+    def tearDown(self):
+        # Merely catching an ORM failure and falling back is not database independence.
+        self.get_settings.assert_not_called()
+
+    def router(self, mapping, settings=None):
+        self.config_path.write_text(
+            json.dumps({"parsers": mapping, "settings": settings or {}})
+        )
+        return LocalParsers(str(self.config_path))
+
+    def test_canonical_mimes(self):
+        for raw, expected in [
+            (PDF, PDF),
+            (DOCX, DOCX),
+            (TEXT, TEXT),
+            ("application/txt", TEXT),
+            ("TEXT/PLAIN; charset=utf-8", TEXT),
+        ]:
+            self.assertEqual(canonical_mime(raw), expected)
+        for unsupported in [None, "pdf", "application/zip", "text/markdown"]:
+            with self.assertRaisesRegex(ValueError, "Unsupported source MIME"):
+                canonical_mime(unsupported)
+
+    def test_routing_errors_fail_at_startup(self):
+        cases = [
+            ({PDF: "missing_parser"}, "not found"),
+            ({PDF: TXT}, "does not support"),
+            ({PDF: DOCLING}, "service_url is required"),
+            ({PDF: WARP}, "api_key is required"),
+            ({TEXT: TXT, "application/txt": TXT}, "Duplicate parser mapping"),
+        ]
+        for mapping, message in cases:
+            with self.subTest(mapping=mapping), self.assertRaisesRegex(
+                ValueError, message
+            ):
+                self.router(mapping)
+
+    def test_settings_coercion_precedence_and_snapshot(self):
+        with patch.dict(
+            os.environ,
+            {
+                "WARP_INGEST_API_KEY": "private-key",
+                "WARP_INGEST_PARSER_TIMEOUT": "70",
+                "WARP_INGEST_DISABLE_OCR": "yes",
+            },
+        ):
+            router = self.router({PDF: WARP}, {WARP: {"request_timeout": "90"}})
+        identity = router.identity(PDF)
+        self.assertEqual(identity["settings"]["request_timeout"], 90)
+        self.assertIs(identity["settings"]["disable_ocr"], True)
+        self.assertEqual(identity["parser_name"], "Warp-Ingest Parser (REST)")
+        self.assertEqual(identity["parser_version"], "1.0")
+        identity["settings"]["api_key"] = "changed"
+        self.assertEqual(router.identity(PDF)["settings"]["api_key"], "private-key")
+        parser, _ = router.parsers[PDF]
+        parser.reload_settings()
+        self.assertEqual(parser.settings.api_key, "private-key")
+
+    def test_invalid_settings_do_not_echo_values(self):
+        for setting, value in [
+            ("request_timeout", "secret-value"),
+            ("disable_ocr", "secret-value"),
+            ("request_timeout", -1),
+        ]:
+            with self.subTest(setting=setting), self.assertRaises(ValueError) as caught:
+                self.router(
+                    {PDF: WARP}, {WARP: {"api_key": "private-key", setting: value}}
+                )
+            self.assertNotIn("secret-value", str(caught.exception))
+            self.assertNotIn("private-key", str(caught.exception))
+        with self.assertRaisesRegex(ValueError, "declared schema"):
+            self.router({TEXT: TXT}, {TXT: {"typo": "secret-value"}})
+        with self.assertRaisesRegex(ValueError, "mutually exclusive"):
+            self.router(
+                {PDF: WARP},
+                {
+                    WARP: {
+                        "api_key": "private-key",
+                        "apply_ocr": True,
+                        "disable_ocr": True,
+                    }
+                },
+            )
+        with self.assertRaisesRegex(ValueError, "chunkers"):
+            self.router({TEXT: TXT}, {TXT: {"chunkers": "paragraph"}})
+
+    def test_secret_and_custom_validation_after_coercion(self):
+        @dataclass
+        class Settings:
+            credential: str = field(
+                default="",
+                metadata={
+                    "pipeline_setting": PipelineSetting(
+                        setting_type=SettingType.SECRET, required=True
+                    )
+                },
+            )
+            count: int = field(
+                default=1,
+                metadata={
+                    "pipeline_setting": PipelineSetting(
+                        setting_type=SettingType.OPTIONAL,
+                        validation=lambda value: value > 0,
+                    )
+                },
+            )
+
+        component = type(
+            "LocalComponent", (PipelineComponentBase,), {"Settings": Settings}
+        )
+        with self.assertRaisesRegex(ValueError, "credential is required"):
+            local_settings(component, {})
+        self.assertEqual(
+            local_settings(component, {"credential": "secret", "count": "2"})["count"],
+            2,
+        )
+        with self.assertRaisesRegex(ValueError, "count failed validation"):
+            local_settings(component, {"credential": "secret", "count": "-2"})
+
+    def test_txt_server_and_remote_share_offsets_and_ids(self):
+        text = "Heading\n\nBody paragraph with café.\n\nFinal paragraph."
+        router = self.router(
+            {"application/txt": TXT},
+            {
+                TXT: {
+                    "chunkers": [
+                        "paragraph",
+                        {"name": "sliding_window", "window_size": 35, "overlap": 5},
+                    ]
+                }
+            },
+        )
+        parser, _ = router.parsers[TEXT]
+        doc = SimpleNamespace(
+            title="source.txt",
+            description="",
+            txt_extract_file=SimpleNamespace(name="source.txt"),
+        )
+        with patch(
+            "opencontractserver.pipeline.parsers.oc_text_parser.Document.objects.get",
+            return_value=doc,
+        ), patch(
+            "opencontractserver.pipeline.parsers.oc_text_parser.default_storage.open",
+            return_value=StringIO(text),
+        ):
+            server = parser.parse_document(1, 2)
+        with patch(
+            "opencontractserver.documents.models.Document.objects.get",
+            side_effect=AssertionError("ORM read"),
+        ):
+            remote = router.parse(text.encode(), filename="misleading.pdf")
+        for key in ("content", "pawls_file_content", "page_count", "labelled_text"):
+            self.assertEqual(remote[key], server[key])
+        self.assertEqual(remote["file_type"], TEXT)
+        self.assertEqual(
+            len({ann["id"] for ann in remote["labelled_text"]}),
+            len(remote["labelled_text"]),
+        )
+        for ann in remote["labelled_text"]:
+            span = ann["annotation_json"]
+            self.assertEqual(text[span["start"] : span["end"]], ann["rawText"])
+            self.assertEqual(ann["annotation_type"], "SPAN_LABEL")
+
+    def test_docx_server_and_remote_share_normalization_and_links(self):
+        router = self.router({DOCX: DOCXODUS})
+        parser, _ = router.parsers[DOCX]
+        payload = span_export()
+        payload["labelledText"] = payload.pop("labelled_text")
+        for ann in payload["labelledText"]:
+            ann["annotationJson"] = ann.pop("annotation_json")
+            ann["annotationType"] = "UnrecognizedDocxodusType"
+            if "parent_id" in ann:
+                ann["parentId"] = ann.pop("parent_id")
+        source = make_minimal_docx()
+        doc = SimpleNamespace(
+            title="source.docx", pdf_file=SimpleNamespace(name="source.docx")
+        )
+        with patch(
+            "requests.post", return_value=Mock(json=lambda: deepcopy(payload))
+        ) as post:
+            with patch(
+                "opencontractserver.documents.models.Document.objects.get",
+                return_value=doc,
+            ), patch(
+                "opencontractserver.pipeline.parsers.docxodus_parser.default_storage.open",
+                return_value=BytesIO(source),
+            ):
+                server = parser.parse_document(1, 2)
+            with patch(
+                "opencontractserver.documents.models.Document.objects.get",
+                side_effect=AssertionError("ORM read"),
+            ):
+                remote = router.parse(source, filename="source.docx")
+            self.assertEqual(post.call_args.kwargs["json"]["filename"], doc.title)
+        # Worker envelope canonicalizes MIME and materializes the same fallback
+        # that BaseParser.save_parsed_data applies to the server export.
+        normalize_and_validate_export(server)
+        for key in (
+            "content",
+            "pawls_file_content",
+            "page_count",
+            "labelled_text",
+            "relationships",
+        ):
+            self.assertEqual(remote[key], server[key])
+
+    def test_pdf_server_bytes_and_remote_parity(self):
+        source = pdf_bytes()
+        for path in (DOCLING, WARP):
+            with self.subTest(parser=path):
+                overrides: dict[str, Any] = {"service_url": "http://parser/parse"}
+                if path == DOCLING:
+                    overrides["extract_images"] = False
+                    overrides["max_chord_tasks"] = (
+                        0  # Valid: disable server chord fan-out.
+                    )
+                else:
+                    overrides["api_key"] = "private-key"
+                router = self.router({PDF: path}, {path: overrides})
+                parser, _ = router.parsers[PDF]
+                payload = _sample_export()
+                body = {"result": payload} if path == WARP else payload
+                module = get_component_by_name(path).__module__
+                storage_module = (
+                    module
+                    if path == WARP
+                    else "opencontractserver.pipeline.base.chunked_parser"
+                )
+                doc = SimpleNamespace(
+                    title="source.pdf", pdf_file=SimpleNamespace(name="source.pdf")
+                )
+                with patch(
+                    "requests.post", return_value=Mock(json=lambda: deepcopy(body))
+                ):
+                    with patch(
+                        "opencontractserver.documents.models.Document.objects.get",
+                        return_value=doc,
+                    ), patch(
+                        storage_module + ".default_storage.open",
+                        return_value=BytesIO(source),
+                    ), patch(
+                        storage_module + ".default_storage.size",
+                        return_value=len(source),
+                    ):
+                        server = parser.parse_document(1, 2)
+                    with patch(
+                        "opencontractserver.documents.models.Document.objects.get",
+                        side_effect=AssertionError("ORM read"),
+                    ):
+                        raw = parser.parse_pdf_bytes(source)
+                        remote = router.parse(source, filename="misleading.txt")
+                for key in (
+                    "content",
+                    "pawls_file_content",
+                    "page_count",
+                    "labelled_text",
+                    "relationships",
+                ):
+                    self.assertEqual(server[key], raw[key])
+                self.assertEqual(
+                    remote["content"],
+                    build_translation_layer(server["pawls_file_content"]).doc_text,
+                )
+                for key in (
+                    "pawls_file_content",
+                    "page_count",
+                    "labelled_text",
+                    "relationships",
+                ):
+                    self.assertEqual(remote[key], server[key])
+                self.assertEqual(remote["file_type"], PDF)
+
+    def test_unsupported_or_unmapped_input(self):
+        router = self.router({TEXT: TXT}, {TXT: {"chunkers": ["paragraph"]}})
+        for source, name, error in [
+            (b"\x89PNG\r\n\x1a\n" + bytes(100), "fake.txt", "Unsupported"),
+            (pdf_bytes(), "fake.txt", "No local parser"),
+            (b"# Markdown", "file.md", "Unsupported"),
+        ]:
+            with self.subTest(name=name), self.assertRaisesRegex(ValueError, error):
+                router.parse(source, filename=name)
+
+    def test_prepare_and_multipart_use_source_mime_and_selected_provenance(self):
+        router = self.router({TEXT: TXT}, {TXT: {"chunkers": ["paragraph"]}})
+        source = Path(self.tmp.name) / "source.pdf"
+        source.write_text("Plain text paragraph.")
+        cfg = worker_config(
+            embeddings=False,
+            target_folder_from_tree=True,
+            target_url="https://target",
+            worker_token="secret",
+            verify_tls=True,
+        )
+        client = cli.TargetClient(cfg)
+        captured = []
+
+        def post(url, *, files, data, **kwargs):
+            captured.append(
+                (
+                    files["file"][2],
+                    files["file"][1].read(),
+                    json.loads(data["metadata"]),
+                )
+            )
+            return Mock(status_code=202, json=lambda: {"upload_id": "receipt"})
+
+        with patch.object(client.session, "post", side_effect=post):
+            result = cli._process_one(
+                cfg,
+                router,
+                None,
+                client,
+                {"rel_path": "folder/source.pdf", "abs_path": str(source)},
+            )
+        self.assertTrue(result[1], result[2])
+        mime, uploaded, metadata = captured[0]
+        self.assertEqual(mime, TEXT)
+        self.assertEqual(uploaded, source.read_bytes())
+        self.assertEqual(metadata["file_type"], TEXT)
+        self.assertEqual(metadata["parser_name"], "Text Parser")
+        self.assertEqual(metadata["parser_version"], "1.0")
+        self.assertEqual(metadata["target_folder_path"], "folder")
+        self.assertTrue(
+            all(
+                label["label_type"] == "SPAN_LABEL"
+                for label in metadata["text_labels"].values()
+            )
+        )
+
+    def test_metadata_mime_fallback_and_multipart_for_each_parser(self):
+        cfg = worker_config(
+            target_url="https://target", worker_token="secret", verify_tls=True
+        )
+        source = Path(self.tmp.name) / "source"
+        source.write_bytes(b"source bytes")
+        for mime, name in [
+            (PDF, "Docling Parser (REST)"),
+            (PDF, "Warp-Ingest Parser (REST)"),
+            (DOCX, "Docxodus Parser (REST)"),
+            (TEXT, "Text Parser"),
+        ]:
+            with self.subTest(mime=mime, name=name):
+                export = _sample_export() if mime == PDF else span_export()
+                export["file_type"] = mime
+                metadata = cli._build_metadata(
+                    title="source",
+                    export=export,
+                    content=export["content"],
+                    embedder_path="unused",
+                    embeddings=None,
+                    target_folder_path=None,
+                    parser_name=name,
+                )
+                self.assertEqual(metadata["file_type"], mime)
+                self.assertEqual(metadata["parser_name"], name)
+                fallback = "TOKEN_LABEL" if mime == PDF else "SPAN_LABEL"
+                for ann in export["labelled_text"]:
+                    self.assertEqual(
+                        metadata["text_labels"][ann["annotationLabel"]]["label_type"],
+                        fallback,
+                    )
+                client = cli.TargetClient(cfg)
+                with patch.object(
+                    client.session,
+                    "post",
+                    return_value=Mock(
+                        status_code=202, json=lambda: {"upload_id": "receipt"}
+                    ),
+                ) as post:
+                    client.upload(str(source), metadata)
+                self.assertEqual(post.call_args.kwargs["files"]["file"][2], mime)
+
+    def test_malformed_export_never_reaches_embedder_or_upload(self):
+        export = span_export()
+        export["labelled_text"][1]["parent_id"] = "missing"
+        source = Path(self.tmp.name) / "source.docx"
+        source.write_bytes(make_minimal_docx())
+        parser = Mock(parse=Mock(return_value=export))
+        embedder, client = Mock(), Mock()
+        result = cli._process_one(
+            worker_config(embeddings=True),
+            parser,
+            embedder,
+            client,
+            {"rel_path": source.name, "abs_path": str(source)},
+        )
+        self.assertFalse(result[1])
+        self.assertIn("parent_id", result[2])
+        embedder.embed_text.assert_not_called()
+        client.upload.assert_not_called()
+
+    def test_config_errors_redact_json_and_secret_values_from_logs(self):
+        self.config_path.write_text('{"credential": "secret-value", invalid')
+        with self.assertRaisesRegex(ValueError, "readable JSON") as caught:
+            LocalParsers(str(self.config_path))
+        self.assertNotIn("secret-value", str(caught.exception))
+        with self.assertLogs(level="INFO") as logs:
+            self.router({PDF: WARP}, {WARP: {"api_key": "secret-value"}})
+        self.assertNotIn("secret-value", "\n".join(logs.output))
+
+
+class ExportValidationTests(SimpleTestCase):
+    def test_span_defaults_and_links_preserved(self):
+        export = span_export()
+        normalize_and_validate_export(export)
+        self.assertEqual(export["labelled_text"][1]["parent_id"], "heading")
+        self.assertTrue(
+            all(a["annotation_type"] == "SPAN_LABEL" for a in export["labelled_text"])
+        )
+
+    def test_enrichment_preserves_zero_id_and_its_relationship(self):
+        from scripts.remote_ingest.enrichers import (
+            Enrichment,
+            apply_enrichment,
+            label_def,
+            validate_enrichment,
+        )
+
+        export = span_export()
+        enrichment = Enrichment(
+            annotations=[
+                {
+                    "id": 0,
+                    "annotationLabel": "Extra",
+                    "rawText": "Heading",
+                    "annotation_type": "SPAN_LABEL",
+                    "annotation_json": {"start": 0, "end": 7},
+                }
+            ],
+            annotation_labels={"Extra": label_def("Extra", "SPAN_LABEL")},
+            relationships=[
+                {
+                    "relationshipLabel": "contains",
+                    "source_annotation_ids": [0],
+                    "target_annotation_ids": ["body"],
+                }
+            ],
+        )
+        self.assertEqual(validate_enrichment(export, enrichment), [])
+        apply_enrichment(export, enrichment)
+        self.assertEqual(export["labelled_text"][-1]["id"], 0)
+        normalize_and_validate_export(export)
+
+    def test_malformed_spans_and_ids_rejected(self):
+        cases = [
+            lambda e: e["labelled_text"][0]["annotation_json"].update(start=-1),
+            lambda e: e["labelled_text"][0]["annotation_json"].update(end=100),
+            lambda e: e["labelled_text"][0].update(rawText="wrong"),
+            lambda e: e["labelled_text"][0].update(id=None),
+            lambda e: e["labelled_text"][1].update(id="heading"),
+            lambda e: e["labelled_text"][1].update(parent_id="missing"),
+            lambda e: e["relationships"][0].update(target_annotation_ids=["missing"]),
+            lambda e: e["labelled_text"][0].update(annotation_type="TOKEN_LABEL"),
+        ]
+        for mutate in cases:
+            export = span_export()
+            mutate(export)
+            with self.assertRaises(ValueError):
+                normalize_and_validate_export(export)
+        export = span_export()
+        export["labelled_text"][0]["id"] = 1
+        export["labelled_text"][1]["id"] = "1"
+        with self.assertRaisesRegex(ValueError, "unique"):
+            normalize_and_validate_export(export)
+
+    def test_docling_one_based_page_metadata_keeps_zero_based_token_refs(self):
+        export = _sample_export()
+        export["pawls_file_content"][0]["page"]["index"] = 1
+        normalize_and_validate_export(export)
+        self.assertEqual(export["pawls_file_content"][0]["page"]["index"], 1)
+        self.assertEqual(
+            export["labelled_text"][0]["annotation_json"]["0"]["tokensJsons"][0][
+                "pageIndex"
+            ],
+            0,
+        )
+
+    def test_docx_container_span_text_is_exact_without_changing_heading_text(self):
+        from opencontractserver.pipeline.parsers.docxodus_parser import (
+            DocxodusServiceParser,
+        )
+
+        export = span_export()
+        export["labelled_text"][0]["rawText"] = ""
+        export["labelled_text"][0]["annotation_json"] = {
+            "start": 0,
+            "end": len(export["content"]),
+            "text": "",
+        }
+        normalized = DocxodusServiceParser._normalize_response(export)
+        normalize_and_validate_export(normalized)
+        parent = normalized["labelled_text"][0]
+        self.assertEqual(parent["rawText"], "")
+        self.assertEqual(parent["annotation_json"]["text"], export["content"])
+        self.assertEqual(normalized["labelled_text"][1]["parent_id"], parent["id"])
+
+    def test_bad_token_references_rejected(self):
+        for reference in [
+            {"pageIndex": 1, "tokenIndex": 0},
+            {"pageIndex": 0, "tokenIndex": 9},
+            {"pageIndex": 0, "tokenIndex": -1},
+        ]:
+            export = _sample_export()
+            export["labelled_text"][0]["annotation_json"]["0"]["tokensJsons"] = [
+                reference
+            ]
+            with self.assertRaisesRegex(ValueError, "token reference"):
+                normalize_and_validate_export(export)

--- a/opencontractserver/tests/test_worker_uploads.py
+++ b/opencontractserver/tests/test_worker_uploads.py
@@ -1769,6 +1769,61 @@ class TestWorkerUploadFidelity(TestCase):
         parent = on_set.get(raw_text="SECTION 1")
         self.assertEqual(child.parent_id, parent.id)
 
+    def test_span_mime_fallback_preserves_structural_tree_and_relationships(self):
+        from opencontractserver.annotations.models import Relationship
+        from opencontractserver.pipeline.base.file_types import FileTypeEnum
+        from opencontractserver.tests.test_remote_ingest_parsers import span_export
+
+        for mime in (FileTypeEnum.DOCX.mimetype, "text/plain", "application/txt"):
+            with self.subTest(mime=mime):
+                export = span_export()
+                metadata = {
+                    **export,
+                    "title": "Span document",
+                    "file_type": mime,
+                    # Omit annotation_type and label_type, as a normalized
+                    # Docxodus response can do. Both must use the MIME fallback.
+                    "text_labels": {
+                        "Heading": {"text": "Heading", "read_only": True},
+                        "Paragraph": {"text": "Paragraph", "read_only": True},
+                        "contains": {
+                            "text": "contains",
+                            "label_type": "RELATIONSHIP_LABEL",
+                        },
+                    },
+                    "parser_name": "Span parser",
+                    "parser_version": "1.0",
+                }
+                upload = self._stage(metadata)
+                with patch(
+                    "opencontractserver.tasks.embeddings_task.calculate_embeddings_for_annotation_batch.delay"
+                ):
+                    upload, _ = self._process(upload)
+                self.assertEqual(
+                    upload.status, UploadStatus.COMPLETED, upload.error_message
+                )
+                doc = upload.result_document
+                self.assertEqual(doc.file_type, mime)
+                with doc.txt_extract_file.open("r") as source:
+                    self.assertEqual(source.read(), export["content"])
+                structural_set = doc.structural_annotation_set
+                self.assertEqual(structural_set.parser_name, "Span parser")
+                annotations = Annotation.objects.filter(structural_set=structural_set)
+                self.assertEqual(annotations.count(), 2)
+                parent = annotations.get(raw_text="Heading")
+                child = annotations.get(raw_text="Body paragraph.")
+                self.assertEqual(child.parent_id, parent.pk)
+                for ann in annotations:
+                    self.assertEqual(ann.annotation_type, "SPAN_LABEL")
+                    self.assertEqual(ann.annotation_label.label_type, "SPAN_LABEL")
+                rel = Relationship.objects.get(
+                    relationship_label__text="contains", source_annotations=parent
+                )
+                self.assertEqual(
+                    list(rel.target_annotations.values_list("pk", flat=True)),
+                    [child.pk],
+                )
+
     def test_thumbnail_dispatched(self):
         upload = self._stage(_structural_metadata())
         upload, mock_thumb = self._process(upload)

--- a/opencontractserver/worker_uploads/tasks.py
+++ b/opencontractserver/worker_uploads/tasks.py
@@ -269,7 +269,12 @@ def _process_single_upload(upload_id: UUID) -> None:
             doc_filename.strip().lstrip(".")[:_MAX_FILENAME_LENGTH] or "document"
         )
         if "." not in doc_filename:
-            doc_filename += ".pdf"
+            from opencontractserver.pipeline.base.file_types import FileTypeEnum
+
+            file_type = FileTypeEnum.from_mimetype(
+                metadata.get("file_type", "application/pdf")
+            )
+            doc_filename += f".{file_type.value if file_type else 'pdf'}"
 
         pawls_content = metadata.get("pawls_file_content", [])
         text_content = metadata.get("content", "")
@@ -362,6 +367,9 @@ def _process_single_upload(upload_id: UUID) -> None:
             corpus_obj=corpus,
             annotations_data=metadata.get("labelled_text", []),
             label_lookup=label_lookup,
+            label_type=settings.ANNOTATION_LABELS.get(
+                corpus_doc.file_type, "SPAN_LABEL"
+            ),
             dispatch_embeddings=not bool(embeddings_data),
         )
 
@@ -475,7 +483,13 @@ def _prepare_labels(
     Load or create text and document labels from the upload metadata.
     Returns (label_lookup, doc_label_lookup).
     """
-    text_labels = metadata.get("text_labels", {})
+    fallback = settings.ANNOTATION_LABELS.get(
+        metadata.get("file_type", "application/pdf"), "SPAN_LABEL"
+    )
+    text_labels = {
+        name: {**definition, "label_type": definition.get("label_type") or fallback}
+        for name, definition in metadata.get("text_labels", {}).items()
+    }
     doc_labels_defs = metadata.get("doc_labels_definitions", {})
 
     existing_text = load_or_create_labels(

--- a/scripts/remote_ingest/README.md
+++ b/scripts/remote_ingest/README.md
@@ -1,6 +1,6 @@
 # Remote Ingest Worker
 
-Run the OpenContracts ingestion pipeline (Docling parse + embeddings) on a
+Run the OpenContracts ingestion pipeline (PDF/DOCX/TXT parsing + embeddings) on a
 beefy **off-cluster** host and stream **fully-processed, faithfully-mirrored**
 documents into a target OpenContracts corpus — without giving the remote host
 any access to the target's database.
@@ -26,9 +26,8 @@ cheap.
 
 ## Faithful by construction
 
-The worker runs the **same Docling microservice image** and the **same
-`DoclingParser` code** the server runs, and embeds against the **same
-vector-embedder image**. So:
+The worker uses the same parser adapters as the server, with explicit local
+settings. With equivalent settings, service versions and source metadata:
 
 - **PAWLs token layer** — identical tokenisation (no drift; the worker-upload
   path trusts these tokens verbatim, and they *are* what the server would
@@ -40,12 +39,39 @@ vector-embedder image**. So:
   subtree-group relationships exactly as in-cluster ingestion does.
 - **Embeddings** — same 384-dim model, same inputs (full text for the document,
   `rawText` per annotation).
-- **Thumbnail** — regenerated server-side from the uploaded PDF.
-
-The net result: a document ingested through this worker is indistinguishable
-from one ingested in-cluster.
+- **Thumbnail** — regenerated server-side from the uploaded source document (asynchronously).
 
 ---
+
+## Parser selection and local settings
+
+Docling PDF remains the default. To enable PDF, DOCX and TXT:
+
+```bash
+export OC_PARSER_CONFIG=/app/scripts/remote_ingest/parser-config.example.json
+docker compose -f remote_worker.yml up -d docling-parser docxodus-parser vector-embedder
+docker compose -f remote_worker.yml run --rm worker plan --extensions .pdf,.docx,.txt
+docker compose -f remote_worker.yml run --rm worker run
+```
+
+The [example config](parser-config.example.json) maps canonical MIME types to
+parser class paths and supplies optional settings by full class path.
+`--parser-config` overrides `OC_PARSER_CONFIG`; the file must be mounted inside
+the worker. Settings precedence is schema defaults, declared environment
+variables, then JSON. All selected parsers are validated before processing.
+Target admin/GUI settings are independent and are never fetched.
+
+For Warp PDF, change the PDF mapping to
+`opencontractserver.pipeline.parsers.warp_ingest_parser.WarpIngestParser` and
+start `warp-ingest`. `WARP_INGEST_API_KEY` configures both worker and service.
+TXT paragraph/window chunking needs no service; the sentence default needs
+spaCy and its model. The worker starts no services automatically, and
+`--no-embeddings` also removes the need for the vector embedder.
+
+See the public [parser configuration reference](../../docs/upload_methods/remote_ingest_worker.md#parser-selection-and-local-settings)
+for settings, dependencies, MIME detection, annotation parity and provenance.
+`parser_version="1.0"` follows structural-set convention, not a discovered
+service version. Keep credentials in environment variables, outside config files.
 
 ## Setup
 
@@ -296,13 +322,12 @@ rate limiting (the per-token limit is best-effort).
 
 ## How it works (per document)
 
-1. Read the PDF bytes.
-2. `DoclingParser.parse_pdf_bytes(bytes)` → `OpenContractDocExport` (PAWLs,
-   structural annotations, relationships) — the real parser, no database.
-3. Rebuild the text layer from the PAWLs (`build_translation_layer`).
+1. Read source bytes and detect the canonical MIME type.
+2. Call the selected parser’s shared bytes/text method → `OpenContractDocExport`.
+3. Rebuild PDF text from PAWLS; preserve DOCX/TXT content and validate anchors.
 4. Embed the document text + each annotation's `rawText` against the
    vector-embedder.
-5. POST `multipart/form-data` (the PDF + a metadata JSON) to
+5. POST `multipart/form-data` (the source file + metadata JSON) to
    `/api/worker-uploads/documents/`.
 6. The server stages the upload and a Celery worker ingests it: creates the
    document, imports annotations/relationships, stores the embeddings,
@@ -324,8 +349,8 @@ state so the whole run is crash-resumable.
   CPU. On a GPU, VRAM is the constraint instead.
 
 The driver itself runs inside the OpenContracts image and uses
-`config.settings.remote_worker`, which points Django at a throwaway SQLite file
-so the worker needs **no Postgres and no Redis**.
+`config.settings.remote_worker`, which disables the Django database backend. Explicit local component settings mean
+the worker needs **no Postgres and no Redis**.
 
 ---
 

--- a/scripts/remote_ingest/enrichers.py
+++ b/scripts/remote_ingest/enrichers.py
@@ -456,7 +456,7 @@ def apply_enrichment(
 
     n = 0
     for ann in enrichment.annotations:
-        if not ann.get("id"):
+        if ann.get("id") is None:
             new_id = f"{id_prefix}-{n}"
             while new_id in existing_ids:
                 n += 1
@@ -508,7 +508,9 @@ def validate_enrichment(export: dict, enrichment: Enrichment) -> list[str]:
     # collision silently maps two annotations to one row (and drops one
     # embedding). Auto-assigned ids are collision-safe by construction; this
     # guards explicit ids an enricher set by hand.
-    parser_ids = {a.get("id") for a in export.get("labelled_text", []) if a.get("id")}
+    parser_ids = {
+        a.get("id") for a in export.get("labelled_text", []) if a.get("id") is not None
+    }
     seen_injected: set = set()
 
     for i, ann in enumerate(enrichment.annotations):
@@ -604,8 +606,10 @@ def validate_enrichment(export: dict, enrichment: Enrichment) -> list[str]:
     # references an injected annotation (by the explicit id its author set) must
     # still resolve here. (Auto-assigned ids can't be referenced anyway — the
     # author doesn't know them — so only explicit ids matter.)
-    all_ids = {a.get("id") for a in export.get("labelled_text", []) if a.get("id")}
-    all_ids |= {a.get("id") for a in enrichment.annotations if a.get("id")}
+    all_ids = {
+        a.get("id") for a in export.get("labelled_text", []) if a.get("id") is not None
+    }
+    all_ids |= {a.get("id") for a in enrichment.annotations if a.get("id") is not None}
 
     # An injected annotation's parent_id must resolve to a real annotation id
     # (parser or injected) — import_annotations silently skips an unresolvable

--- a/scripts/remote_ingest/oc_remote_ingest.py
+++ b/scripts/remote_ingest/oc_remote_ingest.py
@@ -1,69 +1,13 @@
 #!/usr/bin/env python3
-"""
-oc_remote_ingest.py — run the OpenContracts ingestion pipeline on a remote host
-and stream FAITHFUL, fully-processed documents into a target OpenContracts
-corpus via the worker-upload REST API.
+"""Parse PDF, DOCX and TXT files remotely and upload prepared artifacts.
 
-WHY THIS EXISTS
----------------
-``scripts/bulk_import/oc_bulk_import.py`` ships *raw* PDFs to the server and lets
-the SERVER parse them (Docling + embeddings). That offloads nothing — the
-expensive work still runs in-cluster. This driver instead does the heavy lifting
-(Docling parse + embedding) on a beefy *remote* worker and ships the finished
-artifacts — PAWLs token layer, text layer, structural annotations, relationships
-and pre-computed embeddings — to the target via ``POST /api/worker-uploads/
-documents/``, which bypasses the server parser entirely. The result is a faithful
-mirror: because the worker runs the SAME Docling microservice and the SAME
-``DoclingParser`` code the server would run, the PAWLs and structural layer are
-identical to an in-cluster ingestion (no tokenizer drift).
+Reuses the application's parser implementations with worker-local settings and
+no target database access. PDF text is reconstructed from PAWLS; DOCX/TXT retain
+parser character spans. Local enrichers run before embedding and worker-upload.
 
-FAITHFUL-BY-CONSTRUCTION
-------------------------
-* PAWLs / structural annotations / relationships: produced by the real
-  ``DoclingParser.parse_pdf_bytes`` (same parser, same docling service).
-* Text layer (``content``): rebuilt from the shipped PAWLs with the same
-  ``plasmapdf.build_translation_layer`` the server's ``save_parsed_data`` uses,
-  so the stored text layer matches byte-for-byte.
-* Embeddings: computed against the same vector-embedder microservice the server
-  uses, over the same inputs (full text for the doc, ``rawText`` per annotation).
-* Structural set + thumbnail: materialised server-side by the worker-upload
-  ingestion path (see opencontractserver/worker_uploads/tasks.py).
-
-DESIGN
-------
-* Resumable: a SQLite ledger records every document's state (PENDING / UPLOADED /
-  COMPLETED / FAILED / PARKED). Re-running ``run`` skips finished work. Each doc
-  is keyed by its path relative to ``--root-dir`` (its corpus folder path).
-* Per-document streaming (NO archive): scales to 100k–1M docs without ever
-  building a ZIP. The slow step is the remote Docling parse, so the driver runs
-  a thread pool of workers and paces itself against the server's worker-upload
-  backlog (the ``documents/list/`` counts) instead of detonating the queue.
-* Secure: auth is a corpus-scoped ``CorpusAccessToken`` sent as
-  ``Authorization: WorkerKey <token>`` over TLS. The corpus is fixed by the
-  token binding — the remote host cannot target another corpus. NO database
-  access to the target is required or possible.
-
-SUBCOMMANDS
------------
-    plan     Scan ``--root-dir`` and record every PDF in the ledger (no network,
-             no parsing).
-    run      Parse + embed + upload PENDING/FAILED docs (resumable, paced,
-             concurrent).
-    verify   Poll the target for each uploaded doc's terminal status and update
-             the ledger (UPLOADED -> COMPLETED / FAILED).
-    status   Print ledger counts + the target's live worker-upload backlog.
-
-ENVIRONMENT / FLAGS (flags override env)
-----------------------------------------
-    OC_TARGET_URL     Base URL of the target OC instance (e.g. https://oc.example.com)
-    OC_WORKER_TOKEN   CorpusAccessToken plaintext (WorkerKey auth)
-    OC_CORPUS_ID      Informational; the bound corpus is enforced by the token
-    DOCLING_PARSER_SERVICE_URL    Docling microservice (default from Django settings)
-    EMBEDDINGS_MICROSERVICE_URL   Vector embedder microservice
-
-This script runs INSIDE the OpenContracts image (it imports the real parser),
-so Django must be importable. Only the ``run`` subcommand needs Django/Docling;
-``plan`` / ``status`` / ``verify`` are pure HTTP + SQLite.
+Commands: plan scans extensions into a SQLite ledger; run prepares/uploads
+pending or failed documents; verify polls receipts; status prints ledger counts.
+Only run boots Django. See README.md for parser configuration and service setup.
 """
 
 from __future__ import annotations
@@ -78,15 +22,18 @@ import sqlite3
 import sys
 import threading
 import time
+from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import requests
 
 if TYPE_CHECKING:  # avoid importing enrichers (needs Django path) at module load
     from enrichers import MetadataOverlay
+
+    from scripts.remote_ingest.parsers import LocalParsers
 
 logger = logging.getLogger("oc_remote_ingest")
 
@@ -257,6 +204,7 @@ class Config:
     verify_tls: bool
     limit: int
     enrichers: list[str]
+    parser_config: str | None = None
 
 
 class TargetClient:
@@ -273,21 +221,21 @@ class TargetClient:
     def _backoff(attempt: int) -> float:
         return min(2.0 * (2 ** (attempt - 1)), 60.0) * random.uniform(_JITTER_MIN, 1.0)
 
-    def upload(self, pdf_path: str, metadata: dict) -> str:
+    def upload(self, source_path: str, metadata: dict) -> str:
         """POST a document. Returns the server upload_id. Raises on permanent failure."""
         url = f"{self.base}/api/worker-uploads/documents/"
         meta_json = json.dumps(metadata)
         last_error = "unknown"
         for attempt in range(1, _HTTP_MAX_RETRIES + 1):
             try:
-                with open(pdf_path, "rb") as fh:
+                with open(source_path, "rb") as fh:
                     resp = self.session.post(
                         url,
                         files={
                             "file": (
-                                PurePosixPath(pdf_path).name,
+                                PurePosixPath(source_path).name,
                                 fh,
-                                "application/pdf",
+                                metadata["file_type"],
                             )
                         },
                         data={"metadata": meta_json},
@@ -410,135 +358,41 @@ class EmbedderClient:
 
 
 # ======================================================================
-# Parser wrapper (lazy Django + DoclingParser singleton)
+# Parser wrapper (Django imports + worker-local configuration)
 # ======================================================================
 
 
 class _Parser:
-    """Lazily-initialised, thread-safe singleton wrapper around DoclingParser."""
+    """Bootstrap Django imports, then use explicitly configured local parsers."""
 
-    def __init__(self) -> None:
-        self._parser = None
-        self._build_translation_layer = None
-        self._default_embedder_path = None
-        self._lock = threading.Lock()
+    def __init__(self, config_path: str | None = None) -> None:
+        self.config_path = config_path
+        self._parsers: LocalParsers | None = None
 
-    def _ensure(self) -> None:
-        if self._parser is not None:
-            return
-        with self._lock:
-            if self._parser is not None:
-                return
-            # Ensure the OpenContracts repo root is importable. When this file is
-            # run directly (``python .../oc_remote_ingest.py``) sys.path[0] is the
-            # script's own directory, so ``config`` / ``opencontractserver`` are
-            # not importable until we add the repo root (this file lives at
-            # ``<root>/scripts/remote_ingest/oc_remote_ingest.py``).
-            repo_root = str(Path(__file__).resolve().parents[2])
-            if repo_root not in sys.path:
-                sys.path.insert(0, repo_root)
+    def ensure_ready(self) -> LocalParsers:
+        if self._parsers is not None:
+            return self._parsers
+        repo_root = str(Path(__file__).resolve().parents[2])
+        if repo_root not in sys.path:
+            sys.path.insert(0, repo_root)
+        os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.remote_worker")
+        import django
 
-            os.environ.setdefault(
-                "DJANGO_SETTINGS_MODULE", "config.settings.remote_worker"
-            )
-            import django
+        django.setup()
+        from scripts.remote_ingest.parsers import LocalParsers
 
-            django.setup()
-            from plasmapdf.models.PdfDataLayer import build_translation_layer
-
-            from opencontractserver.pipeline.parsers.docling_parser_rest import (
-                DoclingParser,
-            )
-
-            try:
-                from opencontractserver.pipeline.utils import get_default_embedder_path
-
-                self._default_embedder_path = get_default_embedder_path()
-            except Exception:
-                self._default_embedder_path = (
-                    "opencontractserver.pipeline.embedders."
-                    "sent_transformer_microservice.MicroserviceEmbedder"
-                )
-
-            self._build_translation_layer = build_translation_layer
-            self._parser = DoclingParser()
-
-            # Pipeline component settings (incl. the Docling service URL) are
-            # normally sourced from the PipelineSettings DB table — the
-            # ``env_var`` declared on each setting only SEEDS that table via
-            # ``migrate_pipeline_settings``, it is not read at runtime. The
-            # remote worker runs WITHOUT that DB, so the parser comes up with
-            # dataclass defaults (service_url=""). Backfill the Docling knobs
-            # from the environment so the worker is configured purely via env,
-            # mirroring how the in-cluster parser is seeded from the same vars.
-            self._backfill_parser_settings_from_env()
-
-            if not self._parser.service_url:
-                raise RuntimeError(
-                    "DOCLING_PARSER_SERVICE_URL must be set so the remote worker "
-                    "can reach the Docling microservice."
-                )
-            logger.info(
-                f"DoclingParser ready (service={self._parser.service_url!r}, "
-                f"extract_images={self._parser.extract_images}, "
-                f"embedder_path={self._default_embedder_path})"
-            )
-
-    def _backfill_parser_settings_from_env(self) -> None:
-        """Override DoclingParser instance settings from DOCLING_* env vars.
-
-        Only applied when the value is present in the environment, so a worker
-        that sets nothing inherits the same defaults the in-cluster parser uses.
-        """
-
-        def _set(attr: str, env_var: str, cast) -> None:
-            raw = os.environ.get(env_var)
-            if raw is None or raw == "":
-                return
-            try:
-                setattr(self._parser, attr, cast(raw))
-            except (ValueError, TypeError):
-                logger.warning(f"Ignoring invalid {env_var}={raw!r}")
-
-        def _as_bool(v: str) -> bool:
-            return v.strip().lower() in ("1", "true", "yes", "on")
-
-        _set("service_url", "DOCLING_PARSER_SERVICE_URL", str)
-        _set("request_timeout", "DOCLING_PARSER_TIMEOUT", int)
-        _set("extract_images", "DOCLING_EXTRACT_IMAGES", _as_bool)
-        _set("image_format", "DOCLING_IMAGE_FORMAT", str)
-        _set("image_quality", "DOCLING_IMAGE_QUALITY", int)
-        _set("image_dpi", "DOCLING_IMAGE_DPI", int)
-        _set("min_image_width", "DOCLING_MIN_IMAGE_WIDTH", int)
-        _set("min_image_height", "DOCLING_MIN_IMAGE_HEIGHT", int)
-        _set("max_pages_per_chunk", "DOCLING_MAX_PAGES_PER_CHUNK", int)
-        _set("min_pages_for_chunking", "DOCLING_MIN_PAGES_FOR_CHUNKING", int)
-        _set("max_concurrent_chunks", "DOCLING_MAX_CONCURRENT_CHUNKS", int)
-        _set("chunk_overlap", "DOCLING_CHUNK_OVERLAP", int)
-
-    def ensure_ready(self) -> None:
-        """Eagerly set up Django + the parser (used to fail fast on config errors
-        and to make ``config`` / ``opencontractserver`` importable before
-        enrichers are loaded)."""
-        self._ensure()
+        self._parsers = LocalParsers(self.config_path)
+        return self._parsers
 
     @property
     def default_embedder_path(self) -> str:
-        self._ensure()
-        return self._default_embedder_path
+        return self.ensure_ready().default_embedder_path
 
-    def parse(self, pdf_bytes: bytes) -> dict:
-        self._ensure()
-        result = self._parser.parse_pdf_bytes(pdf_bytes, user_id=0, doc_id=0)
-        if result is None:
-            raise RuntimeError("parser returned no result")
-        return result
+    def parse(self, source_bytes: bytes, *, filename: str) -> dict:
+        return self.ensure_ready().parse(source_bytes, filename=filename)
 
-    def text_from_pawls(self, pawls_pages: list) -> str:
-        self._ensure()
-        if not pawls_pages:
-            return ""
-        return self._build_translation_layer(pawls_pages).doc_text
+    def identity(self, mime: str) -> dict:
+        return self.ensure_ready().identity(mime)
 
 
 # ======================================================================
@@ -547,7 +401,6 @@ class _Parser:
 
 # Mirror save_parsed_data's structural-label definitions so the target
 # auto-creates any labels the parser emitted with identical presentation.
-_TOKEN_LABEL = "TOKEN_LABEL"
 _RELATIONSHIP_LABEL = "RELATIONSHIP_LABEL"
 _DOC_TYPE_LABEL = "DOC_TYPE_LABEL"
 
@@ -560,8 +413,16 @@ def _build_metadata(
     embedder_path: str,
     embeddings: dict | None,
     target_folder_path: str | None,
+    parser_name: str,
+    parser_version: str = "1.0",
     overlay: MetadataOverlay | None = None,
 ) -> dict:
+    from django.conf import settings
+
+    from scripts.remote_ingest.parsers import canonical_mime
+
+    file_type = canonical_mime(export.get("file_type"))
+    fallback = settings.ANNOTATION_LABELS.get(file_type, "SPAN_LABEL")
     labelled_text = export.get("labelled_text", []) or []
     relationships = export.get("relationships", []) or []
     doc_label_names = list(export.get("doc_labels", []) or [])
@@ -574,7 +435,7 @@ def _build_metadata(
         name = ann.get("annotationLabel")
         if name and name not in text_labels:
             text_labels[name] = {
-                "label_type": ann.get("annotation_type") or _TOKEN_LABEL,
+                "label_type": ann.get("annotation_type") or fallback,
                 "color": "grey",
                 "description": "Parser Structural Label",
                 "icon": "expand",
@@ -625,15 +486,15 @@ def _build_metadata(
         "content": content,
         "page_count": export.get("page_count")
         or len(export.get("pawls_file_content", [])),
-        "file_type": export.get("file_type", "application/pdf") or "application/pdf",
+        "file_type": file_type,
         "pawls_file_content": export.get("pawls_file_content", []),
         "labelled_text": labelled_text,
         "relationships": relationships,
         "doc_labels": doc_label_names,
         "text_labels": text_labels,
         "doc_labels_definitions": doc_labels_definitions,
-        "parser_name": "Docling Parser (REST)",
-        "parser_version": "1.0",
+        "parser_name": parser_name,
+        "parser_version": parser_version,
     }
     if target_folder_path:
         metadata["target_folder_path"] = target_folder_path
@@ -742,7 +603,7 @@ def _process_one(
     parser: _Parser,
     embedder: EmbedderClient | None,
     client: TargetClient,
-    row: sqlite3.Row,
+    row: sqlite3.Row | Mapping[str, Any],
     enrichers: list | None = None,
 ) -> tuple[str, bool, str]:
     """Parse + (enrich) + embed + upload one document. Returns (rel_path, ok, message)."""
@@ -750,14 +611,10 @@ def _process_one(
     abs_path = row["abs_path"]
     try:
         with open(abs_path, "rb") as fh:
-            pdf_bytes = fh.read()
+            source_bytes = fh.read()
 
-        export = parser.parse(pdf_bytes)
-        pawls = export.get("pawls_file_content", []) or []
-
-        # Rebuild the text layer the same way the server's save_parsed_data does
-        # (PAWLs translation), falling back to the parser-reported content.
-        content = parser.text_from_pawls(pawls) or (export.get("content") or "")
+        export = parser.parse(source_bytes, filename=PurePosixPath(rel_path).name)
+        content = export["content"]
         if not content.strip():
             return (rel_path, False, "empty content/text layer (would be unsearchable)")
 
@@ -787,6 +644,11 @@ def _process_one(
                     )
                 overlay = apply_enrichment(export, enrichment)
 
+        # Check the complete export again after enrichment to catch cross-stage
+        # ID collisions, dangling links and invalid spans before embedding/upload.
+        from scripts.remote_ingest.parsers import normalize_and_validate_export
+
+        normalize_and_validate_export(export)
         embeddings = None
         if cfg.embeddings and embedder is not None:
             # Compute over the (possibly enriched) labelled_text so injected
@@ -804,6 +666,7 @@ def _process_one(
             target_folder_path = None if parent in (".", "") else parent
 
         title = PurePosixPath(rel_path).name
+        identity = parser.identity(export["file_type"])
         metadata = _build_metadata(
             title=title,
             export=export,
@@ -812,6 +675,8 @@ def _process_one(
             embeddings=embeddings,
             target_folder_path=target_folder_path,
             overlay=overlay,
+            parser_name=identity["parser_name"],
+            parser_version=identity["parser_version"],
         )
 
         upload_id = client.upload(abs_path, metadata)
@@ -825,7 +690,7 @@ def _process_one(
 
 def cmd_run(cfg: Config) -> int:
     ledger = Ledger(cfg.ledger_path)
-    parser = _Parser()
+    parser = _Parser(cfg.parser_config)
     # Set up Django + the parser eagerly so config errors (missing service URL,
     # broken enricher import) surface before we start churning documents.
     parser.ensure_ready()
@@ -1013,6 +878,7 @@ def _build_config(args: argparse.Namespace) -> Config:
         verify_tls=not args.insecure,
         limit=args.limit,
         enrichers=enrichers,
+        parser_config=args.parser_config or os.environ.get("OC_PARSER_CONFIG"),
     )
 
 
@@ -1027,8 +893,14 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--target-url", help="Target OC base URL (env OC_TARGET_URL)")
     p.add_argument("--worker-token", help="WorkerKey token (env OC_WORKER_TOKEN)")
     p.add_argument("--corpus-id", help="Corpus id (informational; env OC_CORPUS_ID)")
-    p.add_argument("--root-dir", help="Root directory of PDFs (for plan/run)")
+    p.add_argument(
+        "--root-dir", help="Root directory of source documents (for plan/run)"
+    )
     p.add_argument("--extensions", help="Comma-separated extensions (default .pdf)")
+    p.add_argument(
+        "--parser-config",
+        help="Local parser mapping/settings JSON file (env OC_PARSER_CONFIG)",
+    )
     p.add_argument("--max-workers", type=int, default=DEFAULT_MAX_WORKERS)
     p.add_argument("--max-attempts", type=int, default=DEFAULT_MAX_ATTEMPTS)
     p.add_argument("--queue-high", type=int, default=DEFAULT_QUEUE_HIGH)

--- a/scripts/remote_ingest/parser-config.example.json
+++ b/scripts/remote_ingest/parser-config.example.json
@@ -1,0 +1,12 @@
+{
+  "parsers": {
+    "application/pdf": "opencontractserver.pipeline.parsers.docling_parser_rest.DoclingParser",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document": "opencontractserver.pipeline.parsers.docxodus_parser.DocxodusServiceParser",
+    "text/plain": "opencontractserver.pipeline.parsers.oc_text_parser.TxtParser"
+  },
+  "settings": {
+    "opencontractserver.pipeline.parsers.oc_text_parser.TxtParser": {
+      "chunkers": ["paragraph"]
+    }
+  }
+}

--- a/scripts/remote_ingest/parsers.py
+++ b/scripts/remote_ingest/parsers.py
@@ -1,0 +1,402 @@
+"""Worker-local parser selection, settings and export validation (no ORM calls)."""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import os
+from copy import deepcopy
+from dataclasses import asdict, fields
+from io import BytesIO, TextIOWrapper
+from pathlib import Path
+from typing import Any
+
+from django.conf import settings
+from plasmapdf.models.PdfDataLayer import build_translation_layer
+
+from opencontractserver.document_imports.services import detect_mime_type
+from opencontractserver.pipeline.base.base_component import PipelineComponentBase
+from opencontractserver.pipeline.base.file_types import FileTypeEnum
+from opencontractserver.pipeline.base.settings_schema import (
+    create_settings_instance,
+    get_pipeline_setting,
+    get_settings_schema,
+)
+from opencontractserver.pipeline.utils import get_component_by_name
+from opencontractserver.utils.compact_pawls import expand_pawls_pages
+
+logger = logging.getLogger(__name__)
+
+DOCLING = "opencontractserver.pipeline.parsers.docling_parser_rest.DoclingParser"
+WARP = "opencontractserver.pipeline.parsers.warp_ingest_parser.WarpIngestParser"
+DOCXODUS = "opencontractserver.pipeline.parsers.docxodus_parser.DocxodusServiceParser"
+TXT = "opencontractserver.pipeline.parsers.oc_text_parser.TxtParser"
+# Only adapters with an audited database-independent entry point are supported.
+ENTRY_POINTS = {
+    DOCLING: "parse_pdf_bytes",
+    WARP: "parse_pdf_bytes",
+    DOCXODUS: "parse_docx_bytes",
+    TXT: "parse_text",
+}
+DEFAULT_EMBEDDER = "opencontractserver.pipeline.embedders.sent_transformer_microservice.MicroserviceEmbedder"
+
+
+def canonical_mime(mime: str | None) -> str:
+    file_type = FileTypeEnum.from_mimetype(
+        (mime or "").split(";", 1)[0].strip().lower()
+    )
+    if file_type not in (FileTypeEnum.PDF, FileTypeEnum.TXT, FileTypeEnum.DOCX):
+        raise ValueError(
+            f"Unsupported source MIME type: {mime!r}; expected PDF, DOCX or TXT"
+        )
+    return file_type.mimetype
+
+
+def local_settings(
+    component: type[PipelineComponentBase], overrides: dict, environ=None
+) -> dict:
+    """Defaults < schema-declared environment < explicit JSON settings.
+
+    Reuse component coercion, then validate *typed* values, including secrets.
+    Diagnostics contain field names only, never values or validator exceptions.
+    """
+    environ = os.environ if environ is None else environ
+    schema = get_settings_schema(component)
+    if not isinstance(overrides, dict) or overrides.keys() - schema.keys():
+        raise ValueError(
+            f"{component.__name__}: settings must use declared schema fields"
+        )
+    values = {}
+    for name, info in schema.items():
+        value = deepcopy(info.get("default"))
+        if info.get("env_var") and info["env_var"] in environ:
+            value = environ[info["env_var"]]
+        value = overrides.get(name, value)
+        hint = info["python_type"]
+        try:
+            # Guard coercion failures before the shared coercer can log raw input.
+            if hint == "bool" and not (
+                isinstance(value, bool)
+                or isinstance(value, str)
+                and value.lower()
+                in ("true", "false", "1", "0", "yes", "no", "on", "off")
+                or type(value) in (int, float)
+                and value in (0, 1)
+            ):
+                raise ValueError
+            if hint in ("int", "float"):
+                if value is None or isinstance(value, bool):
+                    raise ValueError
+                number = float(value)
+                if not math.isfinite(number):
+                    raise ValueError
+                if hint == "int":
+                    int(value)
+            if hint.startswith("list") and not isinstance(value, list):
+                raise ValueError
+            if hint == "str" and not isinstance(value, str):
+                raise ValueError
+        except (TypeError, ValueError, OverflowError):
+            raise ValueError(
+                f"{component.__name__}.{name} ({info.get('env_var', 'JSON config')}): "
+                f"expected {hint}"
+            ) from None
+        values[name] = value
+
+    effective = asdict(create_settings_instance(component, values, strict=False))
+    assert component.Settings is not None
+    for field in fields(component.Settings):
+        field_info = get_pipeline_setting(field)
+        value = effective[field.name]
+        if (
+            field_info
+            and field_info.required
+            and (value is None or isinstance(value, str) and not value.strip())
+        ):
+            raise ValueError(
+                f"{component.__name__}.{field.name} is required "
+                f"(set {field_info.env_var or 'JSON config'})"
+            )
+        if field_info and field_info.validation and value is not None:
+            try:
+                valid = field_info.validation(value)
+            except Exception:
+                valid = False
+            if not valid:
+                raise ValueError(f"{component.__name__}.{field.name} failed validation")
+    return effective
+
+
+class LocalParsers:
+    """Eagerly validate all selected parsers before any document is processed."""
+
+    default_embedder_path = DEFAULT_EMBEDDER
+
+    def __init__(self, config_path: str | None = None):
+        config: dict[str, Any] = {"parsers": {FileTypeEnum.PDF.mimetype: DOCLING}}
+        if config_path:
+            try:
+                config = json.loads(Path(config_path).read_text())
+            except (ValueError, OSError):
+                raise ValueError(
+                    "Cannot read parser config: expected a readable JSON file"
+                ) from None
+        if not isinstance(config, dict) or config.keys() - {"parsers", "settings"}:
+            raise ValueError(
+                "Parser config supports only 'parsers' and 'settings' objects"
+            )
+        mapping = config.get("parsers")
+        overrides = config.get("settings", {})
+        if (
+            not isinstance(mapping, dict)
+            or not mapping
+            or not isinstance(overrides, dict)
+        ):
+            raise ValueError(
+                "Parser config requires a non-empty MIME-to-parser 'parsers' object"
+            )
+        self.parsers: dict[str, tuple[PipelineComponentBase, str]] = {}
+        self.identities = {}
+        selected_paths = set()
+        for mime, name in mapping.items():
+            mime = canonical_mime(mime)
+            if mime in self.parsers:
+                raise ValueError(
+                    f"Duplicate parser mapping for {mime} (including MIME aliases)"
+                )
+            if not isinstance(name, str):
+                raise ValueError(
+                    f"Parser for {mime} must be a component name or class path"
+                )
+            component = get_component_by_name(name)
+            path = f"{component.__module__}.{component.__name__}"
+            if FileTypeEnum.from_mimetype(mime) not in getattr(
+                component, "supported_file_types", []
+            ):
+                raise ValueError(
+                    f"{path} does not support {mime}; check supported_file_types"
+                )
+            if path not in ENTRY_POINTS:
+                raise ValueError(f"{path} has no supported remote parse entry point")
+            selected_paths.add(path)
+            effective = local_settings(component, overrides.get(path, {}))
+            positive = {
+                "request_timeout",
+                "max_file_size_mb",
+                "max_pages_per_chunk",
+                "min_pages_for_chunking",
+                "max_concurrent_chunks",
+            }
+            for field_name in positive & effective.keys():
+                if effective[field_name] <= 0:
+                    raise ValueError(
+                        f"{component.__name__}.{field_name} must be positive"
+                    )
+            if (
+                path == DOCLING
+                and not 0
+                <= effective["chunk_overlap"]
+                < effective["max_pages_per_chunk"]
+            ):
+                raise ValueError(
+                    "DoclingParser.chunk_overlap must be nonnegative and smaller than max_pages_per_chunk"
+                )
+            if path == WARP:
+                if not effective["api_key"].strip():
+                    raise ValueError(
+                        "WarpIngestParser.api_key is required (set WARP_INGEST_API_KEY)"
+                    )
+                if effective["apply_ocr"] and effective["disable_ocr"]:
+                    raise ValueError(
+                        "WarpIngestParser: apply_ocr and disable_ocr are mutually exclusive"
+                    )
+            parser = component(component_settings=effective)
+            if path == TXT:
+                # Resolve recipes now so unknown strategies/invalid kwargs fail at startup.
+                from opencontractserver.pipeline.parsers.oc_text_parser import TxtParser
+
+                assert isinstance(parser, TxtParser)
+                parser._resolve_chunkers()
+            self.parsers[mime] = (parser, ENTRY_POINTS[path])
+            # Caller may use this in memory for #2318. Never log/persist secrets.
+            self.identities[mime] = {
+                "class_path": path,
+                "settings": deepcopy(effective),
+                "parser_name": parser.title,
+                "parser_version": "1.0",
+            }
+            logger.info("%s ready for %s", parser.title, mime)
+        if overrides.keys() - selected_paths:
+            raise ValueError(
+                "Settings keys must be full class paths of selected parsers"
+            )
+
+    def identity(self, mime: str) -> dict:
+        return deepcopy(self.identities[canonical_mime(mime)])
+
+    def parse(self, source_bytes: bytes, *, filename: str) -> dict:
+        mime = canonical_mime(detect_mime_type(source_bytes, filename))
+        if mime not in self.parsers:
+            raise ValueError(
+                f"No local parser selected for {mime}; add it to the parser config"
+            )
+        parser, method = self.parsers[mime]
+        kwargs = {}
+        source: bytes | str = source_bytes
+        if method == "parse_text":
+            # Match text-mode storage reads, including universal newline handling.
+            with TextIOWrapper(BytesIO(source_bytes), encoding="utf-8") as stream:
+                source = stream.read()
+        if self.identities[mime]["class_path"] != DOCLING:
+            kwargs["title"] = filename
+        export = getattr(parser, method)(source, **kwargs)
+        if not isinstance(export, dict):
+            raise ValueError(f"{parser.title} returned no export object")
+        export["file_type"] = (
+            mime  # source detection wins over short/omitted export types
+        )
+        pawls = expand_pawls_pages(export.get("pawls_file_content") or [])
+        export["pawls_file_content"] = pawls
+        if mime == FileTypeEnum.PDF.mimetype and pawls:
+            export["content"] = build_translation_layer(pawls).doc_text
+            export["page_count"] = len(pawls)
+        normalize_and_validate_export(export)
+        return export
+
+
+def normalize_and_validate_export(export: dict) -> None:
+    """Validate anchors and correlation IDs before embedding/upload; preserve IDs."""
+    mime = canonical_mime(export.get("file_type"))
+    fallback = settings.ANNOTATION_LABELS.get(mime, "SPAN_LABEL")
+    content = export.get("content")
+    if not isinstance(content, str) or not content.strip():
+        raise ValueError("Parser output has empty or invalid content")
+    if type(export.get("page_count")) is not int or export["page_count"] < 1:
+        raise ValueError("Parser output needs a positive integer page_count")
+    pages = export.get("pawls_file_content", [])
+    annotations = export.get("labelled_text", [])
+    relationships = export.get("relationships", [])
+    if not all(isinstance(v, list) for v in (pages, annotations, relationships)):
+        raise ValueError(
+            "Parser output pages, annotations and relationships must be lists"
+        )
+    if mime == FileTypeEnum.PDF.mimetype and len(pages) != export["page_count"]:
+        raise ValueError("PDF page_count does not match PAWLS pages")
+    for i, page in enumerate(pages):
+        if (
+            not isinstance(page, dict)
+            or not isinstance(page.get("page"), dict)
+            or type(page["page"].get("index")) is not int
+            or page["page"]["index"] < 0
+            or not isinstance(page.get("tokens"), list)
+        ):
+            raise ValueError(f"Invalid PAWLS page {i}")
+
+    ids = set()
+    label_types: dict[str, str] = {}
+    for i, ann in enumerate(annotations):
+        if not isinstance(ann, dict):
+            raise ValueError(f"annotation[{i}] must be an object")
+        aid = ann.get("id")
+        if type(aid) not in (str, int) or aid == "" or str(aid) in ids:
+            raise ValueError(
+                f"annotation[{i}] needs a unique string/integer id (including JSON keys)"
+            )
+        ids.add(str(aid))
+        atype = ann.get("annotation_type") or fallback
+        ann["annotation_type"] = atype
+        label = ann.get("annotationLabel")
+        if (
+            not isinstance(label, str)
+            or not label
+            or not isinstance(ann.get("rawText"), str)
+        ):
+            raise ValueError(
+                f"annotation[{i}] needs annotationLabel and rawText strings"
+            )
+        if (
+            atype not in ("SPAN_LABEL", "TOKEN_LABEL")
+            or mime != FileTypeEnum.PDF.mimetype
+            and atype != "SPAN_LABEL"
+        ):
+            raise ValueError(
+                f"annotation[{i}] has an incompatible annotation_type for {mime}"
+            )
+        if label in label_types and label_types[label] != atype:
+            raise ValueError(f"annotation[{i}] reuses a label with a different type")
+        label_types[label] = atype
+        aj = ann.get("annotation_json")
+        if not isinstance(aj, dict) or not aj:
+            raise ValueError(f"annotation[{i}] needs non-empty annotation_json")
+        if atype == "SPAN_LABEL":
+            start, end = aj.get("start"), aj.get("end")
+            if (
+                type(start) is not int
+                or type(end) is not int
+                or not 0 <= start <= end <= len(content)
+            ):
+                raise ValueError(f"annotation[{i}] span is out of range")
+            # Docxodus containers carry heading-only rawText; their normalized
+            # span.text describes the whole covered section, including children.
+            span_text = (
+                aj.get("text", ann["rawText"])
+                if mime == FileTypeEnum.DOCX.mimetype
+                else ann["rawText"]
+            )
+            if content[start:end] != span_text:
+                raise ValueError(
+                    f"annotation[{i}] rawText does not match its content span"
+                )
+        else:
+            for key, data in aj.items():
+                try:
+                    page_index = int(key)
+                except (TypeError, ValueError):
+                    raise ValueError(
+                        f"annotation[{i}] has an invalid page key"
+                    ) from None
+                if not 0 <= page_index < len(pages) or not isinstance(data, dict):
+                    raise ValueError(f"annotation[{i}] page is out of range")
+                bounds = data.get("bounds")
+                if not isinstance(bounds, dict) or not all(
+                    k in bounds for k in ("top", "bottom", "left", "right")
+                ):
+                    raise ValueError(f"annotation[{i}] needs page bounds")
+                refs = data.get("tokensJsons", [])
+                if not isinstance(refs, list):
+                    raise ValueError(f"annotation[{i}] tokensJsons must be a list")
+                for ref in refs:
+                    if (
+                        not isinstance(ref, dict)
+                        or ref.get("pageIndex") != page_index
+                        or type(ref.get("tokenIndex")) is not int
+                        or not 0 <= ref["tokenIndex"] < len(pages[page_index]["tokens"])
+                    ):
+                        raise ValueError(
+                            f"annotation[{i}] has an invalid PAWLS token reference"
+                        )
+
+    def resolves(value):
+        return type(value) in (str, int) and str(value) in ids
+
+    for i, ann in enumerate(annotations):
+        if ann.get("parent_id") is not None and not resolves(ann["parent_id"]):
+            raise ValueError(f"annotation[{i}] parent_id does not resolve")
+    for i, rel in enumerate(relationships):
+        if not isinstance(rel, dict) or not rel.get("relationshipLabel"):
+            raise ValueError(f"relationship[{i}] needs a relationshipLabel")
+        if rel["relationshipLabel"] in label_types:
+            raise ValueError(
+                f"relationship[{i}] label conflicts with an annotation label"
+            )
+        for endpoint in ("source_annotation_ids", "target_annotation_ids"):
+            refs = rel.get(endpoint)
+            if (
+                not isinstance(refs, list)
+                or not refs
+                or not all(resolves(ref) for ref in refs)
+            ):
+                raise ValueError(
+                    f"relationship[{i}] {endpoint} must resolve to emitted annotations"
+                )

--- a/scripts/remote_ingest/remote_worker.yml
+++ b/scripts/remote_ingest/remote_worker.yml
@@ -7,17 +7,16 @@
 # inbound ports, no access to the target's Postgres — just outbound HTTPS to
 # the target's /api/worker-uploads/ endpoint with a corpus-scoped token.
 #
-# This bundle runs the SAME Docling microservice and the SAME embedder image
-# the server uses, and the worker driver imports the SAME DoclingParser code,
-# so the PAWLs token layer, structural annotations and embeddings are identical
-# to an in-cluster ingestion (faithful by construction).
+# The worker reuses the application's Docling/Warp PDF, Docxodus DOCX and TXT
+# parsers with explicit local settings. Start only the selected parser services
+# and (unless --no-embeddings) vector-embedder; worker has no service dependencies.
 #
 # ---------------------------------------------------------------------------
 # Quick start (a remote host with Docker + this repo cloned):
 #
 #   export OC_TARGET_URL=https://opencontracts.example.com
 #   export OC_WORKER_TOKEN=<token from `manage.py mint_worker_token` on the server>
-#   export OC_DATA_DIR=/data/pdfs           # directory tree of PDFs to ingest
+#   export OC_DATA_DIR=/data/pdfs           # directory tree of documents to ingest
 #   export VECTOR_EMBEDDER_API_KEY=change-me # one value, wired to BOTH the
 #                                            # embedder service + the worker below
 #                                            # (mismatch -> HTTP 401 on embedding)
@@ -43,6 +42,19 @@ services:
     image: jscrudato/docsling-local
     restart: unless-stopped
 
+  # Optional parser services: start only those selected in the local mapping.
+  docxodus-parser:
+    image: ghcr.io/open-source-legal/docxodus-service:1.1.0-docxodus5.4.2
+    profiles: [docxodus]
+    restart: unless-stopped
+
+  warp-ingest:
+    image: ghcr.io/open-source-legal/warp-ingest:1.0.0
+    profiles: [warp-ingest]
+    restart: unless-stopped
+    environment:
+      WARP_API_KEY: ${WARP_INGEST_API_KEY:-abc123}
+
   # The exact vector-embedder image the server uses — identical 384-dim
   # embeddings over identical inputs.
   vector-embedder:
@@ -66,12 +78,13 @@ services:
         - type=registry,ref=ghcr.io/open-source-legal/opencontracts/django-local-cache:main
     image: opencontractserver_local_django
     entrypoint: ["/app/scripts/remote_ingest/worker-entrypoint.sh"]
-    depends_on:
-      - docling-parser
-      - vector-embedder
     environment:
       DJANGO_SETTINGS_MODULE: config.settings.remote_worker
-      DOCLING_PARSER_SERVICE_URL: http://docling-parser:8000/parse/
+      OC_PARSER_CONFIG: ${OC_PARSER_CONFIG:-}
+      DOCLING_PARSER_SERVICE_URL: ${DOCLING_PARSER_SERVICE_URL:-http://docling-parser:8000/parse/}
+      DOCXODUS_PARSER_SERVICE_URL: ${DOCXODUS_PARSER_SERVICE_URL:-http://docxodus-parser:8080/parse}
+      WARP_INGEST_PARSER_SERVICE_URL: ${WARP_INGEST_PARSER_SERVICE_URL:-http://warp-ingest:5001/api/parse}
+      WARP_INGEST_API_KEY: ${WARP_INGEST_API_KEY:-abc123}
       EMBEDDINGS_MICROSERVICE_URL: http://vector-embedder:8000
       VECTOR_EMBEDDER_API_KEY: ${VECTOR_EMBEDDER_API_KEY:-abc123}
       # Target instance + corpus-scoped token (set on the host before running).
@@ -82,6 +95,6 @@ services:
       DOCLING_MAX_CONCURRENT_CHUNKS: ${DOCLING_MAX_CONCURRENT_CHUNKS:-3}
     volumes:
       - ../..:/app
-      - ${OC_DATA_DIR:?set OC_DATA_DIR to the directory tree of PDFs to ingest}:/data:ro
+      - ${OC_DATA_DIR:?set OC_DATA_DIR to the directory tree of documents to ingest}:/data:ro
       - oc_remote_ledger:/ledger
     working_dir: /app

--- a/scripts/remote_ingest/worker-entrypoint.sh
+++ b/scripts/remote_ingest/worker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Entrypoint for the remote-ingest worker container.
 #
-# Prepends the fixed in-container paths (ledger + mounted PDF root) to every
+# Prepends the fixed in-container paths (ledger + mounted document root) to every
 # invocation, so the user only types the subcommand + tuning flags, e.g.:
 #
 #   docker compose -f remote_worker.yml run --rm worker plan


### PR DESCRIPTION
## Summary

Remote ingestion currently assumes Docling and PDF throughout parsing and upload. This adds explicit local PDF/DOCX/TXT parser routing through the same parser internals used by the server, with validated settings and no database access during remote parsing.

Fixes #2316. Reviewed related issues #2317, #2318, #2319, and #2320; checkpointing, scheduling, backpressure changes, and embedding-completeness policy remain separate work.

## Changes

- Share Warp PDF, Docxodus DOCX, and TXT parsing entry points alongside the existing Docling byte parser. Resolve configured parsers through the component registry and validate MIME compatibility and local settings without querying database-backed pipeline settings.
- Preserve canonical source MIME, selected-parser provenance, annotation IDs, parent links, relationships, and exact text offsets. Validate exports before upload, preserve DOCX source text when display PAWLS is present, and retain zero-valued IDs during enrichment.
- Import non-PDF uploads with matching filename extensions and annotation label types. Expose effective parser identity/settings for subsequent cache fingerprint work.
- Add configuration examples, optional Docxodus/Warp Compose services, documentation, a changelog fragment, and regression coverage.

## Test plan

- Focused backend regressions in the running Compose worker: 201 tests and 20 subtests passed across `test_chunked_parser.py`, `test_doc_parser_warp_ingest.py`, `test_doc_parser_docxodus.py`, `test_worker_uploads.py`, and `test_remote_ingest_parsers.py`. Supplemental parser, DOCX, and enrichment regressions passed (56 tests and 17 subtests); the final parser-only rerun passed (19 tests and 17 subtests).
  - Command prefix: `docker exec -e DJANGO_SETTINGS_MODULE=config.settings.test -e STORAGE_BACKEND=LOCAL -e USE_AWS=false celeryworker pytest … --no-cov`.
- Live Compose validation passed for Docling PDF, Warp PDF, Docxodus DOCX, and TXT with actual parser services and database reads forbidden during remote preparation.
- Four live HTTP upload/import checks passed against a test database, verifying stored content, MIME, parser provenance, annotation types, parent/relationship mappings, and completed receipts. Only asynchronous thumbnail and embedding dispatch were suppressed.
- Both remote-worker Compose configurations validate with `docker compose … config --quiet`.
- `BLACK_NUM_WORKERS=1 pre-commit run --all-files` and changed-file hooks passed, including full backend mypy checking.
- `cd frontend && ./node_modules/.bin/tsc --noEmit` passed.

## Checklist

- [x] Tests pass locally for affected code
- [x] Repository-wide pre-commit checks pass
- [x] TypeScript compiles cleanly
- [x] Changelog fragment added
- [x] No new SDK or library dependency

## Contributor License Agreement

By submitting this pull request, you agree to license your contribution under the project's [Contributor License Agreement](../CLA.md).
