### PR TITLE
Bound remote-ingest scanning, ledger pages, and task scheduling

### DIFF
--- a/changelog.d/2317-bounded-remote-ingest.fixed.md
+++ b/changelog.d/2317-bounded-remote-ingest.fixed.md
@@ -1,0 +1,1 @@
+- Bound remote-ingest discovery, ledger reads, and unfinished futures in `scripts/remote_ingest/oc_remote_ingest.py` (#2317). Stream directory traversal, page by relative path without skipping status transitions or retrying failures within a pass, and gracefully cancel queued/paused work on Ctrl-C while saving active upload results for resume.

--- a/docs/upload_methods/remote_ingest_worker.md
+++ b/docs/upload_methods/remote_ingest_worker.md
@@ -63,9 +63,13 @@ is a resumable, per-document CLI:
    to `/api/worker-uploads/documents/` with `Authorization: WorkerKey <token>`.
 3. `verify` polls the target for each upload's terminal status.
 
-It streams per document (no archive is ever built), runs a thread pool of
-workers, and paces itself against the target's worker-upload backlog. The ledger
-makes the whole run crash-resumable -- re-running `run` skips finished documents.
+Discovery streams in filesystem order; ledger reads use bounded keyset pages,
+and submitted unfinished work is capped at twice `--max-workers`. The worker
+paces itself against the target's worker-upload backlog. Re-running `run` skips
+uploaded documents and retries unfinished work. Ctrl-C cancels queued work and
+drains already-started calls; use one invocation per ledger at a time. See
+[bounded traversal and resume](../../scripts/remote_ingest/README.md#bounded-traversal-and-resume)
+for ordering, memory bounds, and upload replay limitations.
 The worker needs **no database access** to the target: it only makes outbound
 HTTPS calls to the worker-upload endpoint.
 

--- a/opencontractserver/tests/test_remote_ingest_scheduling.py
+++ b/opencontractserver/tests/test_remote_ingest_scheduling.py
@@ -1,0 +1,457 @@
+"""Bounded remote CLI tests: generated paths/SQLite rows, no Django or services.
+
+Can also run directly with ``python -m unittest
+opencontractserver.tests.test_remote_ingest_scheduling``.
+"""
+
+import hashlib
+import os
+import sqlite3
+import threading
+import time
+import unittest
+import weakref
+from concurrent.futures import Future, ThreadPoolExecutor
+from contextlib import closing
+from dataclasses import replace
+from io import StringIO
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import Mock, patch
+
+from scripts.remote_ingest import oc_remote_ingest as cli
+
+
+class ObservedCursor(sqlite3.Cursor):
+    def execute(self, sql, parameters=()):
+        self.sql = sql
+        if sql.startswith("SELECT * FROM docs"):
+            observer = cast(ObservedConnection, self.connection).observer
+            observer["test"].assertFalse(observer["interrupted"])
+            observer["queries"].append((sql, parameters))
+        return super().execute(sql, parameters)
+
+    def fetchmany(self, size=1):
+        rows = super().fetchmany(size)
+        cast(ObservedConnection, self.connection).observer["fetches"].append(
+            (size, len(rows))
+        )
+        return rows
+
+    def fetchall(self):
+        if self.sql.startswith("SELECT * FROM docs"):
+            raise AssertionError("document reads must be bounded")
+        return super().fetchall()
+
+
+class ObservedConnection(sqlite3.Connection):
+    observer: dict[str, Any]
+
+    def execute(self, sql, parameters=()):
+        return self.cursor(ObservedCursor).execute(sql, parameters)
+
+
+class SchedulingTests(unittest.TestCase):
+    def setUp(self):
+        tmp = TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.root = Path(tmp.name)
+        self.cfg = cli.Config(
+            target_url="https://target.invalid",
+            worker_token="test-token",
+            corpus_id=None,
+            root_dir=tmp.name,
+            ledger_path=str(self.root / "ledger.sqlite3"),
+            extensions=(".pdf",),
+            max_workers=3,
+            max_attempts=5,
+            queue_high=0,
+            queue_low=0,
+            embeddings=False,
+            target_folder_from_tree=True,
+            verify_tls=True,
+            limit=0,
+            enrichers=[],
+            ledger_page_size=7,
+        )
+        self.observer: dict[str, Any] = dict(
+            test=self, interrupted=False, queries=[], fetches=[]
+        )
+        connect = sqlite3.connect
+        coordinator = threading.get_ident()
+
+        def observed_connect(*args, **kwargs):
+            conn = connect(*args, **kwargs, factory=ObservedConnection)
+            conn.observer = self.observer
+            if threading.get_ident() == coordinator:
+                self.addCleanup(conn.close)
+            return conn
+
+        self.patch("sqlite3.connect", observed_connect)
+        self.ledger = cli.Ledger(self.cfg.ledger_path)
+        self.patch("scripts.remote_ingest.oc_remote_ingest._Parser", Mock())
+        self.client = Mock()
+        self.client.backlog_count.return_value = 0
+        self.patch(
+            "scripts.remote_ingest.oc_remote_ingest.TargetClient",
+            Mock(return_value=self.client),
+        )
+        self.patch("scripts.remote_ingest.oc_remote_ingest._print_status", Mock())
+        self.patch("scripts.remote_ingest.oc_remote_ingest.logger", Mock())
+        self.patch("sys.stderr", StringIO())
+
+    def patch(self, target, value):
+        patcher = patch(target, value)
+        self.addCleanup(patcher.stop)
+        return patcher.start()
+
+    def populate(self, count, statuses=(cli.PENDING, cli.FAILED)):
+        # Reverse insertion order ensures traversal uses the key, not insertion order.
+        with self.ledger._conn() as conn:
+            conn.executemany(
+                "INSERT INTO docs(rel_path, abs_path, status, upload_id) VALUES(?, ?, ?, ?)",
+                (
+                    (
+                        f"{i:05}.pdf",
+                        f"/generated/{i}.pdf",
+                        statuses[i % len(statuses)],
+                        f"receipt-{i}",
+                    )
+                    for i in reversed(range(count))
+                ),
+            )
+
+    def assert_pages_bounded(self, page_size, minimum_pages=2):
+        self.assertGreaterEqual(len(self.observer["fetches"]), minimum_pages)
+        for requested, fetched in self.observer["fetches"]:
+            self.assertEqual(requested, page_size)
+            self.assertLessEqual(fetched, page_size)
+        for sql, params in self.observer["queries"]:
+            self.assertNotIn("OFFSET", sql)
+            self.assertIn("LIMIT ?", sql)
+            self.assertEqual(params[-1], page_size)
+            plan = (
+                self.ledger._conn()
+                .execute("EXPLAIN QUERY PLAN " + sql, params)
+                .fetchall()
+            )
+            self.assertFalse(any("TEMP B-TREE" in row[3] for row in plan))
+
+    def test_keyset_transitions_and_retry_next_pass(self):
+        self.populate(1003, (cli.PENDING, cli.FAILED, cli.COMPLETED, cli.PARKED))
+        expected = [f"{i:05}.pdf" for i in range(1003) if i % 4 < 2]
+        self.assertEqual(self.ledger.claimable_count(), len(expected))
+        selected = []
+        for row in self.ledger.claimable(7):
+            rel = row["rel_path"]
+            selected.append(rel)
+            if int(rel[:5]) % 4 == 0:
+                self.ledger.mark_uploaded(rel, "accepted", 1, 1)
+            else:
+                self.ledger.mark_failed(rel, "retry later", 5)
+        self.assertEqual(selected, expected)
+        retry = [row["rel_path"] for row in self.ledger.claimable(7)]
+        self.assertEqual(retry, [rel for rel in expected if int(rel[:5]) % 4 == 1])
+        self.assert_pages_bounded(7, minimum_pages=100)
+
+    def test_run_bounds_futures_and_releases_completed_work(self):
+        self.populate(1003)
+        window = cli.FUTURES_PER_WORKER * self.cfg.max_workers
+        live: weakref.WeakSet[Future[None]] = weakref.WeakSet()
+        peaks = dict(unfinished=0, retained=0, submitted=0)
+        release = threading.Event()
+        self.addCleanup(release.set)
+        attempts = []
+        test = self
+
+        class ObservedExecutor(ThreadPoolExecutor):
+            def submit(self, *args, **kwargs):
+                future = super().submit(*args, **kwargs)
+                live.add(future)
+                peaks["submitted"] += 1
+                peaks["unfinished"] = max(
+                    peaks["unfinished"], sum(not f.done() for f in live)
+                )
+                peaks["retained"] = max(peaks["retained"], len(live))
+                test.assertLessEqual(peaks["unfinished"], window)
+                return future
+
+        def process(cfg, parser, embedder, client, row, enrichers):
+            self.assertTrue(
+                release.wait(3), "coordinator did not reach its bounded window"
+            )
+            rel = row["rel_path"]
+            attempts.append(rel)
+            return (
+                rel,
+                rel != "00000.pdf",
+                "receipt|1" if rel != "00000.pdf" else "failed",
+            )
+
+        real_wait = cli.wait
+
+        def observed_wait(futures, **kwargs):
+            self.assertLessEqual(len(futures), window)
+            release.set()
+            return real_wait(futures, **kwargs)
+
+        with patch.object(cli, "ThreadPoolExecutor", ObservedExecutor), patch.object(
+            cli, "wait", observed_wait
+        ), patch.object(cli, "_process_one", process):
+            self.assertEqual(cli.cmd_run(self.cfg), 1)
+        self.assertEqual(sorted(attempts), [f"{i:05}.pdf" for i in range(1003)])
+        self.assertEqual(peaks["submitted"], 1003)
+        self.assertEqual(peaks["unfinished"], window)
+        self.assertLessEqual(peaks["retained"], window)
+        self.assertEqual(len(live), 0)
+        self.assert_pages_bounded(7, minimum_pages=100)
+        self.assertEqual(self.ledger.claimable_count(), 1)
+        with patch.object(
+            cli, "_process_one", return_value=("00000.pdf", True, "retried|1")
+        ) as process:
+            self.assertEqual(cli.cmd_run(self.cfg), 0)
+            process.assert_called_once()
+        self.assertEqual(self.ledger.status_counts(), {cli.UPLOADED: 1003})
+
+    def test_verify_pages_keep_terminal_and_outstanding_outcomes(self):
+        self.populate(1003, (cli.UPLOADED,))
+        self.ledger._conn().execute(
+            "UPDATE docs SET upload_id=NULL WHERE rel_path='01002.pdf'"
+        )
+        self.assertEqual(self.ledger.uploaded_unconfirmed_count(), 1002)
+        selected = []
+        outcomes = ["COMPLETED", "FAILED", "PENDING", "PROCESSING", None]
+
+        def status(receipt):
+            i = int(receipt.split("-")[1])
+            selected.append(i)
+            outcome = outcomes[i % len(outcomes)]
+            return (
+                None
+                if outcome is None
+                else {"status": outcome, "error_message": "server error"}
+            )
+
+        self.client.upload_status.side_effect = status
+        self.assertEqual(cli.cmd_verify(self.cfg), 0)
+        self.assertEqual(selected, list(range(1002)))
+        self.assert_pages_bounded(7, minimum_pages=100)
+        failed = (
+            self.ledger._conn()
+            .execute("SELECT * FROM docs WHERE rel_path='00001.pdf'")
+            .fetchone()
+        )
+        self.assertEqual(
+            (failed["status"], failed["upload_id"], failed["last_error"]),
+            (cli.FAILED, "receipt-1", "server: server error"),
+        )
+        selected.clear()
+        cli.cmd_verify(self.cfg)
+        self.assertEqual(selected, [i for i in range(1002) if i % len(outcomes) >= 2])
+
+    def test_interrupt_wakes_paused_workers_cancels_queue_and_resumes(self):
+        self.populate(103)
+        cfg = replace(self.cfg, max_workers=1, queue_high=10)
+        polled = threading.Event()
+        queued = []
+        test = self
+
+        def backlog():
+            polled.set()
+            return 20
+
+        self.client.backlog_count.side_effect = backlog
+
+        class ObservedExecutor(ThreadPoolExecutor):
+            def submit(self, *args, **kwargs):
+                test.assertFalse(test.observer["interrupted"])
+                future = super().submit(*args, **kwargs)
+                queued.append(future)
+                return future
+
+        def interrupt(futures, **kwargs):
+            self.assertTrue(polled.wait(3))
+            self.observer["interrupted"] = True
+            raise KeyboardInterrupt
+
+        start = time.monotonic()
+        with patch.object(cli, "wait", interrupt), patch.object(
+            cli, "ThreadPoolExecutor", ObservedExecutor
+        ), patch.object(cli, "_process_one") as process:
+            self.assertEqual(cli.cmd_run(cfg), 130)
+            process.assert_not_called()
+        self.assertLess(time.monotonic() - start, 3)
+        self.assertEqual(len(queued), 2)
+        self.assertTrue(queued[1].cancelled())
+        self.assertEqual(len(self.observer["fetches"]), 1)
+        self.assertEqual(self.ledger.claimable_count(), 103)
+        self.assertEqual(
+            self.ledger._conn().execute("SELECT SUM(attempts) FROM docs").fetchone()[0],
+            0,
+        )
+        self.observer["interrupted"] = False
+        with patch.object(
+            cli,
+            "_process_one",
+            side_effect=lambda *args: (args[4]["rel_path"], True, "receipt|1"),
+        ):
+            self.assertEqual(cli.cmd_run(self.cfg), 0)
+        self.assertEqual(self.ledger.status_counts(), {cli.UPLOADED: 103})
+
+    def test_interrupt_preserves_running_success_and_failure(self):
+        self.populate(103)
+        cfg = replace(self.cfg, max_workers=2)
+        started = threading.Barrier(3)
+        release = threading.Event()
+        self.addCleanup(release.set)
+        queued = []
+        test = self
+
+        class ObservedExecutor(ThreadPoolExecutor):
+            def submit(self, *args, **kwargs):
+                test.assertFalse(test.observer["interrupted"])
+                future = super().submit(*args, **kwargs)
+                queued.append(future)
+                return future
+
+            def shutdown(self, wait=True, *, cancel_futures=False):
+                test.assertTrue(all(f.cancelled() for f in queued[2:]))
+                release.set()
+                return super().shutdown(wait, cancel_futures=cancel_futures)
+
+        def process(*args):
+            started.wait(timeout=3)
+            self.assertTrue(release.wait(3))
+            rel = args[4]["rel_path"]
+            return (
+                rel,
+                rel == "00000.pdf",
+                "accepted|1" if rel == "00000.pdf" else "failed",
+            )
+
+        def interrupt(*args, **kwargs):
+            started.wait(timeout=3)
+            self.observer["interrupted"] = True
+            raise KeyboardInterrupt
+
+        with patch.object(cli, "wait", interrupt), patch.object(
+            cli, "ThreadPoolExecutor", ObservedExecutor
+        ), patch.object(cli, "_process_one", process):
+            self.assertEqual(cli.cmd_run(cfg), 130)
+        self.assertEqual(len(queued), 4)
+        self.assertTrue(all(f.done() for f in queued))
+        self.assertEqual(self.ledger.claimable_count(), 102)
+        self.observer["interrupted"] = False
+        failed = next(self.ledger.claimable(7))
+        self.assertEqual(
+            (failed["rel_path"], failed["status"], failed["attempts"]),
+            ("00001.pdf", cli.FAILED, 1),
+        )
+        resumed = []
+
+        def resume(*args):
+            rel = args[4]["rel_path"]
+            resumed.append(rel)
+            return rel, True, "resumed|1"
+
+        with patch.object(cli, "_process_one", resume):
+            self.assertEqual(cli.cmd_run(cfg), 0)
+        self.assertEqual(sorted(resumed), [f"{i:05}.pdf" for i in range(1, 103)])
+
+    def test_positive_bounds_and_empty_passes(self):
+        for flag in ("--max-workers", "--ledger-page-size"):
+            for value in ("0", "-1"):
+                with self.subTest(flag=flag, value=value), self.assertRaises(
+                    SystemExit
+                ) as exc:
+                    cli.main([flag, value, "status"])
+                self.assertEqual(exc.exception.code, 2)
+        with self.assertRaises(ValueError):
+            next(self.ledger.claimable(0))
+        with patch.object(cli, "ThreadPoolExecutor") as pool:
+            self.assertEqual(cli.cmd_run(self.cfg), 0)
+            pool.assert_not_called()
+        self.assertEqual(cli.cmd_verify(self.cfg), 0)
+        self.client.upload_status.assert_not_called()
+
+    def synthetic_tree(self, names):
+        """Lazy directory handles explode if a caller scans beyond the limit."""
+        sub = self.root / "sub"
+        sub.mkdir()
+        for name in names:
+            (sub / name).write_bytes(name.encode())
+        handles = []
+
+        class Directory:
+            def __init__(self, entries):
+                self.entries = iter(entries)
+                self.consumed = 0
+                self.closed = False
+
+            def __next__(self):
+                self.consumed += 1
+                return next(self.entries)
+
+            def close(self):
+                self.closed = True
+
+        def entries(path):
+            for child in (
+                [sub] if Path(path) == self.root else [sub / name for name in names]
+            ):
+                yield SimpleNamespace(
+                    path=str(child),
+                    is_dir=lambda **kwargs: child.is_dir(),
+                    is_file=child.is_file,
+                )
+            raise AssertionError("consumed the rest of the synthetic tree")
+
+        def scandir(path):
+            handle = Directory(entries(path))
+            handles.append(handle)
+            return handle
+
+        return scandir, handles
+
+    def test_scanner_yields_before_consuming_wide_or_deep_tree(self):
+        scandir, handles = self.synthetic_tree(["first.PDF"])
+        with patch.object(cli.os, "scandir", scandir), closing(
+            cli._scan(str(self.root), (".pdf",))
+        ) as paths:
+            rel, absolute = next(paths)
+            self.assertEqual(rel, "sub/first.PDF")
+            self.assertEqual(absolute, str(self.root / "sub/first.PDF"))
+            self.assertEqual([handle.consumed for handle in handles], [1, 1])
+        self.assertTrue(all(handle.closed for handle in handles))
+
+    def test_plan_limit_counts_new_documents_and_closes_scan(self):
+        scandir, handles = self.synthetic_tree(["old.PDF", "new.PDF"])
+        self.ledger.upsert_doc(
+            "sub/old.PDF", str(self.root / "sub/old.PDF"), 7, "old-hash", 1
+        )
+        with patch.object(cli.os, "scandir", scandir):
+            self.assertEqual(cli.cmd_plan(replace(self.cfg, limit=1)), 0)
+        rows = {row["rel_path"]: row for row in self.ledger.claimable(7)}
+        self.assertEqual(set(rows), {"sub/old.PDF", "sub/new.PDF"})
+        self.assertEqual(rows["sub/old.PDF"]["sha256"], "old-hash")
+        self.assertEqual(
+            rows["sub/new.PDF"]["sha256"], hashlib.sha256(b"new.PDF").hexdigest()
+        )
+        self.assertEqual(rows["sub/new.PDF"]["size"], 7)
+        self.assertEqual([handle.consumed for handle in handles], [1, 2])
+        self.assertTrue(all(handle.closed for handle in handles))
+
+    def test_scanner_extensions_links_and_posix_paths(self):
+        (self.root / "nested").mkdir()
+        for name in ("a.PDF", "nested/b.txt", "c.docx", "skip.csv"):
+            (self.root / name).touch()
+        (self.root / "directory.pdf").mkdir()
+        os.symlink(self.root / "a.PDF", self.root / "linked.pdf")
+        os.symlink(self.root, self.root / "nested" / "cycle")
+        os.symlink(self.root / "missing", self.root / "broken.pdf")
+        self.assertEqual(
+            {rel for rel, _ in cli._scan(str(self.root), (".pdf", ".txt", ".docx"))},
+            {"a.PDF", "nested/b.txt", "c.docx", "linked.pdf"},
+        )

--- a/scripts/remote_ingest/README.md
+++ b/scripts/remote_ingest/README.md
@@ -186,11 +186,14 @@ Useful flags (append after the subcommand):
   the bottleneck. On CPU each OCR parse is serial and uses **3-6 GB RAM**, so size
   this to **available RAM** (and parser replicas), not raw CPU count —
   over-parallelizing OCR on CPU can exhaust memory/swap. On a capable GPU, scale up.
+- `--ledger-page-size N` — maximum rows read per ledger page by `run`/`verify`
+  (default 256, must be positive). The submitted-but-unfinished future window is
+  bounded separately at **2 × `--max-workers`**, including active workers.
 - `--no-embeddings` — skip remote embedding and let the **server** embed instead
   (the worker still offloads parsing). By default the worker embeds and the
   server is told not to re-embed.
-- `--limit N` — (on `plan`) cap how many documents are recorded; handy for a
-  trial run.
+- `--limit N` — (on `plan`) stop after recording N **new** documents; existing
+  ledger paths do not consume the limit. Zero means no cap.
 - `--flat` — do not mirror the directory tree into corpus folders.
 - `--queue-high / --queue-low` — back-pressure thresholds against the target's
   worker-upload backlog (pause when `PENDING+PROCESSING` exceeds high, resume
@@ -200,6 +203,38 @@ Useful flags (append after the subcommand):
 - `--max-attempts N` — retries per document before it is PARKED (default 5).
 - `--insecure` — disable TLS verification (testing only; e.g. a self-signed or
   local HTTPS target).
+
+### Bounded traversal and resume
+
+`plan` walks depth-first in filesystem order, yielding files without collecting
+or sorting the tree (including within a large directory). Directory symlinks are
+not traversed; matching file symlinks remain eligible. `--limit` stops discovery
+immediately, but its selected subset is no longer globally sorted or guaranteed
+to repeat after filesystem changes. Relative POSIX paths, case-insensitive
+extension matching and SHA-256 recording are unchanged; replanning skips known
+paths and can add the next limited set.
+
+`run` and `verify` visit ledger rows in ascending relative-path order, in bounded
+pages using a keyset cursor. Updating earlier rows cannot skip later rows, and a
+document that fails stays behind the cursor until the next `run`. Totals use
+separate SQL counts. Partial path indexes are added automatically to existing
+ledgers; no manual migration is needed. Coordinator storage is proportional to
+the page size plus the future window, independent of the document count. Active
+documents still require memory for their source and preparation artifacts.
+
+On **Ctrl-C**, `run` stops fetching/submitting rows, cancels queued futures, and
+wakes workers paused by backpressure without consuming a retry attempt. At most
+`--max-workers` already-started document/status calls finish before exit **130**;
+their upload/failure transitions are saved. This is a graceful drain, so it can
+take as long as those operations and their configured timeouts/retries. Run the
+command again to resume unfinished rows.
+
+Use one CLI invocation per ledger at a time, including `plan` and `verify`.
+These cursors do not coordinate ownership across processes. Local resume also
+does not guarantee exactly-once delivery: an upload accepted by the server whose
+response is lost may be repeated. Preparation checkpoints, source-change
+reconciliation, admission error classification, and verification exit outcomes
+are tracked separately in #2318, #2319, and #2320.
 
 ---
 

--- a/scripts/remote_ingest/oc_remote_ingest.py
+++ b/scripts/remote_ingest/oc_remote_ingest.py
@@ -22,8 +22,9 @@ import sqlite3
 import sys
 import threading
 import time
-from collections.abc import Mapping
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from collections.abc import Generator, Mapping
+from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
+from contextlib import closing
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Any
@@ -40,6 +41,8 @@ logger = logging.getLogger("oc_remote_ingest")
 # --- Defaults --------------------------------------------------------------
 DEFAULT_EXTENSIONS = ".pdf"
 DEFAULT_MAX_WORKERS = 4
+DEFAULT_LEDGER_PAGE_SIZE = 256
+FUTURES_PER_WORKER = 2
 DEFAULT_EMBED_BATCH = 100
 DEFAULT_MAX_ATTEMPTS = 5
 # Backpressure: pause submitting when the target has more than HIGH worker
@@ -48,6 +51,10 @@ DEFAULT_QUEUE_HIGH = 2000
 DEFAULT_QUEUE_LOW = 500
 _HTTP_MAX_RETRIES = 6
 _JITTER_MIN = 0.5
+_GOVERNOR_WAIT_SECONDS = 10
+
+_CLAIMABLE_WHERE = "status IN ('PENDING', 'FAILED')"
+_UNCONFIRMED_WHERE = "status='UPLOADED' AND upload_id IS NOT NULL"
 
 # Ledger statuses
 PENDING = "PENDING"
@@ -85,6 +92,10 @@ class Ledger:
                     completed_at REAL
                 );
                 CREATE INDEX IF NOT EXISTS idx_docs_status ON docs(status);
+                CREATE INDEX IF NOT EXISTS idx_docs_claimable_path
+                    ON docs(rel_path) WHERE status IN ('PENDING', 'FAILED');
+                CREATE INDEX IF NOT EXISTS idx_docs_unconfirmed_path
+                    ON docs(rel_path) WHERE status='UPLOADED' AND upload_id IS NOT NULL;
                 CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT);
                 PRAGMA journal_mode=WAL;
                 PRAGMA synchronous=NORMAL;
@@ -127,23 +138,63 @@ class Ledger:
         )
         return cur.rowcount > 0
 
-    def claimable(self) -> list[sqlite3.Row]:
-        return list(
+    def _iter_rows(
+        self, where: str, index: str, page_size: int
+    ) -> Generator[sqlite3.Row]:
+        """One pass in immutable path order; visited failures wait for the next run.
+
+        Pages release their read cursor before yielding so worker writes neither
+        shift an OFFSET nor keep a long-lived SQLite read snapshot/WAL open.
+        One CLI invocation owns the ledger; concurrent plan/run/verify is unsupported.
+        ``where``/``index`` are internal SQL constants, never operator input.
+        """
+        if page_size <= 0:
+            raise ValueError("ledger page size must be positive")
+        after = None
+        while True:
+            keyset = "" if after is None else " AND rel_path > ?"
+            params = (page_size,) if after is None else (after, page_size)
+            with closing(
+                self._conn().execute(
+                    # Force the matching path index: SQLite can otherwise choose the
+                    # status index and re-sort the remaining ledger on every page.
+                    f"SELECT * FROM docs INDEXED BY {index} "
+                    f"WHERE {where}{keyset} ORDER BY rel_path LIMIT ?",
+                    params,
+                )
+            ) as cursor:
+                rows = cursor.fetchmany(page_size)
+            if not rows:
+                return
+            after = rows[-1]["rel_path"]
+            yield from rows
+            if len(rows) < page_size:
+                return
+            del rows
+
+    def _count(self, where: str) -> int:
+        return (
             self._conn()
-            .execute(
-                "SELECT * FROM docs WHERE status IN ('PENDING', 'FAILED') "
-                "ORDER BY rel_path"
-            )
-            .fetchall()
+            .execute(f"SELECT COUNT(*) FROM docs WHERE {where}")
+            .fetchone()[0]
         )
 
-    def uploaded_unconfirmed(self) -> list[sqlite3.Row]:
-        return list(
-            self._conn()
-            .execute(
-                "SELECT * FROM docs WHERE status='UPLOADED' AND upload_id IS NOT NULL"
-            )
-            .fetchall()
+    def claimable_count(self) -> int:
+        return self._count(_CLAIMABLE_WHERE)
+
+    def claimable(
+        self, page_size: int = DEFAULT_LEDGER_PAGE_SIZE
+    ) -> Generator[sqlite3.Row]:
+        return self._iter_rows(_CLAIMABLE_WHERE, "idx_docs_claimable_path", page_size)
+
+    def uploaded_unconfirmed_count(self) -> int:
+        return self._count(_UNCONFIRMED_WHERE)
+
+    def uploaded_unconfirmed(
+        self, page_size: int = DEFAULT_LEDGER_PAGE_SIZE
+    ) -> Generator[sqlite3.Row]:
+        return self._iter_rows(
+            _UNCONFIRMED_WHERE, "idx_docs_unconfirmed_path", page_size
         )
 
     def mark_uploaded(
@@ -205,6 +256,7 @@ class Config:
     limit: int
     enrichers: list[str]
     parser_config: str | None = None
+    ledger_page_size: int = DEFAULT_LEDGER_PAGE_SIZE
 
 
 class TargetClient:
@@ -560,14 +612,27 @@ def _sha256(path: str) -> str:
 
 
 def _scan(root: str, extensions: tuple[str, ...]):
+    """Stream depth-first in filesystem order, without following directory links.
+
+    Retain only one scandir iterator per depth, even for a very wide directory.
+    Closing the generator (e.g. at --limit) closes every open directory handle.
+    """
     root_path = Path(root).resolve()
-    for path in sorted(root_path.rglob("*")):
-        if not path.is_file():
-            continue
-        if path.suffix.lower() not in extensions:
-            continue
-        rel = path.relative_to(root_path).as_posix()
-        yield rel, str(path)
+    stack = [os.scandir(root_path)]
+    try:
+        while stack:
+            entry = next(stack[-1], None)
+            if entry is None:
+                stack.pop().close()
+            elif entry.is_dir(follow_symlinks=False):
+                stack.append(os.scandir(entry.path))
+            elif entry.is_file():
+                path = Path(entry.path)
+                if path.suffix.lower() in extensions:
+                    yield path.relative_to(root_path).as_posix(), str(path)
+    finally:
+        for entries in stack:
+            entries.close()
 
 
 # ======================================================================
@@ -582,17 +647,18 @@ def cmd_plan(cfg: Config) -> int:
         ledger.set_meta("corpus_id", cfg.corpus_id)
     now = time.time()
     added = scanned = 0
-    for rel, abs_path in _scan(cfg.root_dir, cfg.extensions):
-        scanned += 1
-        size = os.path.getsize(abs_path)
-        # sha256 is recorded for provenance/dedup; cheap enough at plan time.
-        if ledger.upsert_doc(rel, abs_path, size, _sha256(abs_path), now):
-            added += 1
-        if cfg.limit and added >= cfg.limit:
-            logger.info(f"reached --limit {cfg.limit}; stopping scan")
-            break
-        if scanned % 500 == 0:
-            logger.info(f"planned {scanned} files ({added} new)…")
+    with closing(_scan(cfg.root_dir, cfg.extensions)) as paths:
+        for rel, abs_path in paths:
+            scanned += 1
+            size = os.path.getsize(abs_path)
+            # sha256 is recorded for provenance/dedup; cheap enough at plan time.
+            if ledger.upsert_doc(rel, abs_path, size, _sha256(abs_path), now):
+                added += 1
+            if cfg.limit and added >= cfg.limit:
+                logger.info(f"reached --limit {cfg.limit}; stopping scan")
+                break
+            if scanned % 500 == 0:
+                logger.info(f"planned {scanned} files ({added} new)…")
     logger.info(f"plan complete: scanned={scanned}, new={added}")
     _print_status(ledger, None)
     return 0
@@ -716,14 +782,16 @@ def cmd_run(cfg: Config) -> int:
         )
     client = TargetClient(cfg)
 
-    todo = ledger.claimable()
-    if not todo:
+    total = ledger.claimable_count()
+    if not total:
         logger.info("nothing to do — run `plan` first or everything is done.")
         _print_status(ledger, client)
         return 0
 
+    window = FUTURES_PER_WORKER * cfg.max_workers
     logger.info(
-        f"run: {len(todo)} docs to process with {cfg.max_workers} workers "
+        f"run: {total} docs to process with {cfg.max_workers} workers "
+        f"(future window={window}, ledger page size={cfg.ledger_page_size}) "
         f"(embeddings={'on' if cfg.embeddings else 'off'}, "
         f"enrichers={len(enrichers)})"
     )
@@ -731,11 +799,12 @@ def cmd_run(cfg: Config) -> int:
     # Backpressure gate shared by all workers.
     pause_event = threading.Event()
     pause_event.set()  # set == "go"
-    governor_state = {"last_poll": 0.0, "stop": False}
+    stop_event = threading.Event()
+    governor_state = {"last_poll": 0.0}
     gov_lock = threading.Lock()
 
     def maybe_poll_backpressure() -> None:
-        if cfg.queue_high <= 0:
+        if stop_event.is_set() or cfg.queue_high <= 0:
             return
         with gov_lock:
             now = time.time()
@@ -754,10 +823,14 @@ def cmd_run(cfg: Config) -> int:
     done_lock = threading.Lock()
 
     def worker(row: sqlite3.Row) -> None:
-        # Wait while paused (re-poll periodically to unblock).
-        while not pause_event.wait(timeout=10):
+        # Cancellation wakes paused workers without consuming a document attempt.
+        while not stop_event.is_set():
             maybe_poll_backpressure()
-        maybe_poll_backpressure()
+            if pause_event.is_set():
+                break
+            stop_event.wait(_GOVERNOR_WAIT_SECONDS)
+        if stop_event.is_set():
+            return
         rel, ok, msg = _process_one(cfg, parser, embedder, client, row, enrichers)
         now = time.time()
         if ok:
@@ -766,20 +839,56 @@ def cmd_run(cfg: Config) -> int:
             with done_lock:
                 done["ok"] += 1
                 n = done["ok"] + done["fail"]
-            logger.info(f"[{n}/{len(todo)}] uploaded {rel} -> {upload_id}")
+            logger.info(f"[{n}/{total}] uploaded {rel} -> {upload_id}")
         else:
             ledger.mark_failed(rel, msg, cfg.max_attempts)
             with done_lock:
                 done["fail"] += 1
                 n = done["ok"] + done["fail"]
-            logger.warning(f"[{n}/{len(todo)}] FAILED {rel}: {msg}")
+            logger.warning(f"[{n}/{total}] FAILED {rel}: {msg}")
 
-    with ThreadPoolExecutor(max_workers=cfg.max_workers) as pool:
-        futures = [pool.submit(worker, row) for row in todo]
-        for fut in as_completed(futures):
-            exc = fut.exception()
-            if exc is not None:
-                logger.error(f"worker crashed: {exc}")
+    todo = ledger.claimable(cfg.ledger_page_size)
+    pool = ThreadPoolExecutor(max_workers=cfg.max_workers)
+    pending: set[Future[None]] = set()
+    exhausted = interrupted = False
+    try:
+        while pending or not exhausted:
+            while not exhausted and len(pending) < window:
+                row = next(todo, None)
+                if row is None:
+                    exhausted = True
+                    break
+                pending.add(pool.submit(worker, row))
+            if not pending:
+                break
+            finished, pending = wait(pending, return_when=FIRST_COMPLETED)
+            for future in finished:
+                exc = future.exception()
+                if exc is not None:
+                    logger.error(f"worker crashed: {exc}")
+                    with done_lock:
+                        done["fail"] += 1
+            finished.clear()
+            del future
+    except KeyboardInterrupt:
+        interrupted = True
+    finally:
+        stop_event.set()
+        for future in pending:
+            future.cancel()
+        todo.close()
+        if interrupted:
+            logger.info(
+                "interrupted: cancelling queued work; waiting for at most "
+                f"{cfg.max_workers} already-running document/status calls"
+            )
+        # Avoid the context manager's unconditional wait on governor-paused work.
+        # In-flight preparation/uploads finish and persist their ledger transitions.
+        pool.shutdown(wait=True, cancel_futures=True)
+
+    if interrupted:
+        _print_status(ledger, None)
+        return 130
 
     logger.info(f"run complete: uploaded={done['ok']}, failed={done['fail']}")
     _print_status(ledger, client)
@@ -789,8 +898,9 @@ def cmd_run(cfg: Config) -> int:
 def cmd_verify(cfg: Config) -> int:
     ledger = Ledger(cfg.ledger_path)
     client = TargetClient(cfg)
-    pending = ledger.uploaded_unconfirmed()
-    logger.info(f"verify: polling {len(pending)} uploaded docs for terminal status")
+    pending = ledger.uploaded_unconfirmed(cfg.ledger_page_size)
+    total = ledger.uploaded_unconfirmed_count()
+    logger.info(f"verify: polling {total} uploaded docs for terminal status")
     confirmed = failed = still = 0
     now = time.time()
     for row in pending:
@@ -879,7 +989,15 @@ def _build_config(args: argparse.Namespace) -> Config:
         limit=args.limit,
         enrichers=enrichers,
         parser_config=args.parser_config or os.environ.get("OC_PARSER_CONFIG"),
+        ledger_page_size=args.ledger_page_size,
     )
+
+
+def _positive_int(value: str) -> int:
+    number = int(value)
+    if number <= 0:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return number
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -901,7 +1019,18 @@ def main(argv: list[str] | None = None) -> int:
         "--parser-config",
         help="Local parser mapping/settings JSON file (env OC_PARSER_CONFIG)",
     )
-    p.add_argument("--max-workers", type=int, default=DEFAULT_MAX_WORKERS)
+    p.add_argument(
+        "--max-workers",
+        type=_positive_int,
+        default=DEFAULT_MAX_WORKERS,
+        help="Active workers; submitted unfinished work is capped at twice this value",
+    )
+    p.add_argument(
+        "--ledger-page-size",
+        type=_positive_int,
+        default=DEFAULT_LEDGER_PAGE_SIZE,
+        help="Maximum ledger rows fetched per page for run/verify (default 256)",
+    )
     p.add_argument("--max-attempts", type=int, default=DEFAULT_MAX_ATTEMPTS)
     p.add_argument("--queue-high", type=int, default=DEFAULT_QUEUE_HIGH)
     p.add_argument("--queue-low", type=int, default=DEFAULT_QUEUE_LOW)


### PR DESCRIPTION
Remote ingestion loaded the entire input tree and eligible ledger rows, then queued one future per document. This change keeps coordinator memory bounded by the ledger page size and a future window of twice `--max-workers`.

- Stream discovery in filesystem depth-first order and stop immediately after `plan --limit` new documents. Preserve extension matching, relative POSIX paths, hashes, and file-symlink behavior; document the ordering trade-off.
- Share indexed keyset pagination between `run` and `verify`, with separate `COUNT(*)` totals and configurable `--ledger-page-size` (default 256). Earlier status transitions cannot skip later rows or retry failures within the same pass.
- Replenish a bounded future window and release completed futures. Ctrl-C stops fetching/admission, cancels queued work, wakes paused workers, and drains at most `--max-workers` active document/status operations before exit 130, preserving their ledger transitions.

Closes #2317. Based on latest `main`, including #2316. Preparation/receipt boundaries and existing verification outcomes remain available for #2318 and #2320; #2319 can use the same cancellation event for its admission policy. One invocation owns a ledger at a time. This does not provide end-to-end exactly-once upload delivery.

Validation:
- 52 scheduler, parser, and enrichment regressions passed in an isolated container with networking disabled and Django's standard test runner.
- New tests use generated paths and 1,003-row SQLite ledgers with seven-row pages and a six-future window; instrument fetch sizes, query plans, retained/unfinished futures, status transitions, cancellation, and restart.
- All pre-commit hooks passed, including project-wide mypy; TypeScript `tsc --noEmit` passed.
