### PR TITLE
Checkpoint remote-ingest preparation and reconcile source changes

### DIFF
--- a/changelog.d/2318.fixed.md
+++ b/changelog.d/2318.fixed.md
@@ -1,0 +1,1 @@
+Remote ingest now checkpoints parsing, enrichment and validated embeddings in the existing ledger volume, reconciles source changes, and uploads a stable byte snapshot. Accepted-source conflicts retain receipts; ambiguous POST outcomes stop automatic replay. Adds explicit deployment/configuration identities, in-place ledger migration and bounded artifact cleanup.

--- a/docs/upload_methods/remote_ingest_worker.md
+++ b/docs/upload_methods/remote_ingest_worker.md
@@ -81,6 +81,8 @@ To enable PDF, DOCX and TXT, use the bundled
 
 ```bash
 export OC_PARSER_CONFIG=/app/scripts/remote_ingest/parser-config.example.json
+export OC_PARSER_IDENTITY=parser-deployment-v1
+export OC_EMBEDDING_IDENTITY=embedding-model-v1
 # Start the services selected in that file, plus the optional embedder:
 docker compose -f remote_worker.yml up -d docling-parser docxodus-parser vector-embedder
 docker compose -f remote_worker.yml run --rm worker plan --extensions .pdf,.docx,.txt
@@ -143,11 +145,47 @@ TXT emits stable `txt-N` IDs; other parser IDs are preserved.
 `parser_name` is the selected component's title. `parser_version="1.0"` preserves
 the normal structural-set provenance convention: it is **not a discovered
 service/model version**. `LocalParsers.identity(mime)` exposes a defensive copy
-of the class path and effective settings for future preparation fingerprints.
+of the class path, effective settings and implementation fingerprints.
 That in-memory snapshot includes secrets: do not log or persist it. Callers may
 supply different title/description envelopes; PDF `content` is reconstructed
-exactly as normal persistence does. Preparation caching, settings synchronization,
-file conversion, and embedding/completion validation are separate work.
+exactly as normal persistence does. Settings synchronization, file conversion and
+broader completion/readiness reporting remain separate work.
+
+## Preparation checkpoints and source conflicts
+
+The existing `/ledger` volume stores three atomic, digest-verified checkpoints:
+complete parsed export/text, enriched export plus the existing metadata overlay,
+and validated document/annotation embeddings. Restarts and rejected uploads reuse
+every valid stage. Changing a stage's configuration invalidates it and its
+dependents while retaining earlier work. Required annotation IDs, parents,
+relationships and JSON embedding keys are validated consistently on fresh and
+resumed preparation. The uploaded source is the same byte snapshot that was
+hashed and prepared, even if its filesystem path changes in the meantime.
+
+Set `OC_PARSER_IDENTITY` for the parser service deployment (or per-parser
+`identities` in the JSON config), `OC_EMBEDDING_IDENTITY` for the embedding model,
+and `OC_ENRICHER_IDENTITY` when using enrichers. Use stable non-secret revisions;
+bump them when external models, helpers or effective enricher configuration/data
+change. Parser service identities and embedding identities are required for
+`run`; pure TXT parsing and `--no-embeddings` need neither service identity.
+The expected vector dimension is `OC_EMBEDDING_DIMENSION` / `--embedding-dimension`
+(default 384). Partial or invalid embedding responses fail before checkpointing
+or upload. Only `--no-embeddings` requests server annotation fallback.
+
+Replanning changed, unaccepted bytes resets retry exhaustion and stale receipts.
+Changes after `UPLOADED`/`COMPLETED`, or an uncertain POST, produce `CONFLICT` and
+retain the old receipt. Lost responses, 5xx and unusable receipts produce
+`AMBIGUOUS`; these rows are never automatically replayed. An operator must
+reconcile acceptance/replacement with the server. Checkpoints provide local
+recovery, not upload idempotency. Receipt access still requires the exact token
+that created the receipt, even after rotating tokens for the same corpus.
+
+Existing ledgers migrate in place; legacy rows start uncached. `worker cleanup`
+removes unreferenced artifacts older than 24 hours using bounded traversal and
+retains every artifact referenced by an active ledger row, including completed
+or blocked rows. Run one command per ledger at a time. See the
+[checkpoint and recovery reference](../../scripts/remote_ingest/README.md#durable-preparation-identities-and-source-versions)
+for identity examples, retention rules and conflict diagnostics.
 
 ## Setup
 
@@ -197,6 +235,8 @@ export OC_DATA_DIR=/data/pdfs                 # your directory tree of PDFs
 # The embedder authorizes by comparing it to the request's X-API-Key header
 # (its built-in default is "abc123"); a mismatch yields HTTP 401 on embedding.
 export VECTOR_EMBEDDER_API_KEY=<any-value>
+export OC_PARSER_IDENTITY=docling-deployment-v1
+export OC_EMBEDDING_IDENTITY=embedding-model-v1
 
 docker compose -f remote_worker.yml up -d --build docling-parser vector-embedder
 docker compose -f remote_worker.yml run --rm worker plan
@@ -283,7 +323,7 @@ def enrich(ctx: EnricherContext) -> Enrichment:
 ```
 
 ```bash
-docker compose -f remote_worker.yml run --rm worker run --enricher my_enrichers:enrich
+docker compose -f remote_worker.yml run --rm worker run --enricher my_enrichers:enrich --enricher-identity my-config-v1
 ```
 
 What an `Enrichment` can carry (all optional, additive):

--- a/opencontractserver/tests/test_remote_ingest_checkpoints.py
+++ b/opencontractserver/tests/test_remote_ingest_checkpoints.py
@@ -3,6 +3,7 @@
 import json
 import os
 import sqlite3
+import stat
 import sys
 from collections import Counter
 from copy import deepcopy
@@ -218,6 +219,20 @@ class CheckpointTests(SimpleTestCase):
             (self.cache().path / (entry["digest"] + ".json")).read_bytes()
         )["export"]
         self.assertEqual(export["parser_extension"], {"must_survive": True})
+
+    def test_success_persists_one_receipt_with_the_confirmation_timestamp(self):
+        mark_uploaded = cli.Ledger.mark_uploaded
+        confirmations = []
+
+        def record(ledger, rel_path, upload_id, page_count, now):
+            confirmations.append(now)
+            mark_uploaded(ledger, rel_path, upload_id, page_count, now)
+
+        with patch.object(cli.Ledger, "mark_uploaded", record):
+            self.assertEqual(self.run_worker(), 0)
+        self.assertEqual(len(confirmations), 1)
+        self.assertEqual(self.row()["uploaded_at"], confirmations[0])
+        self.assertEqual(self.row()["upload_id"], "receipt-1")
 
     def test_restart_at_each_durable_boundary_reuses_stages_and_exact_payload(self):
         self.assertEqual(self.run_worker(), 0)
@@ -528,6 +543,48 @@ class CheckpointTests(SimpleTestCase):
         self.assertEqual(self.run_worker(), 0)
         self.assertEqual([self.counts[s] for s in cp.STAGES], [1, 1, 2])
         self.assertEqual(self.counts["upload"], 1)
+
+
+class LedgerPermissionsTests(SimpleTestCase):
+    def setUp(self):
+        tmp = TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.path = str(Path(tmp.name) / "ledger.sqlite3")
+
+    def assert_private(self):
+        for suffix in ("", "-wal", "-shm"):
+            self.assertEqual(stat.S_IMODE(os.stat(self.path + suffix).st_mode), 0o600)
+
+    def test_new_ledger_is_private_before_sqlite_opens_under_permissive_umask(self):
+        connect = sqlite3.connect
+
+        def check_before_connect(*args, **kwargs):
+            self.assertEqual(stat.S_IMODE(os.stat(self.path).st_mode), 0o600)
+            return connect(*args, **kwargs)
+
+        previous_umask = os.umask(0)
+        try:
+            with patch.object(cli.sqlite3, "connect", side_effect=check_before_connect):
+                ledger = cli.Ledger(self.path)
+            self.addCleanup(ledger._conn().close)
+            ledger.set_meta("example", "private data")
+            self.assert_private()
+        finally:
+            os.umask(previous_umask)
+
+    def test_existing_ledger_and_recovery_files_are_hardened_without_data_loss(self):
+        legacy = sqlite3.connect(self.path)
+        self.addCleanup(legacy.close)
+        legacy.execute("PRAGMA journal_mode=WAL")
+        legacy.execute("CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT)")
+        legacy.execute("INSERT INTO meta VALUES('example', 'preserved')")
+        legacy.commit()
+        for suffix in ("", "-wal", "-shm"):
+            os.chmod(self.path + suffix, 0o666)
+        ledger = cli.Ledger(self.path)
+        self.addCleanup(ledger._conn().close)
+        self.assertEqual(ledger.get_meta("example"), "preserved")
+        self.assert_private()
 
 
 class ArtifactStorageTests(SimpleTestCase):

--- a/opencontractserver/tests/test_remote_ingest_checkpoints.py
+++ b/opencontractserver/tests/test_remote_ingest_checkpoints.py
@@ -1,0 +1,772 @@
+"""Preparation recovery with real SQLite/files and mocked services; no target DB."""
+
+import json
+import os
+import sqlite3
+import sys
+from collections import Counter
+from copy import deepcopy
+from dataclasses import replace
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any
+from unittest.mock import Mock, patch
+
+import requests
+from django.test import SimpleTestCase
+
+from scripts.remote_ingest import checkpoints as cp
+from scripts.remote_ingest import oc_remote_ingest as cli
+
+sys.path.insert(0, str(Path(cli.__file__).parent))
+from enrichers import Enrichment, label_def, metadata_field  # noqa: E402
+
+
+class CountingParser:
+    default_embedder_path = "test.Embedder"
+
+    def __init__(self, counts):
+        self.counts = counts
+        self.settings = {"model": "parser-v1", "credential": "parser-private-key"}
+        self.hook = lambda: None
+
+    def ensure_ready(self):
+        return self
+
+    def source_mime(self, source, *, filename):
+        return "text/plain"
+
+    def identity(self, mime):
+        return {
+            "class_path": "test.Parser",
+            "parser_name": "Fixture parser",
+            "parser_version": "1.0",
+            "settings": self.settings,
+        }
+
+    def parse(self, source, *, filename):
+        self.counts["parse"] += 1
+        self.hook()
+        text = source.decode()
+        # Deliberately different on every actual parse, like generated parser IDs.
+        child = f"child-{self.counts['parse']}"
+        return {
+            "content": text,
+            "file_type": "text/plain",
+            "page_count": 1,
+            "pawls_file_content": [],
+            "labelled_text": [
+                {
+                    "id": aid,
+                    "parent_id": None if aid == 0 else 0,
+                    "annotationLabel": "Paragraph",
+                    "annotation_json": {"start": 0, "end": len(text)},
+                    "rawText": text,
+                    "structural": True,
+                }
+                for aid in (0, child)
+            ],
+            "relationships": [
+                {
+                    "relationshipLabel": "contains",
+                    "source_annotation_ids": [0],
+                    "target_annotation_ids": [child],
+                }
+            ],
+            "parser_extension": {"must_survive": True},
+        }
+
+
+class CheckpointTests(SimpleTestCase):
+    def setUp(self):
+        tmp = TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.root = Path(tmp.name)
+        self.source = self.root / "source.txt"
+        self.source.write_text("Hello checkpoint")
+        self.cfg = cli.Config(
+            target_url="https://target.invalid",
+            worker_token="worker-private-key",
+            corpus_id=None,
+            root_dir=tmp.name,
+            ledger_path=str(self.root / "ledger.sqlite3"),
+            extensions=(".txt",),
+            max_workers=1,
+            max_attempts=5,
+            queue_high=0,
+            queue_low=0,
+            embeddings=True,
+            target_folder_from_tree=True,
+            verify_tls=True,
+            limit=0,
+            enrichers=["fixture:enrich"],
+            enricher_identity="config-v1",
+            embedding_identity="model-v1",
+            ledger_page_size=2,
+        )
+        self.counts: Counter[str] = Counter()
+        self.payloads = []
+        self.ledger = cli.Ledger(self.cfg.ledger_path)
+        self.plan()
+        self.parser = CountingParser(self.counts)
+        self.enrich_hook = lambda: None
+
+        def enrich(ctx):
+            self.counts["enrich"] += 1
+            self.enrich_hook()
+            return Enrichment(
+                title="Enriched title",
+                description="Enriched description",
+                annotations=[
+                    {
+                        "parent_id": 0,
+                        "annotationLabel": "Extra",
+                        "rawText": ctx.content,
+                        "annotation_type": "SPAN_LABEL",
+                        "annotation_json": {"start": 0, "end": len(ctx.content)},
+                    }
+                ],
+                annotation_labels={
+                    "Extra": label_def("Extra", "SPAN_LABEL", color="blue")
+                },
+                custom_meta={"retained": [1, "two"]},
+                metadata=[metadata_field("Category", "fixture")],
+            )
+
+        self.enrichers = [("fixture:enrich", enrich)]
+        self.embedding_dimension = 384
+        self.embed_hook = lambda: None
+        self.upload_hook = lambda: None
+        self.upload_error = None
+
+    def plan(self):
+        self.ledger.upsert_doc(
+            "folder/source.txt",
+            str(self.source),
+            self.source.stat().st_size,
+            cli._sha256(str(self.source)),
+            1,
+        )
+
+    def row(self):
+        return self.ledger.get_doc("folder/source.txt")
+
+    def cache(self):
+        return cp.Checkpoints(self.cfg.ledger_path, "folder/source.txt")
+
+    def run_worker(self):
+        # New HTTP clients and ledger connections on each invocation simulate restart.
+        embedder = cli.EmbedderClient(
+            "https://embedder.invalid",
+            "embed-private-key",
+            10,
+            dimension=self.embedding_dimension,
+            identity=self.cfg.embedding_identity,
+        )
+        client = cli.TargetClient(self.cfg)
+
+        def embed_post(url, *, json, **kwargs):
+            self.embed_hook()
+            vector = [0.25] * self.embedding_dimension
+            if url.endswith("/batch"):
+                return Mock(
+                    json=lambda: {"embeddings": [[vector] for _ in json["texts"]]}
+                )
+            self.counts["embed"] += 1
+            return Mock(json=lambda: {"embeddings": [vector]})
+
+        def upload_post(url, *, files, data, **kwargs):
+            self.counts["upload"] += 1
+            self.payloads.append(
+                (files["file"][1].read(), json.loads(data["metadata"]))
+            )
+            self.upload_hook()
+            if self.upload_error:
+                raise self.upload_error
+            return Mock(status_code=202, json=lambda: {"upload_id": "receipt-1"})
+
+        with (
+            patch.object(cli, "_Parser", return_value=self.parser),
+            patch("enrichers.load_enrichers", return_value=self.enrichers),
+            patch.object(cli, "EmbedderClient", return_value=embedder),
+            patch.object(cli, "TargetClient", return_value=client),
+            patch.object(embedder.session, "post", side_effect=embed_post),
+            patch.object(client.session, "post", side_effect=upload_post),
+            patch.object(cli, "_print_status"),
+        ):
+            return cli.cmd_run(self.cfg)
+
+    def retry_server_failure(self):
+        self.ledger.mark_failed("folder/source.txt", "server: rolled back", 100)
+
+    def assert_payload(self):
+        source, payload = self.payloads[-1]
+        self.assertEqual(source.decode(), payload["content"])
+        self.assertEqual(payload["title"], "Enriched title")
+        self.assertEqual(payload["custom_meta"], {"retained": [1, "two"]})
+        self.assertEqual(payload["metadata"][0]["column_name"], "Category")
+        self.assertEqual(payload["text_labels"]["Extra"]["color"], "blue")
+        self.assertEqual(payload["labelled_text"][2]["id"], "enr-0")
+        self.assertEqual(payload["labelled_text"][2]["parent_id"], 0)
+        self.assertEqual(payload["relationships"][0]["source_annotation_ids"], [0])
+        self.assertEqual(
+            set(payload["embeddings"]["annotation_embeddings"]),
+            {"0", "child-1", "enr-0"},
+        )
+        entry = self.cache().manifest["stages"]["enrich"]
+        export = json.loads(
+            (self.cache().path / (entry["digest"] + ".json")).read_bytes()
+        )["export"]
+        self.assertEqual(export["parser_extension"], {"must_survive": True})
+
+    def test_restart_at_each_durable_boundary_reuses_stages_and_exact_payload(self):
+        self.assertEqual(self.run_worker(), 0)
+        uninterrupted = deepcopy(self.payloads[-1])
+        for boundary in cp.STAGES:
+            with self.subTest(boundary=boundary):
+                self.cfg = replace(
+                    self.cfg, ledger_path=str(self.root / (boundary + ".sqlite3"))
+                )
+                self.ledger = cli.Ledger(self.cfg.ledger_path)
+                self.plan()
+                self.counts.clear()
+                self.payloads.clear()
+                stage = cp.Checkpoints.stage
+
+                def interrupt(cache, name, *args):
+                    result = stage(cache, name, *args)
+                    if name == boundary:
+                        raise RuntimeError("process interrupted after durable stage")
+                    return result
+
+                with patch.object(cp.Checkpoints, "stage", interrupt):
+                    self.assertEqual(self.run_worker(), 1)
+                self.assertEqual(self.row()["status"], cli.FAILED)
+                self.assertEqual(self.run_worker(), 0)
+                self.assertEqual([self.counts[s] for s in cp.STAGES], [1, 1, 1])
+                self.assert_payload()
+                self.assertEqual(self.payloads[-1], uninterrupted)
+                first = deepcopy(self.payloads[-1])
+                self.retry_server_failure()
+                self.assertEqual(self.run_worker(), 0)
+                self.assertEqual(first, self.payloads[-1])
+                self.assertEqual([self.counts[s] for s in cp.STAGES], [1, 1, 1])
+
+    def test_upload_rejection_reuses_all_preparation(self):
+        self.upload_error = cli.PermanentUploadError("HTTP 400")
+        self.assertEqual(self.run_worker(), 1)
+        self.assertEqual(self.row()["status"], cli.FAILED)
+        self.upload_error = None
+        self.assertEqual(self.run_worker(), 0)
+        self.assertEqual(self.payloads[0], self.payloads[1])
+        self.assertEqual([self.counts[s] for s in cp.STAGES], [1, 1, 1])
+
+    def test_configuration_changes_invalidate_only_affected_stages(self):
+        self.assertEqual(self.run_worker(), 0)
+        for change, expected in [
+            (
+                lambda: setattr(
+                    self, "cfg", replace(self.cfg, embedding_identity="model-v2")
+                ),
+                [1, 1, 2],
+            ),
+            (lambda: setattr(self, "embedding_dimension", 768), [1, 1, 3]),
+            (
+                lambda: setattr(
+                    self, "cfg", replace(self.cfg, enricher_identity="config-v2")
+                ),
+                [1, 2, 4],
+            ),
+            (lambda: self.parser.settings.update(model="parser-v2"), [2, 3, 5]),
+        ]:
+            self.retry_server_failure()
+            change()
+            self.assertEqual(self.run_worker(), 0)
+            self.assertEqual([self.counts[s] for s in cp.STAGES], expected)
+        for path in self.cache().path.iterdir():
+            data = path.read_bytes()
+            for secret in (
+                b"parser-private-key",
+                b"worker-private-key",
+                b"embed-private-key",
+            ):
+                self.assertNotIn(secret, data)
+
+    def test_enricher_order_is_part_of_identity(self):
+        def other(ctx):
+            return Enrichment()
+
+        self.enrichers.append(("fixture:other", other))
+        self.assertEqual(self.run_worker(), 0)
+        self.retry_server_failure()
+        self.enrichers.reverse()
+        self.assertEqual(self.run_worker(), 0)
+        self.assertEqual([self.counts[s] for s in cp.STAGES], [1, 2, 2])
+
+    def test_missing_corrupt_and_incompatible_artifacts_are_misses(self):
+        for stage in cp.STAGES:
+            for damage in ("missing", "truncated", "modified", "key"):
+                with self.subTest(stage=stage, damage=damage):
+                    if self.row()["status"] == cli.UPLOADED:
+                        self.retry_server_failure()
+                    self.assertEqual(self.run_worker(), 0)
+                    before = self.counts.copy()
+                    cache = self.cache()
+                    entry = cache.manifest["stages"][stage]
+                    artifact = cache.path / (entry["digest"] + ".json")
+                    if damage == "missing":
+                        artifact.unlink()
+                    elif damage == "truncated":
+                        artifact.write_bytes(artifact.read_bytes()[:10])
+                    elif damage == "modified":
+                        artifact.write_bytes(artifact.read_bytes() + b" ")
+                    else:
+                        cache.manifest["stages"][stage]["key"] = "0" * 64
+                        cache._publish()
+                    self.retry_server_failure()
+                    self.assertEqual(self.run_worker(), 0)
+                    for name in cp.STAGES:
+                        self.assertEqual(
+                            self.counts[name] - before[name],
+                            int(cp.STAGES.index(name) >= cp.STAGES.index(stage)),
+                        )
+
+    def test_invalid_annotation_ids_never_commit_dependent_artifacts(self):
+        original = self.parser.parse
+        for bad in (None, True, "", "0"):
+            with self.subTest(bad=bad):
+
+                def malformed(source, *, filename):
+                    export = original(source, filename=filename)
+                    export["labelled_text"][1]["id"] = bad
+                    return export
+
+                with patch.object(self.parser, "parse", side_effect=malformed):
+                    self.assertEqual(self.run_worker(), 1)
+                self.assertEqual(self.cache().manifest["stages"], {})
+        self.assertFalse(self.payloads)
+        self.assertEqual(self.counts["enrich"], 0)
+        self.assertEqual(self.counts["embed"], 0)
+
+    def test_changed_source_resets_retries_and_stale_receipts(self):
+        self.assertEqual(self.run_worker(), 0)
+        self.ledger.mark_failed("folder/source.txt", "server failed", 1)
+        self.assertEqual(self.row()["status"], cli.PARKED)
+        self.source.write_text("Changed source")
+        self.plan()
+        row = self.row()
+        self.assertEqual(row["status"], cli.PENDING)
+        for field in (
+            "last_error",
+            "upload_id",
+            "uploaded_at",
+            "completed_at",
+            "page_count",
+        ):
+            self.assertIsNone(row[field])
+        self.assertEqual(row["attempts"], 0)
+        self.assertEqual(self.run_worker(), 0)
+        self.assertEqual([self.counts[s] for s in cp.STAGES], [2, 2, 2])
+        self.assertEqual(self.payloads[-1][0], b"Changed source")
+
+    def test_changed_accepted_source_conflicts_and_preserves_receipt(self):
+        for status in (cli.UPLOADED, cli.COMPLETED, cli.AMBIGUOUS):
+            with self.subTest(status=status):
+                self.source.write_text("Hello checkpoint")
+                self.plan()
+                self.ledger.mark_uploaded("folder/source.txt", "old-receipt", 1, 12)
+                self.ledger._conn().execute("UPDATE docs SET status=?", (status,))
+                self.source.write_text("Changed source")
+                self.plan()
+                self.assertEqual(self.row()["status"], cli.CONFLICT)
+                self.assertEqual(self.row()["prior_status"], status)
+                self.assertEqual(self.row()["upload_id"], "old-receipt")
+                self.assertNotEqual(self.row()["sha256"], cli._sha256(str(self.source)))
+                self.assertEqual(self.run_worker(), 1)
+                self.assertEqual(self.row()["status"], cli.CONFLICT)
+        self.assertFalse(self.payloads)
+
+    def test_current_bytes_reconciled_without_replanning(self):
+        self.source.write_text("Changed after plan")
+        self.assertEqual(self.run_worker(), 0)
+        self.assertEqual(self.row()["sha256"], cp.digest(b"Changed after plan"))
+        self.assertEqual(self.payloads[-1][0], b"Changed after plan")
+
+    def test_snapshot_survives_source_changes_at_all_stages_and_cached_upload(self):
+        for hook in ("parse", "enrich", "embed", "upload"):
+            with self.subTest(hook=hook):
+                self.cfg = replace(
+                    self.cfg, ledger_path=str(self.root / (hook + ".sqlite3"))
+                )
+                self.ledger = cli.Ledger(self.cfg.ledger_path)
+                self.source.write_text("Hello checkpoint")
+                self.plan()
+
+                def mutate():
+                    self.source.write_text("Concurrent replacement")
+
+                target, field = (
+                    (self.parser, "hook") if hook == "parse" else (self, hook + "_hook")
+                )
+                with patch.object(target, field, mutate):
+                    self.assertEqual(self.run_worker(), 0)
+                self.assertEqual(
+                    self.payloads[-1][0].decode(), self.payloads[-1][1]["content"]
+                )
+                self.assertEqual(self.payloads[-1][0], b"Hello checkpoint")
+                self.assertEqual(self.source.read_text(), "Concurrent replacement")
+
+        # Change the path after a cache hit, before POST. The read snapshot still wins.
+        self.source.write_text("Hello checkpoint")
+        self.retry_server_failure()
+        before = self.counts.copy()
+        stage = cp.Checkpoints.stage
+
+        def mutate_on_hit(cache, name, *args):
+            value = stage(cache, name, *args)
+            self.source.write_text("Replacement after cache reuse")
+            return value
+
+        with patch.object(cp.Checkpoints, "stage", mutate_on_hit):
+            self.assertEqual(self.run_worker(), 0)
+        self.assertEqual(self.payloads[-1][0], b"Hello checkpoint")
+        for name in cp.STAGES:
+            self.assertEqual(self.counts[name], before[name])
+
+    def test_accepted_response_lost_and_crash_before_post_are_unclaimable(self):
+        self.upload_error = requests.ReadTimeout("accepted but response lost")
+        self.assertEqual(self.run_worker(), 1)
+        self.assertEqual(self.row()["status"], cli.AMBIGUOUS)
+        self.assertIsNone(self.row()["upload_id"])
+        self.assertIn("response lost", self.row()["last_error"])
+        self.assertEqual(self.counts["upload"], 1)
+        self.upload_error = None
+        self.assertEqual(self.run_worker(), 1)
+        self.assertEqual(self.counts["upload"], 1)
+        self.assertEqual(set(self.cache().manifest["stages"]), set(cp.STAGES))
+        with patch.object(cli, "_print_status"), patch.object(cli, "TargetClient"):
+            self.assertEqual(cli.cmd_verify(self.cfg), 1)
+
+    def test_missing_source_is_retryable_and_never_uploads_cached_payload(self):
+        self.assertEqual(self.run_worker(), 0)
+        self.retry_server_failure()
+        self.source.unlink()
+        self.assertEqual(self.run_worker(), 1)
+        self.assertEqual(self.row()["status"], cli.FAILED)
+        self.assertEqual(self.counts["upload"], 1)
+
+    def test_no_embeddings_explicitly_omits_payload(self):
+        self.cfg = replace(self.cfg, embeddings=False)
+        self.assertEqual(self.run_worker(), 0)
+        self.assertNotIn("embeddings", self.payloads[-1][1])
+        self.assertNotIn("embed", self.cache().manifest["stages"])
+
+    def test_crash_after_upload_intent_before_post_is_conservatively_ambiguous(self):
+        mark = cli.Ledger.mark_upload_started
+
+        def crash(ledger, rel):
+            mark(ledger, rel)
+            raise RuntimeError("process stopped before HTTP")
+
+        with patch.object(cli.Ledger, "mark_upload_started", crash):
+            self.assertEqual(self.run_worker(), 1)
+        self.assertEqual(self.row()["status"], cli.AMBIGUOUS)
+        self.assertEqual(self.run_worker(), 1)
+        self.assertEqual(self.counts["upload"], 0)
+
+    def test_semantically_invalid_artifacts_with_matching_digests_recompute(self):
+        self.assertEqual(self.run_worker(), 0)
+        for stage in cp.STAGES:
+            cache = self.cache()
+            entry = cache.manifest["stages"][stage]
+            artifact = json.loads(
+                (cache.path / (entry["digest"] + ".json")).read_bytes()
+            )
+            if stage == "embed":
+                artifact["annotation_embeddings"].pop("enr-0")
+            else:
+                export = artifact if stage == "parse" else artifact["export"]
+                export["labelled_text"][1]["parent_id"] = "missing"
+            data = cp.json_bytes(artifact)
+            entry["digest"] = cp.digest(data)
+            (cache.path / (entry["digest"] + ".json")).write_bytes(data)
+            cache._publish()
+            before = self.counts.copy()
+            self.retry_server_failure()
+            self.assertEqual(self.run_worker(), 0)
+            for name in cp.STAGES:
+                self.assertEqual(
+                    self.counts[name] - before[name],
+                    int(cp.STAGES.index(name) >= cp.STAGES.index(stage)),
+                )
+
+    def test_legacy_ledger_migrates_in_place_and_runs_uncached(self):
+        legacy_path = str(self.root / "legacy.sqlite3")
+        with sqlite3.connect(legacy_path) as connection:
+            connection.execute(
+                "CREATE TABLE docs (rel_path TEXT PRIMARY KEY, abs_path TEXT NOT NULL, "
+                "size INTEGER, sha256 TEXT, status TEXT NOT NULL DEFAULT 'PENDING', "
+                "upload_id TEXT, attempts INTEGER NOT NULL DEFAULT 0, page_count INTEGER, "
+                "last_error TEXT, created_at REAL, uploaded_at REAL, completed_at REAL)"
+            )
+            connection.execute(
+                "INSERT INTO docs(rel_path, abs_path, status) VALUES(?, ?, 'FAILED')",
+                ("folder/source.txt", str(self.source)),
+            )
+        self.cfg = replace(self.cfg, ledger_path=legacy_path)
+        self.ledger = cli.Ledger(legacy_path)
+        self.assertEqual(self.row()["status"], cli.FAILED)
+        self.assertEqual(self.run_worker(), 0)
+        self.assertEqual([self.counts[s] for s in cp.STAGES], [1, 1, 1])
+        self.assertEqual(self.row()["upload_id"], "receipt-1")
+
+    def test_partial_embedding_response_is_not_cached_or_uploaded(self):
+        with patch.object(cli.EmbedderClient, "embed_batch", return_value=[]):
+            self.assertEqual(self.run_worker(), 1)
+        self.assertEqual(set(self.cache().manifest["stages"]), {"parse", "enrich"})
+        self.assertEqual(self.row()["status"], cli.FAILED)
+        self.assertEqual(self.run_worker(), 0)
+        self.assertEqual([self.counts[s] for s in cp.STAGES], [1, 1, 2])
+        self.assertEqual(self.counts["upload"], 1)
+
+
+class ArtifactStorageTests(SimpleTestCase):
+    def setUp(self):
+        tmp = TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.ledger_path = str(Path(tmp.name) / "ledger.sqlite3")
+
+    def test_interrupted_artifact_or_manifest_write_never_publishes_partial_stage(self):
+        for boundary in ("artifact", "manifest"):
+            with self.subTest(boundary=boundary):
+                cache = cp.Checkpoints(self.ledger_path, boundary)
+                write = cp._atomic_write
+                prepare = Mock(return_value={"complete": True})
+
+                def validate(value):
+                    self.assertEqual(value, {"complete": True})
+
+                def interrupt(path, data):
+                    if (
+                        boundary == "artifact"
+                        and path.name != "manifest.json"
+                        or boundary == "manifest"
+                        and b'"parse"' in data
+                    ):
+                        raise OSError("interrupted write")
+                    write(path, data)
+
+                with patch.object(cp, "_atomic_write", interrupt):
+                    with self.assertRaises(OSError):
+                        cache.stage("parse", "source", prepare, validate)
+                restarted = cp.Checkpoints(self.ledger_path, boundary)
+                self.assertEqual(restarted.manifest["stages"], {})
+                self.assertEqual(
+                    restarted.stage("parse", "source", prepare, validate)[0],
+                    {"complete": True},
+                )
+                self.assertEqual(prepare.call_count, 2)
+
+    def test_atomic_write_leaves_old_artifact_intact_on_replace_failure(self):
+        path = Path(self.ledger_path)
+        path.write_bytes(b"old complete artifact")
+        with patch.object(cp.os, "replace", side_effect=OSError("interrupted")):
+            with self.assertRaises(OSError):
+                cp._atomic_write(path, b"new artifact")
+        self.assertEqual(path.read_bytes(), b"old complete artifact")
+        self.assertEqual(list(path.parent.glob(".tmp-*")), [])
+
+    def test_corrupt_manifests_miss_and_cleanup_preserves_unknown_references(self):
+        cache = cp.Checkpoints(self.ledger_path, "source")
+        cache.stage("parse", "source", lambda: {"value": 1}, lambda v: None)
+        referenced = cache.path / (
+            cache.manifest["stages"]["parse"]["digest"] + ".json"
+        )
+        os.utime(referenced, (0, 0))
+        for bad in (
+            b'{"truncated":',
+            b"null",
+            b'{"version":0,"stages":{}}',
+            b'{"version":1,"stages":{"parse":{"key":"x","digest":"../../file"}}}',
+        ):
+            with self.subTest(bad=bad):
+                cache.manifest_path.write_bytes(bad)
+                restarted = cp.Checkpoints(self.ledger_path, "source")
+                self.assertEqual(restarted.manifest["stages"], {})
+                self.assertEqual(restarted.prune(), 0)
+                self.assertTrue(referenced.exists())
+                prepare = Mock(return_value={"value": 1})
+                restarted.stage("parse", "source", prepare, lambda v: None)
+                prepare.assert_called_once()
+
+    def test_cleanup_keeps_active_artifacts_and_recent_orphans(self):
+        cache = cp.Checkpoints(self.ledger_path, "source")
+        cache.stage("parse", "source", lambda: {"value": 1}, lambda v: None)
+        referenced = cache.path / (
+            cache.manifest["stages"]["parse"]["digest"] + ".json"
+        )
+        orphan = cache.path / ("0" * 64 + ".json")
+        temporary = cache.path / ".tmp-interrupted"
+        recent = cache.path / ("1" * 64 + ".json")
+        for path in (orphan, temporary, recent):
+            path.write_text("partial or unreferenced")
+        for path in (referenced, orphan, temporary):
+            os.utime(path, (0, 0))
+        self.assertEqual(cache.prune(), 2)
+        self.assertTrue(referenced.exists())
+        self.assertTrue(recent.exists())
+        self.assertEqual(cache.prune(), 0)
+
+
+class EmbeddingContractTests(SimpleTestCase):
+    def test_single_shapes_and_exact_finite_dimension(self):
+        client = cli.EmbedderClient("https://embedder", None, 2, dimension=384)
+        vector = [0.5] * 384
+        response: Any
+        for response in (vector, [vector]):
+            self.assertEqual(client._coerce_vector(response), vector)
+        for response in (
+            None,
+            [],
+            [vector, vector],
+            [None],
+            vector[:-1],
+            vector + [0.1],
+            [True] * 384,
+            ["0.5"] * 384,
+            [float("nan")] * 384,
+            [float("inf")] * 384,
+            [float("-inf")] * 384,
+        ):
+            with self.subTest(response=str(response)[:40]), self.assertRaises(
+                ValueError
+            ):
+                client._coerce_vector(response)
+
+    def test_batch_shapes_cardinality_and_per_item_failure(self):
+        client = cli.EmbedderClient("https://embedder", None, 2, dimension=384)
+        vector = [0.5] * 384
+        response: Any
+        for response in ([vector, vector], [[vector], [vector]]):
+            with patch.object(
+                client.session,
+                "post",
+                return_value=Mock(json=lambda: {"embeddings": response}),
+            ):
+                self.assertEqual(
+                    client.embed_batch(["one", " ", "two"]), [vector, None, vector]
+                )
+        for response in (
+            None,
+            [],
+            [vector],
+            [vector, vector, vector],
+            [vector, None],
+            [vector, vector[:-1]],
+        ):
+            with self.subTest(response=str(response)[:40]), patch.object(
+                client.session,
+                "post",
+                return_value=Mock(json=lambda: {"embeddings": response}),
+            ), self.assertRaises(ValueError):
+                client.embed_batch(["one", "two"])
+
+    def test_required_coverage_and_json_stable_ids(self):
+        embedder = Mock(dimension=384)
+        embedder.embed_text.return_value = [0.5] * 384
+        embedder.embed_batch.return_value = [[0.5] * 384]
+        annotations = [{"id": 0, "rawText": "one"}, {"id": "blank", "rawText": " "}]
+        payload = cli._compute_embeddings(
+            embedder=embedder,
+            embedder_path="test",
+            content="one",
+            labelled_text=annotations,
+        )
+        self.assertEqual(set(payload["annotation_embeddings"]), {"0"})
+        for bad_id in (None, "", True, "0", 0):
+            with self.subTest(bad_id=bad_id), self.assertRaises(ValueError):
+                cli._embedding_ids(annotations + [{"id": bad_id, "rawText": "two"}])
+        embedder.embed_text.return_value = None
+        with self.assertRaisesRegex(ValueError, "finite numeric"):
+            cli._compute_embeddings(
+                embedder=embedder,
+                embedder_path="test",
+                content="one",
+                labelled_text=annotations,
+            )
+
+
+class UploadReplayTests(SimpleTestCase):
+    def setUp(self):
+        self.target_client = cli.TargetClient(
+            Mock(
+                target_url="https://target",
+                worker_token="private",
+                verify_tls=True,
+            )
+        )
+        self.metadata = {"file_type": "text/plain"}
+
+    def upload(self):
+        return self.target_client.upload(
+            b"snapshot", self.metadata, filename="source.txt"
+        )
+
+    def test_only_explicit_rate_limit_rejection_is_retried(self):
+        captured = []
+        responses = iter(
+            [
+                Mock(status_code=429, headers={"Retry-After": "0"}),
+                Mock(status_code=202, json=lambda: {"upload_id": "receipt"}),
+            ]
+        )
+
+        def post(*args, files, **kwargs):
+            captured.append(files["file"][1].read())
+            self.assertFalse(kwargs["allow_redirects"])
+            return next(responses)
+
+        with patch.object(self.target_client.session, "post", side_effect=post):
+            self.assertEqual(self.upload(), "receipt")
+        self.assertEqual(captured, [b"snapshot", b"snapshot"])
+
+    def test_uncertain_responses_never_replay_post(self):
+        for status in (200, 301, 307, 500, 502, 503):
+            with self.subTest(status=status), patch.object(
+                self.target_client.session,
+                "post",
+                return_value=Mock(status_code=status),
+            ) as post, self.assertRaises(cli.AmbiguousUploadError):
+                self.upload()
+            self.assertEqual(post.call_count, 1)
+        body: Any
+        for body in ({}, {"upload_id": None}, {"upload_id": ""}, [], None):
+            with self.subTest(body=body), patch.object(
+                self.target_client.session,
+                "post",
+                return_value=Mock(status_code=202, json=lambda: body),
+            ) as post, self.assertRaises(cli.AmbiguousUploadError):
+                self.upload()
+            self.assertEqual(post.call_count, 1)
+
+    def test_transport_failures_are_ambiguous_and_rejections_remain_retryable(self):
+        for error in (
+            requests.ReadTimeout("secret"),
+            requests.ConnectionError("secret"),
+        ):
+            with patch.object(
+                self.target_client.session, "post", side_effect=error
+            ) as post:
+                with self.assertRaises(cli.AmbiguousUploadError) as caught:
+                    self.upload()
+                self.assertNotIn("secret", str(caught.exception))
+                self.assertEqual(post.call_count, 1)
+        for status in (400, 401, 403, 413):
+            with patch.object(
+                self.target_client.session,
+                "post",
+                return_value=Mock(status_code=status),
+            ) as post:
+                with self.assertRaises(cli.PermanentUploadError):
+                    self.upload()
+                self.assertEqual(post.call_count, 1)

--- a/opencontractserver/tests/test_remote_ingest_parsers.py
+++ b/opencontractserver/tests/test_remote_ingest_parsers.py
@@ -176,6 +176,43 @@ class RemoteParserTests(SimpleTestCase):
         parser.reload_settings()
         self.assertEqual(parser.settings.api_key, "private-key")
 
+    def test_checkpoint_service_identities_and_effective_fingerprints(self):
+        from scripts.remote_ingest.checkpoints import fingerprint
+
+        router = self.router({PDF: WARP}, {WARP: {"api_key": "private-key"}})
+        with self.assertRaisesRegex(ValueError, "Parser service revision is unknown"):
+            router.require_checkpoint_identities()
+        self.config_path.write_text(
+            json.dumps(
+                {
+                    "parsers": {PDF: WARP},
+                    "settings": {
+                        WARP: {"api_key": "private-key", "request_timeout": "90"}
+                    },
+                    "identities": {WARP: "warp-model-v1"},
+                }
+            )
+        )
+        router = LocalParsers(str(self.config_path), identity="deployment-fallback")
+        router.require_checkpoint_identities()
+        first = router.identity(PDF)
+        self.assertEqual(first["operator_identity"], "warp-model-v1")
+        self.assertTrue(first["implementation"])
+        self.assertNotIn("private-key", fingerprint(first))
+        config = json.loads(self.config_path.read_text())
+        config["settings"][WARP]["request_timeout"] = 90
+        self.config_path.write_text(json.dumps(config))
+        self.assertEqual(first, LocalParsers(str(self.config_path)).identity(PDF))
+        config["identities"][WARP] = "warp-model-v2"
+        self.config_path.write_text(json.dumps(config))
+        self.assertNotEqual(
+            fingerprint(first),
+            fingerprint(LocalParsers(str(self.config_path)).identity(PDF)),
+        )
+        self.router(
+            {TEXT: TXT}, {TXT: {"chunkers": ["paragraph"]}}
+        ).require_checkpoint_identities()
+
     def test_invalid_settings_do_not_echo_values(self):
         for setting, value in [
             ("request_timeout", "secret-value"),
@@ -406,6 +443,7 @@ class RemoteParserTests(SimpleTestCase):
         source.write_text("Plain text paragraph.")
         cfg = worker_config(
             embeddings=False,
+            ledger_path=str(Path(self.tmp.name) / "ledger.sqlite3"),
             target_folder_from_tree=True,
             target_url="https://target",
             worker_token="secret",
@@ -424,6 +462,13 @@ class RemoteParserTests(SimpleTestCase):
             )
             return Mock(status_code=202, json=lambda: {"upload_id": "receipt"})
 
+        cli.Ledger(cfg.ledger_path).upsert_doc(
+            "folder/source.pdf",
+            str(source),
+            source.stat().st_size,
+            cli._sha256(str(source)),
+            1,
+        )
         with patch.object(client.session, "post", side_effect=post):
             result = cli._process_one(
                 cfg,
@@ -487,7 +532,7 @@ class RemoteParserTests(SimpleTestCase):
                         status_code=202, json=lambda: {"upload_id": "receipt"}
                     ),
                 ) as post:
-                    client.upload(str(source), metadata)
+                    client.upload(source.read_bytes(), metadata, filename=source.name)
                 self.assertEqual(post.call_args.kwargs["files"]["file"][2], mime)
 
     def test_malformed_export_never_reaches_embedder_or_upload(self):
@@ -495,10 +540,20 @@ class RemoteParserTests(SimpleTestCase):
         export["labelled_text"][1]["parent_id"] = "missing"
         source = Path(self.tmp.name) / "source.docx"
         source.write_bytes(make_minimal_docx())
-        parser = Mock(parse=Mock(return_value=export))
+        parser = Mock(
+            parse=Mock(return_value=export),
+            source_mime=Mock(return_value=DOCX),
+            identity=Mock(return_value={"class_path": DOCXODUS}),
+        )
         embedder, client = Mock(), Mock()
+        cfg = worker_config(
+            embeddings=True, ledger_path=str(Path(self.tmp.name) / "ledger.sqlite3")
+        )
+        cli.Ledger(cfg.ledger_path).upsert_doc(
+            source.name, str(source), source.stat().st_size, cli._sha256(str(source)), 1
+        )
         result = cli._process_one(
-            worker_config(embeddings=True),
+            cfg,
             parser,
             embedder,
             client,

--- a/opencontractserver/tests/test_remote_ingest_scheduling.py
+++ b/opencontractserver/tests/test_remote_ingest_scheduling.py
@@ -178,7 +178,7 @@ class SchedulingTests(unittest.TestCase):
                 test.assertLessEqual(peaks["unfinished"], window)
                 return future
 
-        def process(cfg, parser, embedder, client, row, enrichers):
+        def process(cfg, parser, embedder, client, row, enrichers, ledger):
             self.assertTrue(
                 release.wait(3), "coordinator did not reach its bounded window"
             )
@@ -435,13 +435,42 @@ class SchedulingTests(unittest.TestCase):
             self.assertEqual(cli.cmd_plan(replace(self.cfg, limit=1)), 0)
         rows = {row["rel_path"]: row for row in self.ledger.claimable(7)}
         self.assertEqual(set(rows), {"sub/old.PDF", "sub/new.PDF"})
-        self.assertEqual(rows["sub/old.PDF"]["sha256"], "old-hash")
+        self.assertEqual(
+            rows["sub/old.PDF"]["sha256"], hashlib.sha256(b"old.PDF").hexdigest()
+        )
         self.assertEqual(
             rows["sub/new.PDF"]["sha256"], hashlib.sha256(b"new.PDF").hexdigest()
         )
         self.assertEqual(rows["sub/new.PDF"]["size"], 7)
         self.assertEqual([handle.consumed for handle in handles], [1, 2])
         self.assertTrue(all(handle.closed for handle in handles))
+
+    def test_cleanup_traversal_uses_bounded_pages_and_preserves_every_status(self):
+        from scripts.remote_ingest.checkpoints import Checkpoints
+
+        self.populate(
+            75,
+            statuses=(
+                cli.PENDING,
+                cli.FAILED,
+                cli.PARKED,
+                cli.UPLOADED,
+                cli.COMPLETED,
+                cli.AMBIGUOUS,
+                cli.CONFLICT,
+            ),
+        )
+        visited = []
+
+        def prune(cache):
+            visited.append(cache.path.name)
+            self.assertFalse(cache.path.exists())  # no caches created by cleanup
+            return 0
+
+        with patch.object(Checkpoints, "prune", prune):
+            self.assertEqual(cli.cmd_cleanup(self.cfg), 0)
+        self.assertEqual(len(set(visited)), 75)
+        self.assert_pages_bounded(self.cfg.ledger_page_size)
 
     def test_scanner_extensions_links_and_posix_paths(self):
         (self.root / "nested").mkdir()

--- a/opencontractserver/tests/test_remote_ingest_scheduling.py
+++ b/opencontractserver/tests/test_remote_ingest_scheduling.py
@@ -123,6 +123,11 @@ class SchedulingTests(unittest.TestCase):
                 ),
             )
 
+    def uploaded(self, row, ledger, receipt="receipt"):
+        # A successful _process_one now owns receipt persistence before returning.
+        ledger.mark_uploaded(row["rel_path"], receipt, 1, 1)
+        return row["rel_path"], True, receipt
+
     def assert_pages_bounded(self, page_size, minimum_pages=2):
         self.assertGreaterEqual(len(self.observer["fetches"]), minimum_pages)
         for requested, fetched in self.observer["fetches"]:
@@ -184,11 +189,9 @@ class SchedulingTests(unittest.TestCase):
             )
             rel = row["rel_path"]
             attempts.append(rel)
-            return (
-                rel,
-                rel != "00000.pdf",
-                "receipt|1" if rel != "00000.pdf" else "failed",
-            )
+            if rel == "00000.pdf":
+                return rel, False, "failed"
+            return self.uploaded(row, ledger)
 
         real_wait = cli.wait
 
@@ -209,7 +212,9 @@ class SchedulingTests(unittest.TestCase):
         self.assert_pages_bounded(7, minimum_pages=100)
         self.assertEqual(self.ledger.claimable_count(), 1)
         with patch.object(
-            cli, "_process_one", return_value=("00000.pdf", True, "retried|1")
+            cli,
+            "_process_one",
+            side_effect=lambda *args: self.uploaded(args[4], args[6], "retried"),
         ) as process:
             self.assertEqual(cli.cmd_run(self.cfg), 0)
             process.assert_called_once()
@@ -295,7 +300,7 @@ class SchedulingTests(unittest.TestCase):
         with patch.object(
             cli,
             "_process_one",
-            side_effect=lambda *args: (args[4]["rel_path"], True, "receipt|1"),
+            side_effect=lambda *args: self.uploaded(args[4], args[6]),
         ):
             self.assertEqual(cli.cmd_run(self.cfg), 0)
         self.assertEqual(self.ledger.status_counts(), {cli.UPLOADED: 103})
@@ -325,11 +330,9 @@ class SchedulingTests(unittest.TestCase):
             started.wait(timeout=3)
             self.assertTrue(release.wait(3))
             rel = args[4]["rel_path"]
-            return (
-                rel,
-                rel == "00000.pdf",
-                "accepted|1" if rel == "00000.pdf" else "failed",
-            )
+            if rel == "00000.pdf":
+                return self.uploaded(args[4], args[6], "accepted")
+            return rel, False, "failed"
 
         def interrupt(*args, **kwargs):
             started.wait(timeout=3)
@@ -354,7 +357,7 @@ class SchedulingTests(unittest.TestCase):
         def resume(*args):
             rel = args[4]["rel_path"]
             resumed.append(rel)
-            return rel, True, "resumed|1"
+            return self.uploaded(args[4], args[6], "resumed")
 
         with patch.object(cli, "_process_one", resume):
             self.assertEqual(cli.cmd_run(cfg), 0)

--- a/scripts/remote_ingest/README.md
+++ b/scripts/remote_ingest/README.md
@@ -114,6 +114,8 @@ export OC_DATA_DIR=/data/pdfs            # your directory tree of PDFs
 # (default "abc123"); a mismatch -> HTTP 401 on every embed. Any value works as
 # long as both sides match — which the bundle guarantees from this one var.
 export VECTOR_EMBEDDER_API_KEY=<any-value>
+export OC_PARSER_IDENTITY=docling-deployment-v1   # pin/bump with your service revision
+export OC_EMBEDDING_IDENTITY=embedding-model-v1  # pin/bump with your model revision
 
 # Start the parser + embedder microservices (one-time, ~minutes to pull):
 docker compose -f remote_worker.yml up -d --build docling-parser vector-embedder
@@ -211,8 +213,8 @@ or sorting the tree (including within a large directory). Directory symlinks are
 not traversed; matching file symlinks remain eligible. `--limit` stops discovery
 immediately, but its selected subset is no longer globally sorted or guaranteed
 to repeat after filesystem changes. Relative POSIX paths, case-insensitive
-extension matching and SHA-256 recording are unchanged; replanning skips known
-paths and can add the next limited set.
+extension matching are unchanged. Replanning reconciles known paths by SHA-256
+and can add the next limited set; changed existing paths do not consume `--limit`.
 
 `run` and `verify` visit ledger rows in ascending relative-path order, in bounded
 pages using a keyset cursor. Updating earlier rows cannot skip later rows, and a
@@ -230,11 +232,106 @@ take as long as those operations and their configured timeouts/retries. Run the
 command again to resume unfinished rows.
 
 Use one CLI invocation per ledger at a time, including `plan` and `verify`.
-These cursors do not coordinate ownership across processes. Local resume also
-does not guarantee exactly-once delivery: an upload accepted by the server whose
-response is lost may be repeated. Preparation checkpoints, source-change
-reconciliation, admission error classification, and verification exit outcomes
-are tracked separately in #2318, #2319, and #2320.
+These cursors do not coordinate ownership across processes. Preparation checkpoints
+recover local work; uncertain uploads stop in `AMBIGUOUS` and are never replayed
+automatically. Admission error classification and the broader verification exit
+contract remain separate work in #2319 and #2320.
+
+
+### Durable preparation, identities, and source versions
+
+The worker stores `<ledger>.artifacts/` beside SQLite, inside the existing
+`/ledger` volume in Compose. Each relative path has a small manifest referencing
+three content-digested JSON checkpoints:
+
+| Stage | Durable result | Fingerprint inputs |
+|---|---|---|
+| Parse | Complete normalized export, reconstructed PDF text, original correlation IDs | Source SHA-256, filename, selected parser implementation, effective settings and operator revision |
+| Enrich | Complete enriched export and the existing `MetadataOverlay` | Parse artifact digest, source paths, ordered enricher implementations and configuration identity |
+| Embed | Complete document and eligible annotation vectors | Enriched artifact digest, client implementation, service URL, model identity, expected dimension |
+
+Artifacts and manifests use atomic replacement and file/directory `fsync`. Each
+stage is reusable only after its artifact is durable, its digest matches, and
+its contract validates. Every stage passes through JSON on both fresh and resumed
+runs, preserving annotation IDs, parent links, relationships, and embedding keys.
+Missing, truncated, modified or incompatible artifacts recompute that stage and
+its dependents. Changing only an embedding identity retains parsing/enrichment;
+changing only enrichment retains parsing. Upload rejection or a server-reported
+transaction failure likewise retains valid preparation.
+
+Service revisions cannot be inferred from a mutable URL or the structural-set
+`parser_version="1.0"` convention. Configure these stable, **non-secret** identities:
+
+- `--parser-identity` / `OC_PARSER_IDENTITY`: required for service-backed parsers.
+  Per-component strings in the parser JSON's `identities` object override this
+  shared deployment identity. TXT needs no service identity, but use one when
+  its spaCy model, imported chunker helpers, or other external dependencies change.
+- `--embedding-identity` / `OC_EMBEDDING_IDENTITY`: required unless
+  `--no-embeddings`; identify the deployed model/revision. Set
+  `--embedding-dimension` / `OC_EMBEDDING_DIMENSION` (default 384) to match it.
+- `--enricher-identity` / `OC_ENRICHER_IDENTITY`: required with enrichers; identify
+  the entire chain's effective configuration, environment-dependent behavior,
+  helper/model versions and external data. For pure example functions,
+  `examples-v1` suffices. Enrichers must derive source content from `ctx.export`
+  and `ctx.content`; `ctx.abs_path` is path metadata, not a stable file snapshot.
+
+Keep identities unchanged across restarts of the same deployment; bump the
+relevant identity when an output-affecting dependency changes. Python component
+modules (including parser base classes), normalization and text reconstruction
+implementations are hashed automatically. Arbitrary imported dependencies,
+remote model changes and environment reads by enrichers cannot be discovered
+automatically. Configuration is hashed in memory; manifests contain only opaque
+keys and artifact digests, never credentials or raw settings. Artifacts contain
+source-derived text/metadata and should have the same access controls as the source.
+
+Embedding mode requires a finite numeric document vector and exactly one vector
+of the configured, storage-supported dimension per annotation with nonblank
+`rawText`. Missing/duplicate/string-colliding IDs, partial batches or malformed
+vectors fail preparation before upload and never commit an embedding checkpoint.
+Only explicit `--no-embeddings` omits the payload for server annotation fallback.
+
+`plan` and preparation reconcile actual source bytes. A changed unaccepted source
+resets `PENDING`/`FAILED`/`PARKED` to `PENDING`, clears stale receipts/errors and
+retry exhaustion, and invalidates the old preparation chain on its next run.
+The uploader sends the same immutable in-memory byte snapshot that was hashed
+and parsed, even if the original path changes during preparation or cache reuse.
+The ledger hash therefore describes the uploaded snapshot; replan to detect later
+filesystem changes. A missing source fails before upload, even with cached work.
+
+A change to an `UPLOADED`, `COMPLETED` or `AMBIGUOUS` source produces `CONFLICT`.
+The old source hash, receipt/timestamps, and prior status are retained alongside
+the observed conflict hash. The row is excluded from `run`; restoring the old
+bytes and replanning restores its prior status. Otherwise an operator must
+resolve an explicit server replace/new-document policy. There is no automatic
+replacement or creation of another document for a conflicted path.
+
+Upload state is separate from these checkpoints. Before POST, the worker durably
+records `AMBIGUOUS`; a valid 202 receipt changes it to `UPLOADED`. Only explicit
+429 rejections are retried within the HTTP call. Transport errors, redirects,
+5xx and missing/malformed success receipts remain ambiguous, as does a crash
+between recording intent and receiving the receipt. `run` will not replay them.
+`plan`, `run`, and `verify` return nonzero while any conflict/ambiguous row remains;
+`status` displays the counts. Inspect SQLite `docs` for the path, `prior_status`,
+`sha256`, `conflict_sha256`, receipt and error. Reconcile with the server before
+an operator records a recovered receipt or authorizes another attempt. Local
+artifacts do **not** make POST replay idempotent; server-backed idempotency is a
+separate API change. Receipts also belong to the exact original `CorpusAccessToken`:
+rotating to another token for the same corpus does not grant access to old receipts.
+`COMPLETED` means worker-upload transaction completion, not thumbnail/search readiness.
+
+Existing SQLite ledgers gain two nullable conflict columns in place; no export or
+one-time migration is needed. Rows without a manifest run as uncached work after
+the identities above are configured. Back up SQLite and its artifacts together.
+Do not use an older worker against a ledger containing these new states.
+
+Run `worker cleanup` while no other command owns that ledger. It walks ledger rows
+in bounded pages and one artifact directory at a time, deleting only unreferenced
+files and interrupted temporary writes older than 24 hours. Referenced artifacts
+are retained for **all** rows, including failed, parked, ambiguous, conflicted and
+completed work. An unreadable manifest is left alone until `run` repairs it.
+Cleanup does not create caches for legacy rows or remove whole ledgers. After
+archiving a finished ledger, its owner may delete that ledger's entire artifact
+directory; do not manually delete individual active manifests.
 
 ---
 
@@ -278,7 +375,7 @@ def enrich(ctx: EnricherContext) -> Enrichment:
 
 ```bash
 docker compose -f remote_worker.yml run --rm worker run \
-    --enricher my_enrichers:enrich
+    --enricher my_enrichers:enrich --enricher-identity my-config-v1
 ```
 
 What an `Enrichment` can carry (all optional, additive):
@@ -335,7 +432,7 @@ Context helpers (`EnricherContext`):
 
 Three runnable examples ship in `example_enrichers.py` (filename → metadata,
 detected dates → annotations, content → document-type label). Use them directly:
-`--enricher example_enrichers:effective_date_annotations`.
+`--enricher example_enrichers:effective_date_annotations --enricher-identity examples-v1`.
 
 ---
 

--- a/scripts/remote_ingest/README.md
+++ b/scripts/remote_ingest/README.md
@@ -322,6 +322,8 @@ rotating to another token for the same corpus does not grant access to old recei
 Existing SQLite ledgers gain two nullable conflict columns in place; no export or
 one-time migration is needed. Rows without a manifest run as uncached work after
 the identities above are configured. Back up SQLite and its artifacts together.
+The ledger and its SQLite recovery files are restricted to owner read/write
+(`0600`), including existing ledgers when reopened.
 Do not use an older worker against a ledger containing these new states.
 
 Run `worker cleanup` while no other command owns that ledger. It walks ledger rows
@@ -329,6 +331,8 @@ in bounded pages and one artifact directory at a time, deleting only unreference
 files and interrupted temporary writes older than 24 hours. Referenced artifacts
 are retained for **all** rows, including failed, parked, ambiguous, conflicted and
 completed work. An unreadable manifest is left alone until `run` repairs it.
+Manifest rechecks and the retention grace period do not provide an interprocess
+lock; concurrent `run` and `cleanup` are unsupported and can race during deletion.
 Cleanup does not create caches for legacy rows or remove whole ledgers. After
 archiving a finished ledger, its owner may delete that ledger's entire artifact
 directory; do not manually delete individual active manifests.

--- a/scripts/remote_ingest/checkpoints.py
+++ b/scripts/remote_ingest/checkpoints.py
@@ -1,0 +1,173 @@
+"""Local, content-verified preparation checkpoints; no receipt or HTTP semantics.
+
+One CLI invocation owns a ledger. Each document has a small manifest and at most
+three referenced JSON artifacts. Writers fsync artifacts before publishing their
+references; readers validate both the content digest and the stage contract.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import inspect
+import json
+import os
+import tempfile
+import time
+from functools import lru_cache
+from pathlib import Path
+
+STAGES = ("parse", "enrich", "embed")
+VERSION = 1
+
+
+def json_bytes(value) -> bytes:
+    return json.dumps(
+        value, sort_keys=True, separators=(",", ":"), allow_nan=False
+    ).encode("utf-8")
+
+
+def digest(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def fingerprint(value) -> str:
+    # Effective settings (including credentials) exist only in memory. Persist
+    # only this opaque digest, never configuration or HTTP headers/URLs.
+    return digest(json_bytes(value))
+
+
+@lru_cache(maxsize=128)
+def implementation_digest(component) -> str:
+    """Hash implementation modules, including inherited parser operations.
+
+    External models, imported helpers and data still need operator identities.
+    Read once per process so hashing does not grow with document count.
+    """
+    classes = component.__mro__[:-1] if inspect.isclass(component) else (component,)
+    paths = {inspect.getsourcefile(cls) for cls in classes}
+    return fingerprint(
+        [digest(Path(path).read_bytes()) for path in sorted(p for p in paths if p)]
+    )
+
+
+def _atomic_write(path: Path, data: bytes) -> None:
+    fd, temporary = tempfile.mkstemp(prefix=".tmp-", dir=path.parent)
+    try:
+        with os.fdopen(fd, "wb") as stream:
+            stream.write(data)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+        directory = os.open(path.parent, os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            os.fsync(directory)
+        finally:
+            os.close(directory)
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+
+
+class Checkpoints:
+    def __init__(self, ledger_path: str, rel_path: str, *, create: bool = True):
+        root = Path(ledger_path + ".artifacts")
+        self.path = root / digest(rel_path.encode("utf-8"))
+        # Parent directory entries must also survive a host restart.
+        for directory in (root, self.path) if create else ():
+            if not directory.exists():
+                directory.mkdir(mode=0o700, exist_ok=True)
+                fd = os.open(directory.parent, os.O_RDONLY | os.O_DIRECTORY)
+                try:
+                    os.fsync(fd)
+                finally:
+                    os.close(fd)
+        self.manifest_path = self.path / "manifest.json"
+        self.manifest = self._read_manifest()
+
+    def _read_manifest(self) -> dict:
+        try:
+            manifest = json.loads(self.manifest_path.read_bytes())
+            if (
+                manifest["version"] == VERSION
+                and isinstance(manifest["stages"], dict)
+                and not manifest["stages"].keys() - set(STAGES)
+                and all(
+                    isinstance(entry, dict)
+                    and set(entry) == {"key", "digest"}
+                    and all(
+                        isinstance(value, str)
+                        and len(value) == 64
+                        and all(c in "0123456789abcdef" for c in value)
+                        for value in entry.values()
+                    )
+                    for entry in manifest["stages"].values()
+                )
+            ):
+                return manifest
+        except (OSError, ValueError, KeyError, TypeError):
+            pass
+        return {"version": VERSION, "stages": {}}
+
+    def _publish(self):
+        _atomic_write(self.manifest_path, json_bytes(self.manifest))
+
+    def stage(self, name: str, inputs, prepare, validate):
+        """Return a JSON-round-tripped artifact and its digest on hit AND miss.
+
+        Always drop dependent references on a miss, even when recomputation
+        happens to produce the old digest. Partial/invalid work never commits.
+        """
+        key = fingerprint([VERSION, name, inputs])
+        entry = self.manifest["stages"].get(name)
+        if entry and entry["key"] == key:
+            try:
+                data = (self.path / (entry["digest"] + ".json")).read_bytes()
+                if digest(data) == entry["digest"]:
+                    value = json.loads(data)
+                    validate(value)
+                    return value, entry["digest"]
+            except (OSError, ValueError, KeyError, TypeError, AttributeError):
+                pass
+        for downstream in STAGES[STAGES.index(name) :]:
+            self.manifest["stages"].pop(downstream, None)
+        self._publish()
+        value = prepare()
+        validate(value)
+        data = json_bytes(value)
+        value = json.loads(data)
+        validate(value)  # JSON key coercion must not change the export contract.
+        artifact_digest = digest(data)
+        _atomic_write(self.path / (artifact_digest + ".json"), data)
+        self.manifest["stages"][name] = {"key": key, "digest": artifact_digest}
+        self._publish()
+        return value, artifact_digest
+
+    def prune(self, older_than: float = 86400) -> int:
+        """Offline cleanup: keep every referenced artifact, regardless of row state.
+
+        An unreadable manifest is not evidence that artifacts are unreferenced;
+        leave that directory alone until run repairs it. Traverse one directory
+        at a time, never collect a ledger-wide set of hashes or paths.
+        """
+        if not self.manifest_path.exists() or self._read_manifest() != self.manifest:
+            return 0
+        # A malformed manifest also reads as an empty one; require exact validity.
+        try:
+            if json.loads(self.manifest_path.read_bytes()) != self.manifest:
+                return 0
+        except (OSError, ValueError):
+            return 0
+        keep = {e["digest"] + ".json" for e in self.manifest["stages"].values()}
+        removed = 0
+        cutoff = time.time() - older_than
+        with os.scandir(self.path) as entries:
+            for entry in entries:
+                if (
+                    entry.name != "manifest.json"
+                    and entry.name not in keep
+                    and entry.is_file(follow_symlinks=False)
+                    and entry.stat().st_mtime < cutoff
+                ):
+                    os.unlink(entry.path)
+                    removed += 1
+        return removed

--- a/scripts/remote_ingest/checkpoints.py
+++ b/scripts/remote_ingest/checkpoints.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 STAGES = ("parse", "enrich", "embed")
 VERSION = 1
+DEFAULT_ARTIFACT_RETENTION_SECONDS = 24 * 60 * 60
 
 
 def json_bytes(value) -> bytes:
@@ -142,12 +143,14 @@ class Checkpoints:
         self._publish()
         return value, artifact_digest
 
-    def prune(self, older_than: float = 86400) -> int:
+    def prune(self, older_than: float = DEFAULT_ARTIFACT_RETENTION_SECONDS) -> int:
         """Offline cleanup: keep every referenced artifact, regardless of row state.
 
         An unreadable manifest is not evidence that artifacts are unreferenced;
         leave that directory alone until run repairs it. Traverse one directory
         at a time, never collect a ledger-wide set of hashes or paths.
+        Manifest rechecks are not a lock: concurrent publication/deletion after
+        the check is unsafe. No other command may own this ledger during cleanup.
         """
         if not self.manifest_path.exists() or self._read_manifest() != self.manifest:
             return 0

--- a/scripts/remote_ingest/oc_remote_ingest.py
+++ b/scripts/remote_ingest/oc_remote_ingest.py
@@ -16,6 +16,7 @@ import argparse
 import hashlib
 import json
 import logging
+import math
 import os
 import random
 import sqlite3
@@ -25,11 +26,15 @@ import time
 from collections.abc import Generator, Mapping
 from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from contextlib import closing
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
+from io import BytesIO
 from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Any
 
 import requests
+
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 if TYPE_CHECKING:  # avoid importing enrichers (needs Django path) at module load
     from enrichers import MetadataOverlay
@@ -62,6 +67,8 @@ UPLOADED = "UPLOADED"  # staged on the server (202 accepted), not yet confirmed
 COMPLETED = "COMPLETED"  # server confirmed terminal success
 FAILED = "FAILED"  # retry-eligible
 PARKED = "PARKED"  # retries exhausted (terminal)
+AMBIGUOUS = "AMBIGUOUS"  # POST started; acceptance/receipt cannot be established
+CONFLICT = "CONFLICT"  # changed source with an accepted or ambiguous prior version
 
 
 # ======================================================================
@@ -98,8 +105,12 @@ class Ledger:
                     ON docs(rel_path) WHERE status='UPLOADED' AND upload_id IS NOT NULL;
                 CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT);
                 PRAGMA journal_mode=WAL;
-                PRAGMA synchronous=NORMAL;
+                PRAGMA synchronous=FULL;
                 """)
+            columns = {r["name"] for r in conn.execute("PRAGMA table_info(docs)")}
+            for name in ("prior_status", "conflict_sha256"):
+                if name not in columns:
+                    conn.execute(f"ALTER TABLE docs ADD COLUMN {name} TEXT")
 
     def _conn(self) -> sqlite3.Connection:
         # One connection per thread (sqlite connections are not thread-safe).
@@ -108,6 +119,8 @@ class Ledger:
             conn = sqlite3.connect(self.path, timeout=60, isolation_level=None)
             conn.row_factory = sqlite3.Row
             conn.execute("PRAGMA busy_timeout=60000;")
+            # In particular, the pre-POST AMBIGUOUS marker must survive power loss.
+            conn.execute("PRAGMA synchronous=FULL;")
             self._local.conn = conn
         return conn
 
@@ -129,14 +142,72 @@ class Ledger:
     def upsert_doc(
         self, rel_path: str, abs_path: str, size: int, sha256: str, now: float
     ) -> bool:
-        """Insert a doc if new. Returns True if inserted, False if it already existed."""
+        """Reconcile source versions. Return True only for a newly planned path.
+
+        Accepted/unknown uploads retain their source hash and receipt on conflict.
+        A server-rejected version (FAILED/PARKED) may be replaced safely.
+        """
         cur = self._conn().execute(
             "INSERT INTO docs(rel_path, abs_path, size, sha256, status, created_at) "
             "VALUES(?, ?, ?, ?, 'PENDING', ?) "
             "ON CONFLICT(rel_path) DO NOTHING",
             (rel_path, abs_path, size, sha256, now),
         )
-        return cur.rowcount > 0
+        if cur.rowcount > 0:
+            return True
+        row = self.get_doc(rel_path)
+        if row["sha256"] == sha256:
+            self._conn().execute(
+                "UPDATE docs SET abs_path=?, size=?, "
+                "status=COALESCE(prior_status, status), prior_status=NULL, "
+                "conflict_sha256=NULL WHERE rel_path=?",
+                (abs_path, size, rel_path),
+            )
+        elif row["status"] in (UPLOADED, COMPLETED, AMBIGUOUS, CONFLICT):
+            self._conn().execute(
+                "UPDATE docs SET prior_status=COALESCE(prior_status, status), "
+                "status='CONFLICT', conflict_sha256=?, abs_path=? WHERE rel_path=?",
+                (sha256, abs_path, rel_path),
+            )
+            logger.error(
+                "%s: source changed after upload; prior receipt retained. "
+                "Resolve an explicit replace/new-document policy before continuing.",
+                rel_path,
+            )
+        else:
+            self._conn().execute(
+                "UPDATE docs SET abs_path=?, size=?, sha256=?, status='PENDING', "
+                "upload_id=NULL, attempts=0, page_count=NULL, last_error=NULL, "
+                "uploaded_at=NULL, completed_at=NULL, prior_status=NULL, "
+                "conflict_sha256=NULL WHERE rel_path=?",
+                (abs_path, size, sha256, rel_path),
+            )
+        return False
+
+    def get_doc(self, rel_path: str) -> sqlite3.Row:
+        return (
+            self._conn()
+            .execute("SELECT * FROM docs WHERE rel_path=?", (rel_path,))
+            .fetchone()
+        )
+
+    def mark_upload_started(self, rel_path: str) -> None:
+        self._conn().execute(
+            "UPDATE docs SET status='AMBIGUOUS', upload_id=NULL, "
+            "uploaded_at=NULL, completed_at=NULL, "
+            "last_error='Upload started; outcome unknown. Reconcile with the server before replay.' "
+            "WHERE rel_path=?",
+            (rel_path,),
+        )
+
+    def mark_rejected(self, rel_path: str) -> None:
+        self._conn().execute(
+            "UPDATE docs SET status='FAILED' WHERE rel_path=? AND status='AMBIGUOUS'",
+            (rel_path,),
+        )
+
+    def blocked_count(self) -> int:
+        return self._count("status IN ('CONFLICT', 'AMBIGUOUS')")
 
     def _iter_rows(
         self, where: str, index: str, page_size: int
@@ -215,8 +286,19 @@ class Ledger:
     def mark_failed(self, rel_path: str, error: str, max_attempts: int) -> None:
         conn = self._conn()
         row = conn.execute(
-            "SELECT attempts FROM docs WHERE rel_path=?", (rel_path,)
+            "SELECT attempts, status FROM docs WHERE rel_path=?", (rel_path,)
         ).fetchone()
+        if row and row["status"] == AMBIGUOUS:
+            conn.execute(
+                "UPDATE docs SET last_error=? WHERE rel_path=?",
+                (
+                    f"Ambiguous upload; reconcile before replay: {error}"[:1000],
+                    rel_path,
+                ),
+            )
+            return  # Preparation retries must never authorize an uncertain POST replay.
+        if row and row["status"] == CONFLICT:
+            return
         attempts = (row["attempts"] if row else 0) + 1
         status = PARKED if attempts >= max_attempts else FAILED
         conn.execute(
@@ -257,6 +339,10 @@ class Config:
     enrichers: list[str]
     parser_config: str | None = None
     ledger_page_size: int = DEFAULT_LEDGER_PAGE_SIZE
+    enricher_identity: str | None = None
+    embedding_identity: str | None = None
+    embedding_dimension: int = 384
+    parser_identity: str | None = None
 
 
 class TargetClient:
@@ -273,49 +359,55 @@ class TargetClient:
     def _backoff(attempt: int) -> float:
         return min(2.0 * (2 ** (attempt - 1)), 60.0) * random.uniform(_JITTER_MIN, 1.0)
 
-    def upload(self, source_path: str, metadata: dict) -> str:
-        """POST a document. Returns the server upload_id. Raises on permanent failure."""
+    def upload(self, source_bytes: bytes, metadata: dict, *, filename: str) -> str:
+        """Send the immutable preparation snapshot; never replay an uncertain POST.
+
+        Only explicit 429 rejections are retried. A transport error, 5xx, redirect
+        or unusable success receipt can follow acceptance and is ambiguous.
+        """
         url = f"{self.base}/api/worker-uploads/documents/"
-        meta_json = json.dumps(metadata)
-        last_error = "unknown"
+        meta_json = json.dumps(metadata, allow_nan=False)
         for attempt in range(1, _HTTP_MAX_RETRIES + 1):
             try:
-                with open(source_path, "rb") as fh:
+                with BytesIO(source_bytes) as fh:
                     resp = self.session.post(
                         url,
-                        files={
-                            "file": (
-                                PurePosixPath(source_path).name,
-                                fh,
-                                metadata["file_type"],
-                            )
-                        },
+                        files={"file": (filename, fh, metadata["file_type"])},
                         data={"metadata": meta_json},
                         timeout=300,
                         verify=self._verify,
+                        allow_redirects=False,
                     )
-                if resp.status_code == 202:
-                    return resp.json()["upload_id"]
-                if resp.status_code == 429:
-                    wait = float(resp.headers.get("Retry-After", "60"))
-                    logger.warning(f"429 rate-limited; sleeping {wait}s")
-                    time.sleep(wait)
-                    continue
-                if 400 <= resp.status_code < 500:
-                    # Permanent (bad payload / auth / too large) — do not retry.
-                    raise PermanentUploadError(
-                        f"HTTP {resp.status_code}: {resp.text[:500]}"
-                    )
-                last_error = f"HTTP {resp.status_code}: {resp.text[:300]}"
-            except PermanentUploadError:
-                raise
-            except requests.RequestException as e:
-                last_error = f"network: {e}"
-            if attempt < _HTTP_MAX_RETRIES:
-                time.sleep(self._backoff(attempt))
-        raise TransientUploadError(
-            f"upload failed after {_HTTP_MAX_RETRIES} attempts: {last_error}"
-        )
+            except requests.RequestException:
+                raise AmbiguousUploadError(
+                    "Upload response lost; reconcile server acceptance before replay"
+                ) from None
+            if resp.status_code == 202:
+                try:
+                    receipt = resp.json()["upload_id"]
+                    if not isinstance(receipt, str) or not receipt.strip():
+                        raise ValueError
+                    return receipt
+                except (ValueError, KeyError, TypeError):
+                    raise AmbiguousUploadError(
+                        "Upload accepted without a usable receipt; reconcile with server"
+                    ) from None
+            if resp.status_code == 429:
+                if attempt < _HTTP_MAX_RETRIES:
+                    try:
+                        delay = float(resp.headers.get("Retry-After", "60"))
+                        if not math.isfinite(delay) or delay < 0:
+                            raise ValueError
+                    except (ValueError, TypeError):
+                        delay = self._backoff(attempt)
+                    time.sleep(min(delay, 300))
+                continue
+            if 400 <= resp.status_code < 500:
+                raise PermanentUploadError(f"Upload rejected: HTTP {resp.status_code}")
+            raise AmbiguousUploadError(
+                f"Upload outcome unknown: HTTP {resp.status_code}; reconcile before replay"
+            )
+        raise TransientUploadError("Upload rejected: rate limit retries exhausted")
 
     def upload_status(self, upload_id: str) -> dict | None:
         url = f"{self.base}/api/worker-uploads/documents/{upload_id}/"
@@ -348,6 +440,10 @@ class TransientUploadError(Exception):
     pass
 
 
+class AmbiguousUploadError(Exception):
+    pass
+
+
 # ======================================================================
 # Embedder client (vector-embedder microservice)
 # ======================================================================
@@ -356,12 +452,22 @@ class TransientUploadError(Exception):
 class EmbedderClient:
     """Thin HTTP client for the vector-embedder microservice."""
 
-    def __init__(self, service_url: str, api_key: str | None, batch_size: int):
+    def __init__(
+        self,
+        service_url: str,
+        api_key: str | None,
+        batch_size: int,
+        *,
+        dimension: int = 384,
+        identity: str | None = None,
+    ):
         self.base = service_url.rstrip("/")
         self.session = requests.Session()
         if api_key:
             self.session.headers["X-API-Key"] = api_key
         self.batch_size = batch_size
+        self.dimension = dimension
+        self.identity = identity
 
     def embed_text(self, text: str) -> list[float] | None:
         if not text or not text.strip():
@@ -372,14 +478,11 @@ class EmbedderClient:
         resp.raise_for_status()
         return self._coerce_vector(resp.json().get("embeddings"))
 
-    @staticmethod
-    def _coerce_vector(vec) -> list[float] | None:
-        """Accept either a 1-D vector or a 2-D ``[[...]]`` single-row response."""
-        if not isinstance(vec, list) or not vec:
-            return None
-        if isinstance(vec[0], list):  # 2-D (batch-shaped) single response
-            inner = vec[0]
-            return inner if inner else None
+    def _coerce_vector(self, vec) -> list[float]:
+        """The same flat/singleton-row wire shapes used by MicroserviceEmbedder."""
+        if isinstance(vec, list) and len(vec) == 1 and isinstance(vec[0], list):
+            vec = vec[0]
+        _validate_vector(vec, self.dimension)
         return vec
 
     def embed_batch(self, texts: list[str]) -> list[list[float] | None]:
@@ -397,15 +500,14 @@ class EmbedderClient:
             )
             resp.raise_for_status()
             vecs = resp.json().get("embeddings")
-            if not isinstance(vecs, list):
-                continue
+            if not isinstance(vecs, list) or len(vecs) != len(chunk_idxs):
+                raise ValueError("Embedding batch cardinality does not match inputs")
             for local_i, vec in enumerate(vecs):
                 # The batch endpoint wraps each row one level deeper than the
                 # single endpoint (per-item shape is ``[[...floats...]]``), so
                 # coerce each row down to a flat numeric vector.
                 coerced = self._coerce_vector(vec)
-                if coerced is not None:
-                    out[chunk_idxs[local_i]] = coerced
+                out[chunk_idxs[local_i]] = coerced
         return out
 
 
@@ -417,8 +519,11 @@ class EmbedderClient:
 class _Parser:
     """Bootstrap Django imports, then use explicitly configured local parsers."""
 
-    def __init__(self, config_path: str | None = None) -> None:
+    def __init__(
+        self, config_path: str | None = None, identity: str | None = None
+    ) -> None:
         self.config_path = config_path
+        self.operator_identity = identity
         self._parsers: LocalParsers | None = None
 
     def ensure_ready(self) -> LocalParsers:
@@ -433,7 +538,9 @@ class _Parser:
         django.setup()
         from scripts.remote_ingest.parsers import LocalParsers
 
-        self._parsers = LocalParsers(self.config_path)
+        parsers = LocalParsers(self.config_path, identity=self.operator_identity)
+        parsers.require_checkpoint_identities()
+        self._parsers = parsers
         return self._parsers
 
     @property
@@ -445,6 +552,9 @@ class _Parser:
 
     def identity(self, mime: str) -> dict:
         return self.ensure_ready().identity(mime)
+
+    def source_mime(self, source_bytes: bytes, *, filename: str) -> str:
+        return self.ensure_ready().source_mime(source_bytes, filename=filename)
 
 
 # ======================================================================
@@ -565,37 +675,61 @@ def _compute_embeddings(
     embedder_path: str,
     content: str,
     labelled_text: list,
-) -> dict | None:
+) -> dict:
     """Compute the doc-level + per-annotation embeddings the server would store."""
+    ann_ids = _embedding_ids(labelled_text)
     doc_vec = embedder.embed_text(content)
-
-    # Annotation embeddings keyed by the annotation's stable export ``id``
-    # (the same id the worker-upload path maps to the new DB pk).
-    ann_ids: list = []
-    ann_texts: list[str] = []
-    for ann in labelled_text:
-        ann_id = ann.get("id")
-        raw = ann.get("rawText") or ""
-        if ann_id is not None and raw.strip():
-            ann_ids.append(ann_id)
-            ann_texts.append(raw)
-
-    annotation_embeddings: dict[str, list[float]] = {}
-    if ann_texts:
-        vecs = embedder.embed_batch(ann_texts)
-        for ann_id, vec in zip(ann_ids, vecs):
-            if vec is not None:
-                annotation_embeddings[str(ann_id)] = vec
-
-    if doc_vec is None and not annotation_embeddings:
-        return None
-
-    payload: dict = {"embedder_path": embedder_path}
-    if doc_vec is not None:
-        payload["document_embedding"] = doc_vec
-    if annotation_embeddings:
-        payload["annotation_embeddings"] = annotation_embeddings
+    vecs = embedder.embed_batch(
+        [ann["rawText"] for ann in labelled_text if ann["rawText"].strip()]
+    )
+    if not isinstance(vecs, list) or len(vecs) != len(ann_ids):
+        raise ValueError(
+            "Embedding batch cardinality does not match eligible annotations"
+        )
+    payload = {
+        "embedder_path": embedder_path,
+        "document_embedding": doc_vec,
+        "annotation_embeddings": dict(zip(ann_ids, vecs)),
+    }
+    _validate_embeddings(payload, labelled_text, embedder.dimension, embedder_path)
     return payload
+
+
+def _embedding_ids(annotations: list) -> list[str]:
+    ids = set()
+    eligible = []
+    for ann in annotations:
+        aid = ann.get("id")
+        if type(aid) not in (str, int) or aid == "" or str(aid) in ids:
+            raise ValueError(
+                "Embeddings require unique string/integer annotation IDs (including JSON keys)"
+            )
+        ids.add(str(aid))
+        if ann["rawText"].strip():
+            eligible.append(str(aid))
+    return eligible
+
+
+def _validate_vector(vector, dimension: int) -> None:
+    if (
+        not isinstance(vector, list)
+        or len(vector) != dimension
+        or any(type(v) not in (int, float) or not math.isfinite(v) for v in vector)
+    ):
+        raise ValueError(f"Embedding requires {dimension} finite numeric values")
+
+
+def _validate_embeddings(payload, annotations, dimension, embedder_path) -> None:
+    if not isinstance(payload, dict) or payload.get("embedder_path") != embedder_path:
+        raise ValueError("Embedding payload is missing or has an incompatible embedder")
+    _validate_vector(payload.get("document_embedding"), dimension)
+    vectors = payload.get("annotation_embeddings", {})
+    if not isinstance(vectors, dict) or set(vectors) != set(
+        _embedding_ids(annotations)
+    ):
+        raise ValueError("Embedding coverage does not match eligible annotation IDs")
+    for vector in vectors.values():
+        _validate_vector(vector, dimension)
 
 
 # ======================================================================
@@ -661,7 +795,7 @@ def cmd_plan(cfg: Config) -> int:
                 logger.info(f"planned {scanned} files ({added} new)…")
     logger.info(f"plan complete: scanned={scanned}, new={added}")
     _print_status(ledger, None)
-    return 0
+    return 1 if ledger.blocked_count() else 0
 
 
 def _process_one(
@@ -671,98 +805,177 @@ def _process_one(
     client: TargetClient,
     row: sqlite3.Row | Mapping[str, Any],
     enrichers: list | None = None,
+    ledger: Ledger | None = None,
 ) -> tuple[str, bool, str]:
     """Parse + (enrich) + embed + upload one document. Returns (rel_path, ok, message)."""
+    from scripts.remote_ingest.checkpoints import (
+        Checkpoints,
+        digest,
+        implementation_digest,
+    )
+    from scripts.remote_ingest.parsers import normalize_and_validate_export
+
     rel_path = row["rel_path"]
-    abs_path = row["abs_path"]
+    owns_ledger = ledger is None
+    ledger = ledger or Ledger(cfg.ledger_path)
     try:
-        with open(abs_path, "rb") as fh:
-            source_bytes = fh.read()
-
-        export = parser.parse(source_bytes, filename=PurePosixPath(rel_path).name)
-        content = export["content"]
-        if not content.strip():
-            return (rel_path, False, "empty content/text layer (would be unsearchable)")
-
-        # Pre-processing / enrichment stage: calculate + inject extra metadata
-        # and annotations BEFORE embedding (so injected annotations get embedded)
-        # and BEFORE building the payload. A validation failure fails the doc.
-        overlay = None
-        if enrichers:
-            from enrichers import (  # local import: needs Django path set up
-                EnricherContext,
-                apply_enrichment,
-                run_enrichers,
-                validate_enrichment,
+        current = ledger.get_doc(rel_path)
+        abs_path = current["abs_path"]
+        # Immutable snapshot: neither parser nor uploader reopens the mutable path.
+        source_bytes = Path(abs_path).read_bytes()
+        source_digest = digest(source_bytes)
+        ledger.upsert_doc(
+            rel_path, abs_path, len(source_bytes), source_digest, time.time()
+        )
+        current = ledger.get_doc(rel_path)
+        if current["status"] not in (PENDING, FAILED):
+            return (
+                rel_path,
+                False,
+                f"{current['status']}: source/receipt requires reconciliation",
             )
 
-            ctx = EnricherContext(
-                rel_path=rel_path, abs_path=abs_path, export=export, content=content
-            )
-            enrichment = run_enrichers(enrichers, ctx)
-            if not enrichment.is_empty():
+        filename = PurePosixPath(rel_path).name
+        mime = parser.source_mime(source_bytes, filename=filename)
+        identity = parser.identity(mime)
+        cache = Checkpoints(cfg.ledger_path, rel_path)
+        export, parsed_digest = cache.stage(
+            "parse",
+            [source_digest, filename, identity],
+            lambda: parser.parse(source_bytes, filename=filename),
+            normalize_and_validate_export,
+        )
+
+        from enrichers import (
+            EnricherContext,
+            MetadataOverlay,
+            apply_enrichment,
+            run_enrichers,
+            validate_enrichment,
+        )
+
+        def enrich():
+            overlay = MetadataOverlay()
+            if enrichers:
+                ctx = EnricherContext(
+                    rel_path=rel_path,
+                    abs_path=abs_path,
+                    export=export,
+                    content=export["content"],
+                )
+                enrichment = run_enrichers(enrichers, ctx)
                 errors = validate_enrichment(export, enrichment)
                 if errors:
-                    return (
-                        rel_path,
-                        False,
-                        "enrichment invalid: " + "; ".join(errors[:5]),
-                    )
+                    raise ValueError("enrichment invalid: " + "; ".join(errors[:5]))
                 overlay = apply_enrichment(export, enrichment)
+            return {"export": export, "overlay": asdict(overlay)}
 
-        # Check the complete export again after enrichment to catch cross-stage
-        # ID collisions, dangling links and invalid spans before embedding/upload.
-        from scripts.remote_ingest.parsers import normalize_and_validate_export
+        def validate_enriched(value):
+            normalize_and_validate_export(value["export"])
+            overlay = MetadataOverlay(**value["overlay"])
+            if not all(
+                isinstance(v, dict)
+                for v in (
+                    overlay.custom_meta,
+                    overlay.text_label_defs,
+                    overlay.doc_label_defs,
+                )
+            ) or not isinstance(overlay.metadata, list):
+                raise ValueError("Invalid cached enrichment overlay")
 
-        normalize_and_validate_export(export)
+        if enrichers and not cfg.enricher_identity:
+            raise ValueError(
+                "--enricher-identity must describe the effective enricher configuration"
+            )
+        enriched, enriched_digest = cache.stage(
+            "enrich",
+            [
+                parsed_digest,
+                rel_path,
+                abs_path,
+                cfg.enricher_identity,
+                [(name, implementation_digest(fn)) for name, fn in (enrichers or [])],
+                implementation_digest(apply_enrichment),
+            ],
+            enrich,
+            validate_enriched,
+        )
+        export = enriched["export"]
+        overlay = MetadataOverlay(**enriched["overlay"])
         embeddings = None
-        if cfg.embeddings and embedder is not None:
-            # Compute over the (possibly enriched) labelled_text so injected
-            # annotations are embedded too.
-            embeddings = _compute_embeddings(
-                embedder=embedder,
-                embedder_path=parser.default_embedder_path,
-                content=content,
-                labelled_text=export.get("labelled_text", []) or [],
+        if cfg.embeddings:
+            if embedder is None:
+                raise ValueError("Remote embeddings enabled without an embedder")
+            embeddings, _ = cache.stage(
+                "embed",
+                [
+                    enriched_digest,
+                    parser.default_embedder_path,
+                    embedder.base,
+                    embedder.identity,
+                    embedder.dimension,
+                    implementation_digest(type(embedder).__init__),
+                ],
+                lambda: _compute_embeddings(
+                    embedder=embedder,
+                    embedder_path=parser.default_embedder_path,
+                    content=export["content"],
+                    labelled_text=export.get("labelled_text", []),
+                ),
+                lambda value: _validate_embeddings(
+                    value,
+                    export.get("labelled_text", []),
+                    embedder.dimension,
+                    parser.default_embedder_path,
+                ),
             )
 
-        target_folder_path = None
-        if cfg.target_folder_from_tree:
-            parent = PurePosixPath(rel_path).parent.as_posix()
-            target_folder_path = None if parent in (".", "") else parent
-
-        title = PurePosixPath(rel_path).name
-        identity = parser.identity(export["file_type"])
+        parent = PurePosixPath(rel_path).parent.as_posix()
         metadata = _build_metadata(
-            title=title,
+            title=filename,
             export=export,
-            content=content,
+            content=export["content"],
             embedder_path=parser.default_embedder_path,
             embeddings=embeddings,
-            target_folder_path=target_folder_path,
+            target_folder_path=(
+                parent
+                if cfg.target_folder_from_tree and parent not in (".", "")
+                else None
+            ),
             overlay=overlay,
             parser_name=identity["parser_name"],
             parser_version=identity["parser_version"],
         )
-
-        upload_id = client.upload(abs_path, metadata)
+        # Validate JSON before entering the uncertain network boundary.
+        json.dumps(metadata, allow_nan=False)
+        ledger.mark_upload_started(rel_path)
+        upload_id = client.upload(source_bytes, metadata, filename=filename)
         page_count = metadata["page_count"]
+        ledger.mark_uploaded(rel_path, upload_id, page_count, time.time())
         return (rel_path, True, f"{upload_id}|{page_count}")
-    except PermanentUploadError as e:
-        return (rel_path, False, f"permanent: {e}")
-    except Exception as e:  # noqa: BLE001 — surface any parse/embed/upload failure
+    except (PermanentUploadError, TransientUploadError) as e:
+        ledger.mark_rejected(rel_path)
         return (rel_path, False, str(e))
+    except Exception as e:  # noqa: BLE001 — ambiguous rows stay unclaimable
+        return (rel_path, False, str(e))
+    finally:
+        if owns_ledger:
+            ledger._conn().close()
 
 
 def cmd_run(cfg: Config) -> int:
     ledger = Ledger(cfg.ledger_path)
-    parser = _Parser(cfg.parser_config)
+    parser = _Parser(cfg.parser_config, cfg.parser_identity)
     # Set up Django + the parser eagerly so config errors (missing service URL,
     # broken enricher import) surface before we start churning documents.
     parser.ensure_ready()
 
     enrichers: list = []
     if cfg.enrichers:
+        if not cfg.enricher_identity:
+            raise ValueError(
+                "--enricher-identity is required with --enricher; include configuration/data versions"
+            )
         from enrichers import load_enrichers
 
         enrichers = load_enrichers(cfg.enrichers)
@@ -773,12 +986,22 @@ def cmd_run(cfg: Config) -> int:
 
     embedder = None
     if cfg.embeddings:
+        if not cfg.embedding_identity:
+            raise ValueError(
+                "--embedding-identity is required: identify the deployed model/service revision"
+            )
+        from opencontractserver.annotations.models import EMBEDDING_DIMENSIONS
+
+        if cfg.embedding_dimension not in {dim for dim, _ in EMBEDDING_DIMENSIONS}:
+            raise ValueError("--embedding-dimension is not supported by server storage")
         embedder = EmbedderClient(
             os.environ.get(
                 "EMBEDDINGS_MICROSERVICE_URL", "http://vector-embedder:8000"
             ),
             os.environ.get("VECTOR_EMBEDDER_API_KEY") or None,
             DEFAULT_EMBED_BATCH,
+            dimension=cfg.embedding_dimension,
+            identity=cfg.embedding_identity,
         )
     client = TargetClient(cfg)
 
@@ -786,7 +1009,7 @@ def cmd_run(cfg: Config) -> int:
     if not total:
         logger.info("nothing to do — run `plan` first or everything is done.")
         _print_status(ledger, client)
-        return 0
+        return 1 if ledger.blocked_count() else 0
 
     window = FUTURES_PER_WORKER * cfg.max_workers
     logger.info(
@@ -831,7 +1054,9 @@ def cmd_run(cfg: Config) -> int:
             stop_event.wait(_GOVERNOR_WAIT_SECONDS)
         if stop_event.is_set():
             return
-        rel, ok, msg = _process_one(cfg, parser, embedder, client, row, enrichers)
+        rel, ok, msg = _process_one(
+            cfg, parser, embedder, client, row, enrichers, ledger
+        )
         now = time.time()
         if ok:
             upload_id, _, page_count = msg.partition("|")
@@ -892,7 +1117,7 @@ def cmd_run(cfg: Config) -> int:
 
     logger.info(f"run complete: uploaded={done['ok']}, failed={done['fail']}")
     _print_status(ledger, client)
-    return 0 if done["fail"] == 0 else 1
+    return 0 if done["fail"] == 0 and not ledger.blocked_count() else 1
 
 
 def cmd_verify(cfg: Config) -> int:
@@ -925,6 +1150,21 @@ def cmd_verify(cfg: Config) -> int:
         f"verify complete: confirmed={confirmed}, failed={failed}, still-processing={still}"
     )
     _print_status(ledger, client)
+    return 1 if ledger.blocked_count() else 0
+
+
+def cmd_cleanup(cfg: Config) -> int:
+    from scripts.remote_ingest.checkpoints import Checkpoints
+
+    ledger = Ledger(cfg.ledger_path)
+    removed = 0
+    for row in ledger._iter_rows(
+        "1=1", "sqlite_autoindex_docs_1", cfg.ledger_page_size
+    ):
+        removed += Checkpoints(cfg.ledger_path, row["rel_path"], create=False).prune()
+    logger.info(
+        "cleanup: removed %s unreferenced artifacts older than 24 hours", removed
+    )
     return 0
 
 
@@ -944,7 +1184,7 @@ def _print_status(ledger: Ledger, client: TargetClient | None) -> None:
     print(f"  root_dir : {ledger.get_meta('root_dir')}")
     print(f"  corpus   : {ledger.get_meta('corpus_id')}")
     print(f"  total    : {total}")
-    for st in (PENDING, UPLOADED, COMPLETED, FAILED, PARKED):
+    for st in (PENDING, UPLOADED, COMPLETED, FAILED, PARKED, AMBIGUOUS, CONFLICT):
         if counts.get(st):
             print(f"  {st:<9}: {counts[st]}")
     if client is not None:
@@ -990,6 +1230,12 @@ def _build_config(args: argparse.Namespace) -> Config:
         enrichers=enrichers,
         parser_config=args.parser_config or os.environ.get("OC_PARSER_CONFIG"),
         ledger_page_size=args.ledger_page_size,
+        enricher_identity=args.enricher_identity
+        or os.environ.get("OC_ENRICHER_IDENTITY"),
+        embedding_identity=args.embedding_identity
+        or os.environ.get("OC_EMBEDDING_IDENTITY"),
+        embedding_dimension=args.embedding_dimension,
+        parser_identity=args.parser_identity or os.environ.get("OC_PARSER_IDENTITY"),
     )
 
 
@@ -1018,6 +1264,10 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument(
         "--parser-config",
         help="Local parser mapping/settings JSON file (env OC_PARSER_CONFIG)",
+    )
+    p.add_argument(
+        "--parser-identity",
+        help="Parser deployment revision (env OC_PARSER_IDENTITY); per-parser JSON identities override this",
     )
     p.add_argument(
         "--max-workers",
@@ -1065,8 +1315,25 @@ def main(argv: list[str] | None = None) -> int:
             "E.g. example_enrichers:effective_date_annotations"
         ),
     )
+    p.add_argument(
+        "--enricher-identity",
+        help=(
+            "Stable identity of effective enricher configuration/data "
+            "(required with enrichers; env OC_ENRICHER_IDENTITY)"
+        ),
+    )
+    p.add_argument(
+        "--embedding-identity",
+        help="Operator model/service revision (env OC_EMBEDDING_IDENTITY); bump when the model changes",
+    )
+    p.add_argument(
+        "--embedding-dimension",
+        type=_positive_int,
+        default=os.environ.get("OC_EMBEDDING_DIMENSION", "384"),
+        help="Expected document/annotation vector dimension (default 384)",
+    )
     p.add_argument("-v", "--verbose", action="store_true")
-    p.add_argument("command", choices=["plan", "run", "verify", "status"])
+    p.add_argument("command", choices=["plan", "run", "verify", "status", "cleanup"])
     args = p.parse_args(argv)
 
     logging.basicConfig(
@@ -1090,6 +1357,7 @@ def main(argv: list[str] | None = None) -> int:
         "run": cmd_run,
         "verify": cmd_verify,
         "status": cmd_status,
+        "cleanup": cmd_cleanup,
     }[args.command](cfg)
 
 

--- a/scripts/remote_ingest/oc_remote_ingest.py
+++ b/scripts/remote_ingest/oc_remote_ingest.py
@@ -57,6 +57,16 @@ DEFAULT_QUEUE_LOW = 500
 _HTTP_MAX_RETRIES = 6
 _JITTER_MIN = 0.5
 _GOVERNOR_WAIT_SECONDS = 10
+_GOVERNOR_POLL_INTERVAL_SECONDS = 15
+_HTTP_UPLOAD_TIMEOUT_SECONDS = 300
+_HTTP_STATUS_TIMEOUT_SECONDS = 60
+_HTTP_BACKLOG_TIMEOUT_SECONDS = 30
+_HTTP_EMBED_SINGLE_TIMEOUT_SECONDS = 30
+_HTTP_EMBED_BATCH_TIMEOUT_SECONDS = 120
+_HTTP_INITIAL_BACKOFF_SECONDS = 2
+_HTTP_MAX_BACKOFF_SECONDS = 60
+_HTTP_DEFAULT_RETRY_AFTER_SECONDS = 60
+_HTTP_MAX_RETRY_AFTER_SECONDS = 300
 
 _CLAIMABLE_WHERE = "status IN ('PENDING', 'FAILED')"
 _UNCONFIRMED_WHERE = "status='UPLOADED' AND upload_id IS NOT NULL"
@@ -82,6 +92,18 @@ class Ledger:
     def __init__(self, path: str):
         self.path = path
         self._local = threading.local()
+        # Create privately before SQLite can write; also harden legacy ledgers
+        # and any existing recovery files before opening/recovering the database.
+        fd = os.open(path, os.O_CREAT | os.O_RDWR, 0o600)
+        try:
+            os.fchmod(fd, 0o600)
+        finally:
+            os.close(fd)
+        for suffix in ("-wal", "-shm", "-journal"):
+            try:
+                os.chmod(path + suffix, 0o600)
+            except FileNotFoundError:
+                pass
         with self._conn() as conn:
             conn.executescript("""
                 CREATE TABLE IF NOT EXISTS docs (
@@ -357,7 +379,10 @@ class TargetClient:
 
     @staticmethod
     def _backoff(attempt: int) -> float:
-        return min(2.0 * (2 ** (attempt - 1)), 60.0) * random.uniform(_JITTER_MIN, 1.0)
+        return min(
+            _HTTP_INITIAL_BACKOFF_SECONDS * (2 ** (attempt - 1)),
+            _HTTP_MAX_BACKOFF_SECONDS,
+        ) * random.uniform(_JITTER_MIN, 1.0)
 
     def upload(self, source_bytes: bytes, metadata: dict, *, filename: str) -> str:
         """Send the immutable preparation snapshot; never replay an uncertain POST.
@@ -374,7 +399,7 @@ class TargetClient:
                         url,
                         files={"file": (filename, fh, metadata["file_type"])},
                         data={"metadata": meta_json},
-                        timeout=300,
+                        timeout=_HTTP_UPLOAD_TIMEOUT_SECONDS,
                         verify=self._verify,
                         allow_redirects=False,
                     )
@@ -395,12 +420,16 @@ class TargetClient:
             if resp.status_code == 429:
                 if attempt < _HTTP_MAX_RETRIES:
                     try:
-                        delay = float(resp.headers.get("Retry-After", "60"))
+                        delay = float(
+                            resp.headers.get(
+                                "Retry-After", str(_HTTP_DEFAULT_RETRY_AFTER_SECONDS)
+                            )
+                        )
                         if not math.isfinite(delay) or delay < 0:
                             raise ValueError
                     except (ValueError, TypeError):
                         delay = self._backoff(attempt)
-                    time.sleep(min(delay, 300))
+                    time.sleep(min(delay, _HTTP_MAX_RETRY_AFTER_SECONDS))
                 continue
             if 400 <= resp.status_code < 500:
                 raise PermanentUploadError(f"Upload rejected: HTTP {resp.status_code}")
@@ -411,7 +440,9 @@ class TargetClient:
 
     def upload_status(self, upload_id: str) -> dict | None:
         url = f"{self.base}/api/worker-uploads/documents/{upload_id}/"
-        resp = self.session.get(url, timeout=60, verify=self._verify)
+        resp = self.session.get(
+            url, timeout=_HTTP_STATUS_TIMEOUT_SECONDS, verify=self._verify
+        )
         if resp.status_code == 200:
             return resp.json()
         return None
@@ -422,7 +453,9 @@ class TargetClient:
         for st in ("PENDING", "PROCESSING"):
             url = f"{self.base}/api/worker-uploads/documents/list/?status={st}&page_size=1"
             try:
-                resp = self.session.get(url, timeout=30, verify=self._verify)
+                resp = self.session.get(
+                    url, timeout=_HTTP_BACKLOG_TIMEOUT_SECONDS, verify=self._verify
+                )
                 if resp.status_code == 200:
                     total += int(resp.json().get("count", 0))
             except requests.RequestException:
@@ -473,7 +506,9 @@ class EmbedderClient:
         if not text or not text.strip():
             return None
         resp = self.session.post(
-            f"{self.base}/embeddings", json={"text": text}, timeout=30
+            f"{self.base}/embeddings",
+            json={"text": text},
+            timeout=_HTTP_EMBED_SINGLE_TIMEOUT_SECONDS,
         )
         resp.raise_for_status()
         return self._coerce_vector(resp.json().get("embeddings"))
@@ -496,7 +531,7 @@ class EmbedderClient:
             resp = self.session.post(
                 f"{self.base}/embeddings/batch",
                 json={"texts": chunk_texts},
-                timeout=120,
+                timeout=_HTTP_EMBED_BATCH_TIMEOUT_SECONDS,
             )
             resp.raise_for_status()
             vecs = resp.json().get("embeddings")
@@ -807,7 +842,7 @@ def _process_one(
     enrichers: list | None = None,
     ledger: Ledger | None = None,
 ) -> tuple[str, bool, str]:
-    """Parse + (enrich) + embed + upload one document. Returns (rel_path, ok, message)."""
+    """Prepare/upload and persist the receipt. Return (path, ok, receipt or error)."""
     from scripts.remote_ingest.checkpoints import (
         Checkpoints,
         digest,
@@ -952,7 +987,7 @@ def _process_one(
         upload_id = client.upload(source_bytes, metadata, filename=filename)
         page_count = metadata["page_count"]
         ledger.mark_uploaded(rel_path, upload_id, page_count, time.time())
-        return (rel_path, True, f"{upload_id}|{page_count}")
+        return (rel_path, True, upload_id)
     except (PermanentUploadError, TransientUploadError) as e:
         ledger.mark_rejected(rel_path)
         return (rel_path, False, str(e))
@@ -1031,7 +1066,7 @@ def cmd_run(cfg: Config) -> int:
             return
         with gov_lock:
             now = time.time()
-            if now - governor_state["last_poll"] < 15:
+            if now - governor_state["last_poll"] < _GOVERNOR_POLL_INTERVAL_SECONDS:
                 return
             governor_state["last_poll"] = now
         backlog = client.backlog_count()
@@ -1057,14 +1092,11 @@ def cmd_run(cfg: Config) -> int:
         rel, ok, msg = _process_one(
             cfg, parser, embedder, client, row, enrichers, ledger
         )
-        now = time.time()
         if ok:
-            upload_id, _, page_count = msg.partition("|")
-            ledger.mark_uploaded(rel, upload_id, int(page_count or 0), now)
             with done_lock:
                 done["ok"] += 1
                 n = done["ok"] + done["fail"]
-            logger.info(f"[{n}/{total}] uploaded {rel} -> {upload_id}")
+            logger.info(f"[{n}/{total}] uploaded {rel} -> {msg}")
         else:
             ledger.mark_failed(rel, msg, cfg.max_attempts)
             with done_lock:

--- a/scripts/remote_ingest/parsers.py
+++ b/scripts/remote_ingest/parsers.py
@@ -25,6 +25,7 @@ from opencontractserver.pipeline.base.settings_schema import (
 )
 from opencontractserver.pipeline.utils import get_component_by_name
 from opencontractserver.utils.compact_pawls import expand_pawls_pages
+from scripts.remote_ingest.checkpoints import implementation_digest
 
 logger = logging.getLogger(__name__)
 
@@ -133,7 +134,7 @@ class LocalParsers:
 
     default_embedder_path = DEFAULT_EMBEDDER
 
-    def __init__(self, config_path: str | None = None):
+    def __init__(self, config_path: str | None = None, *, identity: str | None = None):
         config: dict[str, Any] = {"parsers": {FileTypeEnum.PDF.mimetype: DOCLING}}
         if config_path:
             try:
@@ -142,16 +143,23 @@ class LocalParsers:
                 raise ValueError(
                     "Cannot read parser config: expected a readable JSON file"
                 ) from None
-        if not isinstance(config, dict) or config.keys() - {"parsers", "settings"}:
+        if not isinstance(config, dict) or config.keys() - {
+            "parsers",
+            "settings",
+            "identities",
+        }:
             raise ValueError(
-                "Parser config supports only 'parsers' and 'settings' objects"
+                "Parser config supports only 'parsers', 'settings' and 'identities' objects"
             )
         mapping = config.get("parsers")
         overrides = config.get("settings", {})
+        identities = config.get("identities", {})
         if (
             not isinstance(mapping, dict)
             or not mapping
             or not isinstance(overrides, dict)
+            or not isinstance(identities, dict)
+            or any(not isinstance(v, str) or not v.strip() for v in identities.values())
         ):
             raise ValueError(
                 "Parser config requires a non-empty MIME-to-parser 'parsers' object"
@@ -225,22 +233,41 @@ class LocalParsers:
                 "settings": deepcopy(effective),
                 "parser_name": parser.title,
                 "parser_version": "1.0",
+                "operator_identity": identities.get(path) or identity,
+                "implementation": [
+                    implementation_digest(component),
+                    implementation_digest(normalize_and_validate_export),
+                    implementation_digest(build_translation_layer),
+                    implementation_digest(expand_pawls_pages),
+                ],
             }
             logger.info("%s ready for %s", parser.title, mime)
-        if overrides.keys() - selected_paths:
+        if (overrides.keys() | identities.keys()) - selected_paths:
             raise ValueError(
-                "Settings keys must be full class paths of selected parsers"
+                "Settings/identities keys must be full class paths of selected parsers"
             )
 
     def identity(self, mime: str) -> dict:
         return deepcopy(self.identities[canonical_mime(mime)])
 
-    def parse(self, source_bytes: bytes, *, filename: str) -> dict:
+    def require_checkpoint_identities(self) -> None:
+        for identity in self.identities.values():
+            if identity["class_path"] != TXT and not identity["operator_identity"]:
+                raise ValueError(
+                    "Parser service revision is unknown: set --parser-identity "
+                    "or per-parser 'identities' in the parser config"
+                )
+
+    def source_mime(self, source_bytes: bytes, *, filename: str) -> str:
         mime = canonical_mime(detect_mime_type(source_bytes, filename))
         if mime not in self.parsers:
             raise ValueError(
                 f"No local parser selected for {mime}; add it to the parser config"
             )
+        return mime
+
+    def parse(self, source_bytes: bytes, *, filename: str) -> dict:
+        mime = self.source_mime(source_bytes, filename=filename)
         parser, method = self.parsers[mime]
         kwargs = {}
         source: bytes | str = source_bytes

--- a/scripts/remote_ingest/remote_worker.yml
+++ b/scripts/remote_ingest/remote_worker.yml
@@ -21,14 +21,17 @@
 #                                            # embedder service + the worker below
 #                                            # (mismatch -> HTTP 401 on embedding)
 #
+#   export OC_PARSER_IDENTITY=docling-deployment-v1
+#   export OC_EMBEDDING_IDENTITY=embedding-model-v1
+#
 #   cd scripts/remote_ingest
 #   docker compose -f remote_worker.yml up -d --build docling-parser vector-embedder
 #   docker compose -f remote_worker.yml run --rm worker plan
 #   docker compose -f remote_worker.yml run --rm worker run --max-workers 8
 #   docker compose -f remote_worker.yml run --rm worker verify
 #
-# The ledger is persisted in a named volume, so `run` is fully resumable —
-# re-run it after an interruption and it skips finished documents.
+# Ledger and preparation checkpoints persist in one named volume. Ambiguous
+# uploads stop for operator reconciliation; local recovery is not POST idempotency.
 # ===========================================================================
 name: oc-remote-worker
 
@@ -81,6 +84,11 @@ services:
     environment:
       DJANGO_SETTINGS_MODULE: config.settings.remote_worker
       OC_PARSER_CONFIG: ${OC_PARSER_CONFIG:-}
+      # Stable, non-secret deployment/model/config revisions; bump on changes.
+      OC_PARSER_IDENTITY: ${OC_PARSER_IDENTITY:-}
+      OC_EMBEDDING_IDENTITY: ${OC_EMBEDDING_IDENTITY:-}
+      OC_EMBEDDING_DIMENSION: ${OC_EMBEDDING_DIMENSION:-384}
+      OC_ENRICHER_IDENTITY: ${OC_ENRICHER_IDENTITY:-}
       DOCLING_PARSER_SERVICE_URL: ${DOCLING_PARSER_SERVICE_URL:-http://docling-parser:8000/parse/}
       DOCXODUS_PARSER_SERVICE_URL: ${DOCXODUS_PARSER_SERVICE_URL:-http://docxodus-parser:8080/parse}
       WARP_INGEST_PARSER_SERVICE_URL: ${WARP_INGEST_PARSER_SERVICE_URL:-http://warp-ingest:5001/api/parse}


### PR DESCRIPTION
Fixes #2318.

Remote ingestion now resumes durable parsing, enrichment, and embedding checkpoints after interruption or rejected uploads. Each stage stores the complete export (and the existing enrichment overlay), verifies content digests and annotation/link/vector contracts, and invalidates only the affected stage and its dependents when inputs or configuration change. Artifacts use atomic writes and fsync in the existing ledger volume.

Planning and preparation reconcile source SHA-256 values, and uploads use the same immutable byte snapshot as preparation. Changed unaccepted sources clear stale receipts/errors and retry exhaustion; changed accepted or uncertain sources become `CONFLICT`, retaining the prior receipt and status. A durable `AMBIGUOUS` marker prevents automatic POST replay after lost responses, 5xx, malformed receipts, or a crash around the upload boundary. This does not implement server-backed idempotency or change token-scoped receipt access.

Adds explicit parser/model/enricher configuration identities, expected embedding dimensions, automatic legacy-ledger migration, and bounded cleanup of unreferenced artifacts. Service-backed parsing and remote embedding now require stable operator identities because service revisions cannot be inferred from their URLs. Ledger and SQLite recovery files use owner-only permissions. Upload confirmation is persisted once, before returning to the scheduler. Documentation and Compose configuration cover setup, retention, and recovery; cleanup requires exclusive ledger ownership.

Builds on the merged #2316 parser/annotation contract and preserves #2317's bounded traversal and scheduling. Embedding validation covers the completeness needed for reusable checkpoints; #2320's broader verification contract and #2319's admission policy remain separate.

Validation:
- 84 focused checkpoint, parser, enrichment, and scheduling tests pass in the project's Django image with networking disabled and the dummy database backend, including stage invocation counts and exact payload equality against uninterrupted preparation.
- All pre-commit checks pass, including full-project mypy (1,587 source files), Black, isort, flake8, YAML, and changelog validation.

