### PR TITLE
Pause remote-ingest admission when status is unavailable

### DIFF
--- a/changelog.d/2319-remote-ingest-admission.fixed.md
+++ b/changelog.d/2319-remote-ingest-admission.fixed.md
@@ -1,6 +1,7 @@
 - Remote ingestion now pauses admission on unknown token-scoped upload status,
   serializes initial/refresh polls, preserves watermark hysteresis and retries
   transient failures with cancellation-aware backoff. Permanent status errors
-  stop `run` without spending document attempts; `status` distinguishes unknown
-  from measured zero (`scripts/remote_ingest/admission.py`,
+  stop `run` without spending document attempts; aborted polls wake all waiters.
+  `status` distinguishes unknown from measured zero and returns nonzero for
+  permanent configuration errors (`scripts/remote_ingest/admission.py`,
   `scripts/remote_ingest/oc_remote_ingest.py`; #2319).

--- a/changelog.d/2319-remote-ingest-admission.fixed.md
+++ b/changelog.d/2319-remote-ingest-admission.fixed.md
@@ -1,0 +1,6 @@
+- Remote ingestion now pauses admission on unknown token-scoped upload status,
+  serializes initial/refresh polls, preserves watermark hysteresis and retries
+  transient failures with cancellation-aware backoff. Permanent status errors
+  stop `run` without spending document attempts; `status` distinguishes unknown
+  from measured zero (`scripts/remote_ingest/admission.py`,
+  `scripts/remote_ingest/oc_remote_ingest.py`; #2319).

--- a/docs/upload_methods/remote_ingest_worker.md
+++ b/docs/upload_methods/remote_ingest_worker.md
@@ -65,7 +65,10 @@ is a resumable, per-document CLI:
 
 Discovery streams in filesystem order; ledger reads use bounded keyset pages,
 and submitted unfinished work is capped at twice `--max-workers`. The worker
-paces itself against the target's worker-upload backlog. Re-running `run` skips
+paces itself against outstanding uploads visible to its exact worker token.
+Unavailable status pauses admission; permanent HTTP errors stop the run. See the
+[admission policy](../../scripts/remote_ingest/README.md#admission) for watermarks,
+retry/cancellation behavior and token-scope limits. Re-running `run` skips
 uploaded documents and retries unfinished work. Ctrl-C cancels queued work and
 drains already-started calls; use one invocation per ledger at a time. See
 [bounded traversal and resume](../../scripts/remote_ingest/README.md#bounded-traversal-and-resume)

--- a/opencontractserver/tests/test_remote_ingest_admission.py
+++ b/opencontractserver/tests/test_remote_ingest_admission.py
@@ -1,0 +1,512 @@
+"""Admission failures/concurrency with mocked HTTP and real threads/SQLite.
+
+Run without Django/services: python -m unittest
+opencontractserver.tests.test_remote_ingest_admission
+"""
+
+import threading
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import redirect_stdout
+from datetime import datetime, timezone
+from email.utils import format_datetime
+from io import StringIO
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import Mock, patch
+
+import requests
+
+from scripts.remote_ingest import admission as admission
+from scripts.remote_ingest import oc_remote_ingest as cli
+
+
+def response(code=200, body=None, **headers):
+    return Mock(status_code=code, json=Mock(return_value=body), headers=headers)
+
+
+def client():
+    return cli.TargetClient(
+        cast(
+            cli.Config,
+            SimpleNamespace(
+                target_url="https://target.invalid",
+                worker_token="private-token",
+                verify_tls=True,
+            ),
+        )
+    )
+
+
+class BacklogClientTests(unittest.TestCase):
+    def test_complete_count_and_measured_zero(self):
+        for counts in ((0, 0), (3, 7)):
+            with self.subTest(counts=counts):
+                target = client()
+                target.session.get = Mock(
+                    side_effect=[response(body={"count": n}) for n in counts]
+                )
+                self.assertEqual(target.backlog_count(), sum(counts))
+                calls = target.session.get.call_args_list
+                for call, status in zip(calls, ("PENDING", "PROCESSING")):
+                    self.assertIn(f"status={status}&page_size=1", call.args[0])
+                    self.assertEqual(
+                        call.kwargs["timeout"], cli._HTTP_BACKLOG_TIMEOUT_SECONDS
+                    )
+                    self.assertFalse(call.kwargs["allow_redirects"])
+
+    def test_failure_of_either_request_never_returns_partial_or_zero(self):
+        malformed = response()
+        malformed.json.side_effect = ValueError("private-response-body")
+        failures = [
+            (requests.ConnectionError("private-token"), False),
+            (requests.Timeout("private-token"), False),
+            (requests.exceptions.InvalidURL("private-token"), True),
+            (requests.exceptions.InvalidSchema("private-token"), True),
+            (requests.exceptions.MissingSchema("private-token"), True),
+            (requests.exceptions.InvalidHeader("private-token"), True),
+            (malformed, False),
+        ]
+        failures += [
+            (response(code), code != 429 and code < 500)
+            for code in (400, 401, 403, 404, 422, 429, 500, 502, 503, 504, 302)
+        ]
+        bodies: list[Any] = [
+            None,
+            [],
+            0,
+            "private-response-body",
+            {},
+            {"count": None},
+            {"count": True},
+            {"count": False},
+            {"count": "0"},
+            {"count": 0.0},
+            {"count": -1},
+            {"count": []},
+            {"count": {}},
+            {"count": float("nan")},
+        ]
+        failures += [(response(body=body), False) for body in bodies]
+        for failure, permanent in failures:
+            for position in (0, 1):
+                with self.subTest(failure=failure, position=position):
+                    target = client()
+                    outcomes = [response(body={"count": 9})] * position + [failure]
+                    target.session.get = Mock(side_effect=outcomes)
+                    with self.assertRaises(admission.StatusPollError) as caught:
+                        target.backlog_count()
+                    self.assertEqual(caught.exception.permanent, permanent)
+                    self.assertNotIn("private", str(caught.exception))
+                    self.assertEqual(target.session.get.call_count, position + 1)
+
+    def test_retry_after(self):
+        now = 1_800_000_000
+        date = format_datetime(
+            datetime.fromtimestamp(now + 42, timezone.utc), usegmt=True
+        )
+        for value, expected in (
+            ("12", 12),
+            (date, 42),
+            ("999999", 300),
+            ("0", 0),
+            (None, 0),
+            ("", 0),
+            ("nan", 0),
+            ("inf", 0),
+            ("-1", 0),
+            ("1.5", 0),
+            ("invalid", 0),
+        ):
+            with self.subTest(value=value), patch.object(
+                admission.time, "time", return_value=now
+            ):
+                self.assertEqual(admission.retry_after_seconds(value), expected)
+        past = format_datetime(
+            datetime.fromtimestamp(now - 5, timezone.utc), usegmt=True
+        )
+        with patch.object(admission.time, "time", return_value=now):
+            self.assertEqual(admission.retry_after_seconds(past), 0)
+        for code in (429, 503):
+            target = client()
+            target.session.get = Mock(
+                return_value=response(code, **{"Retry-After": "23"})
+            )
+            with self.assertRaises(admission.StatusPollError) as caught:
+                target.backlog_count()
+            self.assertEqual(caught.exception.retry_after, 23)
+
+    def test_status_distinguishes_unknown_and_redacts_details(self):
+        ledger = Mock(
+            status_counts=Mock(return_value={}), get_meta=Mock(return_value=None)
+        )
+        target = client()
+        for outcome, expected in (
+            (response(body={"count": 0}), "PENDING+PROCESSING : 0"),
+            (response(body={}), "PENDING+PROCESSING : unknown"),
+            (response(401), "OC_WORKER_TOKEN"),
+            (requests.ConnectionError("private-token"), "unknown"),
+        ):
+            target.session.get = Mock(
+                side_effect=outcome if isinstance(outcome, Exception) else None,
+                return_value=outcome,
+            )
+            output = StringIO()
+            with redirect_stdout(output):
+                cli._print_status(ledger, target)
+            self.assertIn("Token-scoped outstanding uploads", output.getvalue())
+            self.assertIn(expected, output.getvalue())
+            self.assertNotIn("private", output.getvalue())
+
+
+class GovernorTests(unittest.TestCase):
+    def start_waiters(self, governor, count=6):
+        pool = ThreadPoolExecutor(max_workers=count)
+        # LIFO cleanup must wake workers before joining the executor.
+        self.addCleanup(pool.shutdown, wait=True, cancel_futures=True)
+        self.addCleanup(governor.stop)
+        waiting = threading.Event()
+        original_wait = governor._condition.wait
+        calls = 0
+
+        def observed_wait(timeout=None):
+            nonlocal calls
+            calls += 1
+            if calls >= count - 1:
+                waiting.set()
+            return original_wait(timeout)
+
+        patcher = patch.object(governor._condition, "wait", observed_wait)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        futures = [pool.submit(governor.admit) for _ in range(count)]
+        self.assertTrue(waiting.wait(3))
+        return futures
+
+    def test_first_http_poll_is_single_flight_and_publishes_complete_result(self):
+        for outcome in (response(body={"count": 0}), response(401), response(503)):
+            with self.subTest(outcome=outcome):
+                release = threading.Event()
+                target = client()
+
+                def get(*args, **kwargs):
+                    self.assertTrue(release.wait(3))
+                    return outcome
+
+                target.session.get = Mock(side_effect=get)
+                governor = admission.AdmissionGovernor(target.backlog_count, 10, 5)
+                futures = self.start_waiters(governor)
+                self.addCleanup(release.set)
+                self.assertEqual(target.session.get.call_count, 1)
+                self.assertFalse(any(f.done() for f in futures))
+                release.set()
+                if outcome.status_code == 503:
+                    # Await publication of failure, before the first (>=1s) retry.
+                    with governor._condition:
+                        self.assertTrue(
+                            governor._condition.wait_for(
+                                lambda: not governor._polling, 1
+                            )
+                        )
+                        self.assertIsNone(governor._count)
+                        self.assertFalse(any(f.done() for f in futures))
+                    governor.stop()
+                expected = outcome.status_code == 200
+                self.assertEqual([f.result(3) for f in futures], [expected] * 6)
+                self.assertEqual(target.session.get.call_count, 2 if expected else 1)
+
+    def test_stop_wakes_initial_poll_waiters_before_http_finishes(self):
+        release = threading.Event()
+        poll = Mock(side_effect=lambda: (release.wait(3), 0)[1])
+        governor = admission.AdmissionGovernor(poll, 10, 5)
+        futures = self.start_waiters(governor)
+        self.addCleanup(release.set)
+        governor.stop()
+        # The owner still has its bounded HTTP operation; every other waiter exits.
+        for future in futures[1:]:
+            self.assertFalse(future.result(1))
+        self.assertFalse(futures[0].done())
+        release.set()
+        self.assertFalse(futures[0].result(1))
+        self.assertFalse(governor.admit())
+        poll.assert_called_once()
+
+    def test_stale_refresh_blocks_every_caller_and_dates_success_at_completion(self):
+        now = [100.0]
+        release = threading.Event()
+        target = client()
+        target.session.get = Mock(return_value=response(body={"count": 0}))
+        governor = admission.AdmissionGovernor(target.backlog_count, 10, 5)
+        with patch.object(admission.time, "monotonic", side_effect=lambda: now[0]):
+            self.assertTrue(governor.admit())
+            now[0] += admission.POLL_INTERVAL_SECONDS
+
+            def refresh(*args, **kwargs):
+                self.assertTrue(release.wait(3))
+                return response(body={"count": 0})
+
+            target.session.get = Mock(side_effect=refresh)
+            futures = self.start_waiters(governor)
+            self.addCleanup(release.set)
+            self.assertFalse(any(f.done() for f in futures))
+            target.session.get.assert_called_once()
+            # Slow HTTP must not exhaust freshness before the result is published.
+            now[0] += admission.POLL_INTERVAL_SECONDS * 2
+            release.set()
+            self.assertEqual([f.result(3) for f in futures], [True] * 6)
+            self.assertTrue(governor.admit())
+            self.assertEqual(target.session.get.call_count, 2)
+
+    def test_hysteresis_freshness_and_recovery(self):
+        now = [100.0]
+        outcomes = iter(
+            [0, 10, 11, admission.StatusPollError("unavailable"), 8, 5, 11, 4]
+        )
+        poll = Mock(side_effect=lambda: next(outcomes))
+
+        # Mock side_effect functions return exceptions; raise them explicitly.
+        def measure():
+            result = poll()
+            if isinstance(result, Exception):
+                raise result
+            return result
+
+        governor = admission.AdmissionGovernor(measure, 10, 5)
+        waits = []
+
+        def wait_for_refresh(delay):
+            self.assertTrue(governor._paused)
+            waits.append((poll.call_count, governor._count, delay))
+            now[0] += delay
+
+        with patch.object(
+            admission.time, "monotonic", side_effect=lambda: now[0]
+        ), patch.object(governor._condition, "wait", side_effect=wait_for_refresh):
+            self.assertTrue(governor.admit())  # initial measured zero
+            self.assertTrue(governor.admit())  # fresh successful cache
+            self.assertEqual(poll.call_count, 1)
+            now[0] += admission.POLL_INTERVAL_SECONDS
+            self.assertTrue(governor.admit())  # exactly high stays open
+            now[0] += admission.POLL_INTERVAL_SECONDS
+            self.assertTrue(
+                governor.admit()
+            )  # high -> failure -> middle -> exactly low
+            self.assertEqual(poll.call_count, 6)
+            self.assertEqual(
+                [(n, count) for n, count, _ in waits], [(3, 11), (4, None), (5, 8)]
+            )
+            now[0] += admission.POLL_INTERVAL_SECONDS
+            self.assertTrue(governor.admit())  # below low also resumes
+            self.assertEqual(poll.call_count, 8)
+
+    def test_stale_open_measurement_cannot_admit_on_failure(self):
+        now = [100.0]
+        poll = Mock(side_effect=[0, admission.StatusPollError("unavailable"), 0])
+        governor = admission.AdmissionGovernor(poll, 10, 5)
+
+        def wait_for_retry(delay):
+            self.assertIsNone(governor._count)
+            self.assertEqual(poll.call_count, 2)
+            now[0] += delay
+
+        with patch.object(
+            admission.time, "monotonic", side_effect=lambda: now[0]
+        ), patch.object(
+            governor._condition, "wait", side_effect=wait_for_retry
+        ) as wait:
+            self.assertTrue(governor.admit())
+            now[0] += admission.POLL_INTERVAL_SECONDS
+            self.assertTrue(governor.admit())
+            wait.assert_called_once()
+            self.assertEqual(poll.call_count, 3)
+
+    def test_backoff_is_jittered_capped_nonzero_and_resets_after_success(self):
+        now = [100.0]
+        errors = [admission.StatusPollError("network") for _ in range(10)]
+        poll = Mock(
+            side_effect=errors
+            + [
+                admission.StatusPollError("throttled", retry_after=100),
+                0,
+                admission.StatusPollError("again"),
+                0,
+            ]
+        )
+        governor = admission.AdmissionGovernor(poll, 10, 5)
+        delays = []
+
+        def wait(delay):
+            delays.append(delay)
+            now[0] += delay
+
+        with patch.object(
+            admission.time, "monotonic", side_effect=lambda: now[0]
+        ), patch.object(
+            admission.random, "uniform", return_value=0.5
+        ) as jitter, patch.object(
+            governor._condition, "wait", side_effect=wait
+        ):
+            self.assertTrue(governor.admit())
+            self.assertEqual(delays, [1, 2, 4, 8, 16, 30, 30, 30, 30, 30, 100])
+            now[0] += admission.POLL_INTERVAL_SECONDS
+            self.assertTrue(governor.admit())
+            self.assertEqual(delays[-1], 1)
+            jitter.assert_called_with(admission.JITTER_MIN, 1)
+
+    def test_stop_during_backoff_or_high_pause(self):
+        for result in (20, admission.StatusPollError("throttled", retry_after=300)):
+            with self.subTest(result=result):
+                poll = Mock(
+                    side_effect=result if isinstance(result, Exception) else None,
+                    return_value=result,
+                )
+                governor = admission.AdmissionGovernor(poll, 10, 5)
+                futures = self.start_waiters(governor)
+                governor.stop()
+                self.assertEqual([f.result(1) for f in futures], [False] * 6)
+                poll.assert_called_once()
+
+    def test_disabled_and_watermark_validation(self):
+        for high, low in ((0, -1), (-1, 100)):
+            poll = Mock()
+            governor = admission.AdmissionGovernor(poll, high, low)
+            self.assertTrue(governor.admit())
+            governor.stop()
+            self.assertFalse(governor.admit())
+            poll.assert_not_called()
+        for high, low in ((10, -1), (10, 11)):
+            with self.assertRaises(ValueError):
+                admission.AdmissionGovernor(Mock(), high, low)
+
+
+class RunAdmissionTests(unittest.TestCase):
+    def setUp(self):
+        tmp = TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.cfg = cli.Config(
+            target_url="https://target.invalid",
+            worker_token="private-token",
+            corpus_id=None,
+            root_dir=tmp.name,
+            ledger_path=str(Path(tmp.name) / "ledger.sqlite3"),
+            extensions=(".pdf",),
+            max_workers=4,
+            max_attempts=5,
+            queue_high=10,
+            queue_low=5,
+            embeddings=False,
+            target_folder_from_tree=True,
+            verify_tls=True,
+            limit=0,
+            enrichers=[],
+        )
+        self.ledger = cli.Ledger(self.cfg.ledger_path)
+        self.addCleanup(self.ledger._conn().close)
+        for i in range(40):
+            self.ledger.upsert_doc(f"{i:03}.pdf", f"/data/{i:03}.pdf", 1, "hash", 0)
+        self.target = client()
+        for name, value in (
+            ("_Parser", Mock()),
+            ("TargetClient", Mock(return_value=self.target)),
+            ("Ledger", Mock(return_value=self.ledger)),
+        ):
+            patcher = patch.object(cli, name, value)
+            patcher.start()
+            self.addCleanup(patcher.stop)
+
+    def assert_untouched(self):
+        self.assertEqual(self.ledger.status_counts(), {cli.PENDING: 40})
+        self.assertEqual(
+            self.ledger._conn().execute("SELECT SUM(attempts) FROM docs").fetchone()[0],
+            0,
+        )
+
+    def test_permanent_error_stops_run_without_document_attempts(self):
+        for code in (401, 403, 400, 404):
+            with self.subTest(code=code):
+                self.target.session.get = Mock(return_value=response(code))
+                with patch.object(cli, "_process_one") as process, self.assertLogs(
+                    "oc_remote_ingest", level="ERROR"
+                ) as logs, redirect_stdout(StringIO()):
+                    self.assertEqual(cli.cmd_run(self.cfg), 2)
+                process.assert_not_called()
+                self.target.session.get.assert_called_once()
+                self.assertIn(
+                    (
+                        "check --worker-token"
+                        if code in (401, 403)
+                        else "check --target-url"
+                    ),
+                    str(logs.output),
+                )
+                self.assertNotIn("private-token", str(logs.output))
+                self.assert_untouched()
+
+    def test_interrupt_during_initial_http_obeys_scheduler_drain(self):
+        entered = threading.Event()
+        release = threading.Event()
+        self.addCleanup(release.set)
+
+        def get(*args, **kwargs):
+            entered.set()
+            self.assertTrue(release.wait(3))
+            return response(body={"count": 0})
+
+        self.target.session.get = Mock(side_effect=get)
+
+        def interrupt(*args, **kwargs):
+            self.assertTrue(entered.wait(3))
+            raise KeyboardInterrupt
+
+        class DrainExecutor(ThreadPoolExecutor):
+            def shutdown(self, *args, **kwargs):
+                release.set()
+                return super().shutdown(*args, **kwargs)
+
+        with patch.object(cli, "ThreadPoolExecutor", DrainExecutor), patch.object(
+            cli, "wait", interrupt
+        ), patch.object(cli, "_process_one") as process, redirect_stdout(StringIO()):
+            self.assertEqual(cli.cmd_run(self.cfg), 130)
+        process.assert_not_called()
+        self.assert_untouched()
+
+    def test_disabled_run_never_polls_even_for_final_status(self):
+        self.cfg.queue_high = 0
+        self.target.session.get = Mock()
+
+        def process(*args):
+            return args[4]["rel_path"], True, "receipt"
+
+        with patch.object(cli, "_process_one", side_effect=process), redirect_stdout(
+            StringIO()
+        ):
+            self.assertEqual(cli.cmd_run(self.cfg), 0)
+        self.target.session.get.assert_not_called()
+        # Also cover an empty run's status summary.
+        self.ledger._conn().execute("UPDATE docs SET status='COMPLETED'")
+        with redirect_stdout(StringIO()):
+            self.assertEqual(cli.cmd_run(self.cfg), 0)
+        self.target.session.get.assert_not_called()
+
+    def test_invalid_watermarks_fail_before_initialization(self):
+        for low in (-1, 11):
+            self.cfg.queue_low = low
+            with patch.object(cli, "_Parser") as parser, self.assertLogs(
+                "oc_remote_ingest", level="ERROR"
+            ):
+                self.assertEqual(cli.cmd_run(self.cfg), 2)
+            parser.assert_not_called()
+        with redirect_stdout(StringIO()), patch(
+            "sys.stderr", StringIO()
+        ), self.assertRaises(SystemExit) as caught:
+            cli.main(["run", "--queue-high", "1", "--queue-low", "2"])
+        self.assertEqual(caught.exception.code, 2)
+
+    def test_permanent_summary_error_also_returns_nonzero_for_empty_run(self):
+        self.ledger._conn().execute("UPDATE docs SET status='COMPLETED'")
+        self.target.session.get = Mock(return_value=response(403))
+        with redirect_stdout(StringIO()), patch.object(cli, "_process_one") as process:
+            self.assertEqual(cli.cmd_run(self.cfg), 2)
+        process.assert_not_called()

--- a/opencontractserver/tests/test_remote_ingest_admission.py
+++ b/opencontractserver/tests/test_remote_ingest_admission.py
@@ -233,6 +233,36 @@ class GovernorTests(unittest.TestCase):
         self.assertFalse(governor.admit())
         poll.assert_called_once()
 
+    def test_poll_abort_propagates_and_wakes_waiters_without_external_stop(self):
+        class PollAbort(BaseException):
+            pass
+
+        for kind in (KeyboardInterrupt, SystemExit, GeneratorExit, PollAbort):
+            with self.subTest(kind=kind):
+                release = threading.Event()
+                failure = kind("private-poll-details")
+
+                def poll():
+                    self.assertTrue(release.wait(3))
+                    raise failure
+
+                measure = Mock(side_effect=poll)
+                governor = admission.AdmissionGovernor(measure, 10, 5)
+                futures = self.start_waiters(governor)
+                self.addCleanup(release.set)
+                release.set()
+                with self.assertRaises(kind) as caught:
+                    futures[0].result(1)
+                self.assertIs(caught.exception, failure)
+                self.assertFalse(governor._polling)
+                self.assertTrue(governor.stopped.is_set())
+                self.assertIsNone(governor._count)
+                self.assertEqual([f.result(1) for f in futures[1:]], [False] * 5)
+                self.assertFalse(governor.admit())
+                self.assertIsNotNone(governor.fatal_error)
+                self.assertNotIn("private-poll-details", str(governor.fatal_error))
+                measure.assert_called_once()
+
     def test_stale_refresh_blocks_every_caller_and_dates_success_at_completion(self):
         now = [100.0]
         release = threading.Event()
@@ -472,6 +502,38 @@ class RunAdmissionTests(unittest.TestCase):
         process.assert_not_called()
         self.assert_untouched()
 
+    def test_poll_abort_stops_run_without_attempts_or_sensitive_diagnostics(self):
+        for kind in (KeyboardInterrupt, SystemExit, GeneratorExit, BaseException):
+            with self.subTest(kind=kind):
+                release = threading.Event()
+                self.addCleanup(release.set)
+
+                def get(*args, **kwargs):
+                    self.assertTrue(release.wait(3))
+                    raise kind("private-poll-details")
+
+                self.target.session.get = Mock(side_effect=get)
+                original_wait = cli.wait
+
+                def wait(*args, **kwargs):
+                    # Exercise the scheduler's worker-exception logging path.
+                    release.set()
+                    return original_wait(*args, **kwargs)
+
+                with patch.object(cli, "wait", wait), patch.object(
+                    cli, "_process_one"
+                ) as process, self.assertLogs(
+                    "oc_remote_ingest", level="ERROR"
+                ) as logs, redirect_stdout(
+                    StringIO()
+                ):
+                    self.assertEqual(cli.cmd_run(self.cfg), 2)
+                process.assert_not_called()
+                self.target.session.get.assert_called_once()
+                self.assertIn("Status polling aborted", str(logs.output))
+                self.assertNotIn("private-poll-details", str(logs.output))
+                self.assert_untouched()
+
     def test_disabled_run_never_polls_even_for_final_status(self):
         self.cfg.queue_high = 0
         self.target.session.get = Mock()
@@ -510,3 +572,21 @@ class RunAdmissionTests(unittest.TestCase):
         with redirect_stdout(StringIO()), patch.object(cli, "_process_one") as process:
             self.assertEqual(cli.cmd_run(self.cfg), 2)
         process.assert_not_called()
+
+    def test_status_command_propagates_permanent_configuration_errors(self):
+        for code in (401, 403, 400, 404, 302, 429, 503, 200):
+            with self.subTest(code=code):
+                self.target.session.get = Mock(
+                    return_value=response(code, body={"count": 0})
+                )
+                with redirect_stdout(StringIO()):
+                    self.assertEqual(
+                        cli.cmd_status(self.cfg),
+                        0 if code in (429, 503, 200) else 2,
+                    )
+
+        self.cfg.worker_token = ""
+        self.target.session.get.reset_mock()
+        with redirect_stdout(StringIO()):
+            self.assertEqual(cli.cmd_status(self.cfg), 0)
+        self.target.session.get.assert_not_called()

--- a/scripts/remote_ingest/README.md
+++ b/scripts/remote_ingest/README.md
@@ -253,6 +253,9 @@ values still use backoff. Other HTTP errors, including 401/403 and redirects,
 stop `run` with exit **2** and a credential/configuration diagnostic. Neither
 waiting nor status failure consumes document retry attempts. Ctrl-C wakes all
 waiters and uses the bounded scheduler's graceful drain and exit **130** above.
+If a poll itself aborts (for example, `SystemExit` in its worker), admission stops
+and wakes all waiters before propagating the exception; `run` reports a safe
+diagnostic and exits **2**.
 
 These counts cover only the **exact authenticated token's** outstanding staged
 uploads, including other producers using that token. They are two separate reads,
@@ -264,6 +267,9 @@ Upload status does not establish thumbnail, embedding or search readiness.
 
 `status` displays a measured zero as `0`, and an unavailable/invalid count as
 `unknown` with a safe reason. It does not print response bodies or request secrets.
+Permanent status errors return exit **2**, as in `run`. Otherwise `status` remains
+informational (exit **0**, including transient unknown status or ledger-only output);
+its exit code does not certify availability or worker-upload completion.
 
 ### Durable preparation, identities, and source versions
 

--- a/scripts/remote_ingest/README.md
+++ b/scripts/remote_ingest/README.md
@@ -180,7 +180,7 @@ with `compose/accelerated/bench_parse.py`; its speedup is hardware-specific.
 | `plan` | Scan `OC_DATA_DIR` and record every PDF in the SQLite ledger. No network, no parsing. |
 | `run` | Parse + embed + upload all `PENDING`/`FAILED` docs. Resumable, concurrent, back-pressure-aware. |
 | `verify` | Poll the target for each uploaded doc's terminal status; mark `COMPLETED`/`FAILED`. |
-| `status` | Print ledger counts + the target's live worker-upload backlog. |
+| `status` | Print ledger counts + token-scoped outstanding uploads (or `unknown`). |
 
 Useful flags (append after the subcommand):
 
@@ -197,9 +197,8 @@ Useful flags (append after the subcommand):
 - `--limit N` — (on `plan`) stop after recording N **new** documents; existing
   ledger paths do not consume the limit. Zero means no cap.
 - `--flat` — do not mirror the directory tree into corpus folders.
-- `--queue-high / --queue-low` — back-pressure thresholds against the target's
-  worker-upload backlog (pause when `PENDING+PROCESSING` exceeds high, resume
-  below low).
+- `--queue-high / --queue-low` — token-scoped outstanding upload thresholds:
+  pause above high, resume at/below low. See [Admission](#admission).
 - `--enricher MODULE:CALLABLE` — run a pre-processing enricher (repeatable; also
   `OC_ENRICHERS`, comma-separated). See below.
 - `--max-attempts N` — retries per document before it is PARKED (default 5).
@@ -234,9 +233,37 @@ command again to resume unfinished rows.
 Use one CLI invocation per ledger at a time, including `plan` and `verify`.
 These cursors do not coordinate ownership across processes. Preparation checkpoints
 recover local work; uncertain uploads stop in `AMBIGUOUS` and are never replayed
-automatically. Admission error classification and the broader verification exit
-contract remain separate work in #2319 and #2320.
+automatically. The broader verification exit contract remains separate work in
+#2320.
 
+### Admission
+
+With `--queue-high > 0`, no document starts until both `PENDING` and `PROCESSING`
+status requests succeed with nonnegative integer counts. One caller polls while
+the others wait; a complete measurement is shared for 15 seconds after completion.
+Missing, invalid, failed or stale measurements cannot admit work. After a reading
+above high, admission resumes only with a fresh count at/below low. Enabled
+watermarks require `0 <= queue_low <= queue_high`. `--queue-high <= 0` disables
+admission polling, including the `run` summary; explicit `status` still polls.
+
+Network/timeouts, 429, 5xx and malformed responses pause admission and retry with
+exponential backoff (2–60 seconds before 50–100% jitter). Valid `Retry-After`
+seconds or HTTP dates extend that delay, capped at 300 seconds; zero/invalid/past
+values still use backoff. Other HTTP errors, including 401/403 and redirects,
+stop `run` with exit **2** and a credential/configuration diagnostic. Neither
+waiting nor status failure consumes document retry attempts. Ctrl-C wakes all
+waiters and uses the bounded scheduler's graceful drain and exit **130** above.
+
+These counts cover only the **exact authenticated token's** outstanding staged
+uploads, including other producers using that token. They are two separate reads,
+not an atomic snapshot, corpus-wide count or install-wide Celery capacity metric.
+Already-admitted local workers (up to `--max-workers`) can still parse/upload after
+a high reading, and other tokens are invisible: this is not a hard queue ceiling.
+The server retains batch draining, row claims and stalled-upload recovery.
+Upload status does not establish thumbnail, embedding or search readiness.
+
+`status` displays a measured zero as `0`, and an unavailable/invalid count as
+`unknown` with a safe reason. It does not print response bodies or request secrets.
 
 ### Durable preparation, identities, and source versions
 

--- a/scripts/remote_ingest/admission.py
+++ b/scripts/remote_ingest/admission.py
@@ -1,0 +1,147 @@
+"""Single-flight admission using token-scoped outstanding upload measurements."""
+
+from __future__ import annotations
+
+import logging
+import random
+import threading
+import time
+from collections.abc import Callable
+from datetime import timezone
+from email.utils import parsedate_to_datetime
+
+logger = logging.getLogger("oc_remote_ingest")
+
+POLL_INTERVAL_SECONDS = 15
+INITIAL_BACKOFF_SECONDS = 2
+MAX_BACKOFF_SECONDS = 60
+MAX_RETRY_AFTER_SECONDS = 300
+JITTER_MIN = 0.5
+
+
+class StatusPollError(Exception):
+    """Safe status diagnostic; never include credentials, bodies or request URLs."""
+
+    def __init__(
+        self, message: str, *, permanent: bool = False, retry_after: float = 0
+    ):
+        super().__init__(message)
+        self.permanent = permanent
+        self.retry_after = retry_after
+
+
+def retry_after_seconds(value: str | None) -> float:
+    """Accept HTTP delay-seconds or an HTTP-date, bounded for periodic retries."""
+    if not value:
+        return 0
+    try:
+        delay: float
+        value = value.strip()
+        if value.isascii() and value.isdigit():
+            delay = int(value)
+        else:
+            date = parsedate_to_datetime(value)
+            if date.tzinfo is None:
+                date = date.replace(tzinfo=timezone.utc)
+            delay = date.timestamp() - time.time()
+        return max(0, min(delay, MAX_RETRY_AFTER_SECONDS))
+    except (ValueError, TypeError, OverflowError):
+        return 0
+
+
+def validate_watermarks(high: int, low: int) -> None:
+    if high > 0 and not 0 <= low <= high:
+        raise ValueError("Enabled admission requires 0 <= --queue-low <= --queue-high")
+
+
+class AdmissionGovernor:
+    """Grant admission under one lock; never reuse an in-flight/failed/stale poll.
+
+    A grant precedes preparation, so already-admitted workers can still upload
+    after another caller pauses admission. HTTP runs outside the condition lock;
+    stop() wakes waiters immediately while the poll owner drains its timed call.
+    """
+
+    def __init__(self, poll: Callable[[], int], high: int, low: int):
+        validate_watermarks(high, low)
+        self._poll = poll
+        self._high = high
+        self._low = low
+        self._condition = threading.Condition()
+        self.stopped = threading.Event()
+        self.fatal_error: StatusPollError | None = None
+        self._polling = False
+        self._count: int | None = None
+        self._next_poll = 0.0
+        self._paused = False
+        self._backoff = INITIAL_BACKOFF_SECONDS
+
+    def stop(self) -> None:
+        with self._condition:
+            self.stopped.set()
+            self._condition.notify_all()
+
+    def admit(self) -> bool:
+        while True:
+            with self._condition:
+                if self.stopped.is_set():
+                    return False
+                if self._high <= 0:
+                    return True
+                if self._polling:
+                    self._condition.wait()
+                    continue
+                remaining = self._next_poll - time.monotonic()
+                if remaining > 0:
+                    if self._count is not None and not self._paused:
+                        return True
+                    self._condition.wait(remaining)
+                    continue
+                self._polling = True
+                self._count = None
+
+            error = None
+            try:
+                count = self._poll()
+            except StatusPollError as exc:
+                error = exc
+            except Exception:  # noqa: BLE001 — wake all waiters on unexpected failure
+                error = StatusPollError(
+                    "Unexpected status polling failure; check client/configuration",
+                    permanent=True,
+                )
+
+            with self._condition:
+                self._polling = False
+                self._condition.notify_all()
+                if self.stopped.is_set():
+                    return False
+                if error is not None:
+                    if error.permanent:
+                        self.fatal_error = error
+                        self.stopped.set()
+                        return False
+                    delay = max(
+                        self._backoff * random.uniform(JITTER_MIN, 1),
+                        error.retry_after,
+                    )
+                    self._backoff = min(self._backoff * 2, MAX_BACKOFF_SECONDS)
+                    self._next_poll = time.monotonic() + delay
+                    logger.warning(
+                        "admission paused: token-scoped outstanding uploads unknown "
+                        "(%s); retrying in %.1fs",
+                        error,
+                        delay,
+                    )
+                else:
+                    self._count = count
+                    self._next_poll = time.monotonic() + POLL_INTERVAL_SECONDS
+                    self._backoff = INITIAL_BACKOFF_SECONDS
+                    paused = count > (self._low if self._paused else self._high)
+                    if paused != self._paused:
+                        logger.info(
+                            "admission %s: token-scoped outstanding uploads=%s",
+                            "paused" if paused else "resumed",
+                            count,
+                        )
+                    self._paused = paused

--- a/scripts/remote_ingest/admission.py
+++ b/scripts/remote_ingest/admission.py
@@ -110,6 +110,18 @@ class AdmissionGovernor:
                     "Unexpected status polling failure; check client/configuration",
                     permanent=True,
                 )
+            except BaseException:
+                # Preserve control-flow exceptions, but never strand waiters or
+                # allow another poll to admit work after its owner has aborted.
+                with self._condition:
+                    self._polling = False
+                    self.fatal_error = StatusPollError(
+                        "Status polling aborted; check client/runtime before restarting",
+                        permanent=True,
+                    )
+                    self.stopped.set()
+                    self._condition.notify_all()
+                raise
 
             with self._condition:
                 self._polling = False

--- a/scripts/remote_ingest/oc_remote_ingest.py
+++ b/scripts/remote_ingest/oc_remote_ingest.py
@@ -36,6 +36,13 @@ import requests
 if __package__ in (None, ""):
     sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
+from scripts.remote_ingest.admission import (  # noqa: E402
+    AdmissionGovernor,
+    StatusPollError,
+    retry_after_seconds,
+    validate_watermarks,
+)
+
 if TYPE_CHECKING:  # avoid importing enrichers (needs Django path) at module load
     from enrichers import MetadataOverlay
 
@@ -50,14 +57,11 @@ DEFAULT_LEDGER_PAGE_SIZE = 256
 FUTURES_PER_WORKER = 2
 DEFAULT_EMBED_BATCH = 100
 DEFAULT_MAX_ATTEMPTS = 5
-# Backpressure: pause submitting when the target has more than HIGH worker
-# uploads still PENDING+PROCESSING, resume once it drains below LOW.
+# Token-scoped outstanding uploads: pause above HIGH, resume at/below LOW.
 DEFAULT_QUEUE_HIGH = 2000
 DEFAULT_QUEUE_LOW = 500
 _HTTP_MAX_RETRIES = 6
 _JITTER_MIN = 0.5
-_GOVERNOR_WAIT_SECONDS = 10
-_GOVERNOR_POLL_INTERVAL_SECONDS = 15
 _HTTP_UPLOAD_TIMEOUT_SECONDS = 300
 _HTTP_STATUS_TIMEOUT_SECONDS = 60
 _HTTP_BACKLOG_TIMEOUT_SECONDS = 30
@@ -448,20 +452,60 @@ class TargetClient:
         return None
 
     def backlog_count(self) -> int:
-        """PENDING + PROCESSING uploads for this token (drives backpressure)."""
+        """Complete token-scoped PENDING + PROCESSING count, or StatusPollError.
+
+        The two requests are not an atomic snapshot or a server-wide queue metric.
+        Neither a partial aggregate nor an unavailable count is usable capacity.
+        """
         total = 0
         for st in ("PENDING", "PROCESSING"):
             url = f"{self.base}/api/worker-uploads/documents/list/?status={st}&page_size=1"
             try:
                 resp = self.session.get(
-                    url, timeout=_HTTP_BACKLOG_TIMEOUT_SECONDS, verify=self._verify
+                    url,
+                    timeout=_HTTP_BACKLOG_TIMEOUT_SECONDS,
+                    verify=self._verify,
+                    allow_redirects=False,
                 )
-                if resp.status_code == 200:
-                    total += int(resp.json().get("count", 0))
+            except (
+                requests.exceptions.InvalidURL,
+                requests.exceptions.InvalidSchema,
+                requests.exceptions.MissingSchema,
+                requests.exceptions.InvalidHeader,
+            ):
+                raise StatusPollError(
+                    "Invalid status request; check --target-url and --worker-token configuration",
+                    permanent=True,
+                ) from None
             except requests.RequestException:
-                # Treat polling failure as "no backpressure signal" — better to
-                # keep moving than to stall the whole run on a flaky status call.
-                return 0
+                raise StatusPollError("Status network error or timeout") from None
+            code = resp.status_code
+            if code != 200:
+                if code == 429 or 500 <= code < 600:
+                    raise StatusPollError(
+                        f"Status unavailable: HTTP {code}",
+                        retry_after=retry_after_seconds(
+                            resp.headers.get("Retry-After")
+                        ),
+                    )
+                hint = (
+                    "check --worker-token / OC_WORKER_TOKEN and worker/token permissions"
+                    if code in (401, 403)
+                    else "check --target-url and worker-upload API configuration"
+                )
+                raise StatusPollError(f"Status HTTP {code}; {hint}", permanent=True)
+            try:
+                body = resp.json()
+            except ValueError:
+                raise StatusPollError(
+                    "Invalid status response: malformed JSON"
+                ) from None
+            count = body.get("count") if isinstance(body, dict) else None
+            if type(count) is not int or count < 0:
+                raise StatusPollError(
+                    "Invalid status response: expected a nonnegative integer count"
+                )
+            total += count
         return total
 
 
@@ -999,6 +1043,11 @@ def _process_one(
 
 
 def cmd_run(cfg: Config) -> int:
+    try:
+        validate_watermarks(cfg.queue_high, cfg.queue_low)
+    except ValueError as watermark_error:
+        logger.error("%s", watermark_error)
+        return 2
     ledger = Ledger(cfg.ledger_path)
     parser = _Parser(cfg.parser_config, cfg.parser_identity)
     # Set up Django + the parser eagerly so config errors (missing service URL,
@@ -1043,7 +1092,8 @@ def cmd_run(cfg: Config) -> int:
     total = ledger.claimable_count()
     if not total:
         logger.info("nothing to do — run `plan` first or everything is done.")
-        _print_status(ledger, client)
+        if _print_status(ledger, client if cfg.queue_high > 0 else None) == 2:
+            return 2
         return 1 if ledger.blocked_count() else 0
 
     window = FUTURES_PER_WORKER * cfg.max_workers
@@ -1054,40 +1104,15 @@ def cmd_run(cfg: Config) -> int:
         f"enrichers={len(enrichers)})"
     )
 
-    # Backpressure gate shared by all workers.
-    pause_event = threading.Event()
-    pause_event.set()  # set == "go"
-    stop_event = threading.Event()
-    governor_state = {"last_poll": 0.0}
-    gov_lock = threading.Lock()
-
-    def maybe_poll_backpressure() -> None:
-        if stop_event.is_set() or cfg.queue_high <= 0:
-            return
-        with gov_lock:
-            now = time.time()
-            if now - governor_state["last_poll"] < _GOVERNOR_POLL_INTERVAL_SECONDS:
-                return
-            governor_state["last_poll"] = now
-        backlog = client.backlog_count()
-        if backlog > cfg.queue_high and pause_event.is_set():
-            logger.info(f"backpressure: backlog={backlog} > {cfg.queue_high}; pausing")
-            pause_event.clear()
-        elif backlog <= cfg.queue_low and not pause_event.is_set():
-            logger.info(f"backpressure: backlog={backlog} <= {cfg.queue_low}; resuming")
-            pause_event.set()
+    governor = AdmissionGovernor(client.backlog_count, cfg.queue_high, cfg.queue_low)
+    stop_event = governor.stopped
 
     done = {"ok": 0, "fail": 0}
     done_lock = threading.Lock()
 
     def worker(row: sqlite3.Row) -> None:
-        # Cancellation wakes paused workers without consuming a document attempt.
-        while not stop_event.is_set():
-            maybe_poll_backpressure()
-            if pause_event.is_set():
-                break
-            stop_event.wait(_GOVERNOR_WAIT_SECONDS)
-        if stop_event.is_set():
+        # A grant is atomic with polling/pausing; only admitted work uses attempts.
+        if not governor.admit() or stop_event.is_set():
             return
         rel, ok, msg = _process_one(
             cfg, parser, embedder, client, row, enrichers, ledger
@@ -1109,14 +1134,16 @@ def cmd_run(cfg: Config) -> int:
     pending: set[Future[None]] = set()
     exhausted = interrupted = False
     try:
-        while pending or not exhausted:
-            while not exhausted and len(pending) < window:
+        while not stop_event.is_set() and (pending or not exhausted):
+            while not stop_event.is_set() and not exhausted and len(pending) < window:
                 row = next(todo, None)
                 if row is None:
                     exhausted = True
                     break
+                if stop_event.is_set():
+                    break
                 pending.add(pool.submit(worker, row))
-            if not pending:
+            if stop_event.is_set() or not pending:
                 break
             finished, pending = wait(pending, return_when=FIRST_COMPLETED)
             for future in finished:
@@ -1130,7 +1157,7 @@ def cmd_run(cfg: Config) -> int:
     except KeyboardInterrupt:
         interrupted = True
     finally:
-        stop_event.set()
+        governor.stop()
         for future in pending:
             future.cancel()
         todo.close()
@@ -1147,8 +1174,14 @@ def cmd_run(cfg: Config) -> int:
         _print_status(ledger, None)
         return 130
 
+    if governor.fatal_error is not None:
+        logger.error("Admission stopped: %s", governor.fatal_error)
+        _print_status(ledger, None)
+        return 2
+
     logger.info(f"run complete: uploaded={done['ok']}, failed={done['fail']}")
-    _print_status(ledger, client)
+    if _print_status(ledger, client if cfg.queue_high > 0 else None) == 2:
+        return 2
     return 0 if done["fail"] == 0 and not ledger.blocked_count() else 1
 
 
@@ -1209,7 +1242,9 @@ def cmd_status(cfg: Config) -> int:
     return 0
 
 
-def _print_status(ledger: Ledger, client: TargetClient | None) -> None:
+def _print_status(ledger: Ledger, client: TargetClient | None) -> int:
+    """Print an informational snapshot; return 2 for fatal status configuration."""
+    result = 0
     counts = ledger.status_counts()
     total = sum(counts.values())
     print("\n── Ledger ──")
@@ -1221,11 +1256,13 @@ def _print_status(ledger: Ledger, client: TargetClient | None) -> None:
             print(f"  {st:<9}: {counts[st]}")
     if client is not None:
         try:
-            print("\n── Target worker-upload backlog ──")
+            print("\n── Token-scoped outstanding uploads ──")
             print(f"  PENDING+PROCESSING : {client.backlog_count()}")
-        except Exception as e:  # noqa: BLE001
-            print(f"  (could not reach target: {e})")
+        except StatusPollError as exc:
+            result = 2 if exc.permanent else 0
+            print(f"  PENDING+PROCESSING : unknown ({exc})")
     print("")
+    return result
 
 
 # ======================================================================
@@ -1314,8 +1351,18 @@ def main(argv: list[str] | None = None) -> int:
         help="Maximum ledger rows fetched per page for run/verify (default 256)",
     )
     p.add_argument("--max-attempts", type=int, default=DEFAULT_MAX_ATTEMPTS)
-    p.add_argument("--queue-high", type=int, default=DEFAULT_QUEUE_HIGH)
-    p.add_argument("--queue-low", type=int, default=DEFAULT_QUEUE_LOW)
+    p.add_argument(
+        "--queue-high",
+        type=int,
+        default=DEFAULT_QUEUE_HIGH,
+        help="Pause run admission above this token-scoped outstanding upload count; <= 0 disables polling",
+    )
+    p.add_argument(
+        "--queue-low",
+        type=int,
+        default=DEFAULT_QUEUE_LOW,
+        help="Resume paused admission at/below this token-scoped count (0 <= low <= high when enabled)",
+    )
     p.add_argument(
         "--no-embeddings",
         action="store_true",
@@ -1374,6 +1421,12 @@ def main(argv: list[str] | None = None) -> int:
     )
 
     cfg = _build_config(args)
+
+    if args.command == "run":
+        try:
+            validate_watermarks(cfg.queue_high, cfg.queue_low)
+        except ValueError as exc:
+            p.error(str(exc))
 
     if args.command in ("run", "verify") and (
         not cfg.target_url or not cfg.worker_token

--- a/scripts/remote_ingest/oc_remote_ingest.py
+++ b/scripts/remote_ingest/oc_remote_ingest.py
@@ -1149,7 +1149,7 @@ def cmd_run(cfg: Config) -> int:
             for future in finished:
                 exc = future.exception()
                 if exc is not None:
-                    logger.error(f"worker crashed: {exc}")
+                    logger.error("worker crashed: %s", governor.fatal_error or exc)
                     with done_lock:
                         done["fail"] += 1
             finished.clear()
@@ -1238,8 +1238,7 @@ def cmd_status(cfg: Config) -> int:
     client = None
     if cfg.target_url and cfg.worker_token:
         client = TargetClient(cfg)
-    _print_status(ledger, client)
-    return 0
+    return _print_status(ledger, client)
 
 
 def _print_status(ledger: Ledger, client: TargetClient | None) -> int:


### PR DESCRIPTION
## Summary

Remote ingestion previously treated failed or incomplete status polls as spare capacity and could start documents while its first poll was still running. Admission now requires a fresh, complete token-scoped measurement and pauses whenever that measurement is unavailable.

Closes #2319. Based on latest `main` (`b2897ed9d`), including #2316, #2317 and #2318. Reviewed #2320's verification contract; receipt completion remains separate from admission and downstream readiness.

## Changes

- Validate both `PENDING` and `PROCESSING` responses before returning an aggregate; classify permanent HTTP/request configuration errors separately from transient network, throttling, server and malformed-response failures. Diagnostics omit credentials and response bodies.
- Replace the event/timestamp race with a condition-protected, single-flight governor. Preserve high/low hysteresis, freshness from poll completion, jittered capped retries and bounded `Retry-After` handling.
- Integrate cancellation and fatal errors with the existing bounded scheduler. Waiters wake without spending document attempts; already-running work drains. Poll aborts (including non-`Exception` failures) stop admission and wake waiters before propagating to the caller. Permanent status failures return exit 2, including summary polls; disabled admission performs no `run` status polls.
- Report unavailable status as `unknown` and propagate permanent configuration errors from `status` as exit 2; clarify exact-token scope and queue-ceiling limitations, and document behavior in the worker guides and changelog.

## Test plan

- **104 tests passed** across `test_remote_ingest_{admission,scheduling,checkpoints,parsers,enrichers}` using `unittest` after `django.setup()` in the existing Django image, with networking disabled and this checkout mounted read-only.
- **30 database-free admission/scheduler tests passed** with `python3 -m unittest opencontractserver.tests.test_remote_ingest_admission opencontractserver.tests.test_remote_ingest_scheduling -q`. Coverage includes either-request failure, invalid counts, redaction, blocked initial/refresh HTTP calls with six callers, hysteresis, retries, cancellation, `BaseException` cleanup/propagation, status exit codes and untouched ledger attempts.
- `pre-commit run --all-files` passed, including full-project mypy.
- `frontend/node_modules/.bin/tsc --project frontend/tsconfig.json --noEmit` passed.

## Checklist

- [x] Tests pass locally for affected code
- [x] `pre-commit run --all-files` passes
- [x] TypeScript compiles cleanly
- [x] Changelog fragment added
- [x] No new dependencies

## Contributor License Agreement

By submitting this pull request, you agree to license your contribution under the project's [Contributor License Agreement](../CLA.md).

