### PR TITLE
Make remote-ingest verification truthful and enforce embedding completeness

### DIFF
--- a/changelog.d/2320-remote-verification.fixed.md
+++ b/changelog.d/2320-remote-verification.fixed.md
@@ -1,0 +1,5 @@
+Remote ingest now verifies the whole ledger with stable completion, outstanding,
+failure and unavailable exit codes and streaming JSON Lines results. Receipt HTTP
+errors no longer masquerade as processing or overwrite durable ledger state.
+Embedding response validation is shared with the server microservice client;
+remote preparation requires complete, finite vectors before upload or caching.

--- a/opencontractserver/pipeline/embedders/sent_transformer_microservice.py
+++ b/opencontractserver/pipeline/embedders/sent_transformer_microservice.py
@@ -3,7 +3,6 @@ import threading
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
-import numpy as np
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
@@ -24,6 +23,11 @@ from opencontractserver.pipeline.base.settings_schema import (
     SettingType,
 )
 from opencontractserver.utils.cloud import maybe_add_cloud_run_auth
+from opencontractserver.utils.embedding_validation import (
+    embedding_batch,
+    embedding_values,
+    normalize_embedding_vector,
+)
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
@@ -234,24 +238,7 @@ class MicroserviceEmbedder(BaseEmbedder):
             )
 
             if response.status_code == 200:
-                body = response.json()
-                if "embeddings" not in body:
-                    logger.error(
-                        f"Malformed 200 response: missing 'embeddings' key. "
-                        f"Keys received: {list(body.keys())}"
-                    )
-                    return None
-                embeddings_array = np.array(body["embeddings"])
-                if np.isnan(embeddings_array).any():
-                    logger.error("Embedding contains NaN values")
-                    return None
-                # Handle both 1D (single embedding) and 2D (batch) response formats
-                if embeddings_array.ndim == 1:
-                    # Service returns 1D array directly: [0.1, 0.2, ...]
-                    return embeddings_array.tolist()
-                else:
-                    # Service returns 2D batch array: [[0.1, 0.2, ...]]
-                    return embeddings_array[0].tolist()
+                return normalize_embedding_vector(embedding_values(response.json()))
             elif 400 <= response.status_code < 500:
                 # Client errors (4xx) - don't retry, likely invalid input
                 logger.error(
@@ -326,38 +313,15 @@ class MicroserviceEmbedder(BaseEmbedder):
             )
 
             if response.status_code == 200:
-                body = response.json()
-                if "embeddings" not in body:
-                    logger.error(
-                        f"Malformed 200 response: missing 'embeddings' key. "
-                        f"Keys received: {list(body.keys())}"
-                    )
-                    return None
-                embeddings_array = np.array(body["embeddings"])
-                if embeddings_array.ndim == 3:
-                    if embeddings_array.shape[1] != 1:
-                        logger.error(f"Unexpected 3D shape {embeddings_array.shape}")
-                        return None
-                    embeddings_array = embeddings_array.squeeze(axis=1)
-
-                if len(embeddings_array) != len(texts):
-                    logger.error(
-                        f"Vector count mismatch: sent {len(texts)} texts, "
-                        f"received {len(embeddings_array)} vectors"
-                    )
-                    return None
-
-                # Handle NaN values per-item rather than failing the whole batch
+                rows = embedding_batch(response.json(), len(texts))
+                # Preserve explicit per-item failures for _batch_embed_items.
                 results: list[Optional[list[float]]] = []
-                for i, row in enumerate(embeddings_array):
-                    if np.isnan(row).any():
-                        logger.error(
-                            f"Embedding at index {i} contains NaN values, "
-                            f"returning None for this item"
-                        )
+                for i, row in enumerate(rows):
+                    try:
+                        results.append(normalize_embedding_vector(row))
+                    except ValueError as exc:
+                        logger.error("Invalid embedding at index %s: %s", i, exc)
                         results.append(None)
-                    else:
-                        results.append(row.tolist())
                 return results
             elif 400 <= response.status_code < 500:
                 # Client errors (4xx) - not retriable, likely invalid input.

--- a/opencontractserver/tests/test_batch_embedding.py
+++ b/opencontractserver/tests/test_batch_embedding.py
@@ -707,9 +707,49 @@ class TestMicroserviceEmbedderBatch(unittest.TestCase):
         self.assertIsNone(result[1])  # NaN item
         self.assertIsNotNone(result[2])
 
+    @patch("requests.Session.post")
+    def test_shared_contract_rejects_extra_rows_and_marks_invalid_items(
+        self, mock_post
+    ):
+        embedder = self._make_embedder()
+        vector = [0.5] * 384
+        mock_post.return_value = self._mock_response(200, [vector, vector])
+        self.assertIsNone(embedder.embed_texts_batch(["one"]))
+        for invalid in (
+            None,
+            [True] * 384,
+            ["0.5"] * 384,
+            [float("inf")] * 384,
+            [vector, vector],
+        ):
+            with self.subTest(invalid=str(invalid)[:40]):
+                mock_post.return_value = self._mock_response(200, [vector, invalid])
+                self.assertEqual(
+                    embedder.embed_texts_batch(["one", "two"]), [vector, None]
+                )
+
 
 class TestMicroserviceEmbedderSingleText(unittest.TestCase):
     """Test MicroserviceEmbedder._embed_text_impl and _get_service_config."""
+
+    @patch("requests.Session.post")
+    def test_shared_contract_rejects_non_singleton_and_nonfinite_vectors(
+        self, mock_post
+    ):
+        embedder = self._make_embedder()
+        vector = [0.5] * 384
+        for values in (
+            [vector, vector],
+            [True] * 384,
+            ["0.5"] * 384,
+            [float("inf")] * 384,
+            [10**400] * 384,
+        ):
+            with self.subTest(values=str(values)[:40]):
+                mock_post.return_value = MagicMock(
+                    status_code=200, json=lambda: {"embeddings": values}
+                )
+                self.assertIsNone(embedder._embed_text_impl("document"))
 
     def _make_embedder(self, api_key="", use_cloud_run=False):
         embedder = MicroserviceEmbedder()

--- a/opencontractserver/tests/test_remote_ingest_checkpoints.py
+++ b/opencontractserver/tests/test_remote_ingest_checkpoints.py
@@ -460,7 +460,7 @@ class CheckpointTests(SimpleTestCase):
         self.assertEqual(self.counts["upload"], 1)
         self.assertEqual(set(self.cache().manifest["stages"]), set(cp.STAGES))
         with patch.object(cli, "_print_status"), patch.object(cli, "TargetClient"):
-            self.assertEqual(cli.cmd_verify(self.cfg), 1)
+            self.assertEqual(cli.cmd_verify(self.cfg), cli.VERIFY_FAILED)
 
     def test_missing_source_is_retryable_and_never_uploads_cached_payload(self):
         self.assertEqual(self.run_worker(), 0)
@@ -543,6 +543,26 @@ class CheckpointTests(SimpleTestCase):
         self.assertEqual(self.run_worker(), 0)
         self.assertEqual([self.counts[s] for s in cp.STAGES], [1, 1, 2])
         self.assertEqual(self.counts["upload"], 1)
+
+    def test_missing_document_vector_retries_then_parks_without_fallback(self):
+        self.cfg = replace(self.cfg, max_attempts=2)
+        with patch.object(cli.EmbedderClient, "embed_text", return_value=None):
+            for status in (cli.FAILED, cli.PARKED):
+                self.assertEqual(self.run_worker(), 1)
+                self.assertEqual(self.row()["status"], status)
+                self.assertIn("Document embedding", self.row()["last_error"])
+                self.assertEqual(
+                    set(self.cache().manifest["stages"]), {"parse", "enrich"}
+                )
+        self.assertEqual(self.counts["upload"], 0)
+        self.assertFalse(self.payloads)
+
+    def test_unsupported_embedding_dimension_fails_before_preparation(self):
+        self.cfg = replace(self.cfg, embedding_dimension=3)
+        with self.assertRaisesRegex(ValueError, "not supported by server storage"):
+            self.run_worker()
+        self.assertEqual(self.counts["parse"], 0)
+        self.assertFalse(self.payloads)
 
 
 class LedgerPermissionsTests(SimpleTestCase):
@@ -694,6 +714,7 @@ class EmbeddingContractTests(SimpleTestCase):
             [float("nan")] * 384,
             [float("inf")] * 384,
             [float("-inf")] * 384,
+            [10**400] * 384,
         ):
             with self.subTest(response=str(response)[:40]), self.assertRaises(
                 ValueError
@@ -750,6 +771,52 @@ class EmbeddingContractTests(SimpleTestCase):
                 embedder_path="test",
                 content="one",
                 labelled_text=annotations,
+            )
+
+    def test_http_response_envelopes_and_mixed_dimensions_fail(self):
+        client = cli.EmbedderClient("https://embedder", None, 2, dimension=384)
+        body: Any
+        for body in (
+            None,
+            [],
+            {},
+            {"vectors": [0.1] * 384},
+            {"embeddings": [[0.1] * 384, [0.1] * 768]},
+        ):
+            with self.subTest(body=str(body)[:40]), patch.object(
+                client.session, "post", return_value=Mock(json=lambda: body)
+            ):
+                for call in (
+                    lambda: client.embed_text("document"),
+                    lambda: client.embed_batch(["one", "two"]),
+                ):
+                    with self.assertRaises(ValueError):
+                        call()
+
+    def test_partial_missing_and_unmapped_annotation_vectors_fail(self):
+        embedder = Mock(dimension=384)
+        vector = [0.5] * 384
+        embedder.embed_text.return_value = vector
+        annotations = [{"id": "a", "rawText": "one"}, {"id": "b", "rawText": "two"}]
+        for rows in ([vector], [vector, None], [vector, vector, vector]):
+            embedder.embed_batch.return_value = rows
+            with self.assertRaises(ValueError):
+                cli._compute_embeddings(
+                    embedder=embedder,
+                    embedder_path="test",
+                    content="document",
+                    labelled_text=annotations,
+                )
+        with self.assertRaisesRegex(ValueError, "coverage"):
+            cli._validate_embeddings(
+                {
+                    "embedder_path": "test",
+                    "document_embedding": vector,
+                    "annotation_embeddings": {"a": vector, "unmapped": vector},
+                },
+                annotations,
+                384,
+                "test",
             )
 
 

--- a/opencontractserver/tests/test_remote_ingest_scheduling.py
+++ b/opencontractserver/tests/test_remote_ingest_scheduling.py
@@ -27,7 +27,8 @@ from scripts.remote_ingest import oc_remote_ingest as cli
 class ObservedCursor(sqlite3.Cursor):
     def execute(self, sql, parameters=()):
         self.sql = sql
-        if sql.startswith("SELECT * FROM docs"):
+        # Receipt transitions may read one row back by its unique primary key.
+        if sql.startswith("SELECT * FROM docs") and "WHERE rel_path=?" not in sql:
             observer = cast(ObservedConnection, self.connection).observer
             observer["test"].assertFalse(observer["interrupted"])
             observer["queries"].append((sql, parameters))
@@ -101,6 +102,7 @@ class SchedulingTests(unittest.TestCase):
         self.patch("scripts.remote_ingest.oc_remote_ingest._print_status", Mock())
         self.patch("scripts.remote_ingest.oc_remote_ingest.logger", Mock())
         self.patch("sys.stderr", StringIO())
+        self.patch("sys.stdout", StringIO())
 
     def patch(self, target, value):
         patcher = patch(target, value)
@@ -233,14 +235,12 @@ class SchedulingTests(unittest.TestCase):
             i = int(receipt.split("-")[1])
             selected.append(i)
             outcome = outcomes[i % len(outcomes)]
-            return (
-                None
-                if outcome is None
-                else {"status": outcome, "error_message": "server error"}
-            )
+            if outcome is None:
+                raise cli.StatusPollError("Status unavailable", reason="network_error")
+            return {"status": outcome, "error_message": "server error"}
 
         self.client.upload_status.side_effect = status
-        self.assertEqual(cli.cmd_verify(self.cfg), 0)
+        self.assertEqual(cli.cmd_verify(self.cfg), cli.VERIFY_UNAVAILABLE)
         self.assertEqual(selected, list(range(1002)))
         self.assert_pages_bounded(7, minimum_pages=100)
         failed = (
@@ -376,7 +376,7 @@ class SchedulingTests(unittest.TestCase):
         with patch.object(cli, "ThreadPoolExecutor") as pool:
             self.assertEqual(cli.cmd_run(self.cfg), 0)
             pool.assert_not_called()
-        self.assertEqual(cli.cmd_verify(self.cfg), 0)
+        self.assertEqual(cli.cmd_verify(self.cfg), cli.VERIFY_COMPLETE)
         self.client.upload_status.assert_not_called()
 
     def synthetic_tree(self, names):

--- a/opencontractserver/tests/test_remote_ingest_verification.py
+++ b/opencontractserver/tests/test_remote_ingest_verification.py
@@ -1,0 +1,250 @@
+"""Whole-ledger verification and receipt classification, with no Django/database."""
+
+import json
+import unittest
+from contextlib import redirect_stdout
+from io import StringIO
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any
+from unittest.mock import Mock, patch
+
+import requests
+
+from scripts.remote_ingest import oc_remote_ingest as cli
+
+
+class VerificationTests(unittest.TestCase):
+    def setUp(self):
+        tmp = TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.cfg = cli.Config(
+            target_url="https://target.invalid",
+            worker_token="private-token",
+            corpus_id=None,
+            root_dir=tmp.name,
+            ledger_path=str(Path(tmp.name) / "ledger.sqlite3"),
+            extensions=(".txt",),
+            max_workers=1,
+            max_attempts=2,
+            queue_high=0,
+            queue_low=0,
+            embeddings=False,
+            target_folder_from_tree=False,
+            verify_tls=True,
+            limit=0,
+            enrichers=[],
+            ledger_page_size=2,
+            json_output=True,
+        )
+        self.ledger = cli.Ledger(self.cfg.ledger_path)
+        self.addCleanup(self.ledger._conn().close)
+        self.client = cli.TargetClient(self.cfg)
+        self.addCleanup(self.client.session.close)
+        patcher = patch.object(self.client.session, "get")
+        self.get = patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def add(self, path, status, receipt=None):
+        self.ledger._conn().execute(
+            "INSERT INTO docs(rel_path, abs_path, status, upload_id, attempts, "
+            "last_error, uploaded_at) VALUES(?, ?, ?, ?, 1, 'prior diagnostic', 12)",
+            (path, f"/source/{path}", status, receipt),
+        )
+
+    def response(self, status="COMPLETED", **fields):
+        # document_id is not a readiness signal and may be null in the API.
+        return Mock(
+            status_code=200,
+            json=Mock(return_value=dict(upload_id="receipt", status=status, **fields)),
+        )
+
+    def verify(self):
+        output = StringIO()
+        with patch.object(cli, "Ledger", return_value=self.ledger), patch.object(
+            cli, "TargetClient", return_value=self.client
+        ), redirect_stdout(output):
+            code = cli.cmd_verify(self.cfg)
+        records = [json.loads(line) for line in output.getvalue().splitlines()]
+        summary = records.pop()
+        self.assertEqual(summary["type"], "summary")
+        self.assertEqual(summary["exit_code"], code)
+        self.assertEqual(summary["total"], len(records))
+        self.assertEqual(sum(summary["reason_counts"].values()), len(records))
+        return code, records, summary
+
+    def test_empty_scope_is_explicit_noop_success_without_http(self):
+        code, records, summary = self.verify()
+        self.assertEqual((code, records, summary["outcome"]), (0, [], "empty"))
+        self.assertEqual(summary["scope"], "whole_ledger")
+        self.get.assert_not_called()
+
+    def test_completed_receipt_establishes_only_worker_transaction_completion(self):
+        self.add("new.txt", cli.UPLOADED, "receipt")
+        self.add("old.txt", cli.COMPLETED, "old-receipt")
+        self.get.return_value = self.response(document_id=None)
+        code, records, summary = self.verify()
+        self.assertEqual(code, 0)
+        self.assertEqual(summary["outcome"], "complete")
+        self.assertEqual(summary["completion_boundary"], "worker_upload_transaction")
+        self.assertEqual(summary["counts"], {cli.COMPLETED: 2})
+        self.assertEqual(records[0]["receipt_status"], "COMPLETED")
+        self.assertGreater(self.ledger.get_doc("new.txt")["completed_at"], 12)
+        self.get.assert_called_once_with(
+            "https://target.invalid/api/worker-uploads/documents/receipt/",
+            timeout=cli._HTTP_STATUS_TIMEOUT_SECONDS,
+            verify=True,
+            allow_redirects=False,
+        )
+        self.get.reset_mock()
+        self.assertEqual(self.verify()[0], 0)
+        self.get.assert_not_called()
+
+    def test_local_states_remain_unresolved_across_verification_passes(self):
+        for status, expected, reason in (
+            (cli.PENDING, 1, "not_uploaded"),
+            (cli.FAILED, 2, "failed"),
+            (cli.PARKED, 2, "parked"),
+            (cli.AMBIGUOUS, 2, "ambiguous_upload"),
+            (cli.CONFLICT, 2, "source_conflict"),
+            ("UNKNOWN", 3, "unknown_ledger_state"),
+        ):
+            with self.subTest(status=status):
+                self.ledger._conn().execute("DELETE FROM docs")
+                self.add("source.txt", status, "old-receipt")
+                before = dict(self.ledger.get_doc("source.txt"))
+                for _ in range(2):
+                    code, records, _ = self.verify()
+                    self.assertEqual(code, expected)
+                    self.assertEqual(records[0]["reason"], reason)
+                    self.assertEqual(dict(self.ledger.get_doc("source.txt")), before)
+        self.get.assert_not_called()
+
+    def test_server_failure_is_durable_and_keeps_receipt_and_error(self):
+        for attempts, expected_status in ((0, cli.FAILED), (1, cli.PARKED)):
+            with self.subTest(attempts=attempts):
+                self.ledger._conn().execute("DELETE FROM docs")
+                self.add("source.txt", cli.UPLOADED, "receipt")
+                self.ledger._conn().execute("UPDATE docs SET attempts=?", (attempts,))
+                self.get.return_value = self.response(
+                    "FAILED", error_message="bad data"
+                )
+                self.get.reset_mock()
+                for _ in range(2):
+                    code, records, summary = self.verify()
+                    self.assertEqual(code, 2)
+                    self.assertEqual(summary["counts"], {expected_status: 1})
+                    self.assertEqual(records[0]["upload_id"], "receipt")
+                    self.assertEqual(records[0]["detail"], "server: bad data")
+                self.get.assert_called_once()
+                self.assertEqual(
+                    self.ledger.get_doc("source.txt")["attempts"], attempts + 1
+                )
+
+    def test_pending_and_processing_receipts_are_outstanding_without_mutation(self):
+        self.add("source.txt", cli.UPLOADED, "receipt")
+        before = dict(self.ledger.get_doc("source.txt"))
+        for status in ("PENDING", "PROCESSING"):
+            self.get.return_value = self.response(status)
+            code, records, _ = self.verify()
+            self.assertEqual(code, 1)
+            self.assertEqual(records[0]["reason"], f"receipt_{status.lower()}")
+            self.assertEqual(dict(self.ledger.get_doc("source.txt")), before)
+
+    def test_http_errors_are_distinct_safe_and_do_not_mutate_receipts(self):
+        self.add("source.txt", cli.UPLOADED, "receipt")
+        before = dict(self.ledger.get_doc("source.txt"))
+        for http_status, reason in (
+            (401, "unauthorized"),
+            (403, "forbidden"),
+            (404, "not_found"),
+            (429, "rate_limited"),
+            (500, "server_unavailable"),
+            (503, "server_unavailable"),
+            (302, "http_error"),
+            (422, "http_error"),
+        ):
+            with self.subTest(http_status=http_status):
+                self.get.return_value = Mock(
+                    status_code=http_status,
+                    headers={"Retry-After": "30"},
+                    text="private-token internal server response",
+                )
+                code, records, summary = self.verify()
+                self.assertEqual(code, 3)
+                self.assertEqual(summary["unavailable"], 1)
+                self.assertEqual(records[0]["reason"], reason)
+                self.assertEqual(records[0]["http_status"], http_status)
+                self.assertNotIn("private-token", json.dumps(records))
+                self.assertEqual(dict(self.ledger.get_doc("source.txt")), before)
+                if http_status == 404:
+                    self.assertIn("current worker token", records[0]["detail"])
+
+    def test_transport_and_invalid_responses_are_unavailable_without_mutation(self):
+        self.add("source.txt", cli.UPLOADED, "receipt")
+        before = dict(self.ledger.get_doc("source.txt"))
+        for error, reason in (
+            (requests.Timeout("private-token"), "network_error"),
+            (requests.ConnectionError("private-token"), "network_error"),
+            (requests.exceptions.InvalidURL("private-token"), "invalid_request"),
+        ):
+            self.get.side_effect = error
+            code, records, _ = self.verify()
+            self.assertEqual(code, 3)
+            self.assertEqual(records[0]["reason"], reason)
+            self.assertNotIn("private-token", json.dumps(records))
+        self.get.side_effect = None
+        body: Any
+        for body in (
+            None,
+            [],
+            {},
+            {"status": "COMPLETED"},
+            {"upload_id": "other", "status": "COMPLETED"},
+            {"upload_id": "receipt", "status": "mystery"},
+            {"upload_id": "receipt", "status": ["FAILED"]},
+            {"upload_id": "receipt", "status": "FAILED", "error_message": {}},
+        ):
+            self.get.return_value = Mock(status_code=200, json=Mock(return_value=body))
+            code, records, _ = self.verify()
+            self.assertEqual(code, 3)
+            self.assertEqual(records[0]["reason"], "invalid_response")
+        self.get.return_value.json.side_effect = ValueError("private-token")
+        self.assertEqual(self.verify()[0], 3)
+        self.assertEqual(dict(self.ledger.get_doc("source.txt")), before)
+
+    def test_mixed_scope_prioritizes_unavailability_then_failure_then_outstanding(self):
+        self.add("a.txt", cli.COMPLETED)
+        self.add("b.txt", cli.PENDING)
+        self.add("c.txt", cli.FAILED)
+        self.add("d.txt", cli.UPLOADED)  # Cannot poll a missing receipt.
+        code, records, summary = self.verify()
+        self.assertEqual(code, 3)
+        self.assertEqual(records[-1]["reason"], "missing_receipt")
+        self.assertEqual(summary["counts"], self.ledger.status_counts())
+        self.ledger._conn().execute("DELETE FROM docs WHERE rel_path='d.txt'")
+        self.assertEqual(self.verify()[0], 2)
+        self.ledger._conn().execute("DELETE FROM docs WHERE rel_path='c.txt'")
+        self.assertEqual(self.verify()[0], 1)
+        self.ledger._conn().execute("DELETE FROM docs WHERE rel_path='b.txt'")
+        self.assertEqual(self.verify()[0], 0)
+        self.get.assert_not_called()
+
+    def test_cli_json_flag_reaches_verify_without_booting_django(self):
+        with patch.object(cli, "cmd_verify", return_value=3) as verify:
+            self.assertEqual(
+                cli.main(
+                    [
+                        "--target-url",
+                        self.cfg.target_url,
+                        "--worker-token",
+                        "token",
+                        "--ledger",
+                        self.cfg.ledger_path,
+                        "--json",
+                        "verify",
+                    ]
+                ),
+                3,
+            )
+        self.assertTrue(verify.call_args.args[0].json_output)

--- a/opencontractserver/utils/embedding_validation.py
+++ b/opencontractserver/utils/embedding_validation.py
@@ -1,0 +1,47 @@
+"""JSON embedding response contract, shared by server and database-free workers.
+
+Single vectors may be flat or wrapped in one singleton row. Batch responses
+contain exactly one such vector per input. Callers choose whether invalid items
+fail the whole preparation or are returned as explicit per-item failures.
+"""
+
+import math
+from typing import Any
+
+
+def embedding_values(body: Any) -> list:
+    if not isinstance(body, dict) or not isinstance(body.get("embeddings"), list):
+        raise ValueError("Embedding response requires an 'embeddings' array")
+    return body["embeddings"]
+
+
+def embedding_batch(body: Any, count: int) -> list:
+    rows = embedding_values(body)
+    if len(rows) != count:
+        raise ValueError("Embedding batch cardinality does not match inputs")
+    return rows
+
+
+def validate_embedding_vector(vector: Any, dimension: int | None = None) -> None:
+    """Validate a normalized, nonempty vector without coercing strings or bools."""
+    valid = isinstance(vector, list) and bool(vector)
+    if valid and dimension is not None:
+        valid = len(vector) == dimension
+    try:
+        valid = valid and all(
+            type(value) in (int, float) and math.isfinite(value) for value in vector
+        )
+    except OverflowError:
+        valid = False
+    if not valid:
+        size = str(dimension) if dimension is not None else "nonempty"
+        raise ValueError(f"Embedding requires {size} finite numeric values")
+
+
+def normalize_embedding_vector(
+    vector: Any, dimension: int | None = None
+) -> list[float]:
+    if isinstance(vector, list) and len(vector) == 1 and isinstance(vector[0], list):
+        vector = vector[0]
+    validate_embedding_vector(vector, dimension)
+    return vector

--- a/scripts/remote_ingest/README.md
+++ b/scripts/remote_ingest/README.md
@@ -179,7 +179,7 @@ with `compose/accelerated/bench_parse.py`; its speedup is hardware-specific.
 |---|---|
 | `plan` | Scan `OC_DATA_DIR` and record every PDF in the SQLite ledger. No network, no parsing. |
 | `run` | Parse + embed + upload all `PENDING`/`FAILED` docs. Resumable, concurrent, back-pressure-aware. |
-| `verify` | Poll the target for each uploaded doc's terminal status; mark `COMPLETED`/`FAILED`. |
+| `verify` | Verify the whole ledger; poll uploaded receipts and return a completion, outstanding, failure or unavailable result. |
 | `status` | Print ledger counts + token-scoped outstanding uploads (or `unknown`). |
 
 Useful flags (append after the subcommand):
@@ -204,6 +204,47 @@ Useful flags (append after the subcommand):
 - `--max-attempts N` — retries per document before it is PARKED (default 5).
 - `--insecure` — disable TLS verification (testing only; e.g. a self-signed or
   local HTTPS target).
+
+### Verification contract
+
+`verify` covers **every row in the ledger**, including work never uploaded and
+failures from earlier passes. It polls each `UPLOADED` receipt once, persists valid
+`COMPLETED`/`FAILED` responses, then decides its exit from final ledger state and
+any unavailable observations. It does not poll the unrelated token backlog.
+
+| Exit | Outcome | Meaning |
+|---|---|---|
+| `0` | `complete` / `empty` | Every row is `COMPLETED`; an empty ledger is an explicit successful no-op. |
+| `1` | `outstanding` | Local `PENDING` work or receipts still `PENDING`/`PROCESSING`. |
+| `2` | `failed` | `FAILED`, `PARKED`, `AMBIGUOUS` or `CONFLICT` work needs retry/reconciliation. |
+| `3` | `unable_to_verify` | At least one receipt is unavailable/malformed/missing, or a ledger state is unknown. |
+
+For mixed results, `3` takes precedence over `2`, then `1`. Codes `0`/`1`/`2`
+follow the bulk-import convention where applicable. Repeating verification keeps
+reporting unresolved failures and preserves their receipt/error. HTTP 401/403,
+404 (missing or inaccessible under this exact token), 429, 5xx, transport errors,
+and malformed responses have distinct reasons; none changes the receipt's ledger
+state, attempts or diagnostic history. Correct the cause and rerun verification.
+
+For automation, use `verify --json`. Standard output is **JSON Lines**, with one
+`type: "document"` record per ledger row in path order, followed by one
+`type: "summary"` record. Both carry `schema_version: 1`. Document records include
+`rel_path`, final local `status`, `upload_id`, observed `receipt_status` (or null),
+stable `reason`, diagnostic `detail`, and `http_status` (or null). Reasons include
+`not_uploaded`, `receipt_pending`, `receipt_processing`, `failed`, `parked`,
+`ambiguous_upload`, `source_conflict`, `missing_receipt`, `unauthorized`, `forbidden`,
+`not_found`, `rate_limited`, `server_unavailable`, `network_error`, `invalid_request`,
+`http_error`, `invalid_response`, `unknown_ledger_state`, and `completed`.
+The final summary includes `scope: "whole_ledger"`, `outcome`, `exit_code`, `total`,
+final status `counts`, `reason_counts`, `unavailable`, and
+`completion_boundary: "worker_upload_transaction"`. Consumers must require the
+final summary and successful process exit; a truncated stream is not completion.
+Results stream in bounded pages rather than accumulating all documents in memory.
+
+Success means that the worker-upload transaction committed document, annotations,
+relationships, supplied embeddings, structural set and metadata writes. Thumbnail
+generation, independently queued document embedding, indexing and search readiness
+are asynchronous and are **not** established by the receipt or its `document_id`.
 
 ### Bounded traversal and resume
 
@@ -322,6 +363,14 @@ of the configured, storage-supported dimension per annotation with nonblank
 `rawText`. Missing/duplicate/string-colliding IDs, partial batches or malformed
 vectors fail preparation before upload and never commit an embedding checkpoint.
 Only explicit `--no-embeddings` omits the payload for server annotation fallback.
+The remote worker uses the text embedding policy: document content is required;
+annotations with empty/whitespace `rawText` are exempt. Its response normalization
+is shared with `MicroserviceEmbedder`, without importing ORM persistence helpers.
+A single response must be `{"embeddings": [number, ...]}` or
+`{"embeddings": [[number, ...]]}`. Batch responses contain exactly one flat or
+singleton-wrapped vector per nonblank input; missing and extra rows both fail.
+Strings, booleans, nonfinite values and inconsistent dimensions are rejected.
+Failures retain parse/enrichment checkpoints and follow normal retry/parking rules.
 
 `plan` and preparation reconcile actual source bytes. A changed unaccepted source
 resets `PENDING`/`FAILED`/`PARKED` to `PENDING`, clears stale receipts/errors and

--- a/scripts/remote_ingest/admission.py
+++ b/scripts/remote_ingest/admission.py
@@ -23,11 +23,19 @@ class StatusPollError(Exception):
     """Safe status diagnostic; never include credentials, bodies or request URLs."""
 
     def __init__(
-        self, message: str, *, permanent: bool = False, retry_after: float = 0
+        self,
+        message: str,
+        *,
+        permanent: bool = False,
+        retry_after: float = 0,
+        reason: str = "invalid_response",
+        http_status: int | None = None,
     ):
         super().__init__(message)
         self.permanent = permanent
         self.retry_after = retry_after
+        self.reason = reason
+        self.http_status = http_status
 
 
 def retry_after_seconds(value: str | None) -> float:

--- a/scripts/remote_ingest/oc_remote_ingest.py
+++ b/scripts/remote_ingest/oc_remote_ingest.py
@@ -23,6 +23,7 @@ import sqlite3
 import sys
 import threading
 import time
+from collections import Counter
 from collections.abc import Generator, Mapping
 from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from contextlib import closing
@@ -36,6 +37,12 @@ import requests
 if __package__ in (None, ""):
     sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
+from opencontractserver.utils.embedding_validation import (  # noqa: E402
+    embedding_batch,
+    embedding_values,
+    normalize_embedding_vector,
+    validate_embedding_vector,
+)
 from scripts.remote_ingest.admission import (  # noqa: E402
     AdmissionGovernor,
     StatusPollError,
@@ -55,6 +62,11 @@ DEFAULT_EXTENSIONS = ".pdf"
 DEFAULT_MAX_WORKERS = 4
 DEFAULT_LEDGER_PAGE_SIZE = 256
 FUTURES_PER_WORKER = 2
+VERIFY_COMPLETE = 0
+VERIFY_OUTSTANDING = 1
+VERIFY_FAILED = 2
+VERIFY_UNAVAILABLE = 3
+VERIFY_SCHEMA_VERSION = 1
 DEFAULT_EMBED_BATCH = 100
 DEFAULT_MAX_ATTEMPTS = 5
 # Token-scoped outstanding uploads: pause above HIGH, resume at/below LOW.
@@ -284,6 +296,11 @@ class Ledger:
     ) -> Generator[sqlite3.Row]:
         return self._iter_rows(_CLAIMABLE_WHERE, "idx_docs_claimable_path", page_size)
 
+    def all_docs(
+        self, page_size: int = DEFAULT_LEDGER_PAGE_SIZE
+    ) -> Generator[sqlite3.Row]:
+        return self._iter_rows("1=1", "sqlite_autoindex_docs_1", page_size)
+
     def uploaded_unconfirmed_count(self) -> int:
         return self._count(_UNCONFIRMED_WHERE)
 
@@ -369,6 +386,7 @@ class Config:
     embedding_identity: str | None = None
     embedding_dimension: int = 384
     parser_identity: str | None = None
+    json_output: bool = False
 
 
 class TargetClient:
@@ -442,14 +460,78 @@ class TargetClient:
             )
         raise TransientUploadError("Upload rejected: rate limit retries exhausted")
 
-    def upload_status(self, upload_id: str) -> dict | None:
+    def _status_json(self, url: str, timeout: int) -> dict:
+        """Shared safe HTTP classification; admission and verify choose policy."""
+        try:
+            resp = self.session.get(
+                url, timeout=timeout, verify=self._verify, allow_redirects=False
+            )
+        except (
+            requests.exceptions.InvalidURL,
+            requests.exceptions.InvalidSchema,
+            requests.exceptions.MissingSchema,
+            requests.exceptions.InvalidHeader,
+        ):
+            raise StatusPollError(
+                "Invalid status request; check --target-url and --worker-token configuration",
+                permanent=True,
+                reason="invalid_request",
+            ) from None
+        except requests.RequestException:
+            raise StatusPollError(
+                "Status network error or timeout", reason="network_error"
+            ) from None
+        code = resp.status_code
+        if code != 200:
+            if code == 429 or 500 <= code < 600:
+                raise StatusPollError(
+                    f"Status unavailable: HTTP {code}",
+                    reason="rate_limited" if code == 429 else "server_unavailable",
+                    http_status=code,
+                    retry_after=retry_after_seconds(resp.headers.get("Retry-After")),
+                )
+            hint = (
+                "check --worker-token / OC_WORKER_TOKEN and worker/token permissions"
+                if code in (401, 403)
+                else "check --target-url and worker-upload API configuration"
+            )
+            raise StatusPollError(
+                f"Status HTTP {code}; {hint}",
+                permanent=True,
+                reason={401: "unauthorized", 403: "forbidden", 404: "not_found"}.get(
+                    code, "http_error"
+                ),
+                http_status=code,
+            )
+        try:
+            body = resp.json()
+        except ValueError:
+            raise StatusPollError("Invalid status response: malformed JSON") from None
+        if not isinstance(body, dict):
+            raise StatusPollError("Invalid status response: expected a JSON object")
+        return body
+
+    def upload_status(self, upload_id: str) -> dict:
         url = f"{self.base}/api/worker-uploads/documents/{upload_id}/"
-        resp = self.session.get(
-            url, timeout=_HTTP_STATUS_TIMEOUT_SECONDS, verify=self._verify
-        )
-        if resp.status_code == 200:
-            return resp.json()
-        return None
+        try:
+            body = self._status_json(url, _HTTP_STATUS_TIMEOUT_SECONDS)
+        except StatusPollError as exc:
+            if exc.http_status == 404:
+                raise StatusPollError(
+                    "Receipt missing or inaccessible under the current worker token (HTTP 404)",
+                    reason="not_found",
+                    http_status=404,
+                    permanent=True,
+                ) from None
+            raise
+        if (
+            body.get("upload_id") != upload_id
+            or body.get("status")
+            not in ("PENDING", "PROCESSING", "COMPLETED", "FAILED")
+            or not isinstance(body.get("error_message", ""), str)
+        ):
+            raise StatusPollError("Invalid status response: receipt identity or state")
+        return body
 
     def backlog_count(self) -> int:
         """Complete token-scoped PENDING + PROCESSING count, or StatusPollError.
@@ -460,47 +542,8 @@ class TargetClient:
         total = 0
         for st in ("PENDING", "PROCESSING"):
             url = f"{self.base}/api/worker-uploads/documents/list/?status={st}&page_size=1"
-            try:
-                resp = self.session.get(
-                    url,
-                    timeout=_HTTP_BACKLOG_TIMEOUT_SECONDS,
-                    verify=self._verify,
-                    allow_redirects=False,
-                )
-            except (
-                requests.exceptions.InvalidURL,
-                requests.exceptions.InvalidSchema,
-                requests.exceptions.MissingSchema,
-                requests.exceptions.InvalidHeader,
-            ):
-                raise StatusPollError(
-                    "Invalid status request; check --target-url and --worker-token configuration",
-                    permanent=True,
-                ) from None
-            except requests.RequestException:
-                raise StatusPollError("Status network error or timeout") from None
-            code = resp.status_code
-            if code != 200:
-                if code == 429 or 500 <= code < 600:
-                    raise StatusPollError(
-                        f"Status unavailable: HTTP {code}",
-                        retry_after=retry_after_seconds(
-                            resp.headers.get("Retry-After")
-                        ),
-                    )
-                hint = (
-                    "check --worker-token / OC_WORKER_TOKEN and worker/token permissions"
-                    if code in (401, 403)
-                    else "check --target-url and worker-upload API configuration"
-                )
-                raise StatusPollError(f"Status HTTP {code}; {hint}", permanent=True)
-            try:
-                body = resp.json()
-            except ValueError:
-                raise StatusPollError(
-                    "Invalid status response: malformed JSON"
-                ) from None
-            count = body.get("count") if isinstance(body, dict) else None
+            body = self._status_json(url, _HTTP_BACKLOG_TIMEOUT_SECONDS)
+            count = body.get("count")
             if type(count) is not int or count < 0:
                 raise StatusPollError(
                     "Invalid status response: expected a nonnegative integer count"
@@ -555,14 +598,10 @@ class EmbedderClient:
             timeout=_HTTP_EMBED_SINGLE_TIMEOUT_SECONDS,
         )
         resp.raise_for_status()
-        return self._coerce_vector(resp.json().get("embeddings"))
+        return self._coerce_vector(embedding_values(resp.json()))
 
     def _coerce_vector(self, vec) -> list[float]:
-        """The same flat/singleton-row wire shapes used by MicroserviceEmbedder."""
-        if isinstance(vec, list) and len(vec) == 1 and isinstance(vec[0], list):
-            vec = vec[0]
-        _validate_vector(vec, self.dimension)
-        return vec
+        return normalize_embedding_vector(vec, self.dimension)
 
     def embed_batch(self, texts: list[str]) -> list[list[float] | None]:
         """Embed a list of texts (sub-batched). Empty texts map to None."""
@@ -578,9 +617,7 @@ class EmbedderClient:
                 timeout=_HTTP_EMBED_BATCH_TIMEOUT_SECONDS,
             )
             resp.raise_for_status()
-            vecs = resp.json().get("embeddings")
-            if not isinstance(vecs, list) or len(vecs) != len(chunk_idxs):
-                raise ValueError("Embedding batch cardinality does not match inputs")
+            vecs = embedding_batch(resp.json(), len(chunk_idxs))
             for local_i, vec in enumerate(vecs):
                 # The batch endpoint wraps each row one level deeper than the
                 # single endpoint (per-item shape is ``[[...floats...]]``), so
@@ -757,7 +794,11 @@ def _compute_embeddings(
 ) -> dict:
     """Compute the doc-level + per-annotation embeddings the server would store."""
     ann_ids = _embedding_ids(labelled_text)
-    doc_vec = embedder.embed_text(content)
+    try:
+        doc_vec = embedder.embed_text(content)
+        _validate_vector(doc_vec, embedder.dimension)
+    except ValueError as exc:
+        raise ValueError(f"Document embedding: {exc}") from exc
     vecs = embedder.embed_batch(
         [ann["rawText"] for ann in labelled_text if ann["rawText"].strip()]
     )
@@ -790,12 +831,7 @@ def _embedding_ids(annotations: list) -> list[str]:
 
 
 def _validate_vector(vector, dimension: int) -> None:
-    if (
-        not isinstance(vector, list)
-        or len(vector) != dimension
-        or any(type(v) not in (int, float) or not math.isfinite(v) for v in vector)
-    ):
-        raise ValueError(f"Embedding requires {dimension} finite numeric values")
+    validate_embedding_vector(vector, dimension)
 
 
 def _validate_embeddings(payload, annotations, dimension, embedder_path) -> None:
@@ -807,8 +843,11 @@ def _validate_embeddings(payload, annotations, dimension, embedder_path) -> None
         _embedding_ids(annotations)
     ):
         raise ValueError("Embedding coverage does not match eligible annotation IDs")
-    for vector in vectors.values():
-        _validate_vector(vector, dimension)
+    for annotation_id, vector in vectors.items():
+        try:
+            _validate_vector(vector, dimension)
+        except ValueError as exc:
+            raise ValueError(f"Annotation {annotation_id!r} embedding: {exc}") from exc
 
 
 # ======================================================================
@@ -1185,37 +1224,114 @@ def cmd_run(cfg: Config) -> int:
     return 0 if done["fail"] == 0 and not ledger.blocked_count() else 1
 
 
+def _verification_state(status: str) -> tuple[int, str]:
+    return {
+        COMPLETED: (VERIFY_COMPLETE, "completed"),
+        PENDING: (VERIFY_OUTSTANDING, "not_uploaded"),
+        UPLOADED: (VERIFY_OUTSTANDING, "receipt_outstanding"),
+        FAILED: (VERIFY_FAILED, "failed"),
+        PARKED: (VERIFY_FAILED, "parked"),
+        AMBIGUOUS: (VERIFY_FAILED, "ambiguous_upload"),
+        CONFLICT: (VERIFY_FAILED, "source_conflict"),
+    }.get(status, (VERIFY_UNAVAILABLE, "unknown_ledger_state"))
+
+
 def cmd_verify(cfg: Config) -> int:
+    """Verify the whole ledger, streaming bounded document results before a summary.
+
+    Receipt unavailability is observational: never change state, attempts, receipt,
+    timestamps or last_error without a valid response. Final ledger state governs
+    success, including failures moved out of UPLOADED on an earlier invocation.
+    """
     ledger = Ledger(cfg.ledger_path)
     client = TargetClient(cfg)
-    pending = ledger.uploaded_unconfirmed(cfg.ledger_page_size)
-    total = ledger.uploaded_unconfirmed_count()
-    logger.info(f"verify: polling {total} uploaded docs for terminal status")
-    confirmed = failed = still = 0
-    now = time.time()
-    for row in pending:
-        status = client.upload_status(row["upload_id"])
-        if status is None:
-            still += 1
-            continue
-        st = status.get("status")
-        if st == "COMPLETED":
-            ledger.mark_completed(row["rel_path"], now)
-            confirmed += 1
-        elif st == "FAILED":
-            ledger.mark_failed(
-                row["rel_path"],
-                f"server: {status.get('error_message', 'failed')}",
-                cfg.max_attempts,
-            )
-            failed += 1
-        else:
-            still += 1
-    logger.info(
-        f"verify complete: confirmed={confirmed}, failed={failed}, still-processing={still}"
+    reasons: Counter[str] = Counter()
+    unavailable = 0
+    for row in ledger.all_docs(cfg.ledger_page_size):
+        receipt_status = None
+        poll_error = None
+        if row["status"] == UPLOADED:
+            try:
+                if not row["upload_id"]:
+                    raise StatusPollError(
+                        "Uploaded row has no receipt; reconcile with the server",
+                        reason="missing_receipt",
+                    )
+                receipt = client.upload_status(row["upload_id"])
+                receipt_status = receipt["status"]
+                if receipt_status == COMPLETED:
+                    ledger.mark_completed(row["rel_path"], time.time())
+                elif receipt_status == FAILED:
+                    ledger.mark_failed(
+                        row["rel_path"],
+                        f"server: {receipt.get('error_message') or 'failed'}",
+                        cfg.max_attempts,
+                    )
+                if receipt_status in (COMPLETED, FAILED):
+                    row = ledger.get_doc(row["rel_path"])
+            except StatusPollError as exc:
+                poll_error = exc
+        code, reason = _verification_state(row["status"])
+        detail = row["last_error"]
+        if poll_error is not None:
+            code, reason = VERIFY_UNAVAILABLE, poll_error.reason
+            detail = str(poll_error)
+        elif receipt_status in ("PENDING", "PROCESSING"):
+            reason = f"receipt_{receipt_status.lower()}"
+        unavailable += int(code == VERIFY_UNAVAILABLE)
+        reasons[reason] += 1
+        record = {
+            "type": "document",
+            "schema_version": VERIFY_SCHEMA_VERSION,
+            "rel_path": row["rel_path"],
+            "status": row["status"],
+            "upload_id": row["upload_id"],
+            "receipt_status": receipt_status,
+            "reason": reason,
+            "detail": detail,
+            "http_status": poll_error.http_status if poll_error else None,
+        }
+        if cfg.json_output:
+            print(json.dumps(record, ensure_ascii=True))
+        elif code != VERIFY_COMPLETE:
+            print(f"{row['rel_path']!r}: {reason}" + (f" ({detail})" if detail else ""))
+
+    # Status counts are bounded by ledger states, not document count. A failed
+    # receipt remains a failure on the next pass even though it is no longer polled.
+    counts = ledger.status_counts()
+    code = max(
+        (_verification_state(status)[0] for status in counts),
+        default=VERIFY_COMPLETE,
     )
-    _print_status(ledger, client)
-    return 1 if ledger.blocked_count() else 0
+    if unavailable:
+        code = VERIFY_UNAVAILABLE
+    total = sum(counts.values())
+    outcome = {
+        VERIFY_COMPLETE: "complete" if total else "empty",
+        VERIFY_OUTSTANDING: "outstanding",
+        VERIFY_FAILED: "failed",
+        VERIFY_UNAVAILABLE: "unable_to_verify",
+    }[code]
+    summary = {
+        "type": "summary",
+        "schema_version": VERIFY_SCHEMA_VERSION,
+        "scope": "whole_ledger",
+        "completion_boundary": "worker_upload_transaction",
+        "outcome": outcome,
+        "exit_code": code,
+        "total": total,
+        "counts": counts,
+        "reason_counts": dict(reasons),
+        "unavailable": unavailable,
+    }
+    if cfg.json_output:
+        print(json.dumps(summary, sort_keys=True))
+    else:
+        print(
+            f"verify: {outcome}; {counts.get(COMPLETED, 0)}/{total} worker uploads "
+            f"completed; unavailable={unavailable}; exit={code}"
+        )
+    return code
 
 
 def cmd_cleanup(cfg: Config) -> int:
@@ -1223,9 +1339,7 @@ def cmd_cleanup(cfg: Config) -> int:
 
     ledger = Ledger(cfg.ledger_path)
     removed = 0
-    for row in ledger._iter_rows(
-        "1=1", "sqlite_autoindex_docs_1", cfg.ledger_page_size
-    ):
+    for row in ledger.all_docs(cfg.ledger_page_size):
         removed += Checkpoints(cfg.ledger_path, row["rel_path"], create=False).prune()
     logger.info(
         "cleanup: removed %s unreferenced artifacts older than 24 hours", removed
@@ -1304,6 +1418,7 @@ def _build_config(args: argparse.Namespace) -> Config:
         or os.environ.get("OC_EMBEDDING_IDENTITY"),
         embedding_dimension=args.embedding_dimension,
         parser_identity=args.parser_identity or os.environ.get("OC_PARSER_IDENTITY"),
+        json_output=args.json,
     )
 
 
@@ -1410,6 +1525,11 @@ def main(argv: list[str] | None = None) -> int:
         default=os.environ.get("OC_EMBEDDING_DIMENSION", "384"),
         help="Expected document/annotation vector dimension (default 384)",
     )
+    p.add_argument(
+        "--json",
+        action="store_true",
+        help="Stream verify document results and a final summary as JSON Lines",
+    )
     p.add_argument("-v", "--verbose", action="store_true")
     p.add_argument("command", choices=["plan", "run", "verify", "status", "cleanup"])
     args = p.parse_args(argv)
@@ -1419,6 +1539,8 @@ def main(argv: list[str] | None = None) -> int:
         format="%(asctime)s %(levelname)s %(name)s: %(message)s",
     )
 
+    if args.json and args.command != "verify":
+        p.error("--json is supported only by verify")
     cfg = _build_config(args)
 
     if args.command == "run":


### PR DESCRIPTION
`verify` could report success while the ledger still contained pending or failed work, and unavailable receipts were indistinguishable from processing. It now covers the whole ledger with exits 0 (complete/empty), 1 (outstanding), 2 (failure/reconciliation), and 3 (unable to verify). Optional `--json` streams per-document reasons and a final aggregate in bounded pages. HTTP errors preserve receipt state; repeated verification retains failures. Completion is explicitly the worker-upload transaction, not asynchronous thumbnail, embedding, or search readiness.

Builds on the merged #2317 bounded traversal, #2318 validated checkpoints/embedding coverage, and #2319 admission error handling. Receipt polling shares safe HTTP classification with admission. Remote and server microservice clients now share database-free response normalization; remote mode requires exact cardinality, finite vectors of the expected dimension, and complete eligible annotation coverage before caching/upload. Only explicit `--no-embeddings` requests fallback.

Validation: 150 focused tests passed across remote verification, admission, scheduling, checkpoints, parsers, enrichers, and server microservice embedding; 39 verification/admission/scheduling tests also passed directly without Django. All pre-commit hooks passed, including full-project mypy and changelog validation. Existing verification expectations were updated for the intentional exit-code contract, retaining keyset traversal and receipt/error persistence assertions.

Closes #2320.
