### PR TITLE
Fix label creation and corpus label-set selection

### DIFF
--- a/changelog.d/2295-labelset-state.fixed.md
+++ b/changelog.d/2295-labelset-state.fixed.md
@@ -1,0 +1,5 @@
+- Fixed label-set workflows (#2295): `LabelSetDetailPage` normalizes label colors
+  for the API, preserves failed create forms, and waits for refreshed labels before
+  reporting success. Populated label lists keep **Add Label** beside search, including
+  when no results match. `LabelSetSelector` returns the selected object so
+  `CorpusModal` immediately displays the chosen label set and clears it correctly.

--- a/frontend/.any-baseline.json
+++ b/frontend/.any-baseline.json
@@ -1,15 +1,15 @@
 {
-  "total": 433,
+  "total": 431,
   "byArea": {
-    "components_other": 114,
+    "components_other": 113,
     "annotator": 90,
     "utils": 76,
     "graphql": 27,
     "knowledge_base": 27,
     "types": 27,
     "other": 24,
-    "widgets_other": 18,
     "hooks": 17,
+    "widgets_other": 17,
     "routing": 13
   }
 }

--- a/frontend/src/components/corpuses/CorpusModal.tsx
+++ b/frontend/src/components/corpuses/CorpusModal.tsx
@@ -13,7 +13,10 @@ import {
   Spinner,
 } from "@os-legal/ui";
 import { Info, Image, Settings, Scale, PlusCircle, Pencil } from "lucide-react";
-import { LabelSetSelector } from "../widgets/CRUD/LabelSetSelector";
+import {
+  LabelSetSelector,
+  LabelSetSelection,
+} from "../widgets/CRUD/LabelSetSelector";
 import { EmbedderSelector } from "../widgets/CRUD/EmbedderSelector";
 import { LicenseSelector } from "../widgets/CRUD/LicenseSelector";
 import { FilePreviewAndUpload } from "../widgets/file-controls/FilePreviewAndUpload";
@@ -580,8 +583,9 @@ export const CorpusModal: React.FC<CorpusModalProps> = ({
     []
   );
 
-  const handleLabelSetChange = useCallback((values: any) => {
+  const handleLabelSetChange = useCallback((values: LabelSetSelection) => {
     setLabelSetId(values.labelSet || null);
+    setLabelSetObj(values.labelSetObj);
   }, []);
 
   const handleEmbedderChange = useCallback((values: any) => {

--- a/frontend/src/components/labelsets/LabelSetDetailPage.tsx
+++ b/frontend/src/components/labelsets/LabelSetDetailPage.tsx
@@ -30,6 +30,7 @@ import { getPermissions } from "../../utils/transform";
 import { getCreatorDisplay } from "../../utils/userDisplay";
 import { PermissionTypes } from "../types";
 import { OS_LEGAL_COLORS } from "../../assets/configurations/osLegalStyles";
+import { isValidHexColor, normalizeHexColor } from "../../utils/colorUtils";
 
 // Import extracted components from detail folder
 import {
@@ -89,6 +90,7 @@ import {
   OverviewActions,
   ActionButton,
   LabelsSection,
+  SearchToolbar,
   SearchContainer,
   SearchInput,
   SearchIconWrapper,
@@ -147,39 +149,15 @@ interface LabelSetDetailPageProps {
 // ═══════════════════════════════════════════════════════════════════════════════
 
 /**
- * Validates if a string is a valid hex color (3 or 6 character format)
- * Accepts with or without leading #
- */
-const isValidHexColor = (color: string): boolean => {
-  return /^#?([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/.test(color);
-};
-
-/**
- * Expands a 3-character hex color to 6-character format
- * e.g., "abc" becomes "aabbcc"
- */
-const expandHexColor = (color: string): string => {
-  if (color.length === 3) {
-    return color
-      .split("")
-      .map((c) => c + c)
-      .join("");
-  }
-  return color;
-};
-
-/**
- * Sanitizes a color value, returning the fallback if invalid
- * Strips leading #, validates format, and expands 3-char to 6-char
+ * Sanitizes a color value for the GraphQL API. The backend requires the
+ * leading ``#`` for every accepted hex shape.
  */
 const sanitizeColor = (
   color: string | null | undefined,
   fallback: string = DEFAULT_LABEL_COLOR
 ): string => {
-  if (!color) return fallback;
-  const cleaned = color.replace("#", "");
-  if (!isValidHexColor(cleaned)) return fallback;
-  return expandHexColor(cleaned);
+  const candidate = color || fallback;
+  return normalizeHexColor(isValidHexColor(candidate) ? candidate : fallback);
 };
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -194,6 +172,7 @@ export const LabelSetDetailPage: React.FC<LabelSetDetailPageProps> = ({
 
   const [activeTab, setActiveTab] = useState<TabType>("overview");
   const [searchTerm, setSearchTerm] = useState<string>("");
+  const [createLoading, setCreateLoading] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState<boolean>(false);
   const [editingLabelId, setEditingLabelId] = useState<string | null>(null);
   const [creatingLabelType, setCreatingLabelType] = useState<LabelType | null>(
@@ -212,11 +191,10 @@ export const LabelSetDetailPage: React.FC<LabelSetDetailPageProps> = ({
   const canRemove = my_permissions.includes(PermissionTypes.CAN_REMOVE);
 
   // Mutations with loading states to prevent race conditions
-  const [createAnnotationLabelForLabelset, { loading: createLoading }] =
-    useMutation<
-      CreateAnnotationLabelForLabelsetOutputs,
-      CreateAnnotationLabelForLabelsetInputs
-    >(CREATE_ANNOTATION_LABEL_FOR_LABELSET);
+  const [createAnnotationLabelForLabelset] = useMutation<
+    CreateAnnotationLabelForLabelsetOutputs,
+    CreateAnnotationLabelForLabelsetInputs
+  >(CREATE_ANNOTATION_LABEL_FOR_LABELSET);
 
   const [deleteMultipleLabels, { loading: deleteLabelsLoading }] = useMutation<
     DeleteMultipleAnnotationLabelOutputs,
@@ -312,7 +290,7 @@ export const LabelSetDetailPage: React.FC<LabelSetDetailPageProps> = ({
     setEditForm({
       text: label.text || "",
       description: label.description || "",
-      color: label.color || DEFAULT_LABEL_COLOR,
+      color: sanitizeColor(label.color),
     });
   };
 
@@ -367,6 +345,8 @@ export const LabelSetDetailPage: React.FC<LabelSetDetailPageProps> = ({
     }
     // Cancel any existing edit
     setEditingLabelId(null);
+    // The new form must remain visible even if the search has no matches.
+    setSearchTerm("");
     // Start creating a new label
     setCreatingLabelType(labelType);
     setEditForm({
@@ -391,6 +371,8 @@ export const LabelSetDetailPage: React.FC<LabelSetDetailPageProps> = ({
       return; // Already submitting, prevent double-click
     }
 
+    // Keep submission locked until both the mutation and refresh have settled.
+    setCreateLoading(true);
     createAnnotationLabelForLabelset({
       variables: {
         color: sanitizeColor(editForm.color, PRIMARY_LABEL_COLOR),
@@ -401,15 +383,32 @@ export const LabelSetDetailPage: React.FC<LabelSetDetailPageProps> = ({
         labelsetId: opened_labelset?.id ? opened_labelset.id : "",
       },
     })
-      .then(() => {
+      .then(async (result) => {
+        const payload = result.data?.createAnnotationLabelForLabelset;
+        if (payload?.ok !== true) {
+          toast.error(payload?.message || "Failed to create label");
+          return;
+        }
+
+        // Await the server result so the empty-state/counters cannot render
+        // stale data after the success notification.
+        try {
+          await refetch();
+        } catch (err) {
+          toast.error(
+            "Label created, but failed to refresh labels. Please reload."
+          );
+          console.error("Error refreshing labels:", err);
+          return;
+        }
         toast.success("Label created successfully");
-        refetch();
         handleCancelEdit();
       })
       .catch((err) => {
         toast.error("Failed to create label");
         console.error("Error creating label:", err);
-      });
+      })
+      .finally(() => setCreateLoading(false));
   };
 
   const handleExportJSON = () => {
@@ -607,7 +606,7 @@ export const LabelSetDetailPage: React.FC<LabelSetDetailPageProps> = ({
               <LabelEditLabel>Color</LabelEditLabel>
               <ColorInput
                 type="color"
-                value={`#${editForm.color}`}
+                value={normalizeHexColor(editForm.color)}
                 onChange={(e) =>
                   setEditForm({
                     ...editForm,
@@ -615,12 +614,13 @@ export const LabelSetDetailPage: React.FC<LabelSetDetailPageProps> = ({
                   })
                 }
               />
-              <LabelColor $color={`#${editForm.color}`} />
+              <LabelColor $color={normalizeHexColor(editForm.color)} />
             </LabelEditRow>
             <LabelEditActions>
               <LabelActionButton
                 className="danger"
                 title="Cancel"
+                disabled={isMutating}
                 onClick={handleCancelEdit}
               >
                 <CloseIcon />
@@ -628,6 +628,7 @@ export const LabelSetDetailPage: React.FC<LabelSetDetailPageProps> = ({
               <LabelActionButton
                 className="success"
                 title="Create"
+                disabled={isMutating}
                 onClick={handleSaveCreate}
               >
                 <SaveIcon />
@@ -702,7 +703,7 @@ export const LabelSetDetailPage: React.FC<LabelSetDetailPageProps> = ({
               <LabelEditLabel>Color</LabelEditLabel>
               <ColorInput
                 type="color"
-                value={`#${editForm.color}`}
+                value={normalizeHexColor(editForm.color)}
                 onChange={(e) =>
                   setEditForm({
                     ...editForm,
@@ -710,12 +711,13 @@ export const LabelSetDetailPage: React.FC<LabelSetDetailPageProps> = ({
                   })
                 }
               />
-              <LabelColor $color={`#${editForm.color}`} />
+              <LabelColor $color={normalizeHexColor(editForm.color)} />
             </LabelEditRow>
             <LabelEditActions>
               <LabelActionButton
                 className="danger"
                 title="Cancel"
+                disabled={isMutating}
                 onClick={handleCancelEdit}
               >
                 <CloseIcon />
@@ -723,6 +725,7 @@ export const LabelSetDetailPage: React.FC<LabelSetDetailPageProps> = ({
               <LabelActionButton
                 className="success"
                 title="Create"
+                disabled={isMutating}
                 onClick={handleSaveCreate}
               >
                 <SaveIcon />
@@ -761,7 +764,7 @@ export const LabelSetDetailPage: React.FC<LabelSetDetailPageProps> = ({
                   <LabelEditLabel>Color</LabelEditLabel>
                   <ColorInput
                     type="color"
-                    value={`#${editForm.color}`}
+                    value={normalizeHexColor(editForm.color)}
                     onChange={(e) =>
                       setEditForm({
                         ...editForm,
@@ -769,12 +772,13 @@ export const LabelSetDetailPage: React.FC<LabelSetDetailPageProps> = ({
                       })
                     }
                   />
-                  <LabelColor $color={`#${editForm.color}`} />
+                  <LabelColor $color={normalizeHexColor(editForm.color)} />
                 </LabelEditRow>
                 <LabelEditActions>
                   <LabelActionButton
                     className="danger"
                     title="Cancel"
+                    disabled={isMutating}
                     onClick={handleCancelEdit}
                   >
                     <CloseIcon />
@@ -793,7 +797,9 @@ export const LabelSetDetailPage: React.FC<LabelSetDetailPageProps> = ({
                 <LabelGrip>
                   <GripIcon />
                 </LabelGrip>
-                <LabelColor $color={`#${label.color || DEFAULT_LABEL_COLOR}`} />
+                <LabelColor
+                  $color={normalizeHexColor(label.color || DEFAULT_LABEL_COLOR)}
+                />
                 <LabelContent>
                   <LabelName>{label.text}</LabelName>
                   <LabelDescription>{label.description}</LabelDescription>
@@ -821,16 +827,34 @@ export const LabelSetDetailPage: React.FC<LabelSetDetailPageProps> = ({
             )
           )}
         </LabelsList>
-
-        {/* Add button - hidden when already creating */}
-        {canUpdate && !isCreating && (
-          <AddLabelButton onClick={() => handleStartCreate(labelType)}>
-            <PlusIcon /> Add Label
-          </AddLabelButton>
-        )}
       </>
     );
   };
+
+  const renderLabelToolbar = (
+    placeholder: string,
+    labelType: LabelType,
+    hasExistingLabels: boolean
+  ) => (
+    <SearchToolbar>
+      <SearchContainer>
+        <SearchIconWrapper>
+          <SearchIcon />
+        </SearchIconWrapper>
+        <SearchInput
+          type="text"
+          placeholder={placeholder}
+          value={searchTerm}
+          onChange={(e) => setSearchTerm(e.target.value)}
+        />
+      </SearchContainer>
+      {canUpdate && hasExistingLabels && creatingLabelType !== labelType && (
+        <AddLabelButton onClick={() => handleStartCreate(labelType)}>
+          <PlusIcon /> Add Label
+        </AddLabelButton>
+      )}
+    </SearchToolbar>
+  );
 
   // Render content based on active tab
   const renderContent = () => {
@@ -893,17 +917,11 @@ export const LabelSetDetailPage: React.FC<LabelSetDetailPageProps> = ({
       case "text_labels":
         return (
           <LabelsSection>
-            <SearchContainer>
-              <SearchIconWrapper>
-                <SearchIcon />
-              </SearchIconWrapper>
-              <SearchInput
-                type="text"
-                placeholder="Search text labels..."
-                value={searchTerm}
-                onChange={(e) => setSearchTerm(e.target.value)}
-              />
-            </SearchContainer>
+            {renderLabelToolbar(
+              "Search text labels...",
+              LabelType.TokenLabel,
+              text_labels.length > 0
+            )}
             {renderLabelsList(
               text_label_results,
               LabelType.TokenLabel,
@@ -915,17 +933,11 @@ export const LabelSetDetailPage: React.FC<LabelSetDetailPageProps> = ({
       case "doc_labels":
         return (
           <LabelsSection>
-            <SearchContainer>
-              <SearchIconWrapper>
-                <SearchIcon />
-              </SearchIconWrapper>
-              <SearchInput
-                type="text"
-                placeholder="Search doc labels..."
-                value={searchTerm}
-                onChange={(e) => setSearchTerm(e.target.value)}
-              />
-            </SearchContainer>
+            {renderLabelToolbar(
+              "Search doc labels...",
+              LabelType.DocTypeLabel,
+              doc_type_labels.length > 0
+            )}
             {renderLabelsList(
               doc_label_results,
               LabelType.DocTypeLabel,
@@ -937,17 +949,11 @@ export const LabelSetDetailPage: React.FC<LabelSetDetailPageProps> = ({
       case "relationship_labels":
         return (
           <LabelsSection>
-            <SearchContainer>
-              <SearchIconWrapper>
-                <SearchIcon />
-              </SearchIconWrapper>
-              <SearchInput
-                type="text"
-                placeholder="Search relationship labels..."
-                value={searchTerm}
-                onChange={(e) => setSearchTerm(e.target.value)}
-              />
-            </SearchContainer>
+            {renderLabelToolbar(
+              "Search relationship labels...",
+              LabelType.RelationshipLabel,
+              relationship_labels.length > 0
+            )}
             {renderLabelsList(
               relationship_label_results,
               LabelType.RelationshipLabel,
@@ -959,17 +965,11 @@ export const LabelSetDetailPage: React.FC<LabelSetDetailPageProps> = ({
       case "span_labels":
         return (
           <LabelsSection>
-            <SearchContainer>
-              <SearchIconWrapper>
-                <SearchIcon />
-              </SearchIconWrapper>
-              <SearchInput
-                type="text"
-                placeholder="Search labels..."
-                value={searchTerm}
-                onChange={(e) => setSearchTerm(e.target.value)}
-              />
-            </SearchContainer>
+            {renderLabelToolbar(
+              "Search labels...",
+              LabelType.SpanLabel,
+              span_labels.length > 0
+            )}
             {renderLabelsList(
               span_label_results,
               LabelType.SpanLabel,

--- a/frontend/src/components/labelsets/detail/LabelSetDetailStyles.ts
+++ b/frontend/src/components/labelsets/detail/LabelSetDetailStyles.ts
@@ -518,9 +518,18 @@ export const LabelsSection = styled.div`
   gap: 20px;
 `;
 
+export const SearchToolbar = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  max-width: 600px;
+`;
+
 export const SearchContainer = styled.div`
   position: relative;
-  max-width: 400px;
+  flex: 1;
+  min-width: 0;
 `;
 
 export const SearchInput = styled.input`
@@ -760,6 +769,7 @@ export const AddLabelButton = styled.button`
   cursor: pointer;
   transition: all 0.15s ease;
   align-self: flex-start;
+  white-space: nowrap;
 
   &:hover {
     background: ${OS_LEGAL_COLORS.surfaceHover};

--- a/frontend/src/components/widgets/CRUD/LabelSetSelector.tsx
+++ b/frontend/src/components/widgets/CRUD/LabelSetSelector.tsx
@@ -2,7 +2,6 @@ import { useEffect } from "react";
 import { useQuery, useReactiveVar } from "@apollo/client";
 import { Dropdown } from "@os-legal/ui";
 import styled from "styled-components";
-import _ from "lodash";
 import { OS_LEGAL_COLORS } from "../../../assets/configurations/osLegalStyles";
 import { labelsetSearchTerm } from "../../../graphql/cache";
 import { LoadingOverlay } from "../../common/LoadingOverlay";
@@ -25,11 +24,16 @@ const MobileFriendlyWrapper = styled.div`
   }
 `;
 
+export interface LabelSetSelection {
+  labelSet: string | null;
+  labelSetObj?: LabelSetType;
+}
+
 interface LabelSetSelectorProps {
   read_only?: boolean;
   labelSet?: LabelSetType;
   style?: Record<string, any>;
-  onChange?: (values: any) => void;
+  onChange?: (values: LabelSetSelection) => void;
   /** Open dropdown upward (useful when near bottom of container) */
   upward?: boolean;
 }
@@ -46,7 +50,7 @@ export const LabelSetSelector = ({
   upward = false,
 }: LabelSetSelectorProps) => {
   const search_term = useReactiveVar(labelsetSearchTerm);
-  const { refetch, loading, error, data, fetchMore } = useQuery<
+  const { refetch, loading, data } = useQuery<
     GetLabelsetOutputs,
     GetLabelsetInputs
   >(GET_LABELSETS, {
@@ -60,17 +64,24 @@ export const LabelSetSelector = ({
     refetch();
   }, [search_term, refetch]);
 
+  const items = data?.labelsets?.edges ?? [];
+
   const handleChange = (value: string | null) => {
     // If user has not actually changed the labelSet, do nothing:
     if (value === labelSet?.id) return;
 
     // If user explicitly clears, value === null => labelSet null
     // Otherwise labelSet is new value (the new labelSet.id).
-    onChange?.({ labelSet: value ?? null });
+    const selectedLabelSet = value
+      ? items.find((edge) => edge.node.id === value)?.node
+      : undefined;
+    onChange?.({
+      labelSet: value ?? null,
+      labelSetObj: selectedLabelSet,
+    });
   };
 
-  let items = data?.labelsets?.edges ? data.labelsets.edges : [];
-  let options = items.map((labelsetEdge) => {
+  const options = items.map((labelsetEdge) => {
     const node = labelsetEdge.node;
     return {
       value: node.id,

--- a/frontend/src/graphql/mutations.ts
+++ b/frontend/src/graphql/mutations.ts
@@ -1199,8 +1199,10 @@ export interface CreateAnnotationLabelForLabelsetInputs {
 }
 
 export interface CreateAnnotationLabelForLabelsetOutputs {
-  ok?: boolean;
-  message?: string;
+  createAnnotationLabelForLabelset?: {
+    ok?: boolean | null;
+    message?: string | null;
+  } | null;
 }
 
 export const CREATE_ANNOTATION_LABEL_FOR_LABELSET = gql`

--- a/frontend/tests/CorpusModalLabelSet.ct.tsx
+++ b/frontend/tests/CorpusModalLabelSet.ct.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { test, expect } from "./utils/coverage";
+import { CorpusModalLabelSetTestWrapper } from "./CorpusModalLabelSetTestWrapper";
+
+test.describe("CorpusModal label set selection", () => {
+  for (const clearSelection of [false, true]) {
+    test(`displays and submits ${
+      clearSelection ? "a cleared selection" : "the chosen label set"
+    }`, async ({ mount, page }) => {
+      await mount(<CorpusModalLabelSetTestWrapper />);
+      const selector = page
+        .getByText("Label Set:", { exact: true })
+        .locator("..");
+      await expect(selector.locator(".oc-dropdown__value")).toHaveText(
+        "Default Labels"
+      );
+      await selector.getByRole("combobox").click();
+      await page
+        .getByRole("option")
+        .filter({ hasText: "Financial Labels" })
+        .click();
+      await expect(selector.locator(".oc-dropdown__value")).toHaveText(
+        "Financial Labels"
+      );
+      if (clearSelection) {
+        await selector.locator(".oc-dropdown__clear").click();
+        await expect(selector.locator(".oc-dropdown__placeholder")).toHaveText(
+          "Choose a label set"
+        );
+      }
+      await page
+        .getByPlaceholder("Enter corpus title")
+        .fill("Selected Labels Corpus");
+      await page
+        .getByPlaceholder("Describe what this corpus is about...")
+        .fill("A corpus using the selected label set.");
+      await page
+        .getByRole("button", { name: "Create Corpus", exact: true })
+        .click();
+      await expect(page.getByTestId("submitted-corpus")).toContainText(
+        `"labelSet":${clearSelection ? "null" : '"ls-2"'}`
+      );
+    });
+  }
+});

--- a/frontend/tests/CorpusModalLabelSetTestWrapper.tsx
+++ b/frontend/tests/CorpusModalLabelSetTestWrapper.tsx
@@ -1,0 +1,72 @@
+import React, { useState } from "react";
+import { MockedProvider, MockedResponse } from "@apollo/client/testing";
+import {
+  CorpusModal,
+  CorpusFormData,
+} from "../src/components/corpuses/CorpusModal";
+import {
+  GET_CORPUS_CREATE_DEFAULTS,
+  GET_EMBEDDERS,
+  GET_LABELSETS,
+} from "../src/graphql/queries";
+import { GET_CORPUS_CATEGORIES } from "../src/graphql/landing-queries";
+import { labelsetNodes } from "./LabelSetSelectorTestWrapper";
+
+const defaultLabelset = {
+  ...labelsetNodes[0],
+  title: "Default Labels",
+  isDefault: true,
+};
+const mocks: MockedResponse[] = [
+  {
+    request: { query: GET_CORPUS_CREATE_DEFAULTS },
+    result: {
+      data: { pipelineSettings: { defaultEmbedder: null }, defaultLabelset },
+    },
+  },
+  {
+    request: { query: GET_LABELSETS },
+    variableMatcher: () => true,
+    maxUsageCount: Number.POSITIVE_INFINITY,
+    result: {
+      data: {
+        labelsets: {
+          edges: [defaultLabelset, labelsetNodes[1]].map((node) => ({ node })),
+          pageInfo: {
+            hasNextPage: false,
+            hasPreviousPage: false,
+            startCursor: null,
+            endCursor: null,
+          },
+        },
+      },
+    },
+  },
+  {
+    request: { query: GET_EMBEDDERS },
+    result: { data: { pipelineComponents: { embedders: [] } } },
+  },
+  {
+    request: { query: GET_CORPUS_CATEGORIES },
+    result: { data: { corpusCategories: { edges: [] } } },
+  },
+];
+
+export const CorpusModalLabelSetTestWrapper = () => {
+  const [submitted, setSubmitted] = useState<CorpusFormData>();
+  return (
+    <MockedProvider mocks={mocks} addTypename={false}>
+      <div>
+        <CorpusModal
+          open
+          mode="CREATE"
+          onClose={() => {}}
+          onSubmit={setSubmitted}
+        />
+        <output data-testid="submitted-corpus">
+          {JSON.stringify(submitted)}
+        </output>
+      </div>
+    </MockedProvider>
+  );
+};

--- a/frontend/tests/LabelSetDetailPage.coverage.ct.tsx
+++ b/frontend/tests/LabelSetDetailPage.coverage.ct.tsx
@@ -385,7 +385,7 @@ test.describe("LabelSetDetailPage – coverage", () => {
           updateLabelMock(spanLabel.id, {
             text: "Entity Name Updated",
             description: spanLabel.description,
-            color: spanLabel.color,
+            color: `#${spanLabel.color}`,
           }),
           ...labelsetQueryMocks(updatedLabelset, 2),
         ];
@@ -451,7 +451,7 @@ test.describe("LabelSetDetailPage – coverage", () => {
     test(
       "creates a new span label via CREATE_ANNOTATION_LABEL_FOR_LABELSET",
       { timeout: 25000 },
-      async ({ mount }) => {
+      async ({ mount, page }) => {
         const newLabel = {
           __typename: "AnnotationLabelType" as const,
           id: "label-span-new",
@@ -460,7 +460,7 @@ test.describe("LabelSetDetailPage – coverage", () => {
           readOnly: false,
           text: "Brand New Span",
           description: "",
-          color: "0F766E",
+          color: "#0F766E",
           myPermissions: ["READ", "UPDATE", "DELETE"],
           isPublic: false,
           analyzer: null,
@@ -477,10 +477,13 @@ test.describe("LabelSetDetailPage – coverage", () => {
           createLabelMock(LABELSET_ID, {
             text: "Brand New Span",
             description: "",
-            color: "0F766E",
+            color: "#0F766E",
             labelType: "SPAN_LABEL",
           }),
-          ...labelsetQueryMocks(labelsetAfterCreate, 2),
+          {
+            ...labelsetQueryMocks(labelsetAfterCreate, 1)[0],
+            delay: 1500,
+          },
         ];
 
         const component = await mountPage(mount, mocks);
@@ -501,11 +504,210 @@ test.describe("LabelSetDetailPage – coverage", () => {
 
         await component.getByTitle("Create").click();
 
+        // A resolved mutation must not dismiss the form or enable duplicates
+        // while the label list/count refresh is still in flight.
+        await expect(component.getByTitle("Create")).toBeDisabled();
+        await expect(component.getByTitle("Cancel")).toBeDisabled();
+        await expect(nameInput).toHaveValue("Brand New Span");
+        await expect(page.getByText("Label created successfully")).toHaveCount(
+          0
+        );
+        await expect(
+          page.getByText("Label created successfully")
+        ).toBeVisible();
+        await expect(nameInput).toHaveCount(0);
+        await expect(
+          component.getByRole("button", { name: /Span Labels/i })
+        ).toContainText("2");
         await expect(
           component.getByText("Brand New Span", { exact: true })
         ).toBeVisible({ timeout: 10000 });
       }
     );
+
+    for (const failure of [
+      "rejected",
+      "missing payload",
+      "network error",
+    ] as const) {
+      test(`preserves the form and reports ${failure}`, async ({
+        mount,
+        page,
+      }) => {
+        const mutation = createLabelMock(
+          LABELSET_ID,
+          {
+            text: "Rejected Label",
+            description: "Keep my description",
+            color: "#0F766E",
+            labelType: "SPAN_LABEL",
+          },
+          false
+        );
+        if (failure === "missing payload") {
+          mutation.result = {
+            data: { createAnnotationLabelForLabelset: null },
+          };
+        } else if (failure === "network error") {
+          delete mutation.result;
+          mutation.error = new Error("Connection lost");
+        }
+        const component = await mountPage(mount, [
+          ...labelsetQueryMocks(fullLabelset, 1),
+          mutation,
+        ]);
+        await component.getByRole("button", { name: /Span Labels/i }).click();
+        await component.getByRole("button", { name: /Add Label/i }).click();
+        await component
+          .getByPlaceholder("Enter label name")
+          .fill("Rejected Label");
+        await component
+          .getByPlaceholder("Describe what this label is used for")
+          .fill("Keep my description");
+        await component.getByTitle("Create").click();
+
+        // Wait for the mutation result, so this cannot pass before submission.
+        await expect(page.getByRole("alert")).toContainText(
+          failure === "rejected" ? "Failed to create" : "Failed to create label"
+        );
+        await expect(page.getByText("Label created successfully")).toHaveCount(
+          0
+        );
+        await expect(
+          component.getByPlaceholder("Enter label name")
+        ).toHaveValue("Rejected Label");
+        await expect(
+          component.getByPlaceholder("Describe what this label is used for")
+        ).toHaveValue("Keep my description");
+        await expect(component.getByTitle("Create")).toBeEnabled();
+      });
+    }
+
+    test("distinguishes a refresh failure from a rejected creation", async ({
+      mount,
+      page,
+    }) => {
+      const component = await mountPage(mount, [
+        ...labelsetQueryMocks(fullLabelset, 1),
+        createLabelMock(LABELSET_ID, {
+          text: "Saved Label",
+          description: "",
+          color: "#0F766E",
+          labelType: "SPAN_LABEL",
+        }),
+        {
+          request: {
+            query: GET_LABELSET_WITH_ALL_LABELS,
+            variables: { id: LABELSET_ID },
+          },
+          error: new Error("Refresh unavailable"),
+        },
+      ]);
+      await component.getByRole("button", { name: /Span Labels/i }).click();
+      await component.getByRole("button", { name: /Add Label/i }).click();
+      await component.getByPlaceholder("Enter label name").fill("Saved Label");
+      await component.getByTitle("Create").click();
+      await expect(page.getByRole("alert")).toContainText(
+        "Label created, but failed to refresh labels. Please reload."
+      );
+      await expect(page.getByText("Label created successfully")).toHaveCount(0);
+    });
+
+    test("creates the first text label with a picker color", async ({
+      mount,
+      page,
+    }) => {
+      const empty = {
+        ...fullLabelset,
+        tokenLabelCount: 0,
+        allAnnotationLabels: [],
+      };
+      const newLabel = { ...textLabel, text: "First Text", color: "#123abc" };
+      const component = await mountPage(mount, [
+        ...labelsetQueryMocks(empty, 1),
+        createLabelMock(LABELSET_ID, {
+          text: newLabel.text,
+          description: "",
+          color: newLabel.color,
+          labelType: "TOKEN_LABEL",
+        }),
+        ...labelsetQueryMocks(
+          { ...empty, tokenLabelCount: 1, allAnnotationLabels: [newLabel] },
+          1
+        ),
+      ]);
+      await component.getByRole("button", { name: /Text Labels/i }).click();
+      await component.getByRole("button", { name: /Add First Label/i }).click();
+      await component.getByPlaceholder("Enter label name").fill(newLabel.text);
+      await component.locator('input[type="color"]').fill(newLabel.color);
+      await component.getByTitle("Create").click();
+      await expect(page.getByText("Label created successfully")).toBeVisible();
+      await expect(
+        component.getByText(newLabel.text, { exact: true })
+      ).toBeVisible();
+    });
+  });
+
+  test.describe("Label toolbar and stored colors", () => {
+    for (const tab of [
+      /Text Labels/i,
+      /Doc Labels/i,
+      /Relationships/i,
+      /Span Labels/i,
+    ]) {
+      test(`keeps Add Label beside search in ${tab}`, async ({ mount }) => {
+        const component = await mountPage(
+          mount,
+          labelsetQueryMocks(fullLabelset, 1)
+        );
+        await component.getByRole("button", { name: tab }).click();
+        const search = component.getByPlaceholder(/Search.*labels/);
+        const add = component.getByRole("button", {
+          name: "Add Label",
+          exact: true,
+        });
+        const searchBox = await search.boundingBox();
+        const addBox = await add.boundingBox();
+        expect(searchBox).not.toBeNull();
+        expect(addBox).not.toBeNull();
+        expect(Math.abs(searchBox!.y - addBox!.y)).toBeLessThan(10);
+        expect(addBox!.x).toBeGreaterThanOrEqual(
+          searchBox!.x + searchBox!.width
+        );
+        await search.fill("zzzzzzzzzz");
+        await expect(
+          component.getByText('No labels match "zzzzzzzzzz"')
+        ).toBeVisible();
+        await add.click();
+        await expect(search).toHaveValue("");
+        await expect(
+          component.getByPlaceholder("Enter label name")
+        ).toBeVisible();
+        await expect(add).toHaveCount(0);
+      });
+    }
+
+    for (const color of ["#abc", "abc", "#123abc", "123abc"]) {
+      test(`edits stored color ${color} using a valid native picker value`, async ({
+        mount,
+      }) => {
+        const component = await mountPage(
+          mount,
+          labelsetQueryMocks(
+            {
+              ...fullLabelset,
+              allAnnotationLabels: [{ ...spanLabel, color }],
+            },
+            1
+          )
+        );
+        await component.getByRole("button", { name: /Span Labels/i }).click();
+        await component.getByTitle("Edit").click({ force: true });
+        await expect(component.locator('input[type="color"]')).toHaveValue(
+          color.includes("123") ? "#123abc" : "#aabbcc"
+        );
+      });
+    }
   });
 
   test.describe("Delete label flow", () => {

--- a/frontend/tests/LabelSetDetailPageTestWrapper.tsx
+++ b/frontend/tests/LabelSetDetailPageTestWrapper.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter } from "react-router-dom";
 import { LabelSetDetailPage } from "../src/components/labelsets/LabelSetDetailPage";
 import { openedLabelset } from "../src/graphql/cache";
 import { InMemoryCache } from "@apollo/client";
+import { ToastContainer } from "react-toastify";
 
 interface LabelSetDetailPageTestWrapperProps {
   mocks: MockedResponse[];
@@ -38,6 +39,7 @@ export const LabelSetDetailPageTestWrapper: React.FC<
   return (
     <MockedProvider mocks={mocks} cache={createTestCache()} addTypename>
       <MemoryRouter initialEntries={["/label_sets"]}>
+        <ToastContainer />
         {ready ? (
           <LabelSetDetailPage />
         ) : (

--- a/frontend/tests/LabelSetSelector.ct.tsx
+++ b/frontend/tests/LabelSetSelector.ct.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { test, expect } from "./utils/coverage";
 import { LabelSetSelectorTestWrapper } from "./LabelSetSelectorTestWrapper";
+import { labelsetNodes } from "./LabelSetSelectorTestWrapper";
 import { docScreenshot } from "./utils/docScreenshot";
 import { LabelSetType } from "../src/types/graphql-api";
 
@@ -70,6 +71,39 @@ test.describe("LabelSetSelector", () => {
     await expect(options).toHaveCount(2, { timeout: 10000 });
     await expect(options.first()).toContainText("Contract Labels");
     await expect(options.last()).toContainText("Financial Labels");
+
+    await component.unmount();
+  });
+
+  test("returns the selected label set object to controlled consumers", async ({
+    mount,
+    page,
+  }) => {
+    const component = await mount(
+      <LabelSetSelectorTestWrapper
+        labelSet={labelsetNodes[0] as unknown as LabelSetType}
+      />
+    );
+
+    await expect(page.locator(".oc-dropdown__value")).toContainText(
+      "Contract Labels"
+    );
+    await page.locator(".oc-dropdown__trigger").click();
+    await page
+      .locator(".oc-dropdown__option")
+      .filter({ hasText: "Financial Labels" })
+      .click();
+
+    await expect(component.getByTestId("selected-labelset")).toHaveText("ls-2");
+    await expect(page.locator(".oc-dropdown__value")).toContainText(
+      "Financial Labels"
+    );
+
+    await page.locator(".oc-dropdown__clear").click();
+    await expect(component.getByTestId("selected-labelset")).toHaveText("");
+    await expect(page.locator(".oc-dropdown__placeholder")).toContainText(
+      "Choose a label set"
+    );
 
     await component.unmount();
   });

--- a/frontend/tests/LabelSetSelectorTestWrapper.tsx
+++ b/frontend/tests/LabelSetSelectorTestWrapper.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { MockedProvider, MockedResponse } from "@apollo/client/testing";
 import { LabelSetSelector } from "../src/components/widgets/CRUD/LabelSetSelector";
+import type { LabelSetSelection } from "../src/components/widgets/CRUD/LabelSetSelector";
 import { LabelSetType } from "../src/types/graphql-api";
 import { GET_LABELSETS } from "../src/graphql/queries";
 
@@ -62,16 +63,8 @@ export const LabelSetSelectorTestWrapper: React.FC<WrapperProps> = ({
     LabelSetType | undefined
   >(initialLabelSet);
 
-  const handleChange = (values: any) => {
-    if (values.labelSet === null) {
-      setSelectedLabelSet(undefined);
-    } else {
-      // Find the label set from the mock data to simulate a real selection
-      const found = labelsetNodes.find((ls) => ls.id === values.labelSet);
-      if (found) {
-        setSelectedLabelSet(found as unknown as LabelSetType);
-      }
-    }
+  const handleChange = (values: LabelSetSelection) => {
+    setSelectedLabelSet(values.labelSetObj);
   };
 
   const allMocks = mocks ?? [


### PR DESCRIPTION
## Summary

Label creation could send an invalid bare hex color, report success for a rejected mutation, and close before refreshed labels arrived. Choosing a different label set while creating a corpus also left the dropdown displaying the old selection.

Fixes #2295. Created from current `main`, using #2296 as a reference.

## Changes

- Normalize create/edit colors to `#RRGGBB`, including stored short hex values and values with or without `#`.
- Check the nested mutation payload for `ok: true`, preserve form contents on rejection, and wait for refreshed lists/counts before success feedback. Keep submission disabled during the refresh and distinguish refresh failures from failed creation.
- Put **Add Label** beside search for all four populated label types. Clear the search when starting a label so an unmatched filter cannot hide the form.
- Return a typed label-set selection containing both the ID and object; update and clear both in `CorpusModal`.
- Add browser regressions for mutation failures, delayed/failed refreshes, first-label creation, stored colors, toolbar placement, and corpus selection/submission. Update existing mutation mock colors to match the corrected API payload.
- Ratchet the TypeScript `any` baseline from 433 to 431 and add a changelog fragment.

## Test plan

- Focused Playwright component tests: **53 passed** across `LabelSetDetailPage.ct.tsx`, `LabelSetDetailPage.coverage.ct.tsx`, `LabelSetSelector.ct.tsx`, and `CorpusModalLabelSet.ct.tsx` (including focused reruns after fixing new test fixtures).
- `yarn test:unit run src/utils/__tests__/colorUtils.test.ts`: **18 passed**.
- `NODE_OPTIONS=--max-old-space-size=4096 yarn build`: passed.
- `yarn tsc --noEmit`: passed.
- Prettier checks for changed frontend/test files: passed.
- `yarn any:check:strict`: passed.
- `python3 scripts/collate_changelog.py --check`: passed.
- `pre-commit run --all-files`: passed.

## Checklist

- [x] Tests pass locally for any code this PR touches
- [x] `pre-commit run --all-files` passes
- [x] TypeScript compiles cleanly
- [x] A changelog fragment was added under `changelog.d/`
- [x] No new dependency was introduced

## Contributor License Agreement

By submitting this pull request, I agree to license this contribution under the project's [Contributor License Agreement](../CLA.md).
