### PR TITLE
Upgrade Docxodus service and renderer to 12.4.1

### DIFF
--- a/changelog.d/docxodus-12.4.1.changed.md
+++ b/changelog.d/docxodus-12.4.1.changed.md
@@ -1,0 +1,2 @@
+- Upgrade the DOCX parser service and browser renderer together to Docxodus 12.4.1, pinning the published `1.2.0-docxodus12.4.1` service image in local, production, test, and remote-worker Compose stacks to keep annotation offsets aligned.
+- Include the Docxodus WASM runtime in production frontend builds and load it from the published asset path so DOCX rendering works in the deployed frontend.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,7 +43,7 @@
     "axios": "^1.18.0",
     "d3": "^7.9.0",
     "date-fns": "^4.1.0",
-    "docxodus": "5.5.3",
+    "docxodus": "12.4.1",
     "dompurify": "^3.4.13",
     "framer-motion": "6.*",
     "fuse.js": "^6.5.3",

--- a/frontend/src/components/annotator/renderers/docx/DocxAnnotator.tsx
+++ b/frontend/src/components/annotator/renderers/docx/DocxAnnotator.tsx
@@ -369,7 +369,13 @@ const DocxAnnotator: React.FC<DocxAnnotatorProps> = ({
   // ── Effect 1: Initialize Docxodus WASM ──────────────────────────────
   useEffect(() => {
     let cancelled = false;
-    initDocxodus()
+    // Bundling moves the JS module away from its sibling WASM files. The Vite
+    // plugin publishes the runtime at this stable path in production builds.
+    initDocxodus(
+      import.meta.env.PROD
+        ? `${import.meta.env.BASE_URL}docxodus-wasm/`
+        : undefined
+    )
       .then(() => {
         if (!cancelled) setWasmReady(true);
       })

--- a/frontend/src/utils/__tests__/docxodusWasm.test.ts
+++ b/frontend/src/utils/__tests__/docxodusWasm.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { build } from "vite";
 import { docxodusWasmPlugin } from "../../../tooling/docxodusWasm";
 
 describe("WASM asset containment", () => {
@@ -71,5 +72,43 @@ describe("WASM asset containment", () => {
       "*"
     );
     expect(next).not.toHaveBeenCalled();
+  });
+
+  it("includes the runtime's nested files in production builds without following symlinks", async () => {
+    const root = path.join(directory, "wasm");
+    const framework = path.join(root, "_framework");
+    fs.mkdirSync(framework);
+    fs.writeFileSync(
+      path.join(framework, "dotnet.js"),
+      "export const runtime = true;"
+    );
+    fs.writeFileSync(
+      path.join(framework, "assembly.wasm"),
+      Buffer.from([0, 97, 115, 109])
+    );
+    const entry = path.join(directory, "entry.js");
+    fs.writeFileSync(entry, "console.log('built');");
+    const output = path.join(directory, "dist");
+
+    await build({
+      configFile: false,
+      logLevel: "silent",
+      plugins: [docxodusWasmPlugin(root)],
+      build: { outDir: output, rollupOptions: { input: entry } },
+    });
+
+    for (const relative of [
+      "runtime.wasm",
+      "runtimeconfig.bin",
+      "_framework/dotnet.js",
+      "_framework/assembly.wasm",
+    ]) {
+      expect(
+        fs.readFileSync(path.join(output, "docxodus-wasm", relative))
+      ).toEqual(fs.readFileSync(path.join(root, relative)));
+    }
+    expect(fs.existsSync(path.join(output, "docxodus-wasm/link.json"))).toBe(
+      false
+    );
   });
 });

--- a/frontend/tests/DocxAnnotator.ct.tsx
+++ b/frontend/tests/DocxAnnotator.ct.tsx
@@ -13,7 +13,7 @@ import { setupDocxFixture } from "./utils/docxFixture";
 test.setTimeout(60_000);
 
 test("DocxAnnotator renders DOCX content via WASM", async ({ mount, page }) => {
-  await setupDocxodusWasm(page);
+  // Load the runtime from the built assets, as the deployed frontend does.
   await setupDocxFixture(page);
 
   const component = await mount(<DocxAnnotatorTestWrapper />);
@@ -23,6 +23,7 @@ test("DocxAnnotator renders DOCX content via WASM", async ({ mount, page }) => {
 
   const content = annotator.locator(".docx-content");
   await expect(content).toBeVisible();
+  await expect(content).toContainText("Hello World");
 
   await docScreenshot(page, "annotator--docx-annotator--rendered");
 

--- a/frontend/tooling/docxodusWasm.ts
+++ b/frontend/tooling/docxodusWasm.ts
@@ -18,11 +18,32 @@ function isContained(root: string, candidate: string): boolean {
   );
 }
 
-/** Serve only packaged WASM assets; custom middleware bypasses Vite's fs guard. */
+/** Package the runtime for production and serve it safely in development. */
 export function docxodusWasmPlugin(assetRoot: string): Plugin {
   const prefix = "/node_modules/docxodus/dist/wasm/";
   return {
     name: "docxodus-wasm-server",
+    generateBundle() {
+      // Docxodus imports the runtime dynamically, so Vite cannot discover it.
+      // Keep its relative file layout intact for the .NET runtime loader.
+      const emitDirectory = (directory: string) => {
+        for (const entry of fs.readdirSync(directory, {
+          withFileTypes: true,
+        })) {
+          const sourcePath = path.join(directory, entry.name);
+          if (entry.isDirectory()) emitDirectory(sourcePath);
+          else if (entry.isFile()) {
+            const relative = path.relative(assetRoot, sourcePath);
+            this.emitFile({
+              type: "asset",
+              fileName: `docxodus-wasm/${relative.split(path.sep).join("/")}`,
+              source: fs.readFileSync(sourcePath),
+            });
+          }
+        }
+      };
+      emitDirectory(assetRoot);
+    },
     configureServer(server) {
       server.middlewares.use((req, res, next) => {
         const pathname = (req.url || "").split("?")[0];

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -53,6 +53,32 @@
     "@csstools/css-tokenizer" "^3.0.3"
     lru-cache "^10.4.3"
 
+"@atlaskit/pragmatic-drag-and-drop-auto-scroll@^3.0.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@atlaskit/pragmatic-drag-and-drop-auto-scroll/-/pragmatic-drag-and-drop-auto-scroll-3.2.0.tgz#89cf48a9ff486143a4d6d3a6b9dfe60bf17b21ad"
+  integrity sha512-vuL+AJae6c6lkmFd63v7c/7J7seyi7ZA8uMLNe9GvvApySToun3Zlv8SfyZU0d+wcNG4+Ix6qpRb8jOobZgNNg==
+  dependencies:
+    "@atlaskit/pragmatic-drag-and-drop" "^3.1.0"
+    "@babel/runtime" "^7.0.0"
+
+"@atlaskit/pragmatic-drag-and-drop@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@atlaskit/pragmatic-drag-and-drop/-/pragmatic-drag-and-drop-2.0.2.tgz#3ab79e5b9f9f6b0c77754912f6173ecb8f5cfa3d"
+  integrity sha512-ou1j+lBqutK7p2S80lMresJeKu9qAL1zr1K+N0OyCTzbMpD6pXRHray8VkRoHgJICI7Wp1fk5ScJh6EctyAuPw==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    bind-event-listener "^3.0.0"
+    raf-schd "^4.0.3"
+
+"@atlaskit/pragmatic-drag-and-drop@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@atlaskit/pragmatic-drag-and-drop/-/pragmatic-drag-and-drop-3.1.0.tgz#dcfe6c552e1bf83f80095ad39acbee384d6d1dfd"
+  integrity sha512-VU+2Oh6OgvC6D1xiX3lfm1gZJsaSPD+ZKjAHodOQ9IO6RfOvAyReLlK5ut9gIUpPmbD8d09wlCs7y4A6/I8c5Q==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    bind-event-listener "^3.0.0"
+    raf-schd "^4.0.3"
+
 "@auth0/auth0-react@^2.3.0":
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/@auth0/auth0-react/-/auth0-react-2.8.0.tgz#170b3cb3701bed19fadbd7fe6a51dbd555e7d0f7"
@@ -3181,6 +3207,11 @@ baseline-browser-mapping@^2.11.20:
   resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.11.21.tgz#99af73cb8e54007e4f5345e132278e26c2662f2c"
   integrity sha512-uh8vpY/1/YyFkunIDFH/12p7/7VdPKA1hejMVEbdkEaWnUz0Hesvx5EbiU6XxjyHZIOju+ZMbQJkRh+es3/spQ==
 
+bind-event-listener@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/bind-event-listener/-/bind-event-listener-3.0.0.tgz#c90f9a7fcb65cac21045f810c20ef7e647a74921"
+  integrity sha512-PJvH288AWQhKs2v9zyfYdPzlPqf5bXbGMmhmUIY9x4dAUGIWgomO771oBQNwJnMQSnUIXhKu6sgzpBRXTlvb8Q==
+
 bl@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
@@ -4064,10 +4095,13 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
-docxodus@5.5.3:
-  version "5.5.3"
-  resolved "https://registry.yarnpkg.com/docxodus/-/docxodus-5.5.3.tgz#76fb42cc3221e63f70f5ec7e71d59d91e9853717"
-  integrity sha512-llgB2xKH6OPcf6KRXQNSg7MibNAneNlFcaWJUNYrMorpo3wnEqbnptV+b8qgYjcPTseWMeCri57h0+K5gHutSA==
+docxodus@12.4.1:
+  version "12.4.1"
+  resolved "https://registry.yarnpkg.com/docxodus/-/docxodus-12.4.1.tgz#8a994ec683ce9d22d07cbbda5aeb1d4d0fd86abf"
+  integrity sha512-QKBGr1jix/EyIhz6wBJa8fGi0n4u2uUE3mDXjLv1PFE4rouktkgXz5CiQmwEEQ1n1zV7g5tTw0bqOUFh4LJe4g==
+  dependencies:
+    "@atlaskit/pragmatic-drag-and-drop" "^2.0.2"
+    "@atlaskit/pragmatic-drag-and-drop-auto-scroll" "^3.0.0"
 
 dom-accessibility-api@^0.5.9:
   version "0.5.16"

--- a/local.yml
+++ b/local.yml
@@ -151,7 +151,7 @@ services:
   docxodus-parser:
     # The frontend WASM (docxodus in package.json) and this microservice
     # must use the same Docxodus version for character offset alignment.
-    image: ghcr.io/open-source-legal/docxodus-service:1.1.0-docxodus5.4.2
+    image: ghcr.io/open-source-legal/docxodus-service:1.2.0-docxodus12.4.1
     container_name: docxodus-parser
     # Hard cap — see docling-parser's mem_limit comment.
     mem_limit: 1g

--- a/production.yml
+++ b/production.yml
@@ -139,7 +139,7 @@ services:
   docxodus-parser:
     # The frontend WASM (docxodus in package.json) and this microservice
     # must use the same Docxodus version for character offset alignment.
-    image: ghcr.io/open-source-legal/docxodus-service:1.1.0-docxodus5.4.2
+    image: ghcr.io/open-source-legal/docxodus-service:1.2.0-docxodus12.4.1
     container_name: docxodus-parser
 
   # Optional alternative PDF parser (deterministic, rule-based; renders straight

--- a/scripts/remote_ingest/remote_worker.yml
+++ b/scripts/remote_ingest/remote_worker.yml
@@ -47,7 +47,7 @@ services:
 
   # Optional parser services: start only those selected in the local mapping.
   docxodus-parser:
-    image: ghcr.io/open-source-legal/docxodus-service:1.1.0-docxodus5.4.2
+    image: ghcr.io/open-source-legal/docxodus-service:1.2.0-docxodus12.4.1
     profiles: [docxodus]
     restart: unless-stopped
 

--- a/test.yml
+++ b/test.yml
@@ -36,7 +36,7 @@ services:
   docxodus-parser:
     # The frontend WASM (docxodus in package.json) and this microservice
     # must use the same Docxodus version for character offset alignment.
-    image: ghcr.io/open-source-legal/docxodus-service:1.1.0-docxodus5.4.2
+    image: ghcr.io/open-source-legal/docxodus-service:1.2.0-docxodus12.4.1
     container_name: docxodus-parser
 
   django: &django


### PR DESCRIPTION
Upgrade DOCX ingestion and rendering together to **Docxodus 12.4.1**. Local, production, test, and remote-worker Compose stacks now use `ghcr.io/open-source-legal/docxodus-service:1.2.0-docxodus12.4.1`; the frontend pins the same library version with its updated Yarn lockfile.

The production build previously omitted the dynamically loaded WASM runtime. Include those assets with their original directory layout and give the renderer an explicit production path. The browser regression test now loads the built runtime without mocking its asset requests and checks rendered document text.

The service upgrade to .NET 10 and Docxodus 12.4.1 is already merged in [docxodus-service#1](https://github.com/Open-Source-Legal/docxodus-service/pull/1), and the [image publish workflow passed](https://github.com/Open-Source-Legal/docxodus-service/actions/runs/34671811873). Published image digest: `sha256:e27dfbf8776bfa1ed8a7408f1ffe8632decf1e9582bbd7164d903226552abcc7`.

Validation:
- Service CI and CodeQL passed; all 8 .NET integration cases passed, including Unicode annotation offsets.
- Pulled the published image and verified health, real DOCX parsing, and malformed-request handling. Its text, structural spans, and page/token metadata match the 12.4.1 npm WASM exporter on the OpenContracts fixture.
- `yarn build` passed (TypeScript and production bundle).
- WASM asset tests: 8 passed, including actual Vite build output and symlink exclusion.
- DOCX browser component tests: 8 passed, 1 pre-existing skipped test.
- Pre-commit and formatting checks passed.
